### PR TITLE
style: standardize tooltips

### DIFF
--- a/src/app/[locale]/(platform)/[username]/_components/PublicProfileHeroCards.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicProfileHeroCards.tsx
@@ -398,19 +398,15 @@ function ProfitLossCard({
                   <TooltipTrigger asChild>
                     <button
                       type="button"
-                      className="inline-flex translate-y-[1px] text-muted-foreground hover:text-foreground"
+                      className="inline-flex translate-y-px text-muted-foreground hover:text-foreground"
                     >
                       <CircleHelpIcon className="size-4" />
                     </button>
                   </TooltipTrigger>
                   <TooltipContent
                     side="bottom"
-                    align="start"
-                    sideOffset={8}
-                    hideArrow
-                    className={`
-                      w-56 rounded-md border bg-background p-3 text-left text-xs font-semibold text-foreground shadow-lg
-                    `}
+                    align="center"
+                    className="w-56 p-3 text-left"
                   >
                     <div className="space-y-2">
                       <div className="flex items-center justify-between">

--- a/src/app/[locale]/(platform)/_components/WalletModal.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletModal.tsx
@@ -501,10 +501,7 @@ function WalletSendForm({
                         <Info className="size-4" />
                       </div>
                     </TooltipTrigger>
-                    <TooltipContent
-                      hideArrow
-                      className="border bg-background text-foreground shadow-lg"
-                    >
+                    <TooltipContent>
                       <div className="space-y-1 text-xs text-foreground">
                         <div className="flex items-center justify-between gap-4">
                           <span>Total cost</span>
@@ -534,10 +531,7 @@ function WalletSendForm({
                         <Info className="size-4" />
                       </div>
                     </TooltipTrigger>
-                    <TooltipContent
-                      hideArrow
-                      className="border bg-background text-foreground shadow-lg"
-                    >
+                    <TooltipContent>
                       <div className="space-y-1 text-xs text-foreground">
                         <div className="flex items-center justify-between gap-4">
                           <span>Total impact</span>
@@ -564,13 +558,8 @@ function WalletSendForm({
                         <Info className="size-4" />
                       </div>
                     </TooltipTrigger>
-                    <TooltipContent
-                      hideArrow
-                      className="max-w-56 border bg-background text-foreground shadow-lg"
-                    >
-                      <p className="text-xs text-foreground">
-                        Slippage occurs due to price changes during trade execution. Minimum received: $00.00
-                      </p>
+                    <TooltipContent>
+                      Slippage occurs due to price changes during trade execution. Minimum received: $0.00
                     </TooltipContent>
                   </Tooltip>
                   <span>Auto • 0.00%</span>
@@ -666,7 +655,7 @@ function WalletFundMenu({
                         <Info className="size-3" />
                       </span>
                     </TooltipTrigger>
-                    <TooltipContent hideArrow>
+                    <TooltipContent>
                       Wallet deposits are not available in test mode.
                     </TooltipContent>
                   </Tooltip>
@@ -901,17 +890,12 @@ function WalletTokenList({
                         </span>
                       </div>
                     </TooltipTrigger>
-                    <TooltipContent
-                      hideArrow
-                      className="border bg-background text-foreground shadow-lg"
-                    >
-                      <p className="text-sm text-foreground">
-                        {item.symbol}
-                        {' '}
-                        on
-                        {' '}
-                        {item.network}
-                      </p>
+                    <TooltipContent>
+                      {item.symbol}
+                      {' '}
+                      on
+                      {' '}
+                      {item.network}
                     </TooltipContent>
                   </Tooltip>
                   <div className="space-y-0.5">
@@ -931,11 +915,8 @@ function WalletTokenList({
                           Low Balance
                         </span>
                       </TooltipTrigger>
-                      <TooltipContent
-                        hideArrow
-                        className="border bg-background text-foreground shadow-lg"
-                      >
-                        <p className="text-sm text-foreground">Minimum required: $2.00</p>
+                      <TooltipContent>
+                        Minimum required: $2.00
                       </TooltipContent>
                     </Tooltip>
                   )}
@@ -1434,7 +1415,7 @@ function WalletConfirmStep({
                   <TooltipTrigger asChild>
                     <Info className="size-3" />
                   </TooltipTrigger>
-                  <TooltipContent hideArrow className="border bg-background text-foreground shadow-lg">
+                  <TooltipContent>
                     <div className="space-y-1 text-xs text-foreground">
                       <div className="flex items-center justify-between gap-4">
                         <span>Total cost</span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartControls.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartControls.tsx
@@ -175,14 +175,7 @@ export default function EventChartControls({
                           <XIcon className="size-3.5" />
                         </span>
                       </TooltipTrigger>
-                      <TooltipContent
-                        side="top"
-                        sideOffset={8}
-                        hideArrow
-                        className={`
-                          border border-border bg-background px-2 py-1 text-xs font-semibold text-foreground shadow-xl
-                        `}
-                      >
+                      <TooltipContent side="top">
                         Remove
                       </TooltipContent>
                     </Tooltip>
@@ -245,12 +238,7 @@ export default function EventChartControls({
               <ShuffleIcon className="size-4" />
             </button>
           </TooltipTrigger>
-          <TooltipContent
-            side="left"
-            sideOffset={8}
-            hideArrow
-            className="border border-border bg-background px-3 py-2 text-xs font-semibold text-foreground shadow-xl"
-          >
+          <TooltipContent side="left">
             Switch to
             {' '}
             {oppositeOutcomeLabel}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
@@ -240,7 +240,7 @@ function OpenOrderRow({ order, onCancel, isCancelling }: OpenOrderRowProps) {
                 <XIcon className="size-4" />
               </Button>
             </TooltipTrigger>
-            <TooltipContent side="top" sideOffset={8}>
+            <TooltipContent side="top">
               Cancel
             </TooltipContent>
           </Tooltip>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
@@ -306,9 +306,7 @@ function MarketPositionRow({
           </TooltipTrigger>
           <TooltipContent
             side="bottom"
-            sideOffset={6}
-            hideArrow={true}
-            className="relative w-56 border border-border bg-background text-sm leading-tight text-foreground shadow-lg"
+            className="w-56 p-3"
           >
             <div className="flex flex-col gap-2">
               <div className="flex items-center justify-between gap-3">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMetaInformation.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMetaInformation.tsx
@@ -108,35 +108,33 @@ export default function EventMetaInformation({ event }: EventMetaInformationProp
       {shouldShowNew && (
         <span className="mx-1.5 h-4 w-px bg-muted-foreground/40" aria-hidden="true" />
       )}
-      <div className="flex items-center gap-2 text-foreground">
+      <div className="flex items-center gap-2">
         {isNegRiskEnabled && (
           <Tooltip>
             <TooltipTrigger asChild>
               <button
                 type="button"
                 aria-label="Negative risk details"
-                className="inline-flex items-center justify-center text-foreground transition-colors"
+                className="inline-flex items-center justify-center transition-colors"
               >
                 <TrophyIcon className="size-4" />
               </button>
             </TooltipTrigger>
             <TooltipContent
               side="bottom"
-              sideOffset={8}
               collisionPadding={16}
-              hideArrow
-              className="max-w-68 border border-border bg-background px-4 py-3 text-sm text-foreground shadow-xl"
+              className="max-w-68 p-3 text-left text-sm"
             >
-              <div className="flex flex-col gap-3 text-foreground">
-                <span className="text-base font-bold text-foreground">{t('Winner-take-all')}</span>
+              <div className="flex flex-col gap-3">
+                <span className="text-base font-bold">{t('Winner-take-all')}</span>
                 <div className="flex flex-col gap-3">
                   <div className="flex items-start gap-3">
                     <CheckIcon className="mt-0.5 size-5 shrink-0 text-primary" />
-                    <span className="text-foreground">Only 1 winner</span>
+                    <span className="font-normal">Only 1 winner</span>
                   </div>
                   <div className="flex items-start gap-3">
                     <CheckIcon className="mt-0.5 size-5 shrink-0 text-primary" />
-                    <span className="text-foreground">
+                    <span className="font-normal">
                       Supports negative risk (convert
                       {' '}
                       {tradeT('No')}
@@ -151,8 +149,8 @@ export default function EventMetaInformation({ event }: EventMetaInformationProp
                   {isNegRiskAugmented && (
                     <div className="flex items-start gap-3">
                       <PlusIcon className="mt-0.5 size-5 shrink-0 text-primary" />
-                      <span>
-                        <span className="font-bold text-foreground">Complete negative risk</span>
+                      <span className="font-normal">
+                        <span className="font-bold">Complete negative risk</span>
                         {' '}
                         (users who convert will receive
                         {' '}
@@ -167,7 +165,7 @@ export default function EventMetaInformation({ event }: EventMetaInformationProp
             </TooltipContent>
           </Tooltip>
         )}
-        <span className="text-sm font-semibold text-foreground">{volumeLabel}</span>
+        <span className="text-sm font-semibold">{volumeLabel}</span>
       </div>
       {expiryDate && (
         <span className="mx-1.5 h-4 w-px bg-muted-foreground/40" aria-hidden="true" />
@@ -182,14 +180,10 @@ export default function EventMetaInformation({ event }: EventMetaInformationProp
           </TooltipTrigger>
           <TooltipContent
             side="bottom"
-            sideOffset={8}
             collisionPadding={16}
-            hideArrow
-            className="border border-border bg-background px-3 py-2 text-xs font-semibold text-foreground shadow-xl"
           >
             <p
               dangerouslySetInnerHTML={{ __html: expiryTooltip! }}
-              className="text-center"
             />
           </TooltipContent>
         </Tooltip>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook.tsx
@@ -335,12 +335,7 @@ export default function EventOrderBook({
                   <AlignVerticalSpaceAroundIcon className="size-4" />
                 </button>
               </TooltipTrigger>
-              <TooltipContent
-                side="top"
-                sideOffset={8}
-                hideArrow
-                className="border border-border bg-background px-3 py-2 text-xs font-semibold text-foreground shadow-xl"
-              >
+              <TooltipContent side="top">
                 Recenter Book (Shift + C)
               </TooltipContent>
             </Tooltip>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBookRow.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBookRow.tsx
@@ -82,9 +82,7 @@ export default function EventOrderBookRow({
                 </TooltipTrigger>
                 <TooltipContent
                   side="left"
-                  sideOffset={8}
-                  hideArrow
-                  className="w-48 border border-border bg-background p-3 text-xs text-foreground shadow-xl"
+                  className="w-48 p-3 text-left"
                 >
                   <div className="flex items-center justify-between text-sm font-semibold">
                     <span>Filled</span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelEarnings.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelEarnings.tsx
@@ -115,8 +115,6 @@ export default function EventOrderPanelEarnings({
                 </TooltipTrigger>
                 <TooltipContent
                   side="top"
-                  sideOffset={8}
-                  hideArrow
                   className={`
                     w-52 border border-border bg-background px-4 py-3 text-sm font-semibold text-muted-foreground
                     shadow-xl
@@ -180,12 +178,7 @@ export default function EventOrderPanelEarnings({
                 </TooltipTrigger>
                 <TooltipContent
                   side="top"
-                  sideOffset={8}
-                  hideArrow
-                  className={`
-                    w-52 border border-border bg-background px-4 py-3 text-sm font-semibold text-muted-foreground
-                    shadow-xl
-                  `}
+                  className="w-52 p-3"
                 >
                   <div className="flex flex-col gap-2">
                     <div className="flex items-center justify-between gap-3">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
@@ -460,12 +460,7 @@ export default function EventOrderPanelLimitControls({
                           </TooltipTrigger>
                           <TooltipContent
                             side="top"
-                            sideOffset={8}
-                            hideArrow
-                            className={`
-                              w-52 border border-border bg-background px-4 py-3 text-sm font-semibold
-                              text-muted-foreground shadow-xl
-                            `}
+                            className="w-52 p-3"
                           >
                             <div className="flex flex-col gap-2">
                               <div className="flex items-center justify-between gap-3">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
@@ -37,7 +37,7 @@ interface MarketOutcomeGraphProps {
 
 const PredictionChart = dynamic<PredictionChartProps>(
   () => import('@/components/PredictionChart'),
-  { ssr: false, loading: () => <Skeleton className="h-[318px] w-full" /> },
+  { ssr: false, loading: () => <Skeleton className="h-79.5 w-full" /> },
 )
 
 export default function MarketOutcomeGraph({ market, outcome, allMarkets, eventCreatedAt, isMobile }: MarketOutcomeGraphProps) {
@@ -392,16 +392,9 @@ function MarketOutcomeMetaInformation({ market }: { market: Market }) {
               <span>{formatDate(expiryDate)}</span>
             </div>
           </TooltipTrigger>
-          <TooltipContent
-            side="bottom"
-            sideOffset={8}
-            collisionPadding={16}
-            hideArrow
-            className="border border-border bg-background px-3 py-2 text-xs font-semibold text-foreground shadow-xl"
-          >
+          <TooltipContent side="bottom">
             <p
               dangerouslySetInnerHTML={{ __html: expiryTooltip }}
-              className="text-center"
             />
           </TooltipContent>
         </Tooltip>

--- a/src/components/ProfileLink.tsx
+++ b/src/components/ProfileLink.tsx
@@ -70,7 +70,7 @@ export default function ProfileLink({
   }[position ?? 0] ?? '#000000'
 
   const medalTextColor = medalColor === '#000000' ? '#ffffff' : '#1a1a1a'
-  const normalizedUsername = typeof user.username === 'string' ? user.username.trim() : ''
+  const normalizedUsername = user.username.trim()
   const addressSlug = user.proxy_wallet_address ?? user.address ?? ''
   const displayUsername = normalizedUsername || (addressSlug ? truncateAddress(addressSlug) : 'Anonymous')
   const titleValue = normalizedUsername || addressSlug || displayUsername
@@ -208,7 +208,7 @@ export default function ProfileLink({
                 </div>
               )}
           {!isInline && children
-            ? <div className="pl-[3.25rem]">{children}</div>
+            ? <div className="pl-13">{children}</div>
             : null}
         </div>
         {!isInline && trailing
@@ -222,8 +222,6 @@ export default function ProfileLink({
       <TooltipContent
         side="top"
         align="start"
-        sideOffset={8}
-        hideArrow
         className="max-w-[90vw] border-none bg-transparent p-0 text-popover-foreground shadow-none md:max-w-96"
       >
         <ProfileActivityTooltipCard

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -37,9 +37,9 @@ function TooltipTrigger({
 
 function TooltipContent({
   className,
-  sideOffset = 0,
+  sideOffset = 8,
   children,
-  hideArrow = false,
+  hideArrow = true,
   ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content> & { hideArrow?: boolean }) {
   return (
@@ -49,14 +49,15 @@ function TooltipContent({
         sideOffset={sideOffset}
         className={cn(
           `
-            z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md bg-foreground px-3 py-1.5
-            text-xs text-balance text-background fade-in-0 zoom-in-95
+            z-50 w-fit origin-(--radix-tooltip-content-transform-origin) animate-in rounded-md border bg-background px-3
+            py-1.5 text-center text-xs font-medium text-balance text-foreground shadow-xl fade-in-0 zoom-in-95
             data-[side=bottom]:slide-in-from-top-2
             data-[side=left]:slide-in-from-right-2
             data-[side=right]:slide-in-from-left-2
             data-[side=top]:slide-in-from-bottom-2
             data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95
           `,
+          { shadow: hideArrow },
           className,
         )}
         {...props}
@@ -64,7 +65,7 @@ function TooltipContent({
         {children}
         {!hideArrow && (
           <TooltipPrimitive.Arrow className={`
-            z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground
+            z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-background fill-background
           `}
           />
         )}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized tooltip styles and behavior across the app by centralizing defaults and cleaning up usages. This reduces duplicate code and ensures consistent spacing, colors, and shadows.

- **Refactors**
  - Set TooltipContent defaults: sideOffset 8, hideArrow true, with border, bg-background, text-foreground, shadow-xl, p-3, text-xs font-medium.
  - Updated tooltip callers to rely on defaults; removed redundant props (hideArrow, sideOffset, custom borders/backgrounds), and normalized alignment (added text-left where needed).
  - Simplified tooltip content by removing unnecessary wrappers and repeated text classes.
  - Minor UI tidy-ups: translate-y-px, pl-13, h-79.5, and small text color cleanup.

<sup>Written for commit df50502ac731dc2a99e51e88c2038fcadea592f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

