### PR TITLE
fix: clear localstorage on logout

### DIFF
--- a/src/providers/AppKitProvider.tsx
+++ b/src/providers/AppKitProvider.tsx
@@ -42,7 +42,7 @@ function clearAppKitLocalStorage() {
     })
   }
   catch {
-    // Ignore storage access errors (e.g. private mode, disabled storage).
+    //
   }
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clear AppKit localStorage on logout to remove session data and prevent stale state or auto-reconnect after sign out.

- **Bug Fixes**
  - Added onSignOut handler in AppKitProvider to delete all localStorage keys starting with "@appkit".

<sup>Written for commit f6d8871cbb2314d751c2a96ad7f95472bc8220bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

