### PR TITLE
feat: cancel open orders

### DIFF
--- a/src/app/(platform)/event/[slug]/_actions/cancel-order.ts
+++ b/src/app/(platform)/event/[slug]/_actions/cancel-order.ts
@@ -1,0 +1,99 @@
+'use server'
+
+import { z } from 'zod'
+import { OrderRepository } from '@/lib/db/queries/order'
+import { UserRepository } from '@/lib/db/queries/user'
+import { buildClobHmacSignature } from '@/lib/hmac'
+
+const CancelOrderSchema = z.object({
+  orderId: z.string().min(1, 'Order id is required.'),
+})
+
+const CANCEL_ORDER_ERROR = 'Unable to cancel this order right now. Please try again.'
+
+export async function cancelOrderAction(rawOrderId: string) {
+  const user = await UserRepository.getCurrentUser({ disableCookieCache: true })
+  if (!user) {
+    return { error: 'Unauthenticated.' }
+  }
+
+  const parsed = CancelOrderSchema.safeParse({ orderId: rawOrderId })
+  if (!parsed.success) {
+    return { error: parsed.error.issues[0]?.message ?? 'Invalid order.' }
+  }
+
+  const lookup = await OrderRepository.findUserOrderById(parsed.data.orderId, user.id)
+  if (lookup.error || !lookup.data) {
+    return { error: 'Order not found.' }
+  }
+
+  if (!['live', 'pending'].includes(lookup.data.status)) {
+    return { error: 'This order can no longer be cancelled.' }
+  }
+
+  const method = 'DELETE'
+  const path = '/order'
+  const body = JSON.stringify({ orderId: lookup.data.clob_order_id })
+  const timestamp = Math.floor(Date.now() / 1000)
+  const signature = buildClobHmacSignature(
+    process.env.FORKAST_API_SECRET!,
+    timestamp,
+    method,
+    path,
+    body,
+  )
+
+  try {
+    const response = await fetch(`${process.env.CLOB_URL}${path}`, {
+      method,
+      headers: {
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+        'FORKAST_ADDRESS': process.env.FORKAST_ADDRESS!,
+        'FORKAST_API_KEY': process.env.FORKAST_API_KEY!,
+        'FORKAST_PASSPHRASE': process.env.FORKAST_PASSPHRASE!,
+        'FORKAST_TIMESTAMP': timestamp.toString(),
+        'FORKAST_SIGNATURE': signature,
+      },
+      body,
+      signal: AbortSignal.timeout(5000),
+    })
+
+    let payload: any
+    try {
+      payload = await response.json()
+    }
+    catch {
+      payload = null
+    }
+
+    if (!response.ok) {
+      if (response.status === 404) {
+        return { error: 'Order not found.' }
+      }
+      if (response.status === 409) {
+        return { error: 'Order is already filled or cancelled.' }
+      }
+
+      const message = typeof payload?.error === 'string'
+        ? payload.error
+        : typeof payload?.message === 'string'
+          ? payload.message
+          : null
+
+      console.error('Failed to cancel order on CLOB.', message ?? `Status ${response.status}`)
+      return { error: message || CANCEL_ORDER_ERROR }
+    }
+
+    const { error: cancelError } = await OrderRepository.cancelOrder(lookup.data.id, user.id)
+    if (cancelError) {
+      console.error('Failed to mark order as cancelled locally.', cancelError)
+    }
+
+    return { error: null }
+  }
+  catch (error) {
+    console.error('Failed to cancel order.', error)
+    return { error: CANCEL_ORDER_ERROR }
+  }
+}

--- a/src/lib/db/queries/order.ts
+++ b/src/lib/db/queries/order.ts
@@ -1,10 +1,33 @@
 import type { ClobOrderType, OrderSide } from '@/types'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, inArray } from 'drizzle-orm'
 import { orders } from '@/lib/db/schema/orders/tables'
 import { runQuery } from '@/lib/db/utils/run-query'
 import { db } from '@/lib/drizzle'
 
 export const OrderRepository = {
+  async findUserOrderById(orderId: string, userId: string) {
+    return await runQuery(async () => {
+      const [order] = await db
+        .select({
+          id: orders.id,
+          clob_order_id: orders.clob_order_id,
+          status: orders.status,
+        })
+        .from(orders)
+        .where(and(
+          eq(orders.id, orderId),
+          eq(orders.user_id, userId),
+        ))
+        .limit(1)
+
+      if (!order) {
+        return { data: null, error: 'Order not found' }
+      }
+
+      return { data: order, error: null }
+    })
+  },
+
   async createOrder(args: {
     // begin blockchain data
     salt: bigint
@@ -53,7 +76,7 @@ export const OrderRepository = {
         .where(and(
           eq(orders.id, orderId),
           eq(orders.user_id, userId),
-          eq(orders.status, 'pending'),
+          inArray(orders.status, ['delayed', 'live']),
         ))
         .returning()
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable users to cancel open orders from the event market. Cancels on the CLOB and updates the local order state with clear feedback.

- **New Features**
  - Added cancelOrderAction: validates input, checks ownership/status, sends HMAC-signed DELETE /order, maps 404/409 errors, and updates DB.
  - UI: Cancel button per open order with a loading state, success/error toasts, and query invalidation to refresh the list.
  - OrderRepository: new findUserOrderById; cancelOrder now targets delayed/live statuses. 
  - Network: 5s timeout and safe JSON parsing; friendly error messages.

<sup>Written for commit 3a976ac8e10c60d6ceffba20f4aa8476e66a4ff6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

