### PR TITLE
refactor: allow orders beyond available USDC from open orders

### DIFF
--- a/src/app/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -340,33 +340,7 @@ export default function EventOrderPanelForm({ event, isMobile }: EventOrderPanel
     }, {})
   }, [openOrders])
 
-  const lockedBuyCollateral = useMemo(() => {
-    if (!openOrders.length) {
-      return 0
-    }
-
-    return openOrders.reduce((acc, order) => {
-      if (order.side !== 'buy') {
-        return acc
-      }
-
-      const makerAmountMicro = BigInt(Math.max(0, Math.trunc(order.maker_amount || 0)))
-      const takerAmountMicro = BigInt(Math.max(0, Math.trunc(order.taker_amount || 0)))
-      const filledMicro = BigInt(Math.max(0, Math.trunc(order.size_matched || 0)))
-      if (makerAmountMicro === 0n || takerAmountMicro === 0n) {
-        return acc + (Number(makerAmountMicro) / MICRO_UNIT)
-      }
-
-      const filledRatio = filledMicro >= takerAmountMicro
-        ? BigInt(MICRO_UNIT)
-        : (filledMicro * BigInt(MICRO_UNIT)) / takerAmountMicro
-
-      const remainingMaker = makerAmountMicro - ((makerAmountMicro * filledRatio) / BigInt(MICRO_UNIT))
-      return acc + (Number(remainingMaker) / MICRO_UNIT)
-    }, 0)
-  }, [openOrders])
-
-  const availableBalanceForOrders = Math.max(0, balance.raw - lockedBuyCollateral)
+  const availableBalanceForOrders = Math.max(0, balance.raw)
 
   const mergedSharesByCondition = useMemo(() => {
     const merged: Record<string, Record<typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO, number>> = {}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow placing new buy orders without subtracting USDC locked by existing open orders. The order panel now uses the wallet balance directly, enabling overposting beyond previously reserved collateral.

<sup>Written for commit 9f34aea8bf75f6314b3a1f548251a1abe1fb61e8. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

