### PR TITLE
perf: parallelize page fetches and lazy-load charts

### DIFF
--- a/src/app/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventChart.tsx
@@ -2,8 +2,9 @@
 
 import type { TimeRange } from '@/app/(platform)/event/[slug]/_hooks/useEventPriceHistory'
 import type { EventChartProps } from '@/app/(platform)/event/[slug]/_types/EventChartTypes'
-import type { PredictionChartCursorSnapshot, SeriesConfig } from '@/components/PredictionChart'
 import type { Market } from '@/types'
+import type { PredictionChartCursorSnapshot, PredictionChartProps, SeriesConfig } from '@/types/PredictionChartTypes'
+import dynamic from 'next/dynamic'
 import { memo, useEffect, useMemo, useRef, useState } from 'react'
 import { useMarketChannelSubscription } from '@/app/(platform)/event/[slug]/_components/EventMarketChannelProvider'
 import {
@@ -33,7 +34,7 @@ import {
   getOutcomeLabelForMarket,
   getTopMarketIds,
 } from '@/app/(platform)/event/[slug]/_utils/EventChartUtils'
-import PredictionChart from '@/components/PredictionChart'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useWindowSize } from '@/hooks/useWindowSize'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { formatSharePriceLabel } from '@/lib/formatters'
@@ -54,6 +55,11 @@ interface TradeFlowLabelItem {
 const tradeFlowMaxItems = 6
 const tradeFlowTtlMs = 8000
 const tradeFlowCleanupIntervalMs = 500
+
+const PredictionChart = dynamic<PredictionChartProps>(
+  () => import('@/components/PredictionChart'),
+  { ssr: false, loading: () => <Skeleton className="h-[332px] w-full" /> },
+)
 
 function getOutcomeTokenIds(market: Market | null) {
   if (!market) {

--- a/src/app/(platform)/event/[slug]/_components/EventCommentItem.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventCommentItem.tsx
@@ -84,7 +84,7 @@ export default function EventCommentItem({
   }, [onSetReplyingTo, onSetReplyText])
 
   return (
-    <>
+    <div className="comment-item">
       <ProfileLink
         user={{
           image: comment.user_avatar,
@@ -188,6 +188,6 @@ export default function EventCommentItem({
           )}
         </div>
       )}
-    </>
+    </div>
   )
 }

--- a/src/app/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventContent.tsx
@@ -2,11 +2,11 @@
 
 import type { Event, User } from '@/types'
 import { ArrowUpIcon } from 'lucide-react'
+import dynamic from 'next/dynamic'
 import { useSearchParams } from 'next/navigation'
 import { useEffect, useRef, useState } from 'react'
 import EventHeader from '@/app/(platform)/event/[slug]/_components/EventHeader'
 import EventMarketChannelProvider from '@/app/(platform)/event/[slug]/_components/EventMarketChannelProvider'
-import EventMarketContext from '@/app/(platform)/event/[slug]/_components/EventMarketContext'
 import EventMarkets from '@/app/(platform)/event/[slug]/_components/EventMarkets'
 import EventMetaInformation from '@/app/(platform)/event/[slug]/_components/EventMetaInformation'
 import EventOrderPanelForm from '@/app/(platform)/event/[slug]/_components/EventOrderPanelForm'
@@ -26,6 +26,11 @@ import EventChart from './EventChart'
 import EventMarketHistory from './EventMarketHistory'
 import EventMarketOpenOrders from './EventMarketOpenOrders'
 import EventMarketPositions from './EventMarketPositions'
+
+const EventMarketContext = dynamic(
+  () => import('@/app/(platform)/event/[slug]/_components/EventMarketContext'),
+  { ssr: false, loading: () => null },
+)
 
 interface EventContentProps {
   event: Event

--- a/src/app/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
+++ b/src/app/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import type { TimeRange } from '@/app/(platform)/event/[slug]/_hooks/useEventPriceHistory'
-import type { PredictionChartCursorSnapshot } from '@/components/PredictionChart'
 import type { Market, Outcome } from '@/types'
+import type { PredictionChartCursorSnapshot, PredictionChartProps } from '@/types/PredictionChartTypes'
+import dynamic from 'next/dynamic'
 import { useEffect, useMemo, useState } from 'react'
 import EventChartControls from '@/app/(platform)/event/[slug]/_components/EventChartControls'
 import EventChartHeader from '@/app/(platform)/event/[slug]/_components/EventChartHeader'
@@ -12,7 +13,7 @@ import {
   TIME_RANGES,
   useEventPriceHistory,
 } from '@/app/(platform)/event/[slug]/_hooks/useEventPriceHistory'
-import PredictionChart from '@/components/PredictionChart'
+import { Skeleton } from '@/components/ui/skeleton'
 import { useWindowSize } from '@/hooks/useWindowSize'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { sanitizeSvg } from '@/lib/utils'
@@ -24,6 +25,11 @@ interface MarketOutcomeGraphProps {
   eventCreatedAt: string
   isMobile: boolean
 }
+
+const PredictionChart = dynamic<PredictionChartProps>(
+  () => import('@/components/PredictionChart'),
+  { ssr: false, loading: () => <Skeleton className="h-[318px] w-full" /> },
+)
 
 export default function MarketOutcomeGraph({ market, outcome, allMarkets, eventCreatedAt, isMobile }: MarketOutcomeGraphProps) {
   const [activeTimeRange, setActiveTimeRange] = useState<TimeRange>('ALL')

--- a/src/app/(platform)/event/[slug]/page.tsx
+++ b/src/app/(platform)/event/[slug]/page.tsx
@@ -15,9 +15,11 @@ export async function generateMetadata({ params }: PageProps<'/event/[slug]'>): 
 }
 
 export default async function EventPage({ params }: PageProps<'/event/[slug]'>) {
-  const user = await UserRepository.getCurrentUser()
-  const { slug } = await params
-  const marketContextSettings = await loadMarketContextSettings()
+  const [user, { slug }, marketContextSettings] = await Promise.all([
+    UserRepository.getCurrentUser(),
+    params,
+    loadMarketContextSettings(),
+  ])
   const marketContextEnabled = marketContextSettings.enabled && Boolean(marketContextSettings.apiKey)
 
   const { data: event, error } = await EventRepository.getEventBySlug(slug, user?.id ?? '')

--- a/src/app/admin/affiliate/page.tsx
+++ b/src/app/admin/affiliate/page.tsx
@@ -37,10 +37,16 @@ interface RowSummary {
 }
 
 export default async function AdminSettingsPage() {
-  const { data: allSettings } = await SettingsRepository.getSettings()
+  const [
+    { data: allSettings },
+    { data: overviewData },
+    exchangeBaseFeeBps,
+  ] = await Promise.all([
+    SettingsRepository.getSettings(),
+    AffiliateRepository.listAffiliateOverview(),
+    fetchMaxExchangeBaseFeeRate(),
+  ])
   const affiliateSettings = allSettings?.affiliate
-  const { data: overviewData } = await AffiliateRepository.listAffiliateOverview()
-  const exchangeBaseFeeBps = await fetchMaxExchangeBaseFeeRate()
 
   const overview = (overviewData ?? []) as AffiliateOverviewRow[]
   const userIds = overview.map(row => row.affiliate_user_id)

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -191,6 +191,11 @@
   }
 }
 
+@utility comment-item {
+  content-visibility: auto;
+  contain-intrinsic-size: 0 160px;
+}
+
 @keyframes prediction-chart-radar {
   0% {
     transform: scale(0.4);

--- a/src/providers/Providers.tsx
+++ b/src/providers/Providers.tsx
@@ -2,12 +2,20 @@
 
 import type { ReactNode } from 'react'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { SpeedInsights } from '@vercel/speed-insights/next'
 import { ThemeProvider } from 'next-themes'
-import GoogleAnalytics from '@/components/GoogleAnalytics'
+import dynamic from 'next/dynamic'
 import { Toaster } from '@/components/ui/sonner'
 import AppKitProvider from '@/providers/AppKitProvider'
 import ProgressIndicatorProvider from '@/providers/ProgressIndicatorProvider'
+
+const SpeedInsights = dynamic(
+  () => import('@vercel/speed-insights/next').then(mod => mod.SpeedInsights),
+  { ssr: false },
+)
+const GoogleAnalytics = dynamic(
+  () => import('@/components/GoogleAnalytics'),
+  { ssr: false },
+)
 
 const queryClient = new QueryClient()
 


### PR DESCRIPTION
https://github.com/vercel-labs/agent-skills/tree/react-best-practices/skills/react-best-practices/references/rules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallelized data fetching and lazy-loaded heavy charts and analytics to speed up initial page loads and reduce blocking work. Added skeleton placeholders and content-visibility to improve perceived performance.

- **Refactors**
  - Fetch user, settings, params, stats, and overviews in parallel using Promise.all on event and affiliate pages.
  - Lazy-load PredictionChart (ssr: false) with Skeleton placeholders in EventChart and MarketOutcomeGraph.
  - Dynamically import EventMarketContext to avoid client-only work during SSR.
  - Wrap comment items with a class that uses content-visibility and contain-intrinsic-size to defer offscreen rendering.
  - Lazy-load SpeedInsights and GoogleAnalytics in Providers to reduce initial bundle cost.

<sup>Written for commit a200509af0317e692ec341e6062e878ee3173517. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

