### PR TITLE
fix: resolved_by to use a constant address

### DIFF
--- a/src/app/admin/create-event/_components/AdminCreateEventForm.tsx
+++ b/src/app/admin/create-event/_components/AdminCreateEventForm.tsx
@@ -501,7 +501,7 @@ export default function AdminCreateEventForm() {
           ...market,
           outcomes: market.outcomes.filter(outcome => outcome.outcome.trim()),
           oracle_type: 'native',
-          resolved_by: process.env.NEXT_PUBLIC_UMA_ADAPTER_ADDRESS || '0xF8D795e06e6E29942Fe01704df2587dDfcD921DB',
+          resolved_by: '0xF8D795e06e6E29942Fe01704df2587dDfcD921DB',
         })),
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set resolved_by to a fixed UMA adapter address in AdminCreateEventForm to ensure consistent market resolution across environments.

- **Bug Fixes**
  - Removed reliance on NEXT_PUBLIC_UMA_ADAPTER_ADDRESS to prevent mismatched adapter addresses between envs.

<sup>Written for commit ec57b05c6ef34ec62640cb1a6ba738b2e39d33ac. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

