### PR TITLE
fix: constant negrisk ctfexchange address

### DIFF
--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -44,12 +44,8 @@ export const CAP_MICRO = 990_000n
 export const FLOOR_MICRO = 10_000n
 
 export const CTF_EXCHANGE_ADDRESS = '0x828da759D63e7d7890AF8F30e3Cdc9c456F7533e' as `0x${string}`
-const negRiskExchangeAddress = (
-  process.env.NEGRISK_CTFEXCHANGE_ADDRESS
-  ?? process.env.NEXT_PUBLIC_NEGRISK_CTFEXCHANGE_ADDRESS
-  ?? '0x3314ad2140f1b5F3b305Fd062E2D2d3E75Fc5205'
-) as `0x${string}`
-export const NEG_RISK_CTF_EXCHANGE_ADDRESS = negRiskExchangeAddress
+
+export const NEG_RISK_CTF_EXCHANGE_ADDRESS = '0x3314ad2140f1b5F3b305Fd062E2D2d3E75Fc5205' as `0x${string}`
 
 export const EIP712_DOMAIN = {
   name: 'Forkast CTF Exchange',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hardcoded the correct NEG_RISK_CTF_EXCHANGE_ADDRESS and removed env-based fallbacks to ensure a consistent address across environments.
Prevents misconfiguration and mismatched addresses between server and client.

<sup>Written for commit a105e2870f82ab76c1ed2a27d381116481c5dab4. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

