### PR TITLE
fix: fill limit on outcome change

### DIFF
--- a/src/app/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventContent.tsx
@@ -20,7 +20,7 @@ import EventSingleMarketOrderBook from '@/app/(platform)/event/[slug]/_component
 import EventTabs from '@/app/(platform)/event/[slug]/_components/EventTabs'
 import { Teleport } from '@/components/Teleport'
 import { useIsMobile } from '@/hooks/useIsMobile'
-import { useOrder } from '@/stores/useOrder'
+import { useOrder, useSyncLimitPriceWithOutcome } from '@/stores/useOrder'
 import { useUser } from '@/stores/useUser'
 
 interface EventContentProps {
@@ -126,6 +126,7 @@ export default function EventContent({ event, user, marketContextEnabled }: Even
 
   return (
     <EventOutcomeChanceProvider eventId={event.id}>
+      <OrderLimitPriceSync />
       <div className="grid gap-3" ref={contentRef}>
         <EventHeader event={event} />
         <EventMetaInformation event={event} />
@@ -183,4 +184,9 @@ export default function EventContent({ event, user, marketContextEnabled }: Even
           )}
     </EventOutcomeChanceProvider>
   )
+}
+
+function OrderLimitPriceSync() {
+  useSyncLimitPriceWithOutcome()
+  return null
 }

--- a/src/app/(platform)/event/[slug]/_components/EventRelated.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventRelated.tsx
@@ -248,7 +248,7 @@ export default function EventRelated({ event }: EventRelatedProps) {
         <div
           ref={scrollContainerRef}
           className={cn(
-            `relative scrollbar-hide min-w-0 overflow-x-auto overflow-y-hidden px-2 pb-1 lg:w-[340px] lg:max-w-[340px]`,
+            `relative scrollbar-hide min-w-0 overflow-x-auto overflow-y-hidden px-2 pb-1 lg:w-85 lg:max-w-85`,
             (showLeftShadow || showRightShadow)
             && `
               mask-[linear-gradient(to_right,transparent,black_32px,black_calc(100%-32px),transparent)]
@@ -320,7 +320,7 @@ export default function EventRelated({ event }: EventRelatedProps) {
             )
           : events.length > 0
             ? (
-                <ul className="grid gap-2 lg:w-[340px]">
+                <ul className="grid gap-2 lg:w-85">
                   {events.map(relatedEvent => (
                     <li key={relatedEvent.id}>
                       <Link

--- a/src/app/(platform)/event/[slug]/loading.tsx
+++ b/src/app/(platform)/event/[slug]/loading.tsx
@@ -22,7 +22,7 @@ export default async function Loading() {
       </div>
 
       <Teleport to="#event-order-panel">
-        <section className="rounded-lg border bg-card/60 p-4 shadow-xl/5 lg:w-[340px]">
+        <section className="rounded-lg border bg-card/60 p-4 shadow-xl/5 lg:w-85">
           <Skeleton className="h-4 w-1/3" />
           <div className="mt-6 flex gap-2">
             <Skeleton className="h-12 w-full" />

--- a/src/components/HeaderHowItWorks.tsx
+++ b/src/components/HeaderHowItWorks.tsx
@@ -142,7 +142,7 @@ export default function HeaderHowItWorks() {
       )}
 
       <DialogContent className="max-h-[95vh] gap-0 overflow-y-auto p-0 sm:max-w-md" data-testid="how-it-works-dialog">
-        <div className="h-[340px] overflow-hidden rounded-t-lg">
+        <div className="h-85 overflow-hidden rounded-t-lg">
           <Image
             src={currentStep.image}
             alt={currentStep.imageAlt}

--- a/src/components/HeaderNotifications.tsx
+++ b/src/components/HeaderNotifications.tsx
@@ -89,7 +89,7 @@ export default function HeaderNotifications() {
       </DropdownMenuTrigger>
 
       <DropdownMenuContent
-        className="max-h-[400px] w-[340px] overflow-hidden lg:w-[380px]"
+        className="max-h-100 w-85 overflow-hidden lg:w-95"
         align="end"
         collisionPadding={32}
       >
@@ -97,7 +97,7 @@ export default function HeaderNotifications() {
           <h3 className="text-sm font-semibold text-foreground">Notifications</h3>
         </div>
 
-        <div className="max-h-[400px] overflow-y-auto">
+        <div className="max-h-100 overflow-y-auto">
           {isLoading && (
             <div className="p-4 text-center text-muted-foreground">
               <BellIcon className="mx-auto mb-2 size-8 animate-pulse opacity-50" />
@@ -149,8 +149,8 @@ export default function HeaderNotifications() {
                           )
                         : (
                             <div className={`
-                              flex h-[42px] w-[42px] items-center justify-center rounded-md bg-muted text-xs
-                              font-semibold text-muted-foreground uppercase
+                              flex size-10.5 items-center justify-center rounded-md bg-muted text-xs font-semibold
+                              text-muted-foreground uppercase
                             `}
                             >
                               {notification.title.slice(0, 2)}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Automatically pre-fill and sync the limit price when the selected outcome changes or when switching to a Limit order. This prevents empty or stale limit prices and speeds up order entry.

- **Bug Fixes**
  - Added useSyncLimitPriceWithOutcome to set the limit price from the current Yes/No price (normalized to cents) when the outcome changes.
  - Prefill limit price on type change to LIMIT using the selected outcome’s price.
  - Avoid overwriting user-edited prices by syncing once per outcome change.

- **Refactors**
  - Replaced hard-coded px widths with size tokens (w-85, max-h-100, size-10.5) across order panel, related events, loading state, and notifications for consistent UI.

<sup>Written for commit 96ee1809db81c18ddf6e86cf2b6d49e381e9b01d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

