### PR TITLE
fix: search by multi terms

### DIFF
--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -260,7 +260,15 @@ export const EventRepository = {
       whereConditions.push(eq(events.status, 'active'))
 
       if (search) {
-        whereConditions.push(ilike(events.title, `%${search.toLowerCase()}%`))
+        const normalizedSearch = search.trim().toLowerCase()
+        const searchTerms = normalizedSearch.split(/\s+/).filter(Boolean)
+
+        if (searchTerms.length > 0) {
+          const loweredTitle = sql<string>`LOWER(${events.title})`
+          whereConditions.push(
+            and(...searchTerms.map(term => ilike(loweredTitle, `%${term}%`))),
+          )
+        }
       }
 
       if (tag && tag !== 'trending' && tag !== 'new') {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix event search to handle multi-word queries. We split the input into words, require each word to appear in the title, and match case-insensitively while ignoring extra spaces.

<sup>Written for commit 17fbf4478620bdee12860880574a7ee3ae32efc1. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

