### PR TITLE
feat: locale switcher

### DIFF
--- a/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
@@ -46,9 +46,9 @@ export default function HeaderDropdownUserMenuGuest() {
           <Link href="/terms-of-use" data-testid="header-terms-link">Terms of Use</Link>
         </DropdownMenuItem>
 
-        <DropdownMenuSeparator />
-
         <LocaleSwitcherMenuItem />
+
+        <DropdownMenuSeparator />
 
         <DropdownMenuItem asChild>
           <ThemeSelector />

--- a/src/components/HeaderDropdownUserMenuAuth.tsx
+++ b/src/components/HeaderDropdownUserMenuAuth.tsx
@@ -184,9 +184,9 @@ export default function HeaderDropdownUserMenuAuth() {
             </>
           )}
 
-          <DropdownMenuSeparator />
-
           <LocaleSwitcherMenuItem />
+
+          <DropdownMenuSeparator />
 
           <DropdownMenuItem asChild>
             <ThemeSelector />

--- a/src/components/LocaleSwitcherMenuItem.tsx
+++ b/src/components/LocaleSwitcherMenuItem.tsx
@@ -80,7 +80,7 @@ export default function LocaleSwitcherMenuItem() {
     <DropdownMenuSub>
       <DropdownMenuSubTrigger disabled={isPending}>
         <span className="sr-only">Language</span>
-        <span className="h-5 overflow-hidden text-sm font-medium">
+        <span className="h-5 overflow-hidden text-sm">
           <span
             className="block transition-transform duration-200 ease-in-out"
             style={{


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a locale switcher to the header user menu so users can change the app language (English/Spanish) without reloading. Includes an animated “Language/Idioma” label in the dropdown trigger.

- **New Features**
  - Added LocaleSwitcherMenuItem with a radio list sourced from routing.locales.
  - Integrated into both Auth and Guest user menus, above the separator.
  - Uses next-intl router.replace to switch locales without a full page reload; trigger disables while pending.

<sup>Written for commit a9de4ee69fc5231e0eff83e5cd67302e4df185f1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

