### PR TITLE
fix: appkit pointer events

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -148,6 +148,15 @@
   w3m-modal.open {
     z-index: 999;
   }
+
+  :root:has(w3m-modal.open) body {
+    pointer-events: auto !important;
+  }
+
+  :root:has(w3m-modal.open) [data-slot='dialog-overlay'],
+  :root:has(w3m-modal.open) [data-slot='dialog-content'] {
+    pointer-events: none;
+  }
 }
 
 @utility container {

--- a/src/components/trading/TradingDialogs.tsx
+++ b/src/components/trading/TradingDialogs.tsx
@@ -229,7 +229,7 @@ function TradingRequirementStep({
           <p className="text-base font-semibold text-foreground">{title}</p>
           <p className="text-sm text-muted-foreground">{description}</p>
           {!isComplete && error && (
-            <p className="mt-2 text-sm text-destructive">{error}</p>
+            <p className="mt-2 text-sm break-all text-destructive">{error}</p>
           )}
         </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes AppKit/Web3Modal blocking clicks by restoring pointer events on the page when w3m-modal is present. Also wraps long error messages in Trading dialogs to prevent overflow.

- **Bug Fixes**
  - CSS: When w3m-modal.open exists, force body pointer-events: auto and disable pointer events on its overlay/content.
  - UI: Add break-all to TradingDialogs error text to wrap long strings.

<sup>Written for commit c9e85ea82d93844e198e6ab88c05637d89526ea5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

