### PR TITLE
refactor: load balance from proxy wallet

### DIFF
--- a/src/app/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner'
 import { cancelOrderAction } from '@/app/(platform)/event/[slug]/_actions/cancel-order'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
+import { SAFE_BALANCE_QUERY_KEY } from '@/hooks/useBalance'
 import { formatSharePriceLabel, fromMicro } from '@/lib/formatters'
 import { cn } from '@/lib/utils'
 import { useUser } from '@/stores/useUser'
@@ -243,6 +244,10 @@ export default function EventMarketOpenOrders({ market, eventSlug, collapsible =
       await queryClient.invalidateQueries({
         queryKey: ['user-open-orders', user?.id, eventSlug, market.condition_id],
       })
+      void queryClient.invalidateQueries({ queryKey: [SAFE_BALANCE_QUERY_KEY] })
+      setTimeout(() => {
+        void queryClient.invalidateQueries({ queryKey: [SAFE_BALANCE_QUERY_KEY] })
+      }, 3000)
     }
     catch (error: any) {
       const message = typeof error?.message === 'string'

--- a/src/app/(platform)/event/[slug]/_components/EventMergeSharesDialog.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventMergeSharesDialog.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { CheckIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -11,6 +12,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { SAFE_BALANCE_QUERY_KEY } from '@/hooks/useBalance'
 import { cn } from '@/lib/utils'
 
 interface EventMergeSharesDialogProps {
@@ -28,6 +30,7 @@ export default function EventMergeSharesDialog({
   marketTitle,
   onOpenChange,
 }: EventMergeSharesDialogProps) {
+  const queryClient = useQueryClient()
   const [amount, setAmount] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -108,6 +111,10 @@ export default function EventMergeSharesDialog({
         description: marketTitle ?? 'Request submitted.',
         icon: <SuccessIcon />,
       })
+      void queryClient.invalidateQueries({ queryKey: [SAFE_BALANCE_QUERY_KEY] })
+      setTimeout(() => {
+        void queryClient.invalidateQueries({ queryKey: [SAFE_BALANCE_QUERY_KEY] })
+      }, 3000)
       setAmount('')
       onOpenChange(false)
     }

--- a/src/app/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -18,7 +18,7 @@ import { handleOrderCancelledFeedback, handleOrderErrorFeedback, handleOrderSucc
 import { useUserOutcomePositions } from '@/app/(platform)/event/[slug]/_hooks/useUserOutcomePositions'
 import { useAffiliateOrderMetadata } from '@/hooks/useAffiliateOrderMetadata'
 import { useAppKit } from '@/hooks/useAppKit'
-import { useBalance } from '@/hooks/useBalance'
+import { SAFE_BALANCE_QUERY_KEY, useBalance } from '@/hooks/useBalance'
 import { CLOB_ORDER_TYPE, getExchangeEip712Domain, ORDER_SIDE, ORDER_TYPE, OUTCOME_INDEX } from '@/lib/constants'
 import { formatCentsLabel, formatCurrency } from '@/lib/formatters'
 import { buildOrderPayload, submitOrder } from '@/lib/orders'
@@ -234,7 +234,10 @@ export default function EventOrderPanelForm({ event, isMobile }: EventOrderPanel
         lastMouseEvent: state.lastMouseEvent,
       })
 
+      void queryClient.invalidateQueries({ queryKey: [SAFE_BALANCE_QUERY_KEY] })
+
       setTimeout(() => {
+        void queryClient.invalidateQueries({ queryKey: [SAFE_BALANCE_QUERY_KEY] })
         void queryClient.refetchQueries({ queryKey: ['event-activity'] })
         void queryClient.refetchQueries({ queryKey: ['event-holders'] })
       }, 3000)

--- a/src/app/(platform)/event/[slug]/_components/EventSplitSharesDialog.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventSplitSharesDialog.tsx
@@ -1,3 +1,4 @@
+import { useQueryClient } from '@tanstack/react-query'
 import { CheckIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
@@ -11,6 +12,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
+import { SAFE_BALANCE_QUERY_KEY } from '@/hooks/useBalance'
 import { formatAmountInputValue } from '@/lib/formatters'
 import { cn } from '@/lib/utils'
 
@@ -29,6 +31,7 @@ export default function EventSplitSharesDialog({
   marketTitle,
   onOpenChange,
 }: EventSplitSharesDialogProps) {
+  const queryClient = useQueryClient()
   const [amount, setAmount] = useState('')
   const [error, setError] = useState<string | null>(null)
   const [isSubmitting, setIsSubmitting] = useState(false)
@@ -108,6 +111,10 @@ export default function EventSplitSharesDialog({
         description: marketTitle ?? 'Request submitted.',
         icon: <SuccessIcon />,
       })
+      void queryClient.invalidateQueries({ queryKey: [SAFE_BALANCE_QUERY_KEY] })
+      setTimeout(() => {
+        void queryClient.invalidateQueries({ queryKey: [SAFE_BALANCE_QUERY_KEY] })
+      }, 3000)
       setAmount('')
       onOpenChange(false)
     }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switched USDC balance to read from the user’s proxy wallet and moved balance fetching to React Query for more reliable, up-to-date balances after actions.

- **Refactors**
  - Balance now comes from proxy_wallet_address when the proxy is deployed.
  - Added SAFE_BALANCE_QUERY_KEY and invalidated it after cancel, merge, split, and order submit (immediate and again after 3s).
  - Replaced manual state/effects with React Query (10s refetch interval, 10s staleTime, 5min GC).
  - useBalance now returns balance, isLoadingBalance, and refetchBalance.

<sup>Written for commit 31e7a33a563384726e4bce9789cdaa99ef209f11. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

