### PR TITLE
refactor(db): rename arweave hash to metadata

### DIFF
--- a/src/lib/db/migrations/2026_01_27_001_condition_metadata_hash.sql
+++ b/src/lib/db/migrations/2026_01_27_001_condition_metadata_hash.sql
@@ -1,0 +1,2 @@
+ALTER TABLE conditions
+  RENAME COLUMN arweave_hash TO metadata_hash;

--- a/src/lib/db/schema/events/tables.ts
+++ b/src/lib/db/schema/events/tables.ts
@@ -18,7 +18,7 @@ export const conditions = pgTable(
     oracle: text().notNull(),
     question_id: text().notNull(),
     resolved: boolean().default(false),
-    arweave_hash: text(),
+    metadata_hash: text(),
     creator: char('creator', { length: 42 }),
     uma_request_tx_hash: char('uma_request_tx_hash', { length: 66 }),
     uma_request_log_index: integer('uma_request_log_index'),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -86,7 +86,7 @@ interface Condition {
   resolved: boolean
   payout_numerators?: number[]
   payout_denominator?: number
-  arweave_hash?: string
+  metadata_hash?: string
   creator?: string
   uma_request_tx_hash?: string
   uma_request_log_index?: number


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Renamed the condition metadata field from arweaveHash/arweave_hash to metadataHash/metadata_hash across the sync API and codebase for clearer, storage-agnostic naming. This aligns with the subgraph and Irys gateway.

- **Refactors**
  - Replaced arweaveHash with metadataHash in subgraph interfaces and sync logic.
  - Updated metadata/image fetch and error messages to use the Irys gateway and metadataHash.
  - Adjusted TypeScript types to metadata_hash.

- **Migration**
  - Run migration 2026_01_27_001_condition_metadata_hash.sql to rename conditions.arweave_hash to conditions.metadata_hash.
  - No data changes; values are preserved.
  - Update any clients to read metadata_hash instead of arweave_hash.

<sup>Written for commit 6c47885ba521fecec2d2bcdc0a63484cb4267513. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

