### PR TITLE
refactor: implement profile link on users table for admin panel

### DIFF
--- a/src/app/admin/_components/columns.tsx
+++ b/src/app/admin/_components/columns.tsx
@@ -2,7 +2,7 @@
 
 import type { ColumnDef } from '@tanstack/react-table'
 import { ArrowUpDown, MailIcon } from 'lucide-react'
-import Image from 'next/image'
+import ProfileLink from '@/components/ProfileLink'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -64,27 +64,20 @@ export const columns: ColumnDef<AdminUserRow>[] = [
     },
     cell: ({ row }) => {
       const user = row.original
+      const profileSlug = user.username || user.proxy_wallet_address || user.address
       return (
-        <div className="flex min-w-44 items-center gap-2">
-          <Image
-            src={user.avatarUrl}
-            alt={user.username}
-            width={28}
-            height={28}
-            className="shrink-0 rounded-full sm:size-8"
+        <div className="min-w-44">
+          <ProfileLink
+            user={{
+              address: user.address,
+              proxy_wallet_address: user.proxy_wallet_address,
+              image: user.avatarUrl,
+              username: user.username,
+            }}
+            profileSlug={profileSlug}
+            layout="inline"
+            usernameAddon={user.is_admin ? <Badge variant="outline" className="text-xs">Admin</Badge> : null}
           />
-          <div className="min-w-44 flex-1">
-            <a
-              href={user.profileUrl}
-              target="_blank"
-              className="flex items-center gap-1 font-medium text-foreground hover:text-primary"
-            >
-              <span>
-                {user.username || user.proxy_wallet_address}
-              </span>
-              {user.is_admin && <Badge variant="outline" className="mt-1 text-xs">Admin</Badge>}
-            </a>
-          </div>
         </div>
       )
     },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized profile links in the Admin Users table by replacing custom avatar/link rendering with the shared ProfileLink component. This improves consistency and builds correct slugs from username, proxy wallet, or address, with an inline “Admin” badge when applicable.

- **Refactors**
  - Use ProfileLink (layout="inline") instead of manual Image + anchor.
  - Compute profileSlug with fallback: username || proxy_wallet_address || address.
  - Add Admin badge via usernameAddon when user.is_admin is true.

<sup>Written for commit d717a71a8cc4635d2fc47601d45944914e95fdb1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

