### PR TITLE
fix: allow outcome switching after deep-link selection

### DIFF
--- a/src/app/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/(platform)/event/[slug]/_components/EventContent.tsx
@@ -56,6 +56,8 @@ export default function EventContent({ event, user, marketContextEnabled, market
   const contentRef = useRef<HTMLDivElement | null>(null)
   const eventMarketsRef = useRef<HTMLDivElement | null>(null)
   const appliedOrderParamsRef = useRef<string | null>(null)
+  const appliedMarketSlugRef = useRef<string | null>(null)
+  const appliedEventIdRef = useRef<string | null>(null)
   const currentUser = clientUser ?? user
   const [showBackToTop, setShowBackToTop] = useState(false)
   const [backToTopBounds, setBackToTopBounds] = useState<{ left: number, width: number } | null>(null)
@@ -85,11 +87,14 @@ export default function EventContent({ event, user, marketContextEnabled, market
       return
     }
 
-    if (currentEventId === event.id && !marketSlug) {
-      return
-    }
+    const shouldApplyMarket = marketSlug
+      ? appliedMarketSlugRef.current !== marketSlug
+      || appliedEventIdRef.current !== event.id
+      || !currentMarketId
+      : currentEventId !== event.id
+        || !currentMarketId
 
-    if (currentEventId === event.id && currentMarketId === targetMarket.condition_id) {
+    if (!shouldApplyMarket) {
       return
     }
 
@@ -98,6 +103,8 @@ export default function EventContent({ event, user, marketContextEnabled, market
     if (defaultOutcome) {
       setOutcome(defaultOutcome)
     }
+    appliedMarketSlugRef.current = marketSlug ?? null
+    appliedEventIdRef.current = event.id
   }, [currentEventId, currentMarketId, event, marketSlug, setMarket, setOutcome])
 
   useEffect(() => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes deep-linked market selection so users can switch outcomes after landing on an event via a market slug. We now only re-apply the default market/outcome when the deep link actually changes.

- Bug Fixes
  - Track last applied marketSlug and eventId to avoid reapplying defaults.
  - Add shouldApplyMarket guard to prevent overrides after initial apply.
  - Stops the effect from resetting user-selected outcomes when a deep link is present.

<sup>Written for commit db5bd810a246d3e3bd4e7bdbe2e8b3dc30189540. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

