### PR TITLE
feat: multi market slug

### DIFF
--- a/src/app/(platform)/event/[slug]/[market]/page.tsx
+++ b/src/app/(platform)/event/[slug]/[market]/page.tsx
@@ -1,0 +1,44 @@
+import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
+import EventContent from '@/app/(platform)/event/[slug]/_components/EventContent'
+import { loadMarketContextSettings } from '@/lib/ai/market-context-config'
+import { EventRepository } from '@/lib/db/queries/event'
+import { UserRepository } from '@/lib/db/queries/user'
+
+export async function generateMetadata({ params }: PageProps<'/event/[slug]/[market]'>): Promise<Metadata> {
+  const { slug } = await params
+  const { data } = await EventRepository.getEventTitleBySlug(slug)
+
+  return {
+    title: data?.title,
+  }
+}
+
+export default async function EventMarketPage({ params }: PageProps<'/event/[slug]/[market]'>) {
+  const [user, { slug, market }, marketContextSettings] = await Promise.all([
+    UserRepository.getCurrentUser(),
+    params,
+    loadMarketContextSettings(),
+  ])
+  const marketContextEnabled = marketContextSettings.enabled && Boolean(marketContextSettings.apiKey)
+
+  const { data: event, error } = await EventRepository.getEventBySlug(slug, user?.id ?? '')
+  if (error || !event) {
+    notFound()
+  }
+
+  const selectedMarket = event.markets.find(item => item.slug === market)
+  if (!selectedMarket) {
+    notFound()
+  }
+
+  return (
+    <EventContent
+      event={event}
+      user={user}
+      marketContextEnabled={marketContextEnabled}
+      marketSlug={market}
+      key={`is-bookmarked-${event.is_bookmarked}`}
+    />
+  )
+}

--- a/src/app/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
@@ -436,7 +436,7 @@ export default function EventChartEmbedDialog({
                   <Label className="text-xs font-semibold tracking-wide text-muted-foreground">EMBED CODE</Label>
                   <div className="flex items-center gap-2">
                     <Select value={embedType} onValueChange={value => setEmbedType(value as EmbedType)}>
-                      <SelectTrigger className="h-8 text-xs">
+                      <SelectTrigger size="sm">
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
@@ -466,7 +466,7 @@ export default function EventChartEmbedDialog({
                   title="Embed preview"
                   src={previewSrc}
                   style={{ height: `${iframeHeight}px` }}
-                  className="w-[400px] max-w-full border-0 bg-transparent"
+                  className="w-100 max-w-full border-0 bg-transparent"
                 />
               </div>
             </div>

--- a/src/app/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventContent.tsx
@@ -35,9 +35,10 @@ interface EventContentProps {
   event: Event
   user: User | null
   marketContextEnabled: boolean
+  marketSlug?: string
 }
 
-export default function EventContent({ event, user, marketContextEnabled }: EventContentProps) {
+export default function EventContent({ event, user, marketContextEnabled, marketSlug }: EventContentProps) {
   const setEvent = useOrder(state => state.setEvent)
   const setMarket = useOrder(state => state.setMarket)
   const setOutcome = useOrder(state => state.setOutcome)
@@ -47,6 +48,7 @@ export default function EventContent({ event, user, marketContextEnabled }: Even
   const setLimitShares = useOrder(state => state.setLimitShares)
   const setIsMobileOrderPanelOpen = useOrder(state => state.setIsMobileOrderPanelOpen)
   const currentEventId = useOrder(state => state.event?.id)
+  const currentMarketId = useOrder(state => state.market?.condition_id)
   const isMobile = useIsMobile()
   const searchParams = useSearchParams()
   const clientUser = useUser()
@@ -76,21 +78,27 @@ export default function EventContent({ event, user, marketContextEnabled }: Even
   }, [event, setEvent])
 
   useEffect(() => {
-    if (currentEventId === event.id) {
+    const targetMarket = marketSlug
+      ? event.markets.find(market => market.slug === marketSlug)
+      : event.markets[0]
+    if (!targetMarket) {
       return
     }
 
-    const defaultMarket = event.markets[0]
-    if (!defaultMarket) {
+    if (currentEventId === event.id && !marketSlug) {
       return
     }
 
-    setMarket(defaultMarket)
-    const defaultOutcome = defaultMarket.outcomes[0]
+    if (currentEventId === event.id && currentMarketId === targetMarket.condition_id) {
+      return
+    }
+
+    setMarket(targetMarket)
+    const defaultOutcome = targetMarket.outcomes[0]
     if (defaultOutcome) {
       setOutcome(defaultOutcome)
     }
-  }, [currentEventId, event, setMarket, setOutcome])
+  }, [currentEventId, currentMarketId, event, marketSlug, setMarket, setOutcome])
 
   useEffect(() => {
     const paramsKey = searchParams.toString()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add market-specific event pages at /event/[slug]/[market] so links open a chosen market by slug. Also updates EventContent to respect the market slug and tweaks the embed dialog UI.

- **New Features**
  - Added route /event/[slug]/[market] that loads an event and selects the market by slug.
  - Returns 404 if the event or market is missing.
  - Sets page metadata with the event title and passes marketContextEnabled to the view.

- **Refactors**
  - EventContent accepts an optional marketSlug and sets market/outcome only when needed.
  - Embed dialog: smaller select trigger and responsive iframe width.

<sup>Written for commit 7bd8391b1549072c9ccf272322895b073be1bc14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

