### PR TITLE
fix: invalidate query on bookmark

### DIFF
--- a/src/app/(platform)/event/[slug]/_components/EventBookmark.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventBookmark.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useAppKitAccount } from '@reown/appkit/react'
+import { useQueryClient } from '@tanstack/react-query'
 import { BookmarkIcon } from 'lucide-react'
 import { useCallback, useEffect, useState, useTransition } from 'react'
 import { toggleBookmarkAction } from '@/app/(platform)/event/[slug]/_actions/toggle-bookmark'
@@ -20,6 +21,7 @@ interface EventBookmarkProps {
 export default function EventBookmark({ event }: EventBookmarkProps) {
   const { open } = useAppKit()
   const { isConnected } = useAppKitAccount()
+  const queryClient = useQueryClient()
   const [isBookmarked, setIsBookmarked] = useState(event.is_bookmarked)
   const [isPending, startTransition] = useTransition()
 
@@ -32,13 +34,16 @@ export default function EventBookmark({ event }: EventBookmarkProps) {
         const response = await toggleBookmarkAction(event.id)
         if (response.error) {
           setIsBookmarked(previousState)
+          return
         }
+
+        await queryClient.invalidateQueries({ queryKey: ['events'], refetchType: 'all' })
       }
       catch {
         setIsBookmarked(previousState)
       }
     })
-  }, [isBookmarked, event.id])
+  }, [event.id, isBookmarked, queryClient])
 
   useEffect(() => {
     setIsBookmarked(event.is_bookmarked)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Invalidate the 'events' query after toggling a bookmark so lists update immediately. Improve error handling to revert the UI and avoid refetch on failure.

- **Bug Fixes**
  - Invalidate React Query cache for ['events'] after a successful bookmark toggle.
  - Add early return on error to restore previous state and prevent unwanted refetch.

<sup>Written for commit 9628c6f82e60eb938b7c093774eea04ee5ff8dca. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

