### PR TITLE
fix: sign clob GET requests without query

### DIFF
--- a/src/lib/hmac.ts
+++ b/src/lib/hmac.ts
@@ -6,7 +6,10 @@ function replaceAll(s: string, search: string, replace: string) {
 }
 
 export function buildClobHmacSignature(secret: string, timestamp: number, method: string, requestPath: string, body?: string): string {
-  let message = timestamp + method + requestPath
+  const normalizedPath = method === 'GET'
+    ? requestPath.split('?')[0]
+    : requestPath
+  let message = timestamp + method + normalizedPath
   if (body !== undefined) {
     message += body
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Sign CLOB GET requests using only the path (without query params) when building HMAC signatures. This prevents signature mismatches and failing auth when queries are present.

<sup>Written for commit 179045e0d5acdd8bd0a872449ef93e6fccae1358. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

