### PR TITLE
fix: reorder resolved markets and card outcomes

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
@@ -1,8 +1,8 @@
 import type { Event, Market, Outcome } from '@/types'
 import { Check, X } from 'lucide-react'
 import { Button } from '@/components/ui/button'
-import { OUTCOME_INDEX } from '@/lib/constants'
 import { Link } from '@/i18n/navigation'
+import { OUTCOME_INDEX } from '@/lib/constants'
 
 interface EventCardMarketsListProps {
   event: Event
@@ -19,9 +19,30 @@ export default function EventCardMarketsList({
   onTrade,
   onToggle,
 }: EventCardMarketsListProps) {
+  const marketsToRender = isResolvedEvent
+    ? event.markets
+        .map((market, index) => {
+          const resolvedOutcome = market.outcomes.find(outcome => outcome.is_winning_outcome)
+          const resolvedOutcomeIndex = resolvedOutcome?.outcome_index ?? null
+          const rank = resolvedOutcomeIndex === OUTCOME_INDEX.YES
+            ? 0
+            : resolvedOutcomeIndex === OUTCOME_INDEX.NO
+              ? 1
+              : 2
+
+          return {
+            market,
+            index,
+            rank,
+          }
+        })
+        .sort((a, b) => (a.rank - b.rank) || (a.index - b.index))
+        .map(item => item.market)
+    : event.markets
+
   return (
     <div className="mb-1 scrollbar-hide max-h-16 space-y-2 overflow-y-auto">
-      {event.markets.map((market) => {
+      {marketsToRender.map((market) => {
         const resolvedOutcome = isResolvedEvent
           ? market.outcomes.find(outcome => outcome.is_winning_outcome)
           : null


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reorders resolved markets to show winners first on event cards and sorts resolved markets by end time on the event page. Improves consistency and makes results easier to scan.

- **Bug Fixes**
  - Event cards: For resolved events, sort markets by winning outcome — YES first, then NO, then others; tie-break by original order.
  - Event page: Sort resolved market rows by market end_time (ascending), falling back to original order when end_time is missing or invalid; use the sorted list for inline and "Resolved" sections.

<sup>Written for commit 8ffa34f41eed0452f238958f2cd400c982b60d7b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

