### PR TITLE
refactor: do not load trading onboarding provider in admin

### DIFF
--- a/src/app/(platform)/layout.tsx
+++ b/src/app/(platform)/layout.tsx
@@ -6,17 +6,20 @@ import NavigationTabs from '@/components/NavigationTabs'
 import PlatformLayoutSkeleton from '@/components/PlatformLayoutSkeleton'
 import { FilterProvider } from '@/providers/FilterProvider'
 import { Providers } from '@/providers/Providers'
+import { TradingOnboardingProvider } from '@/providers/TradingOnboardingProvider'
 
 export default async function PlatformLayout({ children }: LayoutProps<'/'>) {
   return (
     <Providers>
-      <FilterProvider>
-        <Header />
-        <Suspense fallback={<PlatformLayoutSkeleton />}>
-          <NavigationTabs />
-          {children}
-        </Suspense>
-      </FilterProvider>
+      <TradingOnboardingProvider>
+        <FilterProvider>
+          <Header />
+          <Suspense fallback={<PlatformLayoutSkeleton />}>
+            <NavigationTabs />
+            {children}
+          </Suspense>
+        </FilterProvider>
+      </TradingOnboardingProvider>
     </Providers>
   )
 }

--- a/src/lib/db/migrations/2025_08_28_004_auth.sql
+++ b/src/lib/db/migrations/2025_08_28_004_auth.sql
@@ -2,7 +2,6 @@
 -- 1. TABLES
 -- ===========================================
 
