### PR TITLE
feat: load event trades activity from data api

### DIFF
--- a/src/lib/data-api/trades.ts
+++ b/src/lib/data-api/trades.ts
@@ -1,0 +1,62 @@
+import type { DataApiActivity } from '@/lib/data-api/user'
+import type { ActivityOrder } from '@/types'
+import { filterActivitiesByMinAmount } from '@/lib/activity/filter'
+import { mapDataApiActivityToActivityOrder } from '@/lib/data-api/user'
+import { toMicro } from '@/lib/formatters'
+
+const DATA_API_URL = process.env.DATA_URL!
+
+interface FetchEventTradesParams {
+  marketIds: string[]
+  pageParam: number
+  minAmountFilter?: string
+  signal?: AbortSignal
+}
+
+export async function fetchEventTrades({
+  marketIds,
+  pageParam,
+  minAmountFilter,
+  signal,
+}: FetchEventTradesParams): Promise<ActivityOrder[]> {
+  if (!DATA_API_URL) {
+    throw new Error('DATA_URL environment variable is not configured.')
+  }
+
+  const markets = Array.from(new Set(marketIds.filter(Boolean)))
+  if (markets.length === 0) {
+    throw new Error('At least one market id is required to load event activity.')
+  }
+
+  const params = new URLSearchParams({
+    limit: '50',
+    offset: pageParam.toString(),
+    market: markets.join(','),
+    takerOnly: 'false',
+  })
+
+  const parsedFilterAmount = Number(minAmountFilter)
+  const hasFilterAmount = Number.isFinite(parsedFilterAmount) && parsedFilterAmount > 0
+  const minAmountMicro = hasFilterAmount ? Number(toMicro(parsedFilterAmount)) : undefined
+
+  if (hasFilterAmount) {
+    params.set('filterType', 'CASH')
+    params.set('filterAmount', parsedFilterAmount.toString())
+  }
+
+  const response = await fetch(`${DATA_API_URL}/trades?${params.toString()}`, { signal })
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => null)
+    const errorMessage = errorBody?.error || 'Failed to load event activity.'
+    throw new Error(errorMessage)
+  }
+
+  const result = await response.json()
+  if (!Array.isArray(result)) {
+    throw new TypeError('Unexpected response from data service.')
+  }
+
+  const activities = (result as DataApiActivity[]).map(mapDataApiActivityToActivityOrder)
+  return filterActivitiesByMinAmount(activities, minAmountMicro)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Load event trades from the Data API and update EventActivity to query by market IDs. Adds clear empty and error states and reduces unnecessary requests.

- **New Features**
  - Added fetchEventTrades in src/lib/data-api/trades.ts to call DATA_URL/trades with pagination, market IDs, and optional CASH filter.
  - EventActivity now uses fetchEventTrades with useInfiniteQuery, includes market IDs in the query key, and enables fetching only when markets exist.
  - Added “No market available for this event” alert; updated error to “Failed to load activity.”
  - Supports request cancellation via AbortSignal and maps/filters results to ActivityOrder.

- **Migration**
  - Set DATA_URL environment variable to the Data API base URL.

<sup>Written for commit 02f9722cf292fc3490a064a0da231421f992bee7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

