### PR TITLE
fix: adjust trade CTA flow and button styling

### DIFF
--- a/src/app/(platform)/event/[slug]/_components/EventOrderPanelSubmitButton.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventOrderPanelSubmitButton.tsx
@@ -5,28 +5,47 @@ interface EventOrderPanelSubmitButtonProps {
   isLoading: boolean
   isDisabled: boolean
   onClick: (event: MouseEvent<HTMLButtonElement>) => void
+  label?: string
+  type?: 'button' | 'submit'
 }
 
-export default function EventOrderPanelSubmitButton({ isLoading, isDisabled, onClick }: EventOrderPanelSubmitButtonProps) {
+export default function EventOrderPanelSubmitButton({
+  isLoading,
+  isDisabled,
+  onClick,
+  label,
+  type = 'submit',
+}: EventOrderPanelSubmitButtonProps) {
   return (
-    <Button
-      type="submit"
-      size="outcome"
-      disabled={isDisabled}
-      aria-disabled={isDisabled}
-      onClick={onClick}
-      className="w-full text-base font-bold"
-    >
-      {isLoading
-        ? (
-            <div className="flex items-center justify-center gap-2">
-              <div className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
-              <span>Processing...</span>
-            </div>
-          )
-        : (
-            <span>Trade</span>
-          )}
-    </Button>
+    <div className="relative w-full pb-[5px]">
+      <div className={`
+        pointer-events-none absolute inset-x-0 bottom-0 h-[10px] rounded-b-md bg-[oklch(0.50_0.11_237.323)]
+      `}
+      />
+      <Button
+        type={type}
+        size="outcome"
+        disabled={isDisabled}
+        aria-disabled={isDisabled}
+        onClick={onClick}
+        className={`
+          relative w-full translate-y-0 rounded-md text-base font-bold transition-transform duration-150 ease-out
+          hover:translate-y-[1px]
+          active:translate-y-[2px]
+        `}
+
+      >
+        {isLoading
+          ? (
+              <div className="flex items-center justify-center gap-2">
+                <div className="size-4 animate-spin rounded-full border-2 border-current border-t-transparent"></div>
+                <span>Processing...</span>
+              </div>
+            )
+          : (
+              <span>{label ?? 'Trade'}</span>
+            )}
+      </Button>
+    </div>
   )
 }

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -51,7 +51,7 @@ const buttonVariants = cva(
         `,
       },
       size: {
-        outcome: 'h-[48px] min-w-0 flex-1 gap-1 px-3',
+        outcome: 'h-[46px] min-w-0 flex-1 gap-1 px-3',
         default: 'h-9 px-4 py-2 has-[>svg]:px-3',
         sm: 'h-8 gap-1.5 px-3 has-[>svg]:px-2.5',
         lg: 'h-10 px-6 has-[>svg]:px-4',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the trade CTA flow to correctly handle wallet connection and deposit requirements, and updates button styling for clearer feedback. This prevents accidental form submits and clarifies the action (Trade/Deposit/Buy/Sell).

- **Bug Fixes**
  - Show deposit CTA only when connected and a market buy exceeds balance.
  - If not connected, clicking the CTA opens the wallet modal instead of submitting the form.
  - Use button type="button" for connect/deposit states to avoid unintended form submit.

- **Refactors**
  - Unified CTA into EventOrderPanelSubmitButton with new props: label and type.
  - Dynamic labels: Trade, Deposit, or Buy/Sell {outcome}.
  - Updated button visuals with press states and a base bar; reduced outcome size height from 48px to 46px.

<sup>Written for commit facc2de4f88b3fc3bc4b4dc8446542dd33135467. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

