### PR TITLE
fix: align chart tooltip with cursor

### DIFF
--- a/src/app/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventChart.tsx
@@ -12,7 +12,6 @@ import {
 } from '@/app/(platform)/event/[slug]/_components/EventOutcomeChanceProvider'
 import {
   buildMarketTargets,
-  CURSOR_STEP_MS,
   TIME_RANGES,
   useEventPriceHistory,
 } from '@/app/(platform)/event/[slug]/_components/useEventPriceHistory'
@@ -317,7 +316,6 @@ function EventChartComponent({ event, isMobile }: EventChartProps) {
           height={280}
           margin={{ top: 30, right: 40, bottom: 52, left: 0 }}
           dataSignature={chartSignature}
-          cursorStepMs={CURSOR_STEP_MS[activeTimeRange]}
           onCursorDataChange={setCursorSnapshot}
           xAxisTickCount={isMobile ? 3 : 6}
           legendContent={legendContent}

--- a/src/app/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
+++ b/src/app/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
@@ -5,7 +5,6 @@ import type { Market, Outcome } from '@/types'
 import { useMemo, useState } from 'react'
 import {
   buildMarketTargets,
-  CURSOR_STEP_MS,
   TIME_RANGES,
 
   useEventPriceHistory,
@@ -74,7 +73,6 @@ export default function MarketOutcomeGraph({ market, outcome, allMarkets, eventC
         height={260}
         margin={{ top: 20, right: 40, bottom: 48, left: 0 }}
         dataSignature={chartSignature}
-        cursorStepMs={CURSOR_STEP_MS[activeTimeRange]}
         xAxisTickCount={isMobile ? 3 : 6}
         legendContent={null}
         showLegend={false}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns the chart tooltip with the cursor so the date and value labels track the pointer and stay within the chart bounds.

- **Bug Fixes**
  - Use raw pointer time clamped to the domain; snap only if cursorStepMs > 0.
  - Date and value labels now anchor to the pointer, flip sides near edges, and clamp to chart bounds.
  - Extended the vertical cursor line for clearer alignment.
  - Removed cursorStepMs usage from EventChart and MarketOutcomeGraph; positioning logic is centralized in PredictionChart.

<sup>Written for commit 5be11b8518144da5616c99cb36806ce81ef769dd. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

