### PR TITLE
feat: disable pending USDC swap in test mode

### DIFF
--- a/src/hooks/usePendingUsdcDeposit.ts
+++ b/src/hooks/usePendingUsdcDeposit.ts
@@ -5,6 +5,7 @@ import { useMemo } from 'react'
 import { createPublicClient, formatUnits, getContract, http } from 'viem'
 import { defaultNetwork } from '@/lib/appkit'
 import { NATIVE_USDC_TOKEN_ADDRESS } from '@/lib/contracts'
+import { IS_TEST_MODE } from '@/lib/network'
 import { normalizeAddress } from '@/lib/wallet'
 import { useUser } from '@/stores/useUser'
 
@@ -28,7 +29,6 @@ const INITIAL_STATE: Balance = {
   text: '0.00',
   symbol: 'USDC',
 }
-
 export const PENDING_USDC_QUERY_KEY = 'safe-native-usdc-balance'
 
 interface UsePendingUsdcDepositOptions {
@@ -69,7 +69,7 @@ export function usePendingUsdcDeposit(options: UsePendingUsdcDepositOptions = {}
     ? normalizeAddress(user.proxy_wallet_address) as Address | null
     : null
 
-  const isOptionsEnabled = options.enabled ?? true
+  const isOptionsEnabled = (options.enabled ?? true) && !IS_TEST_MODE
   const isAwaitingConnection = Boolean(user && isOptionsEnabled && !isConnected)
   const isQueryEnabled = Boolean(isConnected && proxyWalletAddress && isOptionsEnabled)
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disabled pending USDC deposit polling in test mode to avoid unnecessary network calls and misleading UI. The usePendingUsdcDeposit hook now disables queries when IS_TEST_MODE is true.

<sup>Written for commit 205ee39a94cffc9ecc04b5d6f4cd44dabb3e371e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

