### PR TITLE
feat: back to top button

### DIFF
--- a/src/app/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventContent.tsx
@@ -112,7 +112,7 @@ export default function EventContent({ event, user, marketContextEnabled }: Even
       }
 
       const rect = contentRef.current.getBoundingClientRect()
-      setBackToTopBounds({ left: rect.left + window.scrollX, width: rect.width })
+      setBackToTopBounds({ left: rect.left, width: rect.width })
     }
 
     handleResize()


### PR DESCRIPTION






<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a “Back to top” button to the event page that appears after you scroll past the markets on desktop. Helps users quickly return to the top.

- **New Features**
  - Shows on desktop after passing the markets section; hidden on mobile.
  - Centers over the content column and adjusts on resize; smooth scroll to top with an accessible label.

<sup>Written for commit 838bf7125826b8c6ca54e6d670db4e51a1d8413a. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





