### PR TITLE
feat: polish home cards, trade panel, and header navigation

### DIFF
--- a/src/app/(platform)/(home)/_components/EventCard.tsx
+++ b/src/app/(platform)/(home)/_components/EventCard.tsx
@@ -269,6 +269,7 @@ export default function EventCard({ event, priceOverridesByMarket = EMPTY_PRICE_
       <CardContent className="flex h-full flex-col px-3 pt-3 pb-1">
         <EventCardHeader
           event={event}
+          activeOutcome={activeOutcome}
           isInTradingMode={isInTradingMode}
           isSingleMarket={isSingleMarket}
           roundedPrimaryDisplayChance={roundedPrimaryDisplayChance}

--- a/src/app/(platform)/(home)/_components/EventCardHeader.tsx
+++ b/src/app/(platform)/(home)/_components/EventCardHeader.tsx
@@ -1,9 +1,11 @@
 import type { Event } from '@/types'
+import type { SelectedOutcome } from '@/types/EventCardTypes'
 import Image from 'next/image'
 import Link from 'next/link'
 
 interface EventCardHeaderProps {
   event: Event
+  activeOutcome?: SelectedOutcome | null
   isInTradingMode: boolean
   isSingleMarket: boolean
   roundedPrimaryDisplayChance: number
@@ -12,23 +14,32 @@ interface EventCardHeaderProps {
 
 export default function EventCardHeader({
   event,
+  activeOutcome,
   isInTradingMode,
   isSingleMarket,
   roundedPrimaryDisplayChance,
   onCancelTrade,
 }: EventCardHeaderProps) {
+  const activeMarket = activeOutcome?.market
+  const tradingTitle = !isSingleMarket
+    ? activeMarket?.short_title || activeMarket?.title
+    : null
+  const headerTitle = (isInTradingMode && tradingTitle) ? tradingTitle : event.title
+  const headerIcon = (isInTradingMode && activeMarket?.icon_url) ? activeMarket.icon_url : event.icon_url
+  const iconSizeClass = isInTradingMode ? 'size-7' : 'size-10'
+
   return (
     <div className="mb-3 flex items-start justify-between">
       <Link href={`/event/${event.slug}`} className="flex flex-1 items-center gap-2 pr-2">
         <div
           className={`
-            flex size-10 shrink-0 items-center justify-center self-start overflow-hidden rounded bg-muted
-            text-muted-foreground
+            flex ${iconSizeClass}
+            shrink-0 items-center justify-center self-start overflow-hidden rounded bg-muted text-muted-foreground
           `}
         >
           <Image
-            src={event.icon_url}
-            alt={event.creator || 'Market creator'}
+            src={headerIcon}
+            alt={headerTitle || event.creator || 'Market'}
             width={40}
             height={40}
             className="size-full rounded object-cover"
@@ -43,7 +54,7 @@ export default function EventCardHeader({
             `
           }
         >
-          {event.title}
+          {headerTitle}
         </h3>
       </Link>
 
@@ -57,9 +68,9 @@ export default function EventCardHeader({
               }}
               className={
                 `
-                  flex size-6 items-center justify-center rounded-lg bg-slate-200 text-slate-600 transition-colors
-                  hover:bg-slate-300
-                  dark:bg-slate-600 dark:text-slate-400 dark:hover:bg-slate-500
+                  flex size-6 items-center justify-center rounded-md text-slate-600 transition-colors
+                  hover:bg-slate-200
+                  dark:text-slate-400 dark:hover:bg-slate-600
                 `
               }
             >


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Polished the home event cards, trade panel, and header navigation to make trading clearer and add better visual feedback. Adds an amount slider, quick-add controls, dynamic headers, and an animated tab indicator.

- **New Features**
  - Amount slider with balance-aware max and draggable handle.
  - Quick-add buttons (+1, +10) for faster input.
  - Event card header switches title/icon to the active market in trading mode with a smaller icon.
  - Animated active indicator in navigation tabs that updates on scroll and resize.

- **Refactors**
  - Buy button sizing and styles unified with consistent yes/no colors.
  - Input layout moved to a compact grid with inline dollar icon and improved focus states.
  - Stricter amount formatting and balance validation; copy updated to “To win”.
  - EventCard passes activeOutcome to header; alt text and cancel button styles polished.

<sup>Written for commit eee609d9d9e57dcabf592de541f19edc4c261a13. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

