### PR TITLE
fix: event sync lock

### DIFF
--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -824,14 +824,15 @@ async function checkSyncRunning(): Promise<boolean> {
     .select('status')
     .eq('service_name', 'market_sync')
     .eq('subgraph_name', 'pnl')
-    .lt('updated_at', new Date(Date.now() - 15 * 60 * 1000).toISOString())
+    .eq('status', 'running')
+    .gt('updated_at', new Date(Date.now() - 15 * 60 * 1000).toISOString())
     .maybeSingle()
 
   if (error && error.code !== 'PGRST116') {
     throw new Error(`Failed to check sync status: ${error.message}`)
   }
 
-  return data?.status === 'running'
+  return Boolean(data)
 }
 
 async function updateSyncStatus(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the event sync lock by updating checkSyncRunning to only consider a sync “running” if it has status='running' and was updated in the last 15 minutes. This prevents stale locks and stops concurrent syncs.

<sup>Written for commit a0789fce3c59ef177e4adebc5df13c6a935c8fed. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

