### PR TITLE
refactor: do not allow sub cents in merge/split

### DIFF
--- a/src/app/(platform)/[username]/_components/MergePositionsDialog.tsx
+++ b/src/app/(platform)/[username]/_components/MergePositionsDialog.tsx
@@ -45,9 +45,6 @@ export function MergePositionsDialog({
 }: MergePositionsDialogProps) {
   function formatMergeValue(value: number) {
     const safeValue = Number.isFinite(value) ? value : 0
-    if (safeValue !== 0 && Math.abs(safeValue) < 0.01) {
-      return formatCurrency(safeValue, { minimumFractionDigits: 4, maximumFractionDigits: 4 })
-    }
     return formatCurrency(safeValue)
   }
   const totalValue = markets.reduce((total, market) => total + (market.mergeAmount || 0), 0)
@@ -70,7 +67,7 @@ export function MergePositionsDialog({
             {' '}
             in positions
           </DialogTitle>
-          <DialogDescription className="text-center text-sm text-muted-foreground">
+          <DialogDescription className="text-center">
             This will merge all eligible market positions.
           </DialogDescription>
         </DialogHeader>
@@ -78,7 +75,7 @@ export function MergePositionsDialog({
         {isSuccess
           ? (
               <div className="flex flex-col items-center gap-4 py-4 text-center">
-                <div className="grid size-16 place-items-center rounded-full bg-emerald-500">
+                <div className="grid size-16 place-items-center rounded-full bg-yes">
                   <CheckIcon className="size-8 text-white" />
                 </div>
                 <p className="text-sm text-muted-foreground">

--- a/src/app/(platform)/[username]/_hooks/useMergePositionsAction.ts
+++ b/src/app/(platform)/[username]/_hooks/useMergePositionsAction.ts
@@ -90,14 +90,15 @@ export function useMergePositionsAction({
             (positionShares[secondOutcome] ?? 0) - (locked[secondOutcome] ?? 0),
           )
           const safeMergeAmount = Math.min(market.mergeAmount, availableFirst, availableSecond)
+          const normalizedMergeAmount = Math.floor(safeMergeAmount * 100 + 1e-8) / 100
 
-          if (!Number.isFinite(safeMergeAmount) || safeMergeAmount <= 0) {
+          if (!Number.isFinite(normalizedMergeAmount) || normalizedMergeAmount <= 0) {
             return null
           }
 
           return {
             conditionId,
-            mergeAmount: safeMergeAmount,
+            mergeAmount: normalizedMergeAmount,
           }
         })
         .filter((entry): entry is { conditionId: string, mergeAmount: number } => Boolean(entry))

--- a/src/app/(platform)/[username]/_utils/PublicPositionsUtils.ts
+++ b/src/app/(platform)/[username]/_utils/PublicPositionsUtils.ts
@@ -374,8 +374,9 @@ export function buildMergeableMarkets(positions: PublicPosition[]): MergeableMar
     }
 
     const mergeableAmount = Math.min(firstPosition.size ?? 0, secondPosition.size ?? 0)
+    const mergeableCents = Math.floor(mergeableAmount * 100 + 1e-8) / 100
 
-    if (!Number.isFinite(mergeableAmount) || mergeableAmount <= 0) {
+    if (!Number.isFinite(mergeableCents) || mergeableCents <= 0) {
       return
     }
 
@@ -386,7 +387,7 @@ export function buildMergeableMarkets(positions: PublicPosition[]): MergeableMar
       eventSlug: sample.eventSlug || sample.slug,
       title: sample.title,
       icon: sample.icon,
-      mergeAmount: mergeableAmount,
+      mergeAmount: mergeableCents,
       outcomeAssets,
     })
   })

--- a/src/app/(platform)/event/[slug]/_components/EventOrderPanelEarnings.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventOrderPanelEarnings.tsx
@@ -206,7 +206,7 @@ export default function EventOrderPanelEarnings({
                     </div>
                     <div className="flex items-center justify-between gap-3">
                       <div className="flex items-center gap-2">
-                        <span className="h-4 w-1.5 rounded-full bg-emerald-500" />
+                        <span className="h-4 w-1.5 rounded-full bg-yes" />
                         <span>Decimal</span>
                       </div>
                       <span className="text-base font-bold">

--- a/src/app/(platform)/event/[slug]/_components/EventSplitSharesDialog.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventSplitSharesDialog.tsx
@@ -18,7 +18,7 @@ import { SAFE_BALANCE_QUERY_KEY } from '@/hooks/useBalance'
 import { defaultNetwork } from '@/lib/appkit'
 import { DEFAULT_CONDITION_PARTITION, DEFAULT_ERROR_MESSAGE, MICRO_UNIT } from '@/lib/constants'
 import { ZERO_COLLECTION_ID } from '@/lib/contracts'
-import { toMicro } from '@/lib/formatters'
+import { formatAmountInputValue, toMicro } from '@/lib/formatters'
 import {
   aggregateSafeTransactions,
   buildSplitPositionTransaction,
@@ -83,10 +83,15 @@ export default function EventSplitSharesDialog({
 
   function handleAmountChange(value: string) {
     const sanitized = value.replace(/,/g, '.')
-    if (sanitized === '' || /^\d*(?:\.\d*)?$/.test(sanitized)) {
+    if (sanitized === '' || /^\d*(?:\.\d{0,2})?$/.test(sanitized)) {
       setAmount(sanitized)
       setError(null)
     }
+  }
+
+  function isWholeCentAmount(value: number) {
+    const scaled = value * 100
+    return Number.isFinite(scaled) && Math.abs(scaled - Math.round(scaled)) < 1e-8
   }
 
   function handleMaxClick() {
@@ -94,8 +99,8 @@ export default function EventSplitSharesDialog({
       return
     }
 
-    // Use the raw value to avoid rounding up tiny remainders that would fail validation
-    setAmount(`${numericAvailableBalance}`)
+    const floored = formatAmountInputValue(numericAvailableBalance, { roundingMode: 'floor' })
+    setAmount(floored || '0')
     setError(null)
   }
 
@@ -112,6 +117,11 @@ export default function EventSplitSharesDialog({
     const numericAmount = Number.parseFloat(amount)
     if (!Number.isFinite(numericAmount) || numericAmount <= 0) {
       setError('Enter a valid amount.')
+      return
+    }
+
+    if (!isWholeCentAmount(numericAmount)) {
+      setError('Amount must be in whole cents.')
       return
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Block sub-cent amounts when merging or splitting shares. Normalize and validate to whole cents to prevent rounding errors and failed transactions.

- **Bug Fixes**
  - Restrict inputs to two decimals; show error “Amount must be in whole cents.”; Max now floors to two decimals; placeholder set to 0.00.
  - Floor merge amounts to cents in action and market builders, skipping invalid or zero values.
  - Remove sub-cent currency formatting; use standard currency display and update success/indicator colors to the “yes” token.

<sup>Written for commit 358d174c29217b93027900d40aa87a36f36e594b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

