### PR TITLE
feat: kbd search focus

### DIFF
--- a/src/components/HeaderSearch.tsx
+++ b/src/components/HeaderSearch.tsx
@@ -4,12 +4,38 @@ import { SearchIcon } from 'lucide-react'
 import { useEffect, useRef } from 'react'
 import { SearchResults } from '@/components/SearchResults'
 import { Input } from '@/components/ui/input'
+import { Kbd } from '@/components/ui/kbd'
 import { useSearch } from '@/hooks/useSearch'
 
 export default function HeaderSearch() {
   const searchRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
   const { query, handleQueryChange, results, isLoading, showResults, clearSearch, hideResults, activeTab, setActiveTab } = useSearch()
   const sitename = `${process.env.NEXT_PUBLIC_SITE_NAME || 'events and profiles'}`.toLowerCase()
+
+  useEffect(() => {
+    function handleSlashShortcut(event: KeyboardEvent) {
+      if (event.key !== '/') {
+        return
+      }
+
+      const target = event.target as HTMLElement | null
+      const tagName = target?.tagName?.toLowerCase()
+      const isEditable = tagName === 'input' || tagName === 'textarea' || target?.isContentEditable
+
+      if (event.metaKey || event.ctrlKey || event.altKey || isEditable) {
+        return
+      }
+
+      event.preventDefault()
+      inputRef.current?.focus()
+    }
+
+    window.addEventListener('keydown', handleSlashShortcut)
+    return () => {
+      window.removeEventListener('keydown', handleSlashShortcut)
+    }
+  }, [])
 
   useEffect(() => {
     function handleClickOutside(event: MouseEvent) {
@@ -35,12 +61,14 @@ export default function HeaderSearch() {
       <SearchIcon className="absolute top-1/2 left-3 z-10 size-4 -translate-y-1/2 text-muted-foreground" />
       <Input
         type="text"
+        ref={inputRef}
         data-testid="header-search-input"
         placeholder={`Search ${sitename}`}
         value={query}
         onChange={e => handleQueryChange(e.target.value)}
-        className="w-full pl-9 text-sm"
+        className="w-full pr-12 pl-9 text-sm"
       />
+      <Kbd className="absolute top-1/2 right-3 hidden -translate-y-1/2 sm:inline-flex">/</Kbd>
       {(showResults || isLoading.events || isLoading.profiles) && (
         <SearchResults
           results={results}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,9 +2,10 @@ import * as React from 'react'
 
 import { cn } from '@/lib/utils'
 
-function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
+function Input({ ref, className, type, ...props }: React.ComponentProps<'input'> & { ref?: React.RefObject<HTMLInputElement | null> }) {
   return (
     <input
+      ref={ref}
       type={type}
       data-slot="input"
       className={cn(
@@ -26,5 +27,6 @@ function Input({ className, type, ...props }: React.ComponentProps<'input'>) {
     />
   )
 }
+Input.displayName = 'Input'
 
 export { Input }

--- a/src/components/ui/kbd.tsx
+++ b/src/components/ui/kbd.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Kbd({ ref, className, ...props }: React.HTMLAttributes<HTMLElement> & { ref?: React.RefObject<HTMLElement | null> }) {
+  return (
+    <kbd
+      ref={ref}
+      className={cn(
+        `
+          pointer-events-none inline-flex h-5 items-center gap-1 rounded border border-muted-foreground/40 bg-muted
+          px-1.5 font-mono text-[10px] font-medium text-muted-foreground shadow-xs select-none
+        `,
+        className,
+      )}
+      {...props}
+    />
+  )
+}
+Kbd.displayName = 'Kbd'
+
+export { Kbd }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a global “/” shortcut to focus the header search. Show a small “/” key hint in the search box on desktop.

- **New Features**
  - Press “/” focuses the search when not typing and without Ctrl/Cmd/Alt.
  - Added Kbd UI component and integrated a “/” hint in HeaderSearch (sm+ only).
  - Input now accepts a ref for programmatic focus.

<sup>Written for commit d758c60c70fbc3bc4fe8d4c18cc993a6d85c1c0c. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

