### PR TITLE
style: polish profile link tooltip to load profile overview card

### DIFF
--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -97,6 +97,7 @@ export function formatVolume(volume: number): string {
 }
 
 const COMPACT_THRESHOLD = 100_000
+const COMPACT_MILLION = 1_000_000
 
 export function formatCompactCount(value: number) {
   if (!Number.isFinite(value)) {
@@ -104,12 +105,19 @@ export function formatCompactCount(value: number) {
   }
 
   const abs = Math.abs(value)
+  if (abs >= COMPACT_MILLION) {
+    const compact = (abs / COMPACT_MILLION).toFixed(1).replace(/\.0$/, '')
+    return `${value < 0 ? '-' : ''}${compact}M`
+  }
   if (abs >= COMPACT_THRESHOLD) {
     const compact = Math.round(abs / 1_000).toLocaleString(DEFAULT_LOCALE)
     return `${value < 0 ? '-' : ''}${compact}k`
   }
 
-  return new Intl.NumberFormat(DEFAULT_LOCALE).format(value)
+  return new Intl.NumberFormat(DEFAULT_LOCALE, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 0,
+  }).format(value)
 }
 
 export function formatCompactCurrency(value: number) {
@@ -118,6 +126,10 @@ export function formatCompactCurrency(value: number) {
   }
 
   const abs = Math.abs(value)
+  if (abs >= COMPACT_MILLION) {
+    const compact = (abs / COMPACT_MILLION).toFixed(1).replace(/\.0$/, '')
+    return `${value < 0 ? '-' : ''}$${compact}M`
+  }
   if (abs >= COMPACT_THRESHOLD) {
     const compact = Math.round(abs / 1_000).toLocaleString(DEFAULT_LOCALE)
     return `${value < 0 ? '-' : ''}$${compact}k`


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show the ProfileOverviewCard inside the Profile link tooltip with preloaded snapshot stats for a cleaner hover experience and fewer live value requests. Adds compact k/M formatting and support for positions value and biggest win.

- **Refactors**
  - Replace custom tooltip stats with ProfileOverviewCard; pass snapshot (positionsValue, profitLoss, predictions, biggestWin), set portfolioAddress to the stats address, and disable live value fetches.
  - Extend fetchProfileLinkStats to include /value and compute biggestWin from closed positions; make cache abort-aware.
  - Remove local loading UI; tweak tooltip sizing/padding; apply compact currency/count formatting (k/M) for positions value, biggest win, predictions, views, total, and profit/loss.

<sup>Written for commit a84c8b0d59b7637a94f804e34e976ed53eb80b35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

