### PR TITLE
refactor: intl to not use suspense

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,5 @@
 import type { Metadata, Viewport } from 'next'
 import type { ReactNode } from 'react'
-import { Suspense } from 'react'
 import IntlProvider from '@/components/IntlProvider'
 import TestModeBanner from '@/components/TestModeBanner'
 import { defaultLocale } from '@/i18n/locales'
@@ -34,12 +33,10 @@ export default async function RootLayout({ children }: { children: ReactNode }) 
   return (
     <html lang={defaultLocale} className={`${openSauceOne.variable}`} suppressHydrationWarning>
       <body className="flex min-h-screen flex-col font-sans antialiased">
-        <Suspense fallback={null}>
-          <IntlProvider>
-            {IS_TEST_MODE && <TestModeBanner />}
-            {children}
-          </IntlProvider>
-        </Suspense>
+        <IntlProvider>
+          {IS_TEST_MODE && <TestModeBanner />}
+          {children}
+        </IntlProvider>
       </body>
     </html>
   )

--- a/src/components/FilterToolbarSearchInput.tsx
+++ b/src/components/FilterToolbarSearchInput.tsx
@@ -47,7 +47,7 @@ export default function FilterToolbarSearchInput({ search, onSearchChange }: Fil
         onChange={e => setSearchQuery(e.target.value)}
         className={`
           border-transparent bg-input pl-10 shadow-none transition-colors
-          hover:bg-[color:var(--input-hover)]
+          hover:bg-(--input-hover)
           focus-visible:border-border focus-visible:bg-background focus-visible:ring-0 focus-visible:ring-offset-0
         `}
       />

--- a/src/components/IntlProvider.tsx
+++ b/src/components/IntlProvider.tsx
@@ -1,18 +1,79 @@
+'use client'
+
 import type { ReactNode } from 'react'
+import type { Locale } from '@/i18n/locales'
 import { NextIntlClientProvider } from 'next-intl'
-import { getLocale, getMessages, getTimeZone } from 'next-intl/server'
+import { useEffect, useMemo, useState } from 'react'
 import LocaleHtmlLangSync from '@/components/LocaleHtmlLangSync'
+import { defaultLocale, isLocaleSupported } from '@/i18n/locales'
+import enMessages from '@/i18n/messages/en.json'
+import esMessages from '@/i18n/messages/es.json'
 
 interface IntlProviderProps {
   children: ReactNode
 }
 
-export default async function IntlProvider({ children }: IntlProviderProps) {
-  const [locale, messages, timeZone] = await Promise.all([
-    getLocale(),
-    getMessages(),
-    getTimeZone(),
-  ])
+type Messages = typeof enMessages
+
+const messagesByLocale: Record<Locale, Messages> = {
+  en: enMessages,
+  es: esMessages,
+}
+
+function readCookieLocale(): string | null {
+  if (typeof document === 'undefined') {
+    return null
+  }
+
+  const match = document.cookie.match(/(?:^|; )NEXT_LOCALE=([^;]*)/)
+  return match ? decodeURIComponent(match[1]) : null
+}
+
+function resolveClientLocale(): Locale {
+  const cookieLocale = readCookieLocale()
+  if (isLocaleSupported(cookieLocale)) {
+    return cookieLocale
+  }
+
+  const languages = typeof navigator !== 'undefined'
+    ? navigator.languages ?? [navigator.language]
+    : []
+
+  for (const language of languages) {
+    const normalized = language.toLowerCase()
+    if (isLocaleSupported(normalized)) {
+      return normalized
+    }
+    const base = normalized.split('-')[0]
+    if (isLocaleSupported(base)) {
+      return base
+    }
+  }
+
+  return defaultLocale
+}
+
+export default function IntlProvider({ children }: IntlProviderProps) {
+  const [locale, setLocale] = useState<Locale>(defaultLocale)
+  const [messages, setMessages] = useState<Messages>(messagesByLocale[defaultLocale])
+
+  useEffect(() => {
+    const resolvedLocale = resolveClientLocale()
+    if (resolvedLocale === locale) {
+      return
+    }
+
+    setLocale(resolvedLocale)
+    setMessages(messagesByLocale[resolvedLocale])
+  }, [locale])
+
+  const timeZone = useMemo(() => {
+    if (typeof Intl === 'undefined') {
+      return 'America/New_York'
+    }
+
+    return Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York'
+  }, [])
 
   return (
     <NextIntlClientProvider locale={locale} messages={messages} timeZone={timeZone}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced server-side next-intl with a client-side IntlProvider and removed Suspense to simplify rendering and avoid hydration issues.

- **Refactors**
  - Converted IntlProvider to a client component.
  - Locale resolution on client via NEXT_LOCALE cookie or navigator languages; falls back to default.
  - Loaded messages for en and es on the client.
  - Time zone resolved via Intl.DateTimeFormat on the client with a safe fallback.
  - Removed Suspense wrapper from RootLayout.
  - Minor input hover style update in FilterToolbarSearchInput.

<sup>Written for commit b02f169282274fd58246ca58e800e631a2faac85. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