--- Users table - Core user identity with affiliate functionality
 CREATE TABLE users
 (
   id                     CHAR(26) PRIMARY KEY DEFAULT generate_ulid(),
@@ -34,7 +33,6 @@ CREATE TABLE users
   updated_at             TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Sessions table - Better Auth session management
 CREATE TABLE sessions
 (
   id         CHAR(26) PRIMARY KEY DEFAULT generate_ulid(),
@@ -47,7 +45,6 @@ CREATE TABLE sessions
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Accounts table - OAuth/social login accounts
 CREATE TABLE accounts
 (
   id                       CHAR(26) PRIMARY KEY DEFAULT generate_ulid(),
@@ -65,7 +62,6 @@ CREATE TABLE accounts
   updated_at               TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Verifications table - Email/SIWE verification tokens
 CREATE TABLE verifications
 (
   id         CHAR(26) PRIMARY KEY DEFAULT generate_ulid(),
@@ -76,7 +72,6 @@ CREATE TABLE verifications
   updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Wallets table - User Web3 wallet connections
 CREATE TABLE wallets
 (
   id         CHAR(26) PRIMARY KEY DEFAULT generate_ulid(),
@@ -87,7 +82,6 @@ CREATE TABLE wallets
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- two-factor authentication table
 CREATE TABLE two_factors
 (
   id           CHAR(26) NOT NULL DEFAULT generate_ulid(),

--- a/src/lib/db/migrations/2025_08_28_005_events.sql
+++ b/src/lib/db/migrations/2025_08_28_005_events.sql
@@ -2,7 +2,6 @@
 -- 1. TABLES
 -- ===========================================
 
--- Conditions table - Primary entity from Activity/PnL subgraphs
 CREATE TABLE conditions
 (
   id           CHAR(66) PRIMARY KEY,
@@ -18,7 +17,6 @@ CREATE TABLE conditions
   updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Tags table - Hierarchical categorization system for events
 CREATE TABLE tags
 (
   id                   SMALLINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
@@ -34,7 +32,6 @@ CREATE TABLE tags
   updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
--- Events table - Core content structure for prediction markets
 CREATE TABLE events
 (
   id                   CHAR(26) PRIMARY KEY DEFAULT generate_ulid(),
@@ -57,7 +54,6 @@ CREATE TABLE events
   CHECK (status IN ('draft', 'active', 'archived'))
 );
 
--- Event-Tag relationship table - Many-to-many between events and tags
 CREATE TABLE event_tags
 (
   event_id CHAR(26) NOT NULL REFERENCES events (id) ON DELETE CASCADE ON UPDATE CASCADE,
@@ -65,7 +61,6 @@ CREATE TABLE event_tags
   PRIMARY KEY (event_id, tag_id)
 );
 
--- Markets table - Core trading markets (belongs to events)
 CREATE TABLE markets
 (
   -- IDs and Identifiers
@@ -106,7 +101,6 @@ CREATE TABLE markets
   CHECK (volume >= 0)
 );
 
--- Outcomes table - Individual market outcomes (belongs to markets via condition_id)
 CREATE TABLE outcomes
 (
   id                 CHAR(26) PRIMARY KEY DEFAULT generate_ulid(),
@@ -130,7 +124,6 @@ CREATE TABLE outcomes
   CHECK (payout_value IS NULL OR payout_value >= 0)
 );
 
--- subgraph_syncs table - Blockchain synchronization tracking
 CREATE TABLE subgraph_syncs
 (
   id              SMALLINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,

--- a/src/lib/db/migrations/2025_09_24_001_affiliates.sql
+++ b/src/lib/db/migrations/2025_09_24_001_affiliates.sql
@@ -10,26 +10,21 @@ CREATE TABLE affiliate_referrals
   affiliate_user_id CHAR(26)    NOT NULL REFERENCES users (id) ON DELETE CASCADE,        -- The referring affiliate
   created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()                                   -- When attribution was recorded
 );
-
 -- ===========================================
--- 2. INDEXES
--- ===========================================
-
--- ===========================================
--- 3. ROW LEVEL SECURITY
+-- 2. ROW LEVEL SECURITY
 -- ===========================================
 
 ALTER TABLE affiliate_referrals
   ENABLE ROW LEVEL SECURITY;
 
 -- ===========================================
--- 4. POLICIES
+-- 3. POLICIES
 -- ===========================================
 
 CREATE POLICY "service_role_all_affiliate_referrals" ON "affiliate_referrals" AS PERMISSIVE FOR ALL TO "service_role" USING (TRUE) WITH CHECK (TRUE);
 
 -- ===========================================
--- 5. FUNCTIONS
+-- 4. FUNCTIONS
 -- ===========================================
 
 CREATE OR REPLACE FUNCTION get_affiliate_stats(target_user_id CHAR(26))

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -8,7 +8,6 @@ import GoogleAnalytics from '@/components/GoogleAnalytics'
 import { Toaster } from '@/components/ui/sonner'
 import AppKitProvider from '@/providers/AppKitProvider'
 import ProgressIndicatorProvider from '@/providers/ProgressIndicatorProvider'
-import { TradingOnboardingProvider } from '@/providers/TradingOnboardingProvider'
 
 const queryClient = new QueryClient()
 
@@ -18,14 +17,12 @@ export function Providers({ children }: { children: ReactNode }) {
       <ThemeProvider attribute="class">
         <QueryClientProvider client={queryClient}>
           <AppKitProvider>
-            <TradingOnboardingProvider>
-              <div className="min-h-screen bg-background">
-                {children}
-              </div>
-              <Toaster position="top-center" />
-              {process.env.NODE_ENV === 'production' && <SpeedInsights />}
-              {process.env.NODE_ENV === 'production' && <GoogleAnalytics />}
-            </TradingOnboardingProvider>
+            <div className="min-h-screen bg-background">
+              {children}
+            </div>
+            <Toaster position="top-center" />
+            {process.env.NODE_ENV === 'production' && <SpeedInsights />}
+            {process.env.NODE_ENV === 'production' && <GoogleAnalytics />}
           </AppKitProvider>
         </QueryClientProvider>
       </ThemeProvider>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved TradingOnboardingProvider out of the global app wrapper and scoped it to platform pages. Admin no longer initializes trading onboarding logic.

- **Refactors**
  - Removed TradingOnboardingProvider from src/providers/Providers.tsx.
  - Added TradingOnboardingProvider around (platform) layout only.
  - Tidied SQL migration comments and section headers; no schema changes.

<sup>Written for commit bdfb1dc5933b3ae8a07e4d2f524770b5a015fa79. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

