### PR TITLE
refactor: remove unused column

### DIFF
--- a/src/lib/db/migrations/2025_09_24_001_affiliates.sql
+++ b/src/lib/db/migrations/2025_09_24_001_affiliates.sql
@@ -6,10 +6,11 @@
 CREATE TABLE affiliate_referrals
 (
   id                CHAR(26) PRIMARY KEY DEFAULT generate_ulid(),
-  user_id           CHAR(26)    NOT NULL UNIQUE REFERENCES users (id) ON DELETE CASCADE, -- The referred user
-  affiliate_user_id CHAR(26)    NOT NULL REFERENCES users (id) ON DELETE CASCADE,        -- The referring affiliate
-  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()                                   -- When attribution was recorded
+  user_id           CHAR(26)    NOT NULL UNIQUE REFERENCES users (id) ON DELETE CASCADE,
+  affiliate_user_id CHAR(26)    NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
 -- ===========================================
 -- 2. ROW LEVEL SECURITY
 -- ===========================================

--- a/src/lib/db/migrations/2025_10_01_001_settings_table.sql
+++ b/src/lib/db/migrations/2025_10_01_001_settings_table.sql
@@ -44,20 +44,17 @@ EXECUTE FUNCTION set_updated_at();
 -- 6. SEED
 -- ===========================================
 
--- Insert default affiliate settings
 INSERT INTO settings ("group", key, value)
-VALUES ('affiliate', 'trade_fee_bps', '200'),       -- 2.00% trading fee
-       ('affiliate', 'affiliate_share_bps', '5000') -- 50% of trading fees go to affiliates
+VALUES ('affiliate', 'trade_fee_bps', '200'),
+       ('affiliate', 'affiliate_share_bps', '5000')
 ON CONFLICT ("group", key) DO NOTHING;
 
--- Insert default AI settings
 INSERT INTO settings ("group", key, value)
 VALUES ('ai', 'openrouter_api_key', ''),
        ('ai', 'openrouter_model', ''),
        ('ai', 'openrouter_enabled', 'false')
 ON CONFLICT ("group", key) DO NOTHING;
 
--- Insert default locale settings
 INSERT INTO settings ("group", key, value)
 VALUES ('i18n', 'enabled_locales', '["en","de","es","pt","fr","zh"]')
 ON CONFLICT ("group", key) DO NOTHING;

--- a/src/lib/db/schema/events/tables.ts
+++ b/src/lib/db/schema/events/tables.ts
@@ -118,7 +118,6 @@ export const outcomes = pgTable(
     token_id: text().notNull().primaryKey(),
     is_winning_outcome: boolean().default(false),
     payout_value: numeric({ precision: 20, scale: 6 }),
-    current_price: numeric({ precision: 8, scale: 4 }),
     created_at: timestamp({ withTimezone: true }).defaultNow().notNull(),
     updated_at: timestamp({ withTimezone: true }).defaultNow().notNull(),
   },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the unused current_price column from outcomes and its constraint, and updated the TypeScript schema to match. Also cleaned up SQL migrations by removing noisy comments; no functional changes.

- **Refactors**
  - Dropped outcomes.current_price and related CHECK; updated schema/events/tables.ts.
  - Trimmed redundant comments in migration files; behavior unchanged.

- **Migration**
  - Run DB migrations; this drops outcomes.current_price. No data backfill needed.

<sup>Written for commit b82532692b4f6b6302e6ec6bec9a046c3e7491e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

