### PR TITLE
style: fix portfolio horizontal scroll

### DIFF
--- a/src/app/(platform)/[username]/_components/PublicHistoryList.tsx
+++ b/src/app/(platform)/[username]/_components/PublicHistoryList.tsx
@@ -392,76 +392,80 @@ export default function PublicHistoryList({ userAddress }: PublicHistoryListProp
         </div>
       </div>
 
-      <div
-        className={cn(
-          rowGridClass,
-          `px-2 pt-2 pb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase sm:px-3`,
-        )}
-      >
-        <div>Activity</div>
-        <div>Market</div>
-        <div className="text-right">Value</div>
-        <div className="text-right text-transparent" aria-hidden>
-          <span className="invisible">Time</span>
-        </div>
-      </div>
-
-      {isLoading && (
-        <div className="space-y-3 px-2 sm:px-3">
-          {Array.from({ length: 4 }).map((_, index) => (
-            <div
-              key={index}
-              className="h-14 rounded-lg border border-border/50 bg-muted/30"
-            />
-          ))}
-        </div>
-      )}
-
-      {hasError && (
-        <div className="py-10 text-center text-sm text-muted-foreground">
-          Could not load activity.
-          {' '}
-          <button
-            type="button"
-            onClick={() => refetch()}
-            className="underline underline-offset-2"
+      <div className="overflow-x-auto">
+        <div className="min-w-180">
+          <div
+            className={cn(
+              rowGridClass,
+              `px-2 pt-2 pb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase sm:px-3`,
+            )}
           >
-            Retry
-          </button>
-        </div>
-      )}
+            <div>Activity</div>
+            <div>Market</div>
+            <div className="text-right">Value</div>
+            <div className="text-right text-transparent" aria-hidden>
+              <span className="invisible">Time</span>
+            </div>
+          </div>
 
-      {hasNoData && !hasError && (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          No history found.
-        </div>
-      )}
-
-      {!isLoading && !hasError && activities.length > 0 && (
-        <div>
-          {renderRows()}
-          {(isFetchingNextPage || isLoadingMore) && (
-            <div className="py-3 text-center text-xs text-muted-foreground">Loading more...</div>
+          {isLoading && (
+            <div className="space-y-3 px-2 sm:px-3">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="h-14 rounded-lg border border-border/50 bg-muted/30"
+                />
+              ))}
+            </div>
           )}
-          <div ref={loadMoreRef} />
-          {infiniteScrollError && (
-            <div className="py-3 text-center text-xs text-no">
-              {infiniteScrollError}
+
+          {hasError && (
+            <div className="py-10 text-center text-sm text-muted-foreground">
+              Could not load activity.
               {' '}
               <button
                 type="button"
-                onClick={() => {
-                  setInfiniteScrollError(null)
-                  void fetchNextPage()
-                }}
+                onClick={() => refetch()}
                 className="underline underline-offset-2"
               >
                 Retry
               </button>
             </div>
           )}
+
+          {hasNoData && !hasError && (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              No history found.
+            </div>
+          )}
+
+          {!isLoading && !hasError && activities.length > 0 && (
+            <div>
+              {renderRows()}
+              {(isFetchingNextPage || isLoadingMore) && (
+                <div className="py-3 text-center text-xs text-muted-foreground">Loading more...</div>
+              )}
+              <div ref={loadMoreRef} />
+              {infiniteScrollError && (
+                <div className="py-3 text-center text-xs text-no">
+                  {infiniteScrollError}
+                  {' '}
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setInfiniteScrollError(null)
+                      void fetchNextPage()
+                    }}
+                    className="underline underline-offset-2"
+                  >
+                    Retry
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </div>
   )
 }

--- a/src/app/(platform)/[username]/_components/PublicOpenOrdersList.tsx
+++ b/src/app/(platform)/[username]/_components/PublicOpenOrdersList.tsx
@@ -266,47 +266,51 @@ export default function PublicOpenOrdersList({ userAddress }: PublicOpenOrdersLi
         </div>
       </div>
 
-      <div
-        className={cn(
-          rowGridClass,
-          `px-2 pt-2 pb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase sm:px-3`,
-        )}
-      >
-        <div className="pl-15 text-left">Market</div>
-        <div className="text-center">Side</div>
-        <div className="text-left">Outcome</div>
-        <div className="text-center">Price</div>
-        <div className="text-center">Filled</div>
-        <div className="text-center">Total</div>
-        <div className="text-left sm:text-center">Expiration</div>
-        <div className="flex justify-end">
-          <div className="w-10" aria-hidden />
+      <div className="overflow-x-auto">
+        <div className="min-w-180">
+          <div
+            className={cn(
+              rowGridClass,
+              `px-2 pt-2 pb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase sm:px-3`,
+            )}
+          >
+            <div className="pl-15 text-left">Market</div>
+            <div className="text-center">Side</div>
+            <div className="text-left">Outcome</div>
+            <div className="text-center">Price</div>
+            <div className="text-center">Filled</div>
+            <div className="text-center">Total</div>
+            <div className="text-left sm:text-center">Expiration</div>
+            <div className="flex justify-end">
+              <div className="w-10" aria-hidden />
+            </div>
+          </div>
+
+          {loading && (
+            <div className="space-y-3 px-2 sm:px-3">
+              {Array.from({ length: 4 }).map((_, idx) => (
+                <div key={idx} className="h-14 rounded-lg border border-border/50 bg-muted/30" />
+              ))}
+            </div>
+          )}
+
+          {!loading && orders.length === 0 && (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              {emptyText}
+            </div>
+          )}
+
+          {!loading && orders.length > 0 && (
+            <div className="space-y-0">
+              {renderRows()}
+              {(isFetchingNextPage) && (
+                <div className="py-3 text-center text-xs text-muted-foreground">Loading more...</div>
+              )}
+              <div ref={loadMoreRef} className="h-0" />
+            </div>
+          )}
         </div>
       </div>
-
-      {loading && (
-        <div className="space-y-3 px-2 sm:px-3">
-          {Array.from({ length: 4 }).map((_, idx) => (
-            <div key={idx} className="h-14 rounded-lg border border-border/50 bg-muted/30" />
-          ))}
-        </div>
-      )}
-
-      {!loading && orders.length === 0 && (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          {emptyText}
-        </div>
-      )}
-
-      {!loading && orders.length > 0 && (
-        <div className="space-y-0">
-          {renderRows()}
-          {(isFetchingNextPage) && (
-            <div className="py-3 text-center text-xs text-muted-foreground">Loading more...</div>
-          )}
-          <div ref={loadMoreRef} className="h-0" />
-        </div>
-      )}
     </div>
   )
 }

--- a/src/app/(platform)/[username]/_components/PublicPositionsList.tsx
+++ b/src/app/(platform)/[username]/_components/PublicPositionsList.tsx
@@ -870,84 +870,88 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
         onMergeClick={() => setIsMergeDialogOpen(true)}
       />
 
-      <div
-        className={cn(
-          rowGridClass,
-          `px-2 pt-2 pb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase sm:px-3`,
-        )}
-      >
-        <div className="pl-[3.75rem] text-left">Market</div>
-        <div className="text-left">Avg → Now</div>
-        <div className="text-center">Trade</div>
-        <div className="text-center">To win</div>
-        <div className="text-right">Value</div>
-        <div className="flex justify-end">
-          <div className="w-[96px]" aria-hidden />
-        </div>
-      </div>
-
-      {hasInitialError && (
-        <PublicPositionsError
-          isSearchActive={isSearchActive}
-          searchQuery={debouncedSearchQuery}
-          retryCount={retryCount}
-          isLoading={loading}
-          onRetry={retryInitialLoad}
-          onRefreshPage={() => window.location.reload()}
-        />
-      )}
-
-      {loading && (
-        <PublicPositionsLoadingState
-          skeletonCount={5}
-          isSearchActive={isSearchActive}
-          searchQuery={debouncedSearchQuery}
-          marketStatusFilter={marketStatusFilter}
-          retryCount={retryCount}
-        />
-      )}
-
-      {!loading && positions.length === 0 && !hasInitialError && (
-        <div className="py-12 text-center text-sm text-muted-foreground">
-          {marketStatusFilter === 'active' ? 'No positions found.' : 'No closed positions found.'}
-        </div>
-      )}
-
-      {!loading && positions.length > 0 && (
-        <div className="space-y-0">
-          {renderRows()}
-
+      <div className="overflow-x-auto">
+        <div className="min-w-180">
           <div
             className={cn(
               rowGridClass,
-              `border-b border-border/80 px-2 py-3 sm:px-3`,
+              `px-2 pt-2 pb-3 text-xs font-semibold tracking-wide text-muted-foreground uppercase sm:px-3`,
             )}
           >
-            <div className="pl-[3.75rem] text-sm font-semibold text-foreground">Total</div>
-            <div className="text-sm text-muted-foreground" />
-            <div className="text-center text-sm font-semibold text-foreground">
-              {formatCurrencyValue(totals.trade)}
-            </div>
-            <div className="text-center text-sm font-semibold text-foreground">
-              {formatCurrencyValue(totals.toWin)}
-            </div>
-            <div className="text-right text-sm font-semibold text-foreground">
-              {formatCurrencyValue(totals.value)}
-              <div className={cn('text-xs', totals.diff >= 0 ? 'text-yes' : 'text-no')}>
-                {`${totals.diff >= 0 ? '+' : ''}${formatCurrency(Math.abs(totals.diff))}`}
-                {' '}
-                (
-                {totals.pct.toFixed(2)}
-                %)
-              </div>
-            </div>
+            <div className="pl-15 text-left">Market</div>
+            <div className="text-left">Avg → Now</div>
+            <div className="text-center">Trade</div>
+            <div className="text-center">To win</div>
+            <div className="text-right">Value</div>
             <div className="flex justify-end">
-              <div className="w-[96px]" aria-hidden />
+              <div className="w-24" aria-hidden />
             </div>
           </div>
-          <div ref={loadMoreRef} className="h-0" />
+
+          {hasInitialError && (
+            <PublicPositionsError
+              isSearchActive={isSearchActive}
+              searchQuery={debouncedSearchQuery}
+              retryCount={retryCount}
+              isLoading={loading}
+              onRetry={retryInitialLoad}
+              onRefreshPage={() => window.location.reload()}
+            />
+          )}
+
+          {loading && (
+            <PublicPositionsLoadingState
+              skeletonCount={5}
+              isSearchActive={isSearchActive}
+              searchQuery={debouncedSearchQuery}
+              marketStatusFilter={marketStatusFilter}
+              retryCount={retryCount}
+            />
+          )}
+
+          {!loading && positions.length === 0 && !hasInitialError && (
+            <div className="py-12 text-center text-sm text-muted-foreground">
+              {marketStatusFilter === 'active' ? 'No positions found.' : 'No closed positions found.'}
+            </div>
+          )}
+
+          {!loading && positions.length > 0 && (
+            <div className="space-y-0">
+              {renderRows()}
+
+              <div
+                className={cn(
+                  rowGridClass,
+                  `border-b border-border/80 px-2 py-3 sm:px-3`,
+                )}
+              >
+                <div className="pl-15 text-sm font-semibold text-foreground">Total</div>
+                <div className="text-sm text-muted-foreground" />
+                <div className="text-center text-sm font-semibold text-foreground">
+                  {formatCurrencyValue(totals.trade)}
+                </div>
+                <div className="text-center text-sm font-semibold text-foreground">
+                  {formatCurrencyValue(totals.toWin)}
+                </div>
+                <div className="text-right text-sm font-semibold text-foreground">
+                  {formatCurrencyValue(totals.value)}
+                  <div className={cn('text-xs', totals.diff >= 0 ? 'text-yes' : 'text-no')}>
+                    {`${totals.diff >= 0 ? '+' : ''}${formatCurrency(Math.abs(totals.diff))}`}
+                    {' '}
+                    (
+                    {totals.pct.toFixed(2)}
+                    %)
+                  </div>
+                </div>
+                <div className="flex justify-end">
+                  <div className="w-24" aria-hidden />
+                </div>
+              </div>
+              <div ref={loadMoreRef} className="h-0" />
+            </div>
+          )}
         </div>
-      )}
+      </div>
 
       {(isFetchingNextPage || isLoadingMore) && (
         <div className="py-4 text-center text-xs text-muted-foreground">Loading more...</div>

--- a/src/app/(platform)/[username]/_components/PublicPositionsLoadingState.tsx
+++ b/src/app/(platform)/[username]/_components/PublicPositionsLoadingState.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { SearchIcon } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import PublicPositionItemSkeleton from './PublicPositionItemSkeleton'
 
 interface PositionsLoadingStateProps {
@@ -18,12 +19,21 @@ export default function PublicPositionsLoadingState({
   marketStatusFilter = 'active',
   retryCount = 0,
 }: PositionsLoadingStateProps) {
-  const defaultSkeletonCount = typeof window !== 'undefined' && window.innerWidth < 768 ? 6 : 8
-  const finalSkeletonCount = skeletonCount ?? defaultSkeletonCount
+  const [resolvedCount, setResolvedCount] = useState(() => skeletonCount ?? 8)
+
+  useEffect(() => {
+    if (skeletonCount !== undefined) {
+      setResolvedCount(skeletonCount)
+      return
+    }
+
+    setResolvedCount(window.innerWidth < 768 ? 6 : 8)
+  }, [skeletonCount])
+
   return (
     <div className="overflow-hidden rounded-lg border border-border">
       <div className="space-y-0">
-        {Array.from({ length: finalSkeletonCount }).map((_, index) => (
+        {Array.from({ length: resolvedCount }).map((_, index) => (
           <PublicPositionItemSkeleton key={index} />
         ))}
       </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Contain horizontal overflow in public portfolio views (Positions, Open Orders, History) by placing tables inside horizontal scroll containers with a consistent min width. This removes page-level horizontal scroll and keeps headers and rows aligned on small screens.

- **Bug Fixes**
  - Wrap lists in overflow-x-auto with min-w-180 so horizontal scroll stays within the component.
  - Keep loading, empty, and error states inside the scroll area for consistent layout.
  - Standardize column paddings and action column width (pl-15, w-24) for alignment across lists.
  - Make skeleton count in PublicPositionsLoadingState hydration-safe using useEffect, adjusting by viewport without direct window access during SSR.

<sup>Written for commit 78d1978375b911f2d59104376fc8555737a63c86. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

