### PR TITLE
refactor: open guest menu on hover

### DIFF
--- a/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
@@ -2,6 +2,7 @@
 
 import type { Route } from 'next'
 import { MenuIcon } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
 import LocaleSwitcherMenuItem from '@/components/LocaleSwitcherMenuItem'
 import ThemeSelector from '@/components/ThemeSelector'
 import { Button } from '@/components/ui/button'
@@ -17,43 +18,98 @@ import { Link } from '@/i18n/navigation'
 
 export default function HeaderDropdownUserMenuGuest() {
   const { open } = useAppKit()
+  const [menuOpen, setMenuOpen] = useState(false)
+  const wrapperRef = useRef<HTMLDivElement | null>(null)
+  const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => () => clearCloseTimeout(), [])
+
+  function relatedTargetIsWithin(ref: React.RefObject<HTMLElement | null>, relatedTarget: EventTarget | null) {
+    if (!relatedTarget) {
+      return false
+    }
+
+    return Boolean(ref.current?.contains(relatedTarget as Node))
+  }
+
+  function clearCloseTimeout() {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current)
+      closeTimeoutRef.current = null
+    }
+  }
+
+  function handleWrapperPointerEnter() {
+    clearCloseTimeout()
+    setMenuOpen(true)
+  }
+
+  function handleWrapperPointerLeave(event: React.PointerEvent) {
+    if (relatedTargetIsWithin(wrapperRef, event.relatedTarget)) {
+      return
+    }
+
+    clearCloseTimeout()
+    closeTimeoutRef.current = setTimeout(() => {
+      setMenuOpen(false)
+    }, 120)
+  }
 
   return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          variant="ghost"
-          size="headerIconCompact"
-          data-testid="header-menu-button"
+    <div
+      ref={wrapperRef}
+      onPointerEnter={handleWrapperPointerEnter}
+      onPointerLeave={handleWrapperPointerLeave}
+    >
+      <DropdownMenu
+        open={menuOpen}
+        onOpenChange={(nextOpen) => {
+          clearCloseTimeout()
+          setMenuOpen(nextOpen)
+        }}
+        modal={false}
+      >
+        <DropdownMenuTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="headerIconCompact"
+            data-testid="header-menu-button"
+          >
+            <MenuIcon />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          className="w-48"
+          collisionPadding={16}
+          portalled={false}
+          onInteractOutside={() => setMenuOpen(false)}
+          onEscapeKeyDown={() => setMenuOpen(false)}
         >
-          <MenuIcon />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent className="w-48" collisionPadding={16}>
-        <DropdownMenuItem onClick={() => open()}>Sign Up</DropdownMenuItem>
-        <DropdownMenuItem onClick={() => open()}>Log In</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => open()}>Sign Up</DropdownMenuItem>
+          <DropdownMenuItem onClick={() => open()}>Log In</DropdownMenuItem>
 
-        <DropdownMenuSeparator />
+          <DropdownMenuSeparator />
 
-        <DropdownMenuItem asChild>
-          <Link href={'/' as Route}>Rewards</Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link href="/docs/users" data-testid="header-docs-link">Documentation</Link>
-        </DropdownMenuItem>
-        <DropdownMenuItem asChild>
-          <Link href="/terms-of-use" data-testid="header-terms-link">Terms of Use</Link>
-        </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href={'/' as Route}>Rewards</Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/docs/users" data-testid="header-docs-link">Documentation</Link>
+          </DropdownMenuItem>
+          <DropdownMenuItem asChild>
+            <Link href="/terms-of-use" data-testid="header-terms-link">Terms of Use</Link>
+          </DropdownMenuItem>
 
-        <LocaleSwitcherMenuItem />
+          <LocaleSwitcherMenuItem />
 
-        <DropdownMenuSeparator />
+          <DropdownMenuSeparator />
 
-        <DropdownMenuItem asChild>
-          <ThemeSelector />
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
+          <DropdownMenuItem asChild>
+            <ThemeSelector />
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switches the guest user dropdown to open on hover for a faster, smoother header experience. Adds a controlled open state with a small delayed close to avoid flicker.

- **Refactors**
  - Controls DropdownMenu via local state and onOpenChange.
  - Adds pointer enter/leave handlers on a wrapper div with relatedTarget checks.
  - Introduces a 120ms close timeout and proper cleanup to prevent flicker.
  - Sets modal={false} and portalled={false}; closes on outside click and Esc.

<sup>Written for commit 7fe4f06fc49923e8bfbb0b760e5816d57bd0d9ac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

