### PR TITLE
fix: set locale on cached pages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "fumadocs-ui": "^16.4.9",
         "input-otp": "^1.4.2",
         "lucide-react": "^0.562.0",
-        "next": "^16.1.4",
+        "next": "^16.1.6",
         "next-intl": "^4.4.0",
         "next-themes": "^0.4.6",
         "postgres": "^3.4.8",
@@ -117,7 +117,7 @@
       "version": "0.9.31",
       "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
       "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@adobe/css-tools": {
@@ -284,7 +284,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
       "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@csstools/css-calc": "^2.1.4",
@@ -298,7 +298,7 @@
       "version": "11.2.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -308,7 +308,7 @@
       "version": "6.7.6",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
       "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/nwsapi": "^2.3.9",
@@ -322,7 +322,7 @@
       "version": "11.2.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -332,7 +332,7 @@
       "version": "2.3.9",
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
@@ -366,6 +366,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -604,6 +605,101 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@base-org/account": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-2.5.1.tgz",
+      "integrity": "sha512-3VhLcpuUByIXO1elzMSl6Hhn8ac4AKZaEjtHCLppN28Wq5nqWNiWxi1L6koSO8Obtebc6gq7lVVbJkv4X63p/g==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "@coinbase/cdp-sdk": "^1.0.0",
+        "brotli-wasm": "^3.0.0",
+        "clsx": "1.2.1",
+        "eventemitter3": "5.0.1",
+        "idb-keyval": "6.2.1",
+        "ox": "0.6.9",
+        "preact": "10.24.2",
+        "viem": "^2.31.7",
+        "zustand": "5.0.3"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/@base-org/account/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@base-org/account/node_modules/ox": {
+      "version": "0.6.9",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
+      "integrity": "sha512-wi5ShvzE4eOcTwQVsIPdFr+8ycyX+5le/96iAJutaZAvCes1J0+RvpEPg5QDPDiaR0XQQAvZVl7AwqQcINuUug==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.10.1",
+        "@noble/curves": "^1.6.0",
+        "@noble/hashes": "^1.5.0",
+        "@scure/bip32": "^1.5.0",
+        "@scure/bip39": "^1.4.0",
+        "abitype": "^1.0.6",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@base-org/account/node_modules/zustand": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
+      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@bcoe/v8-coverage": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
@@ -615,9 +711,10 @@
       }
     },
     "node_modules/@better-auth/core": {
-      "version": "1.4.17",
-      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.17.tgz",
-      "integrity": "sha512-WSaEQDdUO6B1CzAmissN6j0lx9fM9lcslEYzlApB5UzFaBeAOHNUONTdglSyUs6/idiZBoRvt0t/qMXCgIU8ug==",
+      "version": "1.4.18",
+      "resolved": "https://registry.npmjs.org/@better-auth/core/-/core-1.4.18.tgz",
+      "integrity": "sha512-q+awYgC7nkLEBdx2sW0iJjkzgSHlIxGnOpsN1r/O1+a4m7osJNHtfK2mKJSL1I+GfNyIlxJF8WvD/NLuYMpmcg==",
+      "peer": true,
       "dependencies": {
         "@standard-schema/spec": "^1.0.0",
         "zod": "^4.3.5"
@@ -632,27 +729,29 @@
       }
     },
     "node_modules/@better-auth/telemetry": {
-      "version": "1.4.17",
-      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.17.tgz",
-      "integrity": "sha512-R1BC4e/bNjQbXu7lG6ubpgmsPj7IMqky5DvMlzAtnAJWJhh99pMh/n6w5gOHa0cqDZgEAuj75IPTxv+q3YiInA==",
+      "version": "1.4.18",
+      "resolved": "https://registry.npmjs.org/@better-auth/telemetry/-/telemetry-1.4.18.tgz",
+      "integrity": "sha512-e5rDF8S4j3Um/0LIVATL2in9dL4lfO2fr2v1Wio4qTMRbfxqnUDTa+6SZtwdeJrbc4O+a3c+IyIpjG9Q/6GpfQ==",
       "dependencies": {
         "@better-auth/utils": "0.3.0",
         "@better-fetch/fetch": "1.1.21"
       },
       "peerDependencies": {
-        "@better-auth/core": "1.4.17"
+        "@better-auth/core": "1.4.18"
       }
     },
     "node_modules/@better-auth/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@better-auth/utils/-/utils-0.3.0.tgz",
       "integrity": "sha512-W+Adw6ZA6mgvnSnhOki270rwJ42t4XzSK6YWGF//BbVXL6SwCLWfyzBc1lN2m/4RM28KubdBKQ4X5VMoLRNPQw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@better-fetch/fetch": {
       "version": "1.1.21",
       "resolved": "https://registry.npmjs.org/@better-fetch/fetch/-/fetch-1.1.21.tgz",
-      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="
+      "integrity": "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A==",
+      "peer": true
     },
     "node_modules/@bigmi/core": {
       "version": "0.6.5",
@@ -669,18 +768,6 @@
       },
       "peerDependencies": {
         "bs58": "^6.0.0"
-      }
-    },
-    "node_modules/@bigmi/core/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@bitcoinerlab/secp256k1": {
@@ -750,9 +837,9 @@
       }
     },
     "node_modules/@coinbase/cdp-sdk": {
-      "version": "1.43.1",
-      "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.43.1.tgz",
-      "integrity": "sha512-3eXP24p5q68agRgu8grGlF+ASidf3xYSDQtdRuDOFCMZafbqANsjl/JxLwYDmUenRodhxBBJgYJ65nOALP58tA==",
+      "version": "1.44.0",
+      "resolved": "https://registry.npmjs.org/@coinbase/cdp-sdk/-/cdp-sdk-1.44.0.tgz",
+      "integrity": "sha512-0I5O1DzbchR91GAYQAU8lxx6q9DBvN0no9IBwrTKLHW8t5bABMg8dzQ/jrGRd6lr/QFJJW4L0ZSLGae5jsxGWw==",
       "license": "MIT",
       "dependencies": {
         "@solana-program/system": "^0.10.0",
@@ -795,6 +882,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -804,6 +892,7 @@
       "resolved": "https://registry.npmjs.org/@coinbase/wallet-sdk/-/wallet-sdk-4.3.6.tgz",
       "integrity": "sha512-4q8BNG1ViL4mSAAvPAtpwlOs1gpC+67eQtgIwNvT3xyeyFFd+guwkc8bcX5rTmQhXpqnhzC4f0obACbP9CqMSA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "1.4.0",
         "clsx": "1.2.1",
@@ -815,6 +904,18 @@
         "zustand": "5.0.3"
       }
     },
+    "node_modules/@coinbase/wallet-sdk/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@coinbase/wallet-sdk/node_modules/clsx": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
@@ -823,6 +924,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@coinbase/wallet-sdk/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/@coinbase/wallet-sdk/node_modules/ox": {
       "version": "0.6.9",
@@ -898,7 +1005,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
       "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -918,7 +1025,7 @@
       "version": "2.1.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
       "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -942,7 +1049,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
       "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -970,7 +1077,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
       "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -982,6 +1089,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -993,7 +1101,7 @@
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
       "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1010,7 +1118,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
       "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
-      "devOptional": true,
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1022,6 +1130,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1562,16 +1671,16 @@
       }
     },
     "node_modules/@eslint-react/ast": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-2.7.4.tgz",
-      "integrity": "sha512-es148MgD+yXVT+OW2SKgUZeVq5xIQ3FESjnY6A1XMEO92neDxij8Suo1CTDKurMw4jMHELmB7CPhg/FqsfvnJg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/ast/-/ast-2.8.1.tgz",
+      "integrity": "sha512-4D442lxeFvvd9PMvBbA621rfz/Ne8Kod8RW0/FLKO0vx+IOxm74pP6be1uU56rqL9TvoIHxjclBjfgXplEF+Yw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/eff": "2.7.4",
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/typescript-estree": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1",
+        "@eslint-react/eff": "2.8.1",
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/typescript-estree": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0",
         "string-ts": "^2.3.1"
       },
       "engines": {
@@ -1583,20 +1692,19 @@
       }
     },
     "node_modules/@eslint-react/core": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-2.7.4.tgz",
-      "integrity": "sha512-L2LrKNFqUPhhChPZyHz1ak11GQAxGRRrGBw0q9sNqm9taPO1Eu/U8wrcO/X5jhYT3orROZklCl0z+q8pxM3A/g==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/core/-/core-2.8.1.tgz",
+      "integrity": "sha512-zF73p8blyuX+zrfgyTtpKesichYzK+G54TEjFWtzagWIbnqQjtVscebL/eGep72oWzAOd5B04ACBvJ2hW4fp5g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.7.4",
-        "@eslint-react/eff": "2.7.4",
-        "@eslint-react/shared": "2.7.4",
-        "@eslint-react/var": "2.7.4",
-        "@typescript-eslint/scope-manager": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1",
-        "birecord": "^0.1.1",
+        "@eslint-react/ast": "2.8.1",
+        "@eslint-react/eff": "2.8.1",
+        "@eslint-react/shared": "2.8.1",
+        "@eslint-react/var": "2.8.1",
+        "@typescript-eslint/scope-manager": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -1608,9 +1716,9 @@
       }
     },
     "node_modules/@eslint-react/eff": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eff/-/eff-2.7.4.tgz",
-      "integrity": "sha512-L+ZU/m7UudB7fYaMLrNgt700gjFJ9Wa4HQxe4UXXd6z2LecJbYEXo2Z+dU/e5I21/jxtH+iq+bnZwCxh3SaRtA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eff/-/eff-2.8.1.tgz",
+      "integrity": "sha512-ZASOs8oTZJSiu1giue7V87GEKQvlKLfGfLppal6Rl+aKnfIEz+vartmjpH12pkFQZ9ESRyHzYbU533S6pEDoNg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1618,23 +1726,24 @@
       }
     },
     "node_modules/@eslint-react/eslint-plugin": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-2.7.4.tgz",
-      "integrity": "sha512-J8gXKbXIABuExCx5Rxz3ckmBOQQ4AhuvF7TKoDPCfqpTan4NEwmAqf+wbx2bIGuyaAB5TDFpXVW31r5vWvsjFA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/eslint-plugin/-/eslint-plugin-2.8.1.tgz",
+      "integrity": "sha512-ob+SSDnTPnA5dhiWWJLfyHRLEzWnjilCsohgo5s9PPKF5b5bjxG+c/rwqhQwT3M9Ey83mGNdkrLzt00SOfr4pw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@eslint-react/eff": "2.7.4",
-        "@eslint-react/shared": "2.7.4",
-        "@typescript-eslint/scope-manager": "^8.53.1",
-        "@typescript-eslint/type-utils": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1",
-        "eslint-plugin-react-dom": "2.7.4",
-        "eslint-plugin-react-hooks-extra": "2.7.4",
-        "eslint-plugin-react-naming-convention": "2.7.4",
-        "eslint-plugin-react-web-api": "2.7.4",
-        "eslint-plugin-react-x": "2.7.4",
+        "@eslint-react/eff": "2.8.1",
+        "@eslint-react/shared": "2.8.1",
+        "@typescript-eslint/scope-manager": "^8.54.0",
+        "@typescript-eslint/type-utils": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0",
+        "eslint-plugin-react-dom": "2.8.1",
+        "eslint-plugin-react-hooks-extra": "2.8.1",
+        "eslint-plugin-react-naming-convention": "2.8.1",
+        "eslint-plugin-react-web-api": "2.8.1",
+        "eslint-plugin-react-x": "2.8.1",
         "ts-api-utils": "^2.4.0"
       },
       "engines": {
@@ -1646,14 +1755,14 @@
       }
     },
     "node_modules/@eslint-react/shared": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-2.7.4.tgz",
-      "integrity": "sha512-at8Ib51JJl1GJy+ylRDG3zv64FD2V89sofQ9iemu6DXkya2ZSE5dcO2EN7FmEj6CyYS/YRu3XlJ3dXHShDYPLg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/shared/-/shared-2.8.1.tgz",
+      "integrity": "sha512-NDmJBiMiPDXR6qeZzYOtiILHxWjYwBHxquQ/bMQkWcWK+1qF5LeD8UTRcWtBpZoMPi3sNBWwR3k2Sc5HWZpJ7g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/eff": "2.7.4",
-        "@typescript-eslint/utils": "^8.53.1",
+        "@eslint-react/eff": "2.8.1",
+        "@typescript-eslint/utils": "^8.54.0",
         "ts-pattern": "^5.9.0",
         "zod": "^3.25.0 || ^4.0.0"
       },
@@ -1666,18 +1775,18 @@
       }
     },
     "node_modules/@eslint-react/var": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-2.7.4.tgz",
-      "integrity": "sha512-RdcX5j/3EvI+qchordszVD3pjCAV+3+vNEztTEuZB6G1Le3ulQaLsQGfLP70INut9IyZaZ56hyC0bwfgqIFjQA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/@eslint-react/var/-/var-2.8.1.tgz",
+      "integrity": "sha512-iHIdEBz6kgW4dEFdhEjpy9SEQ6+d4RYg+WBzHg5J5ktT2xSQFi77Dq6Wtemik6QvvAPnYLRseQxgW+m+1rQlfA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.7.4",
-        "@eslint-react/eff": "2.7.4",
-        "@eslint-react/shared": "2.7.4",
-        "@typescript-eslint/scope-manager": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1",
+        "@eslint-react/ast": "2.8.1",
+        "@eslint-react/eff": "2.8.1",
+        "@eslint-react/shared": "2.8.1",
+        "@typescript-eslint/scope-manager": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0",
         "ts-pattern": "^5.9.0"
       },
       "engines": {
@@ -1971,32 +2080,50 @@
         "node": ">=14"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.10.0.tgz",
+      "integrity": "sha512-tf8YdcbirXdPnJ+Nd4UN1EXnz+IP2DI45YVEr3vvzcVTOyrApkmIB4zvOQVd3XPr7RXnfBtAx+PXImXOIU0Ajg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
-      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "version": "1.7.4",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
+      "integrity": "sha512-C3HlIdsBxszvm5McXlB8PeOEWfBhcGBTZGkGlWc2U0KFY5IwG5OQEuQ8rq52DZmcHDlPLd+YFBK+cZcytwIFWg==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
-      "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.5.tgz",
+      "integrity": "sha512-N0bD2kIPInNHUHehXhMke1rBGs1dwqvC9O9KYMyyjK7iXt7GAhnro7UlcuYcGdS/yYOlq0MAVgrow8IbWJwyqg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/core": "^1.7.4",
         "@floating-ui/utils": "^0.2.10"
       }
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.6.tgz",
-      "integrity": "sha512-4JX6rEatQEvlmgU80wZyq9RT96HZJa88q8hp0pBd+LrczeDI4o6uA2M+uvxngVHo4Ihr8uibXxH6+70zhAFrVw==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.7.tgz",
+      "integrity": "sha512-0tLRojf/1Go2JgEVm+3Frg9A3IW8bJgKgdO0BN5RkF//ufuz2joZM63Npau2ff3J6lUVYgDSNzNkR+aH3IVfjg==",
       "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.7.4"
+        "@floating-ui/dom": "^1.7.5"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -2010,33 +2137,15 @@
       "license": "MIT"
     },
     "node_modules/@formatjs/ecma402-abstract": {
-      "version": "2.3.6",
-      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.3.6.tgz",
-      "integrity": "sha512-HJnTFeRM2kVFVr5gr5kH1XP6K0JcJtE7Lzvtr3FS/so5f1kpsqqqxy5JF+FRaO6H2qmcMfAUIox7AJteieRtVw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-3.1.0.tgz",
+      "integrity": "sha512-CjP1sUzM7XiQW6YluDreN+dMvcKZysO/J4ikvuDjDyd6nSOoSqAK9gvD1s75ZFaJVXtYOsz+y3CUXPZ1sKxcxw==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/intl-localematcher": "0.6.2",
-        "decimal.js": "^10.4.3",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/@formatjs/ecma402-abstract/node_modules/@formatjs/intl-localematcher": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.6.2.tgz",
-      "integrity": "sha512-XOMO2Hupl0wdd172Y06h6kLpBz6Dv+J4okPLl4LPtzbr8f66WbIoy4ev98EBuZ6ZK4h5ydTN6XneT4QVpD7cdA==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
+        "@formatjs/fast-memoize": "3.1.0",
+        "@formatjs/intl-localematcher": "0.8.0",
+        "decimal.js": "^10.6.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@formatjs/fast-memoize": {
@@ -2049,24 +2158,24 @@
       }
     },
     "node_modules/@formatjs/icu-messageformat-parser": {
-      "version": "2.11.4",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.11.4.tgz",
-      "integrity": "sha512-7kR78cRrPNB4fjGFZg3Rmj5aah8rQj9KPzuLsmcSn4ipLXQvC04keycTI1F7kJYDwIXtT2+7IDEto842CfZBtw==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.0.tgz",
+      "integrity": "sha512-Q01XuvtbDVCJQsG/E2MSfMZ+UdUoZV8v4Aex8tTH44SqKJZCeu5LjuclaKFUS0o1YoXndfEinJen5k1T1GR1vg==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/icu-skeleton-parser": "1.8.16",
-        "tslib": "^2.8.0"
+        "@formatjs/ecma402-abstract": "3.1.0",
+        "@formatjs/icu-skeleton-parser": "2.1.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@formatjs/icu-skeleton-parser": {
-      "version": "1.8.16",
-      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.16.tgz",
-      "integrity": "sha512-H13E9Xl+PxBd8D5/6TVUluSpxGNvFSlN/b3coUp0e0JpuWXXnQDiavIpY3NnvSp4xhEMoXyyBvVfdFX8jglOHQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.0.tgz",
+      "integrity": "sha512-wNer4imHDFBVAJnMb2OGoSyM4wL/uuLnuo5mrenliqkDaNjRbG4jzlJcwTTDEBhai8iCjnzUsE7xwNJC29SfWw==",
       "license": "MIT",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "tslib": "^2.8.0"
+        "@formatjs/ecma402-abstract": "3.1.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/@formatjs/intl-localematcher": {
@@ -2080,9 +2189,9 @@
       }
     },
     "node_modules/@fumadocs/ui": {
-      "version": "16.4.9",
-      "resolved": "https://registry.npmjs.org/@fumadocs/ui/-/ui-16.4.9.tgz",
-      "integrity": "sha512-MRIwJHm3SObwwPYqsMX4DfY71PYCtuXyBRI+g7NjbhdOD4HNnB2cOZf81I44+DCDvlRlnx6nf/SgsESSY/7cxQ==",
+      "version": "16.4.11",
+      "resolved": "https://registry.npmjs.org/@fumadocs/ui/-/ui-16.4.11.tgz",
+      "integrity": "sha512-3APzHr4Rv5P9YQApTKCQW3cXika0dwHuOo8WxYz74y42nONRo/TMDtvoWaNhB145sBrW9N4j0/0xXfiGLihVRQ==",
       "license": "MIT",
       "dependencies": {
         "next-themes": "^0.4.6",
@@ -2091,7 +2200,7 @@
       },
       "peerDependencies": {
         "@types/react": "*",
-        "fumadocs-core": "16.4.9",
+        "fumadocs-core": "16.4.11",
         "next": "16.x.x",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -2127,6 +2236,7 @@
       "resolved": "https://registry.npmjs.org/@gemini-wallet/core/-/core-0.3.2.tgz",
       "integrity": "sha512-Z4aHi3ECFf5oWYWM3F1rW83GJfB9OvhBYPTmb5q+VyK3uvzvS48lwo+jwh2eOoCRWEuT/crpb9Vwp2QaS5JqgQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@metamask/rpc-errors": "7.0.2",
         "eventemitter3": "5.0.1"
@@ -2134,6 +2244,12 @@
       "peerDependencies": {
         "viem": ">=2.0.0"
       }
+    },
+    "node_modules/@gemini-wallet/core/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/@gql.tada/cli-utils": {
       "version": "1.7.2",
@@ -3239,6 +3355,7 @@
       "version": "0.33.1",
       "resolved": "https://registry.npmjs.org/@metamask/sdk/-/sdk-0.33.1.tgz",
       "integrity": "sha512-1mcOQVGr9rSrVcbKPNVzbZ8eCl1K0FATsYH3WJ/MH4WcZDWGECWrXJPNMZoEAkLxWiMe8jOQBumg2pmcDa9zpQ==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.26.0",
         "@metamask/onboarding": "^1.0.1",
@@ -3304,6 +3421,7 @@
       "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-4.1.0.tgz",
       "integrity": "sha512-uKm5PU+MHTootlWEY+mZ4vvXoCn4fLQxT9dSc1sXVMSFkINTJVN8cAQROpwcKm8bJ/c7rgZVIBWzH5T78sNZZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-fetch": "^2.7.0"
       }
@@ -3451,18 +3569,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@mysten/sui/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@mysten/utils": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@mysten/utils/-/utils-0.2.0.tgz",
@@ -3483,25 +3589,26 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.5.tgz",
-      "integrity": "sha512-CRSCPJiSZoi4Pn69RYBDI9R7YK2g59vLexPQFXY0eyw+ILevIenCywzg+DqmlBik9zszEnw2HLFOUlLAcJbL7g==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.1.6.tgz",
+      "integrity": "sha512-N1ySLuZjnAtN3kFnwhAwPvZah8RJxKasD7x1f8shFqhncnWZn4JMfg37diLNuoHsLAlrDfM3g4mawVdtAG8XLQ==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.5.tgz",
-      "integrity": "sha512-gUWcEsOl+1W7XakmouClcJ0TNFCkblvDUho31wulbDY9na0C6mGtBTSXGRU5GXJY65GjGj0zNaCD/GaBp888Mg==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.1.6.tgz",
+      "integrity": "sha512-/Qq3PTagA6+nYVfryAtQ7/9FEr/6YVyvOtl6rZnGsbReGLf0jZU6gkpr1FuChAQpvV46a78p4cmHOVP8mbfSMQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-glob": "3.3.1"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.5.tgz",
-      "integrity": "sha512-eK7Wdm3Hjy/SCL7TevlH0C9chrpeOYWx2iR7guJDaz4zEQKWcS1IMVfMb9UKBFMg1XgzcPTYPIp1Vcpukkjg6Q==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.1.6.tgz",
+      "integrity": "sha512-wTzYulosJr/6nFnqGW7FrG3jfUUlEf8UjGA0/pyypJl42ExdVgC6xJgcXQ+V8QFn6niSG2Pb8+MIG1mZr2vczw==",
       "cpu": [
         "arm64"
       ],
@@ -3515,9 +3622,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.5.tgz",
-      "integrity": "sha512-foQscSHD1dCuxBmGkbIr6ScAUF6pRoDZP6czajyvmXPAOFNnQUJu2Os1SGELODjKp/ULa4fulnBWoHV3XdPLfA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.1.6.tgz",
+      "integrity": "sha512-BLFPYPDO+MNJsiDWbeVzqvYd4NyuRrEYVB5k2N3JfWncuHAy2IVwMAOlVQDFjj+krkWzhY2apvmekMkfQR0CUQ==",
       "cpu": [
         "x64"
       ],
@@ -3531,9 +3638,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.5.tgz",
-      "integrity": "sha512-qNIb42o3C02ccIeSeKjacF3HXotGsxh/FMk/rSRmCzOVMtoWH88odn2uZqF8RLsSUWHcAqTgYmPD3pZ03L9ZAA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.1.6.tgz",
+      "integrity": "sha512-OJYkCd5pj/QloBvoEcJ2XiMnlJkRv9idWA/j0ugSuA34gMT6f5b7vOiCQHVRpvStoZUknhl6/UxOXL4OwtdaBw==",
       "cpu": [
         "arm64"
       ],
@@ -3547,9 +3654,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.5.tgz",
-      "integrity": "sha512-U+kBxGUY1xMAzDTXmuVMfhaWUZQAwzRaHJ/I6ihtR5SbTVUEaDRiEU9YMjy1obBWpdOBuk1bcm+tsmifYSygfw==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.1.6.tgz",
+      "integrity": "sha512-S4J2v+8tT3NIO9u2q+S0G5KdvNDjXfAv06OhfOzNDaBn5rw84DGXWndOEB7d5/x852A20sW1M56vhC/tRVbccQ==",
       "cpu": [
         "arm64"
       ],
@@ -3563,9 +3670,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.5.tgz",
-      "integrity": "sha512-gq2UtoCpN7Ke/7tKaU7i/1L7eFLfhMbXjNghSv0MVGF1dmuoaPeEVDvkDuO/9LVa44h5gqpWeJ4mRRznjDv7LA==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.1.6.tgz",
+      "integrity": "sha512-2eEBDkFlMMNQnkTyPBhQOAyn2qMxyG2eE7GPH2WIDGEpEILcBPI/jdSv4t6xupSP+ot/jkfrCShLAa7+ZUPcJQ==",
       "cpu": [
         "x64"
       ],
@@ -3579,9 +3686,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.5.tgz",
-      "integrity": "sha512-bQWSE729PbXT6mMklWLf8dotislPle2L70E9q6iwETYEOt092GDn0c+TTNj26AjmeceSsC4ndyGsK5nKqHYXjQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.1.6.tgz",
+      "integrity": "sha512-oicJwRlyOoZXVlxmIMaTq7f8pN9QNbdes0q2FXfRsPhfCi8n8JmOZJm5oo1pwDaFbnnD421rVU409M3evFbIqg==",
       "cpu": [
         "x64"
       ],
@@ -3595,9 +3702,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.5.tgz",
-      "integrity": "sha512-LZli0anutkIllMtTAWZlDqdfvjWX/ch8AFK5WgkNTvaqwlouiD1oHM+WW8RXMiL0+vAkAJyAGEzPPjO+hnrSNQ==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.1.6.tgz",
+      "integrity": "sha512-gQmm8izDTPgs+DCWH22kcDmuUp7NyiJgEl18bcr8irXA5N2m2O+JQIr6f3ct42GOs9c0h8QF3L5SzIxcYAAXXw==",
       "cpu": [
         "arm64"
       ],
@@ -3611,9 +3718,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.5.tgz",
-      "integrity": "sha512-7is37HJTNQGhjPpQbkKjKEboHYQnCgpVt/4rBrrln0D9nderNxZ8ZWs8w1fAtzUx7wEyYjQ+/13myFgFj6K2Ng==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.1.6.tgz",
+      "integrity": "sha512-NRfO39AIrzBnixKbjuo2YiYhB6o9d8v/ymU9m/Xk8cyVk+k7XylniXkHwjs4s70wedVffc6bQNbufk5v0xEm0A==",
       "cpu": [
         "x64"
       ],
@@ -3631,6 +3738,7 @@
       "resolved": "https://registry.npmjs.org/@noble/ciphers/-/ciphers-1.3.0.tgz",
       "integrity": "sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^14.21.3 || >=16"
       },
@@ -3653,25 +3761,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+    "node_modules/@noble/hashes": {
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
       "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
       "license": "MIT",
       "engines": {
         "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -4052,13 +4148,14 @@
       }
     },
     "node_modules/@playwright/test": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.0.tgz",
-      "integrity": "sha512-fWza+Lpbj6SkQKCrU6si4iu+fD2dD3gxNHFhUPxsfXBPhnv3rRSQVd0NtBUT9Z/RhF/boCBcuUaMUSTRTopjZg==",
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
-        "playwright": "1.58.0"
+        "playwright": "1.58.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -5879,17 +5976,11 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@reown/appkit-siwe/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+    "node_modules/@reown/appkit-siwe/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/@reown/appkit-siwe/node_modules/lit": {
       "version": "3.1.0",
@@ -5900,6 +5991,36 @@
         "@lit/reactive-element": "^2.0.0",
         "lit-element": "^4.0.0",
         "lit-html": "^3.1.0"
+      }
+    },
+    "node_modules/@reown/appkit-siwe/node_modules/ox": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.11.3.tgz",
+      "integrity": "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/@reown/appkit-siwe/node_modules/viem": {
@@ -6010,6 +6131,19 @@
         "zustand": "5.0.3"
       }
     },
+    "node_modules/@reown/appkit-utils/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@reown/appkit-utils/node_modules/clsx": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
@@ -6019,6 +6153,13 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/@reown/appkit-utils/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@reown/appkit-utils/node_modules/ox": {
       "version": "0.6.9",
@@ -6115,12 +6256,13 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.56.0.tgz",
-      "integrity": "sha512-LNKIPA5k8PF1+jAFomGe3qN3bbIgJe/IlpDBwuVjrDKrJhVWywgnJvflMt/zkbVNLFtF1+94SljYQS6e99klnw==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz",
+      "integrity": "sha512-A6ehUVSiSaaliTxai040ZpZ2zTevHYbvu/lDoeAteHI8QnaosIzm4qwtezfRg1jOYaUmnzLX1AOD6Z+UJjtifg==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6128,12 +6270,13 @@
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.56.0.tgz",
-      "integrity": "sha512-lfbVUbelYqXlYiU/HApNMJzT1E87UPGvzveGg2h0ktUNlOCxKlWuJ9jtfvs1sKHdwU4fzY7Pl8sAl49/XaEk6Q==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.57.1.tgz",
+      "integrity": "sha512-dQaAddCY9YgkFHZcFNS/606Exo8vcLHwArFZ7vxXq4rigo2bb494/xKMMwRRQW6ug7Js6yXmBZhSBRuBvCCQ3w==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6141,12 +6284,13 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.56.0.tgz",
-      "integrity": "sha512-EgxD1ocWfhoD6xSOeEEwyE7tDvwTgZc8Bss7wCWe+uc7wO8G34HHCUH+Q6cHqJubxIAnQzAsyUsClt0yFLu06w==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.57.1.tgz",
+      "integrity": "sha512-crNPrwJOrRxagUYeMn/DZwqN88SDmwaJ8Cvi/TN1HnWBU7GwknckyosC2gd0IqYRsHDEnXf328o9/HC6OkPgOg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6154,12 +6298,13 @@
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.56.0.tgz",
-      "integrity": "sha512-1vXe1vcMOssb/hOF8iv52A7feWW2xnu+c8BV4t1F//m9QVLTfNVpEdja5ia762j/UEJe2Z1jAmEqZAK42tVW3g==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.57.1.tgz",
+      "integrity": "sha512-Ji8g8ChVbKrhFtig5QBV7iMaJrGtpHelkB3lsaKzadFBe58gmjfGXAOfI5FV0lYMH8wiqsxKQ1C9B0YTRXVy4w==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6167,12 +6312,13 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.56.0.tgz",
-      "integrity": "sha512-bof7fbIlvqsyv/DtaXSck4VYQ9lPtoWNFCB/JY4snlFuJREXfZnm+Ej6yaCHfQvofJDXLDMTVxWscVSuQvVWUQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.57.1.tgz",
+      "integrity": "sha512-R+/WwhsjmwodAcz65guCGFRkMb4gKWTcIeLy60JJQbXrJ97BOXHxnkPFrP+YwFlaS0m+uWJTstrUA9o+UchFug==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6180,12 +6326,13 @@
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.56.0.tgz",
-      "integrity": "sha512-KNa6lYHloW+7lTEkYGa37fpvPq+NKG/EHKM8+G/g9WDU7ls4sMqbVRV78J6LdNuVaeeK5WB9/9VAFbKxcbXKYg==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.57.1.tgz",
+      "integrity": "sha512-IEQTCHeiTOnAUC3IDQdzRAGj3jOAYNr9kBguI7MQAAZK3caezRrg0GxAb6Hchg4lxdZEI5Oq3iov/w/hnFWY9Q==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6193,12 +6340,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.56.0.tgz",
-      "integrity": "sha512-E8jKK87uOvLrrLN28jnAAAChNq5LeCd2mGgZF+fGF5D507WlG/Noct3lP/QzQ6MrqJ5BCKNwI9ipADB6jyiq2A==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.57.1.tgz",
+      "integrity": "sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6206,12 +6354,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.56.0.tgz",
-      "integrity": "sha512-jQosa5FMYF5Z6prEpTCCmzCXz6eKr/tCBssSmQGEeozA9tkRUty/5Vx06ibaOP9RCrW1Pvb8yp3gvZhHwTDsJw==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.57.1.tgz",
+      "integrity": "sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6219,12 +6368,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.56.0.tgz",
-      "integrity": "sha512-uQVoKkrC1KGEV6udrdVahASIsaF8h7iLG0U0W+Xn14ucFwi6uS539PsAr24IEF9/FoDtzMeeJXJIBo5RkbNWvQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.57.1.tgz",
+      "integrity": "sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6232,12 +6382,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.56.0.tgz",
-      "integrity": "sha512-vLZ1yJKLxhQLFKTs42RwTwa6zkGln+bnXc8ueFGMYmBTLfNu58sl5/eXyxRa2RarTkJbXl8TKPgfS6V5ijNqEA==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.57.1.tgz",
+      "integrity": "sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6245,12 +6396,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.56.0.tgz",
-      "integrity": "sha512-FWfHOCub564kSE3xJQLLIC/hbKqHSVxy8vY75/YHHzWvbJL7aYJkdgwD/xGfUlL5UV2SB7otapLrcCj2xnF1dg==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.57.1.tgz",
+      "integrity": "sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==",
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6258,12 +6410,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.56.0.tgz",
-      "integrity": "sha512-z1EkujxIh7nbrKL1lmIpqFTc/sr0u8Uk0zK/qIEFldbt6EDKWFk/pxFq3gYj4Bjn3aa9eEhYRlL3H8ZbPT1xvA==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.57.1.tgz",
+      "integrity": "sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==",
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6271,12 +6424,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.56.0.tgz",
-      "integrity": "sha512-iNFTluqgdoQC7AIE8Q34R3AuPrJGJirj5wMUErxj22deOcY7XwZRaqYmB6ZKFHoVGqRcRd0mqO+845jAibKCkw==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.57.1.tgz",
+      "integrity": "sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6284,12 +6438,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.56.0.tgz",
-      "integrity": "sha512-MtMeFVlD2LIKjp2sE2xM2slq3Zxf9zwVuw0jemsxvh1QOpHSsSzfNOTH9uYW9i1MXFxUSMmLpeVeUzoNOKBaWg==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.57.1.tgz",
+      "integrity": "sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6297,12 +6452,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.56.0.tgz",
-      "integrity": "sha512-in+v6wiHdzzVhYKXIk5U74dEZHdKN9KH0Q4ANHOTvyXPG41bajYRsy7a8TPKbYPl34hU7PP7hMVHRvv/5aCSew==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==",
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6310,12 +6466,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.56.0.tgz",
-      "integrity": "sha512-yni2raKHB8m9NQpI9fPVwN754mn6dHQSbDTwxdr9SE0ks38DTjLMMBjrwvB5+mXrX+C0npX0CVeCUcvvvD8CNQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.57.1.tgz",
+      "integrity": "sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==",
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6323,12 +6480,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.56.0.tgz",
-      "integrity": "sha512-zhLLJx9nQPu7wezbxt2ut+CI4YlXi68ndEve16tPc/iwoylWS9B3FxpLS2PkmfYgDQtosah07Mj9E0khc3Y+vQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.57.1.tgz",
+      "integrity": "sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6336,12 +6494,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.56.0.tgz",
-      "integrity": "sha512-MVC6UDp16ZSH7x4rtuJPAEoE1RwS8N4oK9DLHy3FTEdFoUTCFVzMfJl/BVJ330C+hx8FfprA5Wqx4FhZXkj2Kw==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6349,12 +6508,13 @@
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.56.0.tgz",
-      "integrity": "sha512-ZhGH1eA4Qv0lxaV00azCIS1ChedK0V32952Md3FtnxSqZTBTd6tgil4nZT5cU8B+SIw3PFYkvyR4FKo2oyZIHA==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.57.1.tgz",
+      "integrity": "sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6362,12 +6522,13 @@
       ]
     },
     "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.56.0.tgz",
-      "integrity": "sha512-O16XcmyDeFI9879pEcmtWvD/2nyxR9mF7Gs44lf1vGGx8Vg2DRNx11aVXBEqOQhWb92WN4z7fW/q4+2NYzCbBA==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.57.1.tgz",
+      "integrity": "sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6375,12 +6536,13 @@
       ]
     },
     "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.56.0.tgz",
-      "integrity": "sha512-LhN/Reh+7F3RCgQIRbgw8ZMwUwyqJM+8pXNT6IIJAqm2IdKkzpCh/V9EdgOMBKuebIrzswqy4ATlrDgiOwbRcQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.57.1.tgz",
+      "integrity": "sha512-4wYoDpNg6o/oPximyc/NG+mYUejZrCU2q+2w6YZqrAs2UcNUChIZXjtafAiiZSUc7On8v5NyNj34Kzj/Ltk6dQ==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6388,12 +6550,13 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.56.0.tgz",
-      "integrity": "sha512-kbFsOObXp3LBULg1d3JIUQMa9Kv4UitDmpS+k0tinPBz3watcUiV2/LUDMMucA6pZO3WGE27P7DsfaN54l9ing==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.57.1.tgz",
+      "integrity": "sha512-O54mtsV/6LW3P8qdTcamQmuC990HDfR71lo44oZMZlXU4tzLrbvTii87Ni9opq60ds0YzuAlEr/GNwuNluZyMQ==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6401,12 +6564,13 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.56.0.tgz",
-      "integrity": "sha512-vSSgny54D6P4vf2izbtFm/TcWYedw7f8eBrOiGGecyHyQB9q4Kqentjaj8hToe+995nob/Wv48pDqL5a62EWtg==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.57.1.tgz",
+      "integrity": "sha512-P3dLS+IerxCT/7D2q2FYcRdWRl22dNbrbBEtxdWhXrfIMPP9lQhb5h4Du04mdl5Woq05jVCDPCMF7Ub0NAjIew==",
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6414,12 +6578,13 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.56.0.tgz",
-      "integrity": "sha512-FeCnkPCTHQJFbiGG49KjV5YGW/8b9rrXAM2Mz2kiIoktq2qsJxRD5giEMEOD2lPdgs72upzefaUvS+nc8E3UzQ==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.57.1.tgz",
+      "integrity": "sha512-VMBH2eOOaKGtIJYleXsi2B8CPVADrh+TyNxJ4mWPnKfLB/DBUmzW+5m1xUrcwWoMfSLagIRpjUFeW5CO5hyciQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6427,12 +6592,13 @@
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.56.0.tgz",
-      "integrity": "sha512-H8AE9Ur/t0+1VXujj90w0HrSOuv0Nq9r1vSZF2t5km20NTfosQsGGUXDaKdQZzwuLts7IyL1fYT4hM95TI9c4g==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.57.1.tgz",
+      "integrity": "sha512-mxRFDdHIWRxg3UfIIAwCm6NzvxG0jDX/wBN6KsQFTvKFqqg9vTrWUE68qEjHt19A5wwx5X5aUi2zuZT7YR0jrA==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -6444,6 +6610,7 @@
       "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-provider/-/safe-apps-provider-0.18.6.tgz",
       "integrity": "sha512-4LhMmjPWlIO8TTDC2AwLk44XKXaK6hfBTWyljDm0HQ6TWlOEijVWNrt2s3OCVMSxlXAcEzYfqyu1daHZooTC2Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@safe-global/safe-apps-sdk": "^9.1.0",
         "events": "^3.3.0"
@@ -6454,6 +6621,7 @@
       "resolved": "https://registry.npmjs.org/@safe-global/safe-apps-sdk/-/safe-apps-sdk-9.1.0.tgz",
       "integrity": "sha512-N5p/ulfnnA2Pi2M3YeWjULeWbjo7ei22JwU/IXnhoHzKq3pYCN6ynL9mJBOlvDVv892EgLPCWCOwQk/uBT2v0Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@safe-global/safe-gateway-typescript-sdk": "^3.5.3",
         "viem": "^2.1.1"
@@ -6497,18 +6665,6 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/@scure/bip32/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@scure/bip39": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.6.0.tgz",
@@ -6517,18 +6673,6 @@
       "dependencies": {
         "@noble/hashes": "~1.8.0",
         "@scure/base": "~1.2.5"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -6663,17 +6807,17 @@
       }
     },
     "node_modules/@solana/accounts": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.4.0.tgz",
-      "integrity": "sha512-qHtAtwCcCFTXcya6JOOG1nzYicivivN/JkcYNHr10qOp9b4MVRkfW1ZAAG1CNzjMe5+mwtEl60RwdsY9jXNb+Q==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/accounts/-/accounts-5.5.1.tgz",
+      "integrity": "sha512-TfOY9xixg5rizABuLVuZ9XI2x2tmWUC/OoN556xwfDlhBHBjKfszicYYOyD6nbFmwTGYarCmyGIdteXxTXIdhQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/rpc-spec": "5.4.0",
-        "@solana/rpc-types": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6688,16 +6832,16 @@
       }
     },
     "node_modules/@solana/addresses": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.4.0.tgz",
-      "integrity": "sha512-YRHiH30S8qDV4bZ+mtEk589PGfBuXHzD/fK2Z+YI5f/+s+yi/5le/fVw7PN6LxnnmVQKiRCDUiNF+WmFFKi6QQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/addresses/-/addresses-5.5.1.tgz",
+      "integrity": "sha512-5xoah3Q9G30HQghu/9BiHLb5pzlPKRC3zydQDmE3O9H//WfayxTFppsUDCL6FjYUHqj/wzK6CWHySglc2RkpdA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/assertions": "5.4.0",
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/nominal-types": "5.4.0"
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6712,12 +6856,12 @@
       }
     },
     "node_modules/@solana/assertions": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.4.0.tgz",
-      "integrity": "sha512-8EP7mkdnrPc9y67FqWeAPzdWq2qAOkxsuo+ZBIXNWtIixDtXIdHrgjZ/wqbWxLgSTtXEfBCjpZU55Xw2Qfbwyg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/assertions/-/assertions-5.5.1.tgz",
+      "integrity": "sha512-YTCSWAlGwSlVPnWtWLm3ukz81wH4j2YaCveK+TjpvUU88hTy6fmUqxi0+hvAMAe4zKXpJyj3Az7BrLJRxbIm4Q==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0"
+        "@solana/errors": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6744,16 +6888,16 @@
       }
     },
     "node_modules/@solana/codecs": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.4.0.tgz",
-      "integrity": "sha512-IbDCUvNX0MrkQahxiXj9rHzkd/fYfp1F2nTJkHGH8v+vPfD+YPjl007ZBM38EnCeXj/Xn+hxqBBivPvIHP29dA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-5.5.1.tgz",
+      "integrity": "sha512-Vea29nJub/bXjfzEV7ZZQ/PWr1pYLZo3z0qW0LQL37uKKVzVFRQlwetd7INk3YtTD3xm9WUYr7bCvYUk3uKy2g==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-data-structures": "5.4.0",
-        "@solana/codecs-numbers": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/options": "5.4.0"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/options": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6768,12 +6912,12 @@
       }
     },
     "node_modules/@solana/codecs-core": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.4.0.tgz",
-      "integrity": "sha512-rQ5jXgiDe2vIU+mYCHDjgwMd9WdzZfh4sc5H6JgYleAUjeTUX6mx8hTV2+pcXvvn27LPrgrt9jfxswbDb8O8ww==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-5.5.1.tgz",
+      "integrity": "sha512-TgBt//bbKBct0t6/MpA8ElaOA3sa8eYVvR7LGslCZ84WiAwwjCY0lW/lOYsFHJQzwREMdUyuEyy5YWBKtdh8Rw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0"
+        "@solana/errors": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6788,14 +6932,14 @@
       }
     },
     "node_modules/@solana/codecs-data-structures": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.4.0.tgz",
-      "integrity": "sha512-LVssbdQ1GfY6upnxW3mufYsNfvTWKnHNk5Hx2gHuOYJhm3HZlp+Y8zvuoY65G1d1xAXkPz5YVGxaSeVIRWLGWg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-5.5.1.tgz",
+      "integrity": "sha512-97bJWGyUY9WvBz3mX1UV3YPWGDTez6btCfD0ip3UVEXJbItVuUiOkzcO5iFDUtQT5riKT6xC+Mzl+0nO76gd0w==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-numbers": "5.4.0",
-        "@solana/errors": "5.4.0"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6810,13 +6954,13 @@
       }
     },
     "node_modules/@solana/codecs-numbers": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.4.0.tgz",
-      "integrity": "sha512-z6LMkY+kXWx1alrvIDSAxexY5QLhsso638CjM7XI1u6dB7drTLWKhifyjnm1vOQc1VPVFmbYxTgKKpds8TY8tg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-5.5.1.tgz",
+      "integrity": "sha512-rllMIZAHqmtvC0HO/dc/21wDuWaD0B8Ryv8o+YtsICQBuiL/0U4AGwH7Pi5GNFySYk0/crSuwfIqQFtmxNSPFw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.4.0",
-        "@solana/errors": "5.4.0"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6831,14 +6975,14 @@
       }
     },
     "node_modules/@solana/codecs-strings": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.4.0.tgz",
-      "integrity": "sha512-w0trrjfQDhkCVz7O1GTmHBk9m+MkljKx2uNBbQAD3/yW2Qn9dYiTrZ1/jDVq0/+lPPAUkbT3s3Yo7HUZ2QFmHw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-5.5.1.tgz",
+      "integrity": "sha512-7klX4AhfHYA+uKKC/nxRGP2MntbYQCR3N6+v7bk1W/rSxYuhNmt+FN8aoThSZtWIKwN6BEyR1167ka8Co1+E7A==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-numbers": "5.4.0",
-        "@solana/errors": "5.4.0"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6857,9 +7001,9 @@
       }
     },
     "node_modules/@solana/errors": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.4.0.tgz",
-      "integrity": "sha512-hNoAOmlZAszaVBrAy1Jf7amHJ8wnUnTU0BqhNQXknbSvirvsYr81yEud2iq18YiCqhyJ9SuQ5kWrSAT0x7S0oA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-5.5.1.tgz",
+      "integrity": "sha512-vFO3p+S7HoyyrcAectnXbdsMfwUzY2zYFUc2DEe5BwpiE9J1IAxPBGjOWO6hL1bbYdBrlmjNx8DXCslqS+Kcmg==",
       "license": "MIT",
       "dependencies": {
         "chalk": "5.6.2",
@@ -6881,9 +7025,9 @@
       }
     },
     "node_modules/@solana/fast-stable-stringify": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.4.0.tgz",
-      "integrity": "sha512-KB7PUL7yalPvbWCezzyUDVRDp39eHLPH7OJ6S8VFT8YNIFUANwwj5ctui50Fim76kvSYDdYJOclXV45O2gfQ8Q==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/fast-stable-stringify/-/fast-stable-stringify-5.5.1.tgz",
+      "integrity": "sha512-Ni7s2FN33zTzhTFgRjEbOVFO+UAmK8qi3Iu0/GRFYK4jN696OjKHnboSQH/EacQ+yGqS54bfxf409wU5dsLLCw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -6898,9 +7042,9 @@
       }
     },
     "node_modules/@solana/functional": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.4.0.tgz",
-      "integrity": "sha512-32ghHO0bg6GgX/7++0/7Lps6RgeXD2gKF1okiuyEGuVfKENIapgaQdcGhUwb3q6D6fv6MRAVn/Yve4jopGVNMQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/functional/-/functional-5.5.1.tgz",
+      "integrity": "sha512-tTHoJcEQq3gQx5qsdsDJ0LEJeFzwNpXD80xApW9o/PPoCNimI3SALkZl+zNW8VnxRrV3l3yYvfHWBKe/X3WG3w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -6915,17 +7059,17 @@
       }
     },
     "node_modules/@solana/instruction-plans": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.4.0.tgz",
-      "integrity": "sha512-5xbJ+I/pP2aWECmK75bEM1zCnIITlohAK83dVN+t5X2vBFrr6M9gifo8r4Opdnibsgo6QVVkKPxRo5zow5j0ig==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instruction-plans/-/instruction-plans-5.5.1.tgz",
+      "integrity": "sha512-7z3CB7YMcFKuVvgcnNY8bY6IsZ8LG61Iytbz7HpNVGX2u1RthOs1tRW8luTzSG1MPL0Ox7afyAVMYeFqSPHnaQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0",
-        "@solana/instructions": "5.4.0",
-        "@solana/keys": "5.4.0",
-        "@solana/promises": "5.4.0",
-        "@solana/transaction-messages": "5.4.0",
-        "@solana/transactions": "5.4.0"
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6940,13 +7084,13 @@
       }
     },
     "node_modules/@solana/instructions": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.4.0.tgz",
-      "integrity": "sha512-//a7jpHbNoAgTqy3YyqG1X6QhItJLKzJa6zuYJGCwaAAJye7BxS9pxJBgb2mUt7CGidhUksf+U8pmLlxCNWYyg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/instructions/-/instructions-5.5.1.tgz",
+      "integrity": "sha512-h0G1CG6S+gUUSt0eo6rOtsaXRBwCq1+Js2a+Ps9Bzk9q7YHNFA75/X0NWugWLgC92waRp66hrjMTiYYnLBoWOQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.4.0",
-        "@solana/errors": "5.4.0"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6961,16 +7105,16 @@
       }
     },
     "node_modules/@solana/keys": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.4.0.tgz",
-      "integrity": "sha512-zQVbAwdoXorgXjlhlVTZaymFG6N8n1zn2NT+xI6S8HtbrKIB/42xPdXFh+zIihGzRw+9k8jzU7Axki/IPm6qWQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/keys/-/keys-5.5.1.tgz",
+      "integrity": "sha512-KRD61cL7CRL+b4r/eB9dEoVxIf/2EJ1Pm1DmRYhtSUAJD2dJ5Xw8QFuehobOGm9URqQ7gaQl+Fkc1qvDlsWqKg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/assertions": "5.4.0",
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/nominal-types": "5.4.0"
+        "@solana/assertions": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -6985,33 +7129,34 @@
       }
     },
     "node_modules/@solana/kit": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.4.0.tgz",
-      "integrity": "sha512-aVjN26jOEzJA6UBYxSTQciZPXgTxWnO/WysHrw+yeBL/5AaTZnXEgb4j5xV6cUFzOlVxhJBrx51xtoxSqJ0u3g==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/kit/-/kit-5.5.1.tgz",
+      "integrity": "sha512-irKUGiV2yRoyf+4eGQ/ZeCRxa43yjFEL1DUI5B0DkcfZw3cr0VJtVJnrG8OtVF01vT0OUfYOcUn6zJW5TROHvQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@solana/accounts": "5.4.0",
-        "@solana/addresses": "5.4.0",
-        "@solana/codecs": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/functional": "5.4.0",
-        "@solana/instruction-plans": "5.4.0",
-        "@solana/instructions": "5.4.0",
-        "@solana/keys": "5.4.0",
-        "@solana/offchain-messages": "5.4.0",
-        "@solana/plugin-core": "5.4.0",
-        "@solana/programs": "5.4.0",
-        "@solana/rpc": "5.4.0",
-        "@solana/rpc-api": "5.4.0",
-        "@solana/rpc-parsed-types": "5.4.0",
-        "@solana/rpc-spec-types": "5.4.0",
-        "@solana/rpc-subscriptions": "5.4.0",
-        "@solana/rpc-types": "5.4.0",
-        "@solana/signers": "5.4.0",
-        "@solana/sysvars": "5.4.0",
-        "@solana/transaction-confirmation": "5.4.0",
-        "@solana/transaction-messages": "5.4.0",
-        "@solana/transactions": "5.4.0"
+        "@solana/accounts": "5.5.1",
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instruction-plans": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/plugin-core": "5.5.1",
+        "@solana/programs": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/signers": "5.5.1",
+        "@solana/sysvars": "5.5.1",
+        "@solana/transaction-confirmation": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7026,9 +7171,9 @@
       }
     },
     "node_modules/@solana/nominal-types": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.4.0.tgz",
-      "integrity": "sha512-h4dTRQwTerzksE5B1WmObN6TvLo8dYUd7kpUUynGd8WJjK0zz3zkDhq0MkA3aF6A1C2C82BSGqSsN9EN0E6Exg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/nominal-types/-/nominal-types-5.5.1.tgz",
+      "integrity": "sha512-I1ImR+kfrLFxN5z22UDiTWLdRZeKtU0J/pkWkO8qm/8WxveiwdIv4hooi8pb6JnlR4mSrWhq0pCIOxDYrL9GIQ==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -7043,19 +7188,19 @@
       }
     },
     "node_modules/@solana/offchain-messages": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.4.0.tgz",
-      "integrity": "sha512-DjdlYJCcKfgh4dkdk+owH1bP+Q4BRqCs55mgWWp9PTwm/HHy/a5vcMtCi1GyIQXfhtNNvKBLbXrUE0Fxej8qlg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/offchain-messages/-/offchain-messages-5.5.1.tgz",
+      "integrity": "sha512-g+xHH95prTU+KujtbOzj8wn+C7ZNoiLhf3hj6nYq3MTyxOXtBEysguc97jJveUZG0K97aIKG6xVUlMutg5yxhw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-data-structures": "5.4.0",
-        "@solana/codecs-numbers": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/keys": "5.4.0",
-        "@solana/nominal-types": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7070,16 +7215,16 @@
       }
     },
     "node_modules/@solana/options": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.4.0.tgz",
-      "integrity": "sha512-h4vTWRChEXPhaHo9i1pCyQBWWs+NqYPQRXSAApqpUYvHb9Kct/C6KbHjfyaRMyqNQnDHLcJCX7oW9tk0iRDzIg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-5.5.1.tgz",
+      "integrity": "sha512-eo971c9iLNLmk+yOFyo7yKIJzJ/zou6uKpy6mBuyb/thKtS/haiKIc3VLhyTXty3OH2PW8yOlORJnv4DexJB8A==",
       "license": "MIT",
       "dependencies": {
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-data-structures": "5.4.0",
-        "@solana/codecs-numbers": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/errors": "5.4.0"
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7094,9 +7239,9 @@
       }
     },
     "node_modules/@solana/plugin-core": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.4.0.tgz",
-      "integrity": "sha512-e1aLGLldW7C5113qTOjFYSGq95a4QC9TWb77iq+8l6h085DcNj+195r4E2zKaINrevQjQTwvxo00oUyHP7hSJA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/plugin-core/-/plugin-core-5.5.1.tgz",
+      "integrity": "sha512-VUZl30lDQFJeiSyNfzU1EjYt2QZvoBFKEwjn1lilUJw7KgqD5z7mbV7diJhT+dLFs36i0OsjXvq5kSygn8YJ3A==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -7111,13 +7256,13 @@
       }
     },
     "node_modules/@solana/programs": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.4.0.tgz",
-      "integrity": "sha512-Sc90WK9ZZ7MghOflIvkrIm08JwsFC99yqSJy28/K+hDP2tcx+1x+H6OFP9cumW9eUA1+JVRDeKAhA8ak7e/kUA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/programs/-/programs-5.5.1.tgz",
+      "integrity": "sha512-7U9kn0Jsx1NuBLn5HRTFYh78MV4XN145Yc3WP/q5BlqAVNlMoU9coG5IUTJIG847TUqC1lRto3Dnpwm6T4YRpA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/errors": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/errors": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7132,9 +7277,9 @@
       }
     },
     "node_modules/@solana/promises": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.4.0.tgz",
-      "integrity": "sha512-23mfgNBbuP6Q+4vsixGy+GkyZ7wBLrxTBNXqrG/XWrJhjuuSkjEUGaK4Fx5o7LIrBi6KGqPknKxmTlvqnJhy2Q==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/promises/-/promises-5.5.1.tgz",
+      "integrity": "sha512-T9lfuUYkGykJmppEcssNiCf6yiYQxJkhiLPP+pyAc2z84/7r3UVIb2tNJk4A9sucS66pzJnVHZKcZVGUUp6wzA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -7149,20 +7294,20 @@
       }
     },
     "node_modules/@solana/rpc": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.4.0.tgz",
-      "integrity": "sha512-S6GRG+usnubDs0JSpgc0ZWEh9IPL5KPWMuBoD8ggGVOIVWntp53FpvhYslNzbxWBXlTvJecr2todBipGVM/AqQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc/-/rpc-5.5.1.tgz",
+      "integrity": "sha512-ku8zTUMrkCWci66PRIBC+1mXepEnZH/q1f3ck0kJZ95a06bOTl5KU7HeXWtskkyefzARJ5zvCs54AD5nxjQJ+A==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0",
-        "@solana/fast-stable-stringify": "5.4.0",
-        "@solana/functional": "5.4.0",
-        "@solana/rpc-api": "5.4.0",
-        "@solana/rpc-spec": "5.4.0",
-        "@solana/rpc-spec-types": "5.4.0",
-        "@solana/rpc-transformers": "5.4.0",
-        "@solana/rpc-transport-http": "5.4.0",
-        "@solana/rpc-types": "5.4.0"
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-api": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-transport-http": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7177,22 +7322,22 @@
       }
     },
     "node_modules/@solana/rpc-api": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.4.0.tgz",
-      "integrity": "sha512-FJL6KaAsQ4DhfhLKKMcqbTpToNFwHlABCemIpOunE3OSqJFDrmc/NbsEaLIoeHyIg3d1Imo49GIUOn2TEouFUA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-api/-/rpc-api-5.5.1.tgz",
+      "integrity": "sha512-XWOQQPhKl06Vj0xi3RYHAc6oEQd8B82okYJ04K7N0Vvy3J4PN2cxeK7klwkjgavdcN9EVkYCChm2ADAtnztKnA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/keys": "5.4.0",
-        "@solana/rpc-parsed-types": "5.4.0",
-        "@solana/rpc-spec": "5.4.0",
-        "@solana/rpc-transformers": "5.4.0",
-        "@solana/rpc-types": "5.4.0",
-        "@solana/transaction-messages": "5.4.0",
-        "@solana/transactions": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-parsed-types": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7207,9 +7352,9 @@
       }
     },
     "node_modules/@solana/rpc-parsed-types": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.4.0.tgz",
-      "integrity": "sha512-IRQuSzx+Sj1A3XGiIzguNZlMjMMybXTTjV/RnTwBgnJQPd/H4us4pfPD94r+/yolWDVfGjJRm04hnKVMjJU8Rg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-parsed-types/-/rpc-parsed-types-5.5.1.tgz",
+      "integrity": "sha512-HEi3G2nZqGEsa3vX6U0FrXLaqnUCg4SKIUrOe8CezD+cSFbRTOn3rCLrUmJrhVyXlHoQVaRO9mmeovk31jWxJg==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -7224,13 +7369,13 @@
       }
     },
     "node_modules/@solana/rpc-spec": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.4.0.tgz",
-      "integrity": "sha512-XMhxBb1GuZ3Kaeu5WNHB5KteCQ/aVuMByZmUKPqaanD+gs5MQZr0g62CvN7iwRlFU7GC18Q73ROWR3/JjzbXTA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec/-/rpc-spec-5.5.1.tgz",
+      "integrity": "sha512-m3LX2bChm3E3by4mQrH4YwCAFY57QBzuUSWqlUw7ChuZ+oLLOq7b2czi4i6L4Vna67j3eCmB3e+4tqy1j5wy7Q==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0",
-        "@solana/rpc-spec-types": "5.4.0"
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7245,9 +7390,9 @@
       }
     },
     "node_modules/@solana/rpc-spec-types": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.4.0.tgz",
-      "integrity": "sha512-JU9hC5/iyJx30ym17gpoXDtT9rCbO6hLpB6UDhSFFoNeirxtTVb4OdnKtsjJDfXAiXsynJRsZRwfj3vGxRLgQw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-spec-types/-/rpc-spec-types-5.5.1.tgz",
+      "integrity": "sha512-6OFKtRpIEJQs8Jb2C4OO8KyP2h2Hy1MFhatMAoXA+0Ik8S3H+CicIuMZvGZ91mIu/tXicuOOsNNLu3HAkrakrw==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.0"
@@ -7262,22 +7407,22 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.4.0.tgz",
-      "integrity": "sha512-051t1CEjjAzM9ohjj2zb3ED70yeS3ZY8J5wSytL6tthTGImw/JB2a0D9DWMOKriFKt496n95IC+IdpJ35CpBWA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions/-/rpc-subscriptions-5.5.1.tgz",
+      "integrity": "sha512-CTMy5bt/6mDh4tc6vUJms9EcuZj3xvK0/xq8IQ90rhkpYvate91RjBP+egvjgSayUg9yucU9vNuUpEjz4spM7w==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0",
-        "@solana/fast-stable-stringify": "5.4.0",
-        "@solana/functional": "5.4.0",
-        "@solana/promises": "5.4.0",
-        "@solana/rpc-spec-types": "5.4.0",
-        "@solana/rpc-subscriptions-api": "5.4.0",
-        "@solana/rpc-subscriptions-channel-websocket": "5.4.0",
-        "@solana/rpc-subscriptions-spec": "5.4.0",
-        "@solana/rpc-transformers": "5.4.0",
-        "@solana/rpc-types": "5.4.0",
-        "@solana/subscribable": "5.4.0"
+        "@solana/errors": "5.5.1",
+        "@solana/fast-stable-stringify": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-subscriptions-api": "5.5.1",
+        "@solana/rpc-subscriptions-channel-websocket": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7292,18 +7437,18 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions-api": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.4.0.tgz",
-      "integrity": "sha512-euAFIG6ruEsqK+MsrL1tGSMbbOumm8UAyGzlD/kmXsAqqhcVsSeZdv5+BMIHIBsQ93GHcloA8UYw1BTPhpgl9w==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-api/-/rpc-subscriptions-api-5.5.1.tgz",
+      "integrity": "sha512-5Oi7k+GdeS8xR2ly1iuSFkAv6CZqwG0Z6b1QZKbEgxadE1XGSDrhM2cn59l+bqCozUWCqh4c/A2znU/qQjROlw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/keys": "5.4.0",
-        "@solana/rpc-subscriptions-spec": "5.4.0",
-        "@solana/rpc-transformers": "5.4.0",
-        "@solana/rpc-types": "5.4.0",
-        "@solana/transaction-messages": "5.4.0",
-        "@solana/transactions": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/rpc-transformers": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7318,15 +7463,15 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions-channel-websocket": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.4.0.tgz",
-      "integrity": "sha512-kWCmlW65MccxqXwKsIz+LkXUYQizgvBrrgYOkyclJHPa+zx4gqJjam87+wzvO9cfbDZRer3wtJBaRm61gTHNbw==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-channel-websocket/-/rpc-subscriptions-channel-websocket-5.5.1.tgz",
+      "integrity": "sha512-7tGfBBrYY8TrngOyxSHoCU5shy86iA9SRMRrPSyBhEaZRAk6dnbdpmUTez7gtdVo0BCvh9nzQtUycKWSS7PnFQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0",
-        "@solana/functional": "5.4.0",
-        "@solana/rpc-subscriptions-spec": "5.4.0",
-        "@solana/subscribable": "5.4.0",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/rpc-subscriptions-spec": "5.5.1",
+        "@solana/subscribable": "5.5.1",
         "ws": "^8.19.0"
       },
       "engines": {
@@ -7342,15 +7487,15 @@
       }
     },
     "node_modules/@solana/rpc-subscriptions-spec": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.4.0.tgz",
-      "integrity": "sha512-ELaV9Z39GtKyUO0++he00ymWleb07QXYJhSfA0e1N5Q9hXu/Y366kgXHDcbZ/oUJkT3ylNgTupkrsdtiy8Ryow==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-subscriptions-spec/-/rpc-subscriptions-spec-5.5.1.tgz",
+      "integrity": "sha512-iq+rGq5fMKP3/mKHPNB6MC8IbVW41KGZg83Us/+LE3AWOTWV1WT20KT2iH1F1ik9roi42COv/TpoZZvhKj45XQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0",
-        "@solana/promises": "5.4.0",
-        "@solana/rpc-spec-types": "5.4.0",
-        "@solana/subscribable": "5.4.0"
+        "@solana/errors": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/subscribable": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7365,16 +7510,16 @@
       }
     },
     "node_modules/@solana/rpc-transformers": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.4.0.tgz",
-      "integrity": "sha512-dZ8keYloLW+eRAwAPb471uWCFs58yHloLoI+QH0FulYpsSJ7F2BNWYcdnjSS/WiggsNcU6DhpWzYAzlEY66lGQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transformers/-/rpc-transformers-5.5.1.tgz",
+      "integrity": "sha512-OsWqLCQdcrRJKvHiMmwFhp9noNZ4FARuMkHT5us3ustDLXaxOjF0gfqZLnMkulSLcKt7TGXqMhBV+HCo7z5M8Q==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0",
-        "@solana/functional": "5.4.0",
-        "@solana/nominal-types": "5.4.0",
-        "@solana/rpc-spec-types": "5.4.0",
-        "@solana/rpc-types": "5.4.0"
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7389,15 +7534,15 @@
       }
     },
     "node_modules/@solana/rpc-transport-http": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.4.0.tgz",
-      "integrity": "sha512-vidA+Qtqrnqp3QSVumWHdWJ/986yCr5+qX3fbc9KPm9Ofoto88OMWB/oLJvi2Tfges1UBu/jl+lJdsVckCM1bA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-transport-http/-/rpc-transport-http-5.5.1.tgz",
+      "integrity": "sha512-yv8GoVSHqEV0kUJEIhkdOVkR2SvJ6yoWC51cJn2rSV7plr6huLGe0JgujCmB7uZhhaLbcbP3zxXxu9sOjsi7Fg==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0",
-        "@solana/rpc-spec": "5.4.0",
-        "@solana/rpc-spec-types": "5.4.0",
-        "undici-types": "^7.18.2"
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-spec": "5.5.1",
+        "@solana/rpc-spec-types": "5.5.1",
+        "undici-types": "^7.19.2"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7412,17 +7557,17 @@
       }
     },
     "node_modules/@solana/rpc-types": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.4.0.tgz",
-      "integrity": "sha512-+C4N4/5AYzBdt3Y2yzkScknScy/jTx6wfvuJIY9XjOXtdDyZ8TmrnMwdPMTZPGLdLuHplJwlwy1acu/4hqmrBQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/rpc-types/-/rpc-types-5.5.1.tgz",
+      "integrity": "sha512-bibTFQ7PbHJJjGJPmfYC2I+/5CRFS4O2p9WwbFraX1Keeel+nRrt/NBXIy8veP5AEn2sVJIyJPpWBRpCx1oATA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-numbers": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/nominal-types": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/nominal-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7437,20 +7582,20 @@
       }
     },
     "node_modules/@solana/signers": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.4.0.tgz",
-      "integrity": "sha512-s+fZxpi6UPr6XNk2pH/R84WjNRoSktrgG8AGNfsj/V8MJ++eKX7hhIf4JsHZtnnQXXrHmS3ozB2oHlc8yEJvCQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/signers/-/signers-5.5.1.tgz",
+      "integrity": "sha512-FY0IVaBT2kCAze55vEieR6hag4coqcuJ31Aw3hqRH7mv6sV8oqwuJmUrx+uFwOp1gwd5OEAzlv6N4hOOple4sQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/codecs-core": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/instructions": "5.4.0",
-        "@solana/keys": "5.4.0",
-        "@solana/nominal-types": "5.4.0",
-        "@solana/offchain-messages": "5.4.0",
-        "@solana/transaction-messages": "5.4.0",
-        "@solana/transactions": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/offchain-messages": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7465,12 +7610,12 @@
       }
     },
     "node_modules/@solana/subscribable": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.4.0.tgz",
-      "integrity": "sha512-72LmfNX7UENgA24sn/xjlWpPAOsrxkWb9DQhuPZxly/gq8rl/rvr7Xu9qBkvFF2po9XpdUrKlccqY4awvfpltA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/subscribable/-/subscribable-5.5.1.tgz",
+      "integrity": "sha512-9K0PsynFq0CsmK1CDi5Y2vUIJpCqkgSS5yfDN0eKPgHqEptLEaia09Kaxc90cSZDZU5mKY/zv1NBmB6Aro9zQQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/errors": "5.4.0"
+        "@solana/errors": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7485,15 +7630,15 @@
       }
     },
     "node_modules/@solana/sysvars": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.4.0.tgz",
-      "integrity": "sha512-A5NES7sOlFmpnsiEts5vgyL3NXrt/tGGVSEjlEGvsgwl5EDZNv+xWnNA400uMDqd9O3a5PmH7p/6NsgR+kUzSg==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/sysvars/-/sysvars-5.5.1.tgz",
+      "integrity": "sha512-k3Quq87Mm+geGUu1GWv6knPk0ALsfY6EKSJGw9xUJDHzY/RkYSBnh0RiOrUhtFm2TDNjOailg8/m0VHmi3reFA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/accounts": "5.4.0",
-        "@solana/codecs": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/rpc-types": "5.4.0"
+        "@solana/accounts": "5.5.1",
+        "@solana/codecs": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7508,21 +7653,21 @@
       }
     },
     "node_modules/@solana/transaction-confirmation": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.4.0.tgz",
-      "integrity": "sha512-EdSDgxs84/4gkjQw2r7N+Kgus8x9U+NFo0ufVG+48V8Hzy2t0rlBuXgIxwx0zZwUuTIgaKhpIutJgVncwZ5koA==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-confirmation/-/transaction-confirmation-5.5.1.tgz",
+      "integrity": "sha512-j4mKlYPHEyu+OD7MBt3jRoX4ScFgkhZC6H65on4Fux6LMScgivPJlwnKoZMnsgxFgWds0pl+BYzSiALDsXlYtw==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/keys": "5.4.0",
-        "@solana/promises": "5.4.0",
-        "@solana/rpc": "5.4.0",
-        "@solana/rpc-subscriptions": "5.4.0",
-        "@solana/rpc-types": "5.4.0",
-        "@solana/transaction-messages": "5.4.0",
-        "@solana/transactions": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/promises": "5.5.1",
+        "@solana/rpc": "5.5.1",
+        "@solana/rpc-subscriptions": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1",
+        "@solana/transactions": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7537,20 +7682,20 @@
       }
     },
     "node_modules/@solana/transaction-messages": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.4.0.tgz",
-      "integrity": "sha512-qd/3kZDaPiHM0amhn3vXnupfcsFTVz6CYuHXvq9HFv/fq32+5Kp1FMLnmHwoSxQxdTMDghPdOhC4vhNhuWmuVQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transaction-messages/-/transaction-messages-5.5.1.tgz",
+      "integrity": "sha512-aXyhMCEaAp3M/4fP0akwBBQkFPr4pfwoC5CLDq999r/FUwDax2RE/h4Ic7h2Xk+JdcUwsb+rLq85Y52hq84XvQ==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-data-structures": "5.4.0",
-        "@solana/codecs-numbers": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/functional": "5.4.0",
-        "@solana/instructions": "5.4.0",
-        "@solana/nominal-types": "5.4.0",
-        "@solana/rpc-types": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7565,23 +7710,23 @@
       }
     },
     "node_modules/@solana/transactions": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.4.0.tgz",
-      "integrity": "sha512-OuY4M4x/xna8KZQIrz8tSrI9EEul9Od97XejqFmGGkEjbRsUOfJW8705TveTW8jU3bd5RGecFYscPgS2F+m7jQ==",
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/@solana/transactions/-/transactions-5.5.1.tgz",
+      "integrity": "sha512-8hHtDxtqalZ157pnx6p8k10D7J/KY/biLzfgh9R09VNLLY3Fqi7kJvJCr7M2ik3oRll56pxhraAGCC9yIT6eOA==",
       "license": "MIT",
       "dependencies": {
-        "@solana/addresses": "5.4.0",
-        "@solana/codecs-core": "5.4.0",
-        "@solana/codecs-data-structures": "5.4.0",
-        "@solana/codecs-numbers": "5.4.0",
-        "@solana/codecs-strings": "5.4.0",
-        "@solana/errors": "5.4.0",
-        "@solana/functional": "5.4.0",
-        "@solana/instructions": "5.4.0",
-        "@solana/keys": "5.4.0",
-        "@solana/nominal-types": "5.4.0",
-        "@solana/rpc-types": "5.4.0",
-        "@solana/transaction-messages": "5.4.0"
+        "@solana/addresses": "5.5.1",
+        "@solana/codecs-core": "5.5.1",
+        "@solana/codecs-data-structures": "5.5.1",
+        "@solana/codecs-numbers": "5.5.1",
+        "@solana/codecs-strings": "5.5.1",
+        "@solana/errors": "5.5.1",
+        "@solana/functional": "5.5.1",
+        "@solana/instructions": "5.5.1",
+        "@solana/keys": "5.5.1",
+        "@solana/nominal-types": "5.5.1",
+        "@solana/rpc-types": "5.5.1",
+        "@solana/transaction-messages": "5.5.1"
       },
       "engines": {
         "node": ">=20.18.0"
@@ -7631,6 +7776,7 @@
       "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.98.4.tgz",
       "integrity": "sha512-vv9lfnvjUsRiq//+j5pBdXig0IQdtzA0BRZ3bXEP4KaIyF1CcaydWqgyzQgfZMNIsWNWmG+AUHwPy4AHOD6gpw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.25.0",
         "@noble/curves": "^1.4.2",
@@ -7729,6 +7875,7 @@
       "integrity": "sha512-zjTUwIsEfT+k9BmXwq1QEFYsb4afBlsI1AXFyWQBgggMzwBFOuu92pGrE5OFx90IOjNl+lUbQoTG7f8S0PkOdg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/types": "^8.53.1",
@@ -7745,9 +7892,9 @@
       }
     },
     "node_modules/@supabase/auth-js": {
-      "version": "2.93.1",
-      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.93.1.tgz",
-      "integrity": "sha512-pC0Ek4xk4z6q7A/3+UuZ/eYgfFUUQTg3DhapzrAgJnFGDJDFDyGCj6v9nIz8+3jfLqSZ3QKGe6AoEodYjShghg==",
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.93.3.tgz",
+      "integrity": "sha512-JdnkHZPKexVGSNONtu89RHU4bxz3X9kxx+f5ZnR5osoCIX+vs/MckwWRPZEybAEvlJXt5xjomDb3IB876QCxWQ==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -7757,9 +7904,9 @@
       }
     },
     "node_modules/@supabase/functions-js": {
-      "version": "2.93.1",
-      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.93.1.tgz",
-      "integrity": "sha512-Ott2IcIXHGupaC0nX9WNEiJAX4OdlGRu9upkkURaQHbaLdz9JuCcHxlwTERgtgjMpikbIWHfMM1M9QTQFYABiA==",
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.93.3.tgz",
+      "integrity": "sha512-qWO0gHNDm/5jRjROv/nv9L6sYabCWS1kzorOLUv3kqCwRvEJLYZga93ppJPrZwOgoZfXmJzvpjY8fODA4HQfBw==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -7769,9 +7916,9 @@
       }
     },
     "node_modules/@supabase/postgrest-js": {
-      "version": "2.93.1",
-      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.93.1.tgz",
-      "integrity": "sha512-uRKKQJBDnfi6XFNFPNMh9+u3HT2PCgp065PcMPmG7e0xGuqvLtN89QxO2/SZcGbw2y1+mNBz0yUs5KmyNqF2fA==",
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.93.3.tgz",
+      "integrity": "sha512-+iJ96g94skO2e4clsRSmEXg22NUOjh9BziapsJSAvnB1grOBf/BA8vGtCHjNOA+Z6lvKXL1jwBqcL9+fS1W/Lg==",
       "license": "MIT",
       "dependencies": {
         "tslib": "2.8.1"
@@ -7781,9 +7928,9 @@
       }
     },
     "node_modules/@supabase/realtime-js": {
-      "version": "2.93.1",
-      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.93.1.tgz",
-      "integrity": "sha512-2WaP/KVHPlQDjWM6qe4wOZz6zSRGaXw1lfXf4thbfvk3C3zPPKqXRyspyYnk3IhphyxSsJ2hQ/cXNOz48008tg==",
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.93.3.tgz",
+      "integrity": "sha512-gnYpcFzwy8IkezRP4CDbT5I8jOsiOjrWrqTY1B+7jIriXsnpifmlM6RRjLBm9oD7OwPG0/WksniGPdKW67sXOA==",
       "license": "MIT",
       "dependencies": {
         "@types/phoenix": "^1.6.6",
@@ -7796,9 +7943,9 @@
       }
     },
     "node_modules/@supabase/storage-js": {
-      "version": "2.93.1",
-      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.93.1.tgz",
-      "integrity": "sha512-3KVwd4S1i1BVPL6KIywe5rnruNQXSkLyvrdiJmwnqwbCcDujQumARdGWBPesqCjOPKEU2M9ORWKAsn+2iLzquA==",
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.93.3.tgz",
+      "integrity": "sha512-cw4qXiLrx3apglDM02Tx/w/stvFlrkKocC6vCvuFAz3JtVEl1zH8MUfDQDTH59kJAQVaVdbewrMWSoBob7REnA==",
       "license": "MIT",
       "dependencies": {
         "iceberg-js": "^0.8.1",
@@ -7809,25 +7956,25 @@
       }
     },
     "node_modules/@supabase/supabase-js": {
-      "version": "2.93.1",
-      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.93.1.tgz",
-      "integrity": "sha512-FJTgS5s0xEgRQ3u7gMuzGObwf3jA4O5Ki/DgCDXx94w1pihLM4/WG3XFa4BaCJYfuzLxLcv6zPPA5tDvBUjAUg==",
+      "version": "2.93.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.93.3.tgz",
+      "integrity": "sha512-paUqEqdBI9ztr/4bbMoCgeJ6M8ZTm2fpfjSOlzarPuzYveKFM20ZfDZqUpi9CFfYagYj5Iv3m3ztUjaI9/tM1w==",
       "license": "MIT",
       "dependencies": {
-        "@supabase/auth-js": "2.93.1",
-        "@supabase/functions-js": "2.93.1",
-        "@supabase/postgrest-js": "2.93.1",
-        "@supabase/realtime-js": "2.93.1",
-        "@supabase/storage-js": "2.93.1"
+        "@supabase/auth-js": "2.93.3",
+        "@supabase/functions-js": "2.93.3",
+        "@supabase/postgrest-js": "2.93.3",
+        "@supabase/realtime-js": "2.93.3",
+        "@supabase/storage-js": "2.93.3"
       },
       "engines": {
         "node": ">=20.0.0"
       }
     },
     "node_modules/@swc/core-darwin-arm64": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.10.tgz",
-      "integrity": "sha512-U72pGqmJYbjrLhMndIemZ7u9Q9owcJczGxwtfJlz/WwMaGYAV/g4nkGiUVk/+QSX8sFCAjanovcU1IUsP2YulA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-arm64/-/core-darwin-arm64-1.15.11.tgz",
+      "integrity": "sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==",
       "cpu": [
         "arm64"
       ],
@@ -7841,9 +7988,9 @@
       }
     },
     "node_modules/@swc/core-darwin-x64": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.10.tgz",
-      "integrity": "sha512-NZpDXtwHH083L40xdyj1sY31MIwLgOxKfZEAGCI8xHXdHa+GWvEiVdGiu4qhkJctoHFzAEc7ZX3GN5phuJcPuQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-darwin-x64/-/core-darwin-x64-1.15.11.tgz",
+      "integrity": "sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==",
       "cpu": [
         "x64"
       ],
@@ -7857,9 +8004,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm-gnueabihf": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.10.tgz",
-      "integrity": "sha512-ioieF5iuRziUF1HkH1gg1r93e055dAdeBAPGAk40VjqpL5/igPJ/WxFHGvc6WMLhUubSJI4S0AiZAAhEAp1jDg==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm-gnueabihf/-/core-linux-arm-gnueabihf-1.15.11.tgz",
+      "integrity": "sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==",
       "cpu": [
         "arm"
       ],
@@ -7873,9 +8020,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-gnu": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.10.tgz",
-      "integrity": "sha512-tD6BClOrxSsNus9cJL7Gxdv7z7Y2hlyvZd9l0NQz+YXzmTWqnfzLpg16ovEI7gknH2AgDBB5ywOsqu8hUgSeEQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-gnu/-/core-linux-arm64-gnu-1.15.11.tgz",
+      "integrity": "sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==",
       "cpu": [
         "arm64"
       ],
@@ -7889,9 +8036,9 @@
       }
     },
     "node_modules/@swc/core-linux-arm64-musl": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.10.tgz",
-      "integrity": "sha512-4uAHO3nbfbrTcmO/9YcVweTQdx5fN3l7ewwl5AEK4yoC4wXmoBTEPHAVdKNe4r9+xrTgd4BgyPsy0409OjjlMw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-arm64-musl/-/core-linux-arm64-musl-1.15.11.tgz",
+      "integrity": "sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==",
       "cpu": [
         "arm64"
       ],
@@ -7905,9 +8052,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-gnu": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.10.tgz",
-      "integrity": "sha512-W0h9ONNw1pVIA0cN7wtboOSTl4Jk3tHq+w2cMPQudu9/+3xoCxpFb9ZdehwCAk29IsvdWzGzY6P7dDVTyFwoqg==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-gnu/-/core-linux-x64-gnu-1.15.11.tgz",
+      "integrity": "sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==",
       "cpu": [
         "x64"
       ],
@@ -7921,9 +8068,9 @@
       }
     },
     "node_modules/@swc/core-linux-x64-musl": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.10.tgz",
-      "integrity": "sha512-XQNZlLZB62S8nAbw7pqoqwy91Ldy2RpaMRqdRN3T+tAg6Xg6FywXRKCsLh6IQOadr4p1+lGnqM/Wn35z5a/0Vw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-linux-x64-musl/-/core-linux-x64-musl-1.15.11.tgz",
+      "integrity": "sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==",
       "cpu": [
         "x64"
       ],
@@ -7937,9 +8084,9 @@
       }
     },
     "node_modules/@swc/core-win32-arm64-msvc": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.10.tgz",
-      "integrity": "sha512-qnAGrRv5Nj/DATxAmCnJQRXXQqnJwR0trxLndhoHoxGci9MuguNIjWahS0gw8YZFjgTinbTxOwzatkoySihnmw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-arm64-msvc/-/core-win32-arm64-msvc-1.15.11.tgz",
+      "integrity": "sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==",
       "cpu": [
         "arm64"
       ],
@@ -7953,9 +8100,9 @@
       }
     },
     "node_modules/@swc/core-win32-ia32-msvc": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.10.tgz",
-      "integrity": "sha512-i4X/q8QSvzVlaRtv1xfnfl+hVKpCfiJ+9th484rh937fiEZKxZGf51C+uO0lfKDP1FfnT6C1yBYwHy7FLBVXFw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-ia32-msvc/-/core-win32-ia32-msvc-1.15.11.tgz",
+      "integrity": "sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==",
       "cpu": [
         "ia32"
       ],
@@ -7969,9 +8116,9 @@
       }
     },
     "node_modules/@swc/core-win32-x64-msvc": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.10.tgz",
-      "integrity": "sha512-HvY8XUFuoTXn6lSccDLYFlXv1SU/PzYi4PyUqGT++WfTnbw/68N/7BdUZqglGRwiSqr0qhYt/EhmBpULj0J9rA==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core-win32-x64-msvc/-/core-win32-x64-msvc-1.15.11.tgz",
+      "integrity": "sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==",
       "cpu": [
         "x64"
       ],
@@ -8231,66 +8378,6 @@
         "node": ">=14.0.0"
       }
     },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.7.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.1.0",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.7.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/core": "^1.7.1",
-        "@emnapi/runtime": "^1.7.1",
-        "@tybys/wasm-util": "^0.10.1"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "0BSD",
-      "optional": true
-    },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.1.18.tgz",
@@ -8357,6 +8444,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.20.tgz",
       "integrity": "sha512-OMD2HLpNouXEfZJWcKeVKUgQ5n+n3A2JFmBaScpNDUqSrQSjiveC7dKMe53uJUg1nDG16ttFPz2xfilz6i2uVg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -8367,6 +8455,7 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -8533,8 +8622,7 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@types/canvas-confetti": {
       "version": "1.9.0",
@@ -8743,10 +8831,11 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.9",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
-      "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
+      "version": "19.2.10",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.10.tgz",
+      "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -8793,6 +8882,7 @@
       "integrity": "sha512-hAAP5io/7csFStuOmR782YmTthKBJ9ND3WVL60hcOjvtGFb+HJxH4O5huAcmcZ9v9G8P+JETiZ/G1B8MALnWZQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.54.0",
@@ -8822,6 +8912,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -9406,7 +9497,6 @@
       "integrity": "sha512-gnSBQjZA+//qDZen+6a2EdHqJ68Z7uybrMf3SPjEGgG4dicklwDVmMC1AeIHxtLVPT7sn6sH1KOO+tS6gwOUeQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/parser": "^7.28.5",
         "@vue/shared": "3.5.27",
@@ -9421,7 +9511,6 @@
       "integrity": "sha512-oAFea8dZgCtVVVTEC7fv3T5CbZW9BxpFzGGxC79xakTr6ooeEqmRuvQydIiDAkglZEAd09LgVf1RoDnL54fu5w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-core": "3.5.27",
         "@vue/shared": "3.5.27"
@@ -9452,7 +9541,6 @@
       "integrity": "sha512-Sj7h+JHt512fV1cTxKlYhg7qxBvack+BGncSpH+8vnN+KN95iPIcqB5rsbblX40XorP+ilO7VIKlkuu3Xq2vjw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.5.27",
         "@vue/shared": "3.5.27"
@@ -9463,8 +9551,7 @@
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.27.tgz",
       "integrity": "sha512-dXr/3CgqXsJkZ0n9F3I4elY8wM9jMJpP3pvRG52r6m0tu/MsAFIe6JpXVGeNMd/D9F4hQynWT8Rfuj0bdm9kFQ==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@wagmi/connectors": {
       "version": "7.1.5",
@@ -9550,12 +9637,17 @@
         }
       }
     },
+    "node_modules/@wagmi/core/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/@wagmi/core/node_modules/zustand": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.0.tgz",
       "integrity": "sha512-LE+VcmbartOPM+auOjCCLQOsQ05zUTp8RkgwRzefUk+2jISdMMFnxvyTjA4YNWr5ZGXYbVsEMZosttuxUBkojQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },
@@ -9715,6 +9807,7 @@
       "integrity": "sha512-SSlIG6QEVxClgl1s0LMk4xr2wg4eT3Zn/Hb81IocyqNSGfXpjtawWxKxiC5/9Z95f1INyBD6MctJbL/R1oBwIw==",
       "deprecated": "Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@reown/appkit": "1.7.8",
         "@walletconnect/jsonrpc-http-connection": "1.0.8",
@@ -10506,6 +10599,12 @@
         "benchmarks"
       ]
     },
+    "node_modules/@walletconnect/ethereum-provider/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/@walletconnect/ethereum-provider/node_modules/isows": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/isows/-/isows-1.0.6.tgz",
@@ -10695,6 +10794,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
       "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -10859,46 +10959,6 @@
         "pino": "10.0.0"
       }
     },
-    "node_modules/@walletconnect/logger/node_modules/pino": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
-      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
-      "license": "MIT",
-      "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "on-exit-leak-free": "^2.1.0",
-        "pino-abstract-transport": "^2.0.0",
-        "pino-std-serializers": "^7.0.0",
-        "process-warning": "^5.0.0",
-        "quick-format-unescaped": "^4.0.3",
-        "real-require": "^0.2.0",
-        "safe-stable-stringify": "^2.3.1",
-        "slow-redact": "^0.3.0",
-        "sonic-boom": "^4.0.1",
-        "thread-stream": "^3.0.0"
-      },
-      "bin": {
-        "pino": "bin.js"
-      }
-    },
-    "node_modules/@walletconnect/logger/node_modules/pino-abstract-transport": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
-      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
-      "license": "MIT",
-      "dependencies": {
-        "split2": "^4.0.0"
-      }
-    },
-    "node_modules/@walletconnect/logger/node_modules/thread-stream": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
-      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
-      "license": "MIT",
-      "dependencies": {
-        "real-require": "^0.2.0"
-      }
-    },
     "node_modules/@walletconnect/relay-api": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@walletconnect/relay-api/-/relay-api-1.0.11.tgz",
@@ -11057,17 +11117,11 @@
         "uint8arrays": "3.1.1"
       }
     },
-    "node_modules/@walletconnect/utils/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+    "node_modules/@walletconnect/utils/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/@walletconnect/utils/node_modules/ox": {
       "version": "0.9.3",
@@ -11171,6 +11225,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -11191,7 +11246,7 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
       "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 14"
@@ -11257,7 +11312,6 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11426,10 +11480,11 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.3.tgz",
-      "integrity": "sha512-ERT8kdX7DZjtUm7IitEyV7InTHAF42iJuMArIiDIV5YtPanJkgw4hw5Dyg9fh0mihdWNn1GKaeIWErfe56UQ1g==",
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.4.tgz",
+      "integrity": "sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
@@ -11491,9 +11546,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.9.18",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.18.tgz",
-      "integrity": "sha512-e23vBV1ZLfjb9apvfPk4rHVu2ry6RIr2Wfs+O324okSidrX7pTAnEJPCh/O5BtRlr7QtZI7ktOP3vsqr7Z5XoA==",
+      "version": "2.9.19",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.9.19.tgz",
+      "integrity": "sha512-ipDqC8FrAl/76p2SSWKSI+H9tFwm7vYqXQrItCuiVPt26Km0jS+NzSsBWAaBusvSbQcfJG+JitdMm+wZAgTYqg==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
@@ -11506,13 +11561,13 @@
       "license": "MIT"
     },
     "node_modules/better-auth": {
-      "version": "1.4.17",
-      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.17.tgz",
-      "integrity": "sha512-VmHGQyKsEahkEs37qguROKg/6ypYpNF13D7v/lkbO7w7Aivz0Bv2h+VyUkH4NzrGY0QBKXi1577mGhDCVwp0ew==",
+      "version": "1.4.18",
+      "resolved": "https://registry.npmjs.org/better-auth/-/better-auth-1.4.18.tgz",
+      "integrity": "sha512-bnyifLWBPcYVltH3RhS7CM62MoelEqC6Q+GnZwfiDWNfepXoQZBjEvn4urcERC7NTKgKq5zNBM8rvPvRBa6xcg==",
       "license": "MIT",
       "dependencies": {
-        "@better-auth/core": "1.4.17",
-        "@better-auth/telemetry": "1.4.17",
+        "@better-auth/core": "1.4.18",
+        "@better-auth/telemetry": "1.4.18",
         "@better-auth/utils": "0.3.0",
         "@better-fetch/fetch": "1.1.21",
         "@noble/ciphers": "^2.0.0",
@@ -11634,6 +11689,7 @@
       "resolved": "https://registry.npmjs.org/better-call/-/better-call-1.1.8.tgz",
       "integrity": "sha512-XMQ2rs6FNXasGNfMjzbyroSwKwYbZ/T3IxruSS6U2MJRsSYh3wYtG3o6H00ZlKZ/C/UPOAD97tqgQJNsxyeTXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@better-auth/utils": "^0.3.0",
         "@better-fetch/fetch": "^1.1.4",
@@ -11653,7 +11709,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
       "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
@@ -11787,6 +11843,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/brotli-wasm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/brotli-wasm/-/brotli-wasm-3.0.1.tgz",
+      "integrity": "sha512-U3K72/JAi3jITpdhZBqzSUq+DUY697tLxOuFXB+FpAE/Ug+5C3VZrv4uA674EUZHxNAuQ9wETXNqQkxZD6oL4A==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=v18.0.0"
+      }
+    },
     "node_modules/browserslist": {
       "version": "4.28.1",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.1.tgz",
@@ -11807,6 +11873,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -11870,6 +11937,7 @@
       "integrity": "sha512-ZMANVnAixE6AWWnPzlW2KpUrxhm9woycYvPOo67jWHyFowASTEd9s+QN1EIMsSDtwhIxN4sWE1jotpuDUIgyIw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -12127,9 +12195,9 @@
       }
     },
     "node_modules/ci-info": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
-      "integrity": "sha512-Wdy2Igu8OcBpI2pZePZ5oWjPC38tmDVx5WKUXKwlLYkA0ozo85sLsLvkBbBn/sZaSCMFOGZJ14fvW9t5/d7kdA==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.4.0.tgz",
+      "integrity": "sha512-77PSwercCZU2Fc4sX94eF8k8Pxte6JAwL4/ICZLFjJLqegs7kCuAsqqj/70NQF6TvDpgFjkubQB2FW2ZZddvQg==",
       "dev": true,
       "funding": [
         {
@@ -12500,7 +12568,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
       "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "mdn-data": "2.12.2",
@@ -12514,7 +12582,7 @@
       "version": "2.12.2",
       "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
       "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
-      "devOptional": true,
+      "dev": true,
       "license": "CC0-1.0"
     },
     "node_modules/css.escape": {
@@ -12540,7 +12608,7 @@
       "version": "5.3.7",
       "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
       "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^4.1.1",
@@ -12556,7 +12624,7 @@
       "version": "11.2.5",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
       "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
-      "devOptional": true,
+      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": "20 || >=22"
@@ -12699,7 +12767,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
       "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "whatwg-mimetype": "^5.0.0",
@@ -12713,7 +12781,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
       "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=20"
@@ -12934,14 +13002,14 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/drizzle-orm": {
       "version": "0.45.1",
       "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
       "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
       "license": "Apache-2.0",
+      "peer": true,
       "peerDependencies": {
         "@aws-sdk/client-rds-data": ">=3",
         "@cloudflare/workers-types": ">=4",
@@ -13089,12 +13157,13 @@
       }
     },
     "node_modules/eciesjs": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.16.tgz",
-      "integrity": "sha512-dS5cbA9rA2VR4Ybuvhg6jvdmp46ubLn3E+px8cG/35aEDNclrqoCjg6mt0HYZ/M+OoESS3jSkCrqk1kWAEhWAw==",
+      "version": "0.4.17",
+      "resolved": "https://registry.npmjs.org/eciesjs/-/eciesjs-0.4.17.tgz",
+      "integrity": "sha512-TOOURki4G7sD1wDCjj7NfLaXZZ49dFOeEb5y39IXpb8p0hRzVvfvzZHOi5JcT+PpyAbi/Y+lxPb8eTag2WYH8w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@ecies/ciphers": "^0.2.4",
+        "@ecies/ciphers": "^0.2.5",
         "@noble/ciphers": "^1.3.0",
         "@noble/curves": "^1.9.7",
         "@noble/hashes": "^1.8.0"
@@ -13105,22 +13174,10 @@
         "node": ">=16"
       }
     },
-    "node_modules/eciesjs/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.279",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.279.tgz",
-      "integrity": "sha512-0bblUU5UNdOt5G7XqGiJtpZMONma6WAfq9vsFmtn9x1+joAObr6x1chfqyxFSDCAFwFhCQDrqeAr6MYdpwJ9Hg==",
+      "version": "1.5.283",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.283.tgz",
+      "integrity": "sha512-3vifjt1HgrGW/h76UEeny+adYApveS9dH2h3p57JYzBSXJIKUJAvtmIytDKjcSCt9xHfrNCFJ7gts6vkhuq++w==",
       "dev": true,
       "license": "ISC"
     },
@@ -13218,7 +13275,6 @@
       "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "engines": {
         "node": ">=0.12"
       },
@@ -13418,6 +13474,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -13519,22 +13576,22 @@
       }
     },
     "node_modules/eslint-flat-config-utils/node_modules/@eslint/config-helpers": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.1.tgz",
-      "integrity": "sha512-QN8067dXsXAl9HIvqws7STEviheRFojX3zek5OpC84oBxDGqizW9731ByF/ASxqQihbWrVDdZXS+Ihnsckm9dg==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.5.2.tgz",
+      "integrity": "sha512-a5MxrdDXEvqnIq+LisyCX6tQMPF/dSJpCfBgBauY+pNZ28yCtSsTvyTYrMhaI+LK26bVyCJfJkT0u8KIj2i1dQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^1.0.1"
+        "@eslint/core": "^1.1.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/eslint-flat-config-utils/node_modules/@eslint/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-r18fEAj9uCk+VjzGt2thsbOmychS+4kxI14spVNibUO2vqKX7obOG+ymZljAwuPZl+S3clPGwCwTDtrdqTiY6Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -13684,9 +13741,9 @@
       }
     },
     "node_modules/eslint-plugin-jsdoc": {
-      "version": "62.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.4.1.tgz",
-      "integrity": "sha512-HgX2iN4j104D/mCUqRbhtzSZbph+KO9jfMHiIJjJ19Q+IwLQ5Na2IqvOJYq4S+4kgvEk1w6KYF4vVus6H2wcHg==",
+      "version": "62.5.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-62.5.0.tgz",
+      "integrity": "sha512-D+1haMVDzW/ZMoPwOnsbXCK07rJtsq98Z1v+ApvDKxSzYTTcPgmFc/nyUDCGmxm2cP7g7hszyjYHO7Zodl/43w==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -13927,20 +13984,20 @@
       }
     },
     "node_modules/eslint-plugin-react-dom": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-2.7.4.tgz",
-      "integrity": "sha512-bQb4kkls+TEqkkPib6r5D2r2+WFeSSHBxaHDcpOXVFybz+gMenz9l+bUbQAShzPJVuzn+z65jmt5UEw06rEv9w==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-dom/-/eslint-plugin-react-dom-2.8.1.tgz",
+      "integrity": "sha512-VAVs3cp/0XTxdjTeLePtZVadj+om+N1VNVy7hyzSPACfh5ncAicC0zOIc5MB15KUWCj8PoG/ZnVny0YqeubgRg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.7.4",
-        "@eslint-react/core": "2.7.4",
-        "@eslint-react/eff": "2.7.4",
-        "@eslint-react/shared": "2.7.4",
-        "@eslint-react/var": "2.7.4",
-        "@typescript-eslint/scope-manager": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1",
+        "@eslint-react/ast": "2.8.1",
+        "@eslint-react/core": "2.8.1",
+        "@eslint-react/eff": "2.8.1",
+        "@eslint-react/shared": "2.8.1",
+        "@eslint-react/var": "2.8.1",
+        "@typescript-eslint/scope-manager": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0",
         "compare-versions": "^6.1.1",
         "string-ts": "^2.3.1",
         "ts-pattern": "^5.9.0"
@@ -13959,6 +14016,7 @@
       "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
@@ -13974,21 +14032,21 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks-extra": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks-extra/-/eslint-plugin-react-hooks-extra-2.7.4.tgz",
-      "integrity": "sha512-ieQody9hn+zHPD+yUovM1ll/Ea3ksA2TLKYtJJNaoigDBqDxnAkubGiCKmjhifqIw96UJhvUfFY9EF7gEfSezw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks-extra/-/eslint-plugin-react-hooks-extra-2.8.1.tgz",
+      "integrity": "sha512-YeZLGzcib6UxlY7Gf+3zz8Mfl7u+OoVj3MukGaTuU6zkm1XQMI8/k4o16bKHuWtUauhn7Udl1bLAWfLgQM5UFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.7.4",
-        "@eslint-react/core": "2.7.4",
-        "@eslint-react/eff": "2.7.4",
-        "@eslint-react/shared": "2.7.4",
-        "@eslint-react/var": "2.7.4",
-        "@typescript-eslint/scope-manager": "^8.53.1",
-        "@typescript-eslint/type-utils": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1",
+        "@eslint-react/ast": "2.8.1",
+        "@eslint-react/core": "2.8.1",
+        "@eslint-react/eff": "2.8.1",
+        "@eslint-react/shared": "2.8.1",
+        "@eslint-react/var": "2.8.1",
+        "@typescript-eslint/scope-manager": "^8.54.0",
+        "@typescript-eslint/type-utils": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0",
         "string-ts": "^2.3.1",
         "ts-pattern": "^5.9.0"
       },
@@ -14001,21 +14059,21 @@
       }
     },
     "node_modules/eslint-plugin-react-naming-convention": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-2.7.4.tgz",
-      "integrity": "sha512-bupF/6lI960sZ+Tt3wYUxeGILl6m4GQ2r23gDijO5HnNNFs230qy9YP4uwkIRmh4IMeTyaYBwszx+hM+sZe7IA==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-naming-convention/-/eslint-plugin-react-naming-convention-2.8.1.tgz",
+      "integrity": "sha512-fVj+hSzIe2I6HyPTf1nccMBXq72c4jbM3gk0T+szo/wewEF8/LgenjfquJoxHPpheb1fujFgdlo5HBhsilAX7Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.7.4",
-        "@eslint-react/core": "2.7.4",
-        "@eslint-react/eff": "2.7.4",
-        "@eslint-react/shared": "2.7.4",
-        "@eslint-react/var": "2.7.4",
-        "@typescript-eslint/scope-manager": "^8.53.1",
-        "@typescript-eslint/type-utils": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1",
+        "@eslint-react/ast": "2.8.1",
+        "@eslint-react/core": "2.8.1",
+        "@eslint-react/eff": "2.8.1",
+        "@eslint-react/shared": "2.8.1",
+        "@eslint-react/var": "2.8.1",
+        "@typescript-eslint/scope-manager": "^8.54.0",
+        "@typescript-eslint/type-utils": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0",
         "compare-versions": "^6.1.1",
         "string-ts": "^2.3.1",
         "ts-pattern": "^5.9.0"
@@ -14034,25 +14092,27 @@
       "integrity": "sha512-1RETEylht2O6FM/MvgnyvT+8K21wLqDNg4qD51Zj3guhjt433XbnnkVttHMyaVyAFD03QSV4LPS5iE3VQmO7XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "eslint": ">=8.40"
       }
     },
     "node_modules/eslint-plugin-react-web-api": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-2.7.4.tgz",
-      "integrity": "sha512-UGxSXxx0zjKSdQ0MCdA52fLlWtGSeqVDpLqq/yRWozQKvKTIz3y4MibrdlZQtJuujuTF6Ym4PYjTNJfzyP/nyg==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-web-api/-/eslint-plugin-react-web-api-2.8.1.tgz",
+      "integrity": "sha512-NYsZKW1aJZ2XZuYTPzbwYLShvGcuXKRV/5TW61VO56gik/btil4Snt5UtyxshHbvT/zXx/Z+QsHul51/XM4/Qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.7.4",
-        "@eslint-react/core": "2.7.4",
-        "@eslint-react/eff": "2.7.4",
-        "@eslint-react/shared": "2.7.4",
-        "@eslint-react/var": "2.7.4",
-        "@typescript-eslint/scope-manager": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1",
+        "@eslint-react/ast": "2.8.1",
+        "@eslint-react/core": "2.8.1",
+        "@eslint-react/eff": "2.8.1",
+        "@eslint-react/shared": "2.8.1",
+        "@eslint-react/var": "2.8.1",
+        "@typescript-eslint/scope-manager": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0",
+        "birecord": "^0.1.1",
         "string-ts": "^2.3.1",
         "ts-pattern": "^5.9.0"
       },
@@ -14065,21 +14125,21 @@
       }
     },
     "node_modules/eslint-plugin-react-x": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-2.7.4.tgz",
-      "integrity": "sha512-IZPvMvE3iHxWzKIIfkb0Fcogxr++XHMh6dSjBcFVpmQmzLV4MpwFIe4PUgV8kM0uF/ULfAJ3oVyti3Ydj04yzw==",
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-x/-/eslint-plugin-react-x-2.8.1.tgz",
+      "integrity": "sha512-4IpCMrsb63AVEa9diOApIm+T3wUGIzK+EB5vyYocO31YYPJ16+R7Fh4lV3S3fOuX1+aQ+Ad4SE0cYuZ2pF2Tlg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@eslint-react/ast": "2.7.4",
-        "@eslint-react/core": "2.7.4",
-        "@eslint-react/eff": "2.7.4",
-        "@eslint-react/shared": "2.7.4",
-        "@eslint-react/var": "2.7.4",
-        "@typescript-eslint/scope-manager": "^8.53.1",
-        "@typescript-eslint/type-utils": "^8.53.1",
-        "@typescript-eslint/types": "^8.53.1",
-        "@typescript-eslint/utils": "^8.53.1",
+        "@eslint-react/ast": "2.8.1",
+        "@eslint-react/core": "2.8.1",
+        "@eslint-react/eff": "2.8.1",
+        "@eslint-react/shared": "2.8.1",
+        "@eslint-react/var": "2.8.1",
+        "@typescript-eslint/scope-manager": "^8.54.0",
+        "@typescript-eslint/type-utils": "^8.54.0",
+        "@typescript-eslint/types": "^8.54.0",
+        "@typescript-eslint/utils": "^8.54.0",
         "compare-versions": "^6.1.1",
         "is-immutable-type": "^5.0.1",
         "string-ts": "^2.3.1",
@@ -14149,9 +14209,9 @@
       }
     },
     "node_modules/eslint-plugin-toml/node_modules/@eslint/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-r18fEAj9uCk+VjzGt2thsbOmychS+4kxI14spVNibUO2vqKX7obOG+ymZljAwuPZl+S3clPGwCwTDtrdqTiY6Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14325,9 +14385,9 @@
       }
     },
     "node_modules/eslint-plugin-yml/node_modules/@eslint/core": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.0.1.tgz",
-      "integrity": "sha512-r18fEAj9uCk+VjzGt2thsbOmychS+4kxI14spVNibUO2vqKX7obOG+ymZljAwuPZl+S3clPGwCwTDtrdqTiY6Q==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.1.0.tgz",
+      "integrity": "sha512-/nr9K9wkr3P1EzFTdFdMoLuo1PmIxjmwvPozwoSodjNBdefGujXQUF93u1DDZpEaTuDvMsIQddsd35BwtrW9Xw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -14647,8 +14707,7 @@
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
       "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -14781,6 +14840,18 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/ethereum-cryptography/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/ethereum-cryptography/node_modules/@scure/base": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
@@ -14821,12 +14892,13 @@
       "version": "6.4.9",
       "resolved": "https://registry.npmjs.org/eventemitter2/-/eventemitter2-6.4.9.tgz",
       "integrity": "sha512-JEPTiaOt9f04oa6NOkc4aH+nVp5I3wEjpHbIPqfgCdD5v5bUzy7xQqwcVO2aDQgOWhI28da57HksMrzK9HlRxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
     },
     "node_modules/events": {
@@ -15171,6 +15243,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -15182,10 +15255,11 @@
       }
     },
     "node_modules/fumadocs-core": {
-      "version": "16.4.9",
-      "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-16.4.9.tgz",
-      "integrity": "sha512-DteiSjNxTtdmLS2f9swPMThEd5FMY61K+U+emSjwxtxTxDcXA6mVw9EKHCXMgJUyzObEhxP122DCAgfbm5ETMQ==",
+      "version": "16.4.11",
+      "resolved": "https://registry.npmjs.org/fumadocs-core/-/fumadocs-core-16.4.11.tgz",
+      "integrity": "sha512-ORjWgYetxDgyHZocuvEghfxt6tuEPWE+Km5KvwNKlXPxcNdBIiSVCED8WEMwiw1n/FZ/ys+W+BOe58ZXxhWg2A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@formatjs/intl-localematcher": "^0.8.0",
         "@orama/orama": "^3.1.18",
@@ -15318,12 +15392,12 @@
       }
     },
     "node_modules/fumadocs-ui": {
-      "version": "16.4.9",
-      "resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-16.4.9.tgz",
-      "integrity": "sha512-6OY9zAHz8FUkE/jQ5C1YI540j3UIMIjS40woF4TYSGyTVSzR5cYTQ8Bf1IfjvRzaUR0nv7A6tR3CWX+Kfv6pDQ==",
+      "version": "16.4.11",
+      "resolved": "https://registry.npmjs.org/fumadocs-ui/-/fumadocs-ui-16.4.11.tgz",
+      "integrity": "sha512-LFOzdnNFAFkOHzsUtCMi8cyal1pIZqygoQKSET0LO/C5JOk1YQKAZqiut1jf6pv6o0OKXacDk+MY7kfn61309A==",
       "license": "MIT",
       "dependencies": {
-        "@fumadocs/ui": "16.4.9",
+        "@fumadocs/ui": "16.4.11",
         "@radix-ui/react-accordion": "^1.2.12",
         "@radix-ui/react-collapsible": "^1.1.12",
         "@radix-ui/react-dialog": "^1.1.15",
@@ -15342,7 +15416,7 @@
       },
       "peerDependencies": {
         "@types/react": "*",
-        "fumadocs-core": "16.4.9",
+        "fumadocs-core": "16.4.11",
         "next": "16.x.x",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
@@ -15466,9 +15540,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.0.tgz",
-      "integrity": "sha512-1VKTZJCwBrvbd+Wn3AOgQP/2Av+TfTCOlE4AcRJE72W1ksZXbAx8PPBR9RzgTeSPzlPMHrbANMH3LbltH73wxQ==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.13.1.tgz",
+      "integrity": "sha512-EoY1N2xCn44xU6750Sx7OjOIT59FkmstNc3X6y5xpz7D5cBtZRe/3pSlTkDJgqsOk3WwZPkWfonhhUJfttQo3w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -15498,9 +15572,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.1.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.1.0.tgz",
-      "integrity": "sha512-8HoIcWI5fCvG5NADj4bDav+er9B9JMj2vyL2pI8D0eismKyUvPLTSs+Ln3wqhwcp306i73iyVnEKx3F6T47TGw==",
+      "version": "17.2.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.2.0.tgz",
+      "integrity": "sha512-tovnCz/fEq+Ripoq+p/gN1u7l6A7wwkoBT9pRCzTHzsD/LvADIzXZdjmRymh5Ztf0DYC3Rwg5cZRYjxzBmzbWg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -15567,6 +15641,7 @@
       "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.12.0.tgz",
       "integrity": "sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
       }
@@ -15783,31 +15858,13 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
       "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@exodus/bytes": "^1.6.0"
       },
       "engines": {
         "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      }
-    },
-    "node_modules/html-encoding-sniffer/node_modules/@exodus/bytes": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.10.0.tgz",
-      "integrity": "sha512-tf8YdcbirXdPnJ+Nd4UN1EXnz+IP2DI45YVEr3vvzcVTOyrApkmIB4zvOQVd3XPr7RXnfBtAx+PXImXOIU0Ajg==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
       }
     },
     "node_modules/html-entities": {
@@ -15848,7 +15905,7 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
       "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.0",
@@ -15862,7 +15919,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
       "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "agent-base": "^7.1.2",
@@ -15904,6 +15961,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/icu-minify": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/icu-minify/-/icu-minify-4.8.1.tgz",
+      "integrity": "sha512-RhXrTA19/PUt5/xs3B/eyx3DCjnMmcfdgqNYBE5vdrEqM4PQK2GWjHa1zdArTxPGgEc4jfuDMH1LkKhmIxwLFw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-messageformat-parser": "^3.4.0"
       }
     },
     "node_modules/idb-keyval": {
@@ -16026,24 +16098,15 @@
       }
     },
     "node_modules/intl-messageformat": {
-      "version": "10.7.18",
-      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
-      "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.1.1.tgz",
+      "integrity": "sha512-vnrF2f4vfsdaFY6tuLZfzGcx1GZFMFAq6c7QdK3HSXNcGXEIQncNgbeAcnpjAOszQzq3Jbol2SwgshIGY08WyA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@formatjs/ecma402-abstract": "2.3.6",
-        "@formatjs/fast-memoize": "2.2.7",
-        "@formatjs/icu-messageformat-parser": "2.11.4",
-        "tslib": "^2.8.0"
-      }
-    },
-    "node_modules/intl-messageformat/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
+        "@formatjs/ecma402-abstract": "3.1.0",
+        "@formatjs/fast-memoize": "3.1.0",
+        "@formatjs/icu-messageformat-parser": "3.5.0",
+        "tslib": "^2.8.1"
       }
     },
     "node_modules/iron-webcrypto": {
@@ -16263,7 +16326,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
       "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/is-regex": {
@@ -16471,7 +16534,7 @@
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
       "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
@@ -16482,6 +16545,7 @@
       "resolved": "https://registry.npmjs.org/jose/-/jose-6.1.3.tgz",
       "integrity": "sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/panva"
       }
@@ -16518,7 +16582,7 @@
       "version": "27.4.0",
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
@@ -16554,29 +16618,11 @@
         }
       }
     },
-    "node_modules/jsdom/node_modules/@exodus/bytes": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.10.0.tgz",
-      "integrity": "sha512-tf8YdcbirXdPnJ+Nd4UN1EXnz+IP2DI45YVEr3vvzcVTOyrApkmIB4zvOQVd3XPr7RXnfBtAx+PXImXOIU0Ajg==",
-      "devOptional": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
-      },
-      "peerDependencies": {
-        "@noble/hashes": "^1.8.0 || ^2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@noble/hashes": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/jsdom/node_modules/xml-name-validator": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -16666,6 +16712,7 @@
       "integrity": "sha512-1e4qoRgnn448pRuMvKGsFFymUCquZV0mpGgOyIKNgD3JVDTsVJyRBGH/Fm0tBb8WsWGgmB1mDe6/yJMQM37DUA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "acorn": "^8.5.0",
         "eslint-visitor-keys": "^3.0.0",
@@ -16752,6 +16799,7 @@
       "resolved": "https://registry.npmjs.org/kysely/-/kysely-0.28.10.tgz",
       "integrity": "sha512-ksNxfzIW77OcZ+QWSAPC7yDqUSaIVwkTWnTPNiIy//vifNbwsSgQ57OkkncHxxpcBHM3LRfLAZVEh7kjq5twVA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=20.0.0"
       }
@@ -16774,7 +16822,7 @@
       "version": "1.30.2",
       "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.30.2.tgz",
       "integrity": "sha512-utfs7Pr5uJyyvDETitgsaqSyjCb2qNRAtuqUeWIAKztsOYdcACf2KtARYXg2pSvhkt+9NfoaNY7fxjl6nuMjIQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
@@ -16807,6 +16855,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16827,6 +16876,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16847,6 +16897,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16867,6 +16918,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16887,6 +16939,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16907,6 +16960,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16927,6 +16981,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16947,6 +17002,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16967,6 +17023,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -16987,6 +17044,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17007,6 +17065,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -17198,6 +17257,7 @@
       "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.562.0.tgz",
       "integrity": "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw==",
       "license": "ISC",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -17208,7 +17268,6 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -18605,6 +18664,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": "^20.0.0 || >=22.0.0"
       }
@@ -18636,12 +18696,13 @@
       }
     },
     "node_modules/next": {
-      "version": "16.1.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.1.5.tgz",
-      "integrity": "sha512-f+wE+NSbiQgh3DSAlTaw2FwY5yGdVViAtp8TotNQj4kk4Q8Bh1sC/aL9aH+Rg1YAVn18OYXsRDT7U/079jgP7w==",
+      "version": "16.1.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.1.6.tgz",
+      "integrity": "sha512-hkyRkcu5x/41KoqnROkfTm2pZVbKxvbZRuNvKXLRXxs3VfyO0WhY50TQS40EuKO9SW3rBj/sF3WbVwDACeMZyw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@next/env": "16.1.5",
+        "@next/env": "16.1.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.8.3",
         "caniuse-lite": "^1.0.30001579",
@@ -18655,14 +18716,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.1.5",
-        "@next/swc-darwin-x64": "16.1.5",
-        "@next/swc-linux-arm64-gnu": "16.1.5",
-        "@next/swc-linux-arm64-musl": "16.1.5",
-        "@next/swc-linux-x64-gnu": "16.1.5",
-        "@next/swc-linux-x64-musl": "16.1.5",
-        "@next/swc-win32-arm64-msvc": "16.1.5",
-        "@next/swc-win32-x64-msvc": "16.1.5",
+        "@next/swc-darwin-arm64": "16.1.6",
+        "@next/swc-darwin-x64": "16.1.6",
+        "@next/swc-linux-arm64-gnu": "16.1.6",
+        "@next/swc-linux-arm64-musl": "16.1.6",
+        "@next/swc-linux-x64-gnu": "16.1.6",
+        "@next/swc-linux-x64-musl": "16.1.6",
+        "@next/swc-win32-arm64-msvc": "16.1.6",
+        "@next/swc-win32-x64-msvc": "16.1.6",
         "sharp": "^0.34.4"
       },
       "peerDependencies": {
@@ -18689,9 +18750,9 @@
       }
     },
     "node_modules/next-intl": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.7.0.tgz",
-      "integrity": "sha512-gvROzcNr/HM0jTzQlKWQxUNk8jrZ0bREz+bht3wNbv+uzlZ5Kn3J+m+viosub18QJ72S08UJnVK50PXWcUvwpQ==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/next-intl/-/next-intl-4.8.1.tgz",
+      "integrity": "sha512-7V0Ewm6bP12Lgn6cjcKi6NbVy0JeIp1K9EzHfTIsuLAUn4NuH8dhon2WYJywHCyWnxKepm34xF6G1fR2dsNoqA==",
       "funding": [
         {
           "type": "individual",
@@ -18703,10 +18764,11 @@
         "@formatjs/intl-localematcher": "^0.5.4",
         "@parcel/watcher": "^2.4.1",
         "@swc/core": "^1.15.2",
+        "icu-minify": "^4.8.1",
         "negotiator": "^1.0.0",
-        "next-intl-swc-plugin-extractor": "^4.7.0",
+        "next-intl-swc-plugin-extractor": "^4.8.1",
         "po-parser": "^2.1.1",
-        "use-intl": "^4.7.0"
+        "use-intl": "^4.8.1"
       },
       "peerDependencies": {
         "next": "^12.0.0 || ^13.0.0 || ^14.0.0 || ^15.0.0 || ^16.0.0",
@@ -18720,9 +18782,9 @@
       }
     },
     "node_modules/next-intl-swc-plugin-extractor": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.7.0.tgz",
-      "integrity": "sha512-iAqflu2FWdQMWhwB0B2z52X7LmEpvnMNJXqVERZQ7bK5p9iqQLu70ur6Ka6NfiXLxfb+AeAkUX5qIciQOg+87A==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/next-intl-swc-plugin-extractor/-/next-intl-swc-plugin-extractor-4.8.1.tgz",
+      "integrity": "sha512-4RXyce0ZrQl/6lkfwvDpP8r5B7wbAQakCW9BuMPh+7/DgXFyE+cBXxcmfDkxFDkpXvBFqBZ2HsN4pav49reAZQ==",
       "license": "MIT"
     },
     "node_modules/next-intl/node_modules/@formatjs/intl-localematcher": {
@@ -18735,9 +18797,9 @@
       }
     },
     "node_modules/next-intl/node_modules/@swc/core": {
-      "version": "1.15.10",
-      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.10.tgz",
-      "integrity": "sha512-udNofxftduMUEv7nqahl2nvodCiCDQ4Ge0ebzsEm6P8s0RC2tBM0Hqx0nNF5J/6t9uagFJyWIDjXy3IIWMHDJw==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.15.11.tgz",
+      "integrity": "sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -18752,16 +18814,16 @@
         "url": "https://opencollective.com/swc"
       },
       "optionalDependencies": {
-        "@swc/core-darwin-arm64": "1.15.10",
-        "@swc/core-darwin-x64": "1.15.10",
-        "@swc/core-linux-arm-gnueabihf": "1.15.10",
-        "@swc/core-linux-arm64-gnu": "1.15.10",
-        "@swc/core-linux-arm64-musl": "1.15.10",
-        "@swc/core-linux-x64-gnu": "1.15.10",
-        "@swc/core-linux-x64-musl": "1.15.10",
-        "@swc/core-win32-arm64-msvc": "1.15.10",
-        "@swc/core-win32-ia32-msvc": "1.15.10",
-        "@swc/core-win32-x64-msvc": "1.15.10"
+        "@swc/core-darwin-arm64": "1.15.11",
+        "@swc/core-darwin-x64": "1.15.11",
+        "@swc/core-linux-arm-gnueabihf": "1.15.11",
+        "@swc/core-linux-arm64-gnu": "1.15.11",
+        "@swc/core-linux-arm64-musl": "1.15.11",
+        "@swc/core-linux-x64-gnu": "1.15.11",
+        "@swc/core-linux-x64-musl": "1.15.11",
+        "@swc/core-win32-arm64-msvc": "1.15.11",
+        "@swc/core-win32-ia32-msvc": "1.15.11",
+        "@swc/core-win32-x64-msvc": "1.15.11"
       },
       "peerDependencies": {
         "@swc/helpers": ">=0.5.17"
@@ -19092,9 +19154,9 @@
       }
     },
     "node_modules/ox": {
-      "version": "0.11.3",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.11.3.tgz",
-      "integrity": "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.12.0.tgz",
+      "integrity": "sha512-68ZJdl8woJYThN/E7GKJ9d8RCzPFm49BhrPFpSBPO1CGljupFzKhQopVkrmcudh/Cki7nEqAAR2w6xdizCNs3Q==",
       "funding": [
         {
           "type": "github",
@@ -19102,6 +19164,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@adraffy/ens-normalize": "^1.11.0",
         "@noble/ciphers": "^1.3.0",
@@ -19126,6 +19189,7 @@
       "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
       "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@noble/hashes": "1.8.0"
       },
@@ -19136,17 +19200,12 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/ox/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+    "node_modules/ox/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
       "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+      "optional": true
     },
     "node_modules/p-limit": {
       "version": "3.1.0",
@@ -19265,7 +19324,7 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
       "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "entities": "^6.0.0"
@@ -19278,7 +19337,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
       "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -19371,6 +19430,37 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/pino": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.0.0.tgz",
+      "integrity": "sha512-eI9pKwWEix40kfvSzqEP6ldqOoBIN7dwD/o91TY5z8vQI12sAffpR/pOqAD1IVVwIVHDpHjkq0joBPdJD0rafA==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^2.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "slow-redact": "^0.3.0",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^3.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
+      "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
     "node_modules/pino-std-serializers": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
@@ -19390,13 +19480,13 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.0.tgz",
-      "integrity": "sha512-2SVA0sbPktiIY/MCOPX8e86ehA/e+tDNq+e5Y8qjKYti2Z/JG7xnronT/TXTIkKbYGWlCbuucZ6dziEgkoEjQQ==",
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
       "devOptional": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.58.0"
+        "playwright-core": "1.58.1"
       },
       "bin": {
         "playwright": "cli.js"
@@ -19409,9 +19499,9 @@
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.58.0",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.0.tgz",
-      "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
       "devOptional": true,
       "license": "Apache-2.0",
       "bin": {
@@ -19480,6 +19570,7 @@
       "resolved": "https://registry.npmjs.org/porto/-/porto-0.2.35.tgz",
       "integrity": "sha512-gu9FfjjvvYBgQXUHWTp6n3wkTxVtEcqFotM7i3GEZeoQbvLGbssAicCz6hFZ8+xggrJWwi/RLmbwNra50SMmUQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hono": "^4.10.3",
         "idb-keyval": "^6.2.1",
@@ -19545,17 +19636,11 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/porto/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
+    "node_modules/porto/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
     },
     "node_modules/porto/node_modules/ox": {
       "version": "0.9.17",
@@ -19622,6 +19707,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -19675,6 +19761,7 @@
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
       "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
       "license": "Unlicense",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -19709,7 +19796,6 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -19794,7 +19880,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -19992,6 +20078,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20035,6 +20122,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -20047,8 +20135,7 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-medium-image-zoom": {
       "version": "5.4.0",
@@ -20178,6 +20265,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -20537,7 +20625,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -20645,9 +20733,9 @@
       "license": "Unlicense"
     },
     "node_modules/rollup": {
-      "version": "4.56.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.56.0.tgz",
-      "integrity": "sha512-9FwVqlgUHzbXtDg9RCMgodF3Ua4Na6Gau+Sdt9vyCN4RhHfVKX2DCHy3BjMLTDd47ITDhYAnTwGulWTblJSDLg==",
+      "version": "4.57.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
+      "integrity": "sha512-oQL6lgK3e2QZeQ7gcgIkS2YZPg5slw37hYufJ3edKlfQSGGm8ICoxswK15ntSzF/a8+h7ekRy7k7oWc3BQ7y8A==",
       "devOptional": true,
       "license": "MIT",
       "dependencies": {
@@ -20661,31 +20749,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.56.0",
-        "@rollup/rollup-android-arm64": "4.56.0",
-        "@rollup/rollup-darwin-arm64": "4.56.0",
-        "@rollup/rollup-darwin-x64": "4.56.0",
-        "@rollup/rollup-freebsd-arm64": "4.56.0",
-        "@rollup/rollup-freebsd-x64": "4.56.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.56.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.56.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.56.0",
-        "@rollup/rollup-linux-arm64-musl": "4.56.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.56.0",
-        "@rollup/rollup-linux-loong64-musl": "4.56.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.56.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.56.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.56.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.56.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.56.0",
-        "@rollup/rollup-linux-x64-gnu": "4.56.0",
-        "@rollup/rollup-linux-x64-musl": "4.56.0",
-        "@rollup/rollup-openbsd-x64": "4.56.0",
-        "@rollup/rollup-openharmony-arm64": "4.56.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.56.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.56.0",
-        "@rollup/rollup-win32-x64-gnu": "4.56.0",
-        "@rollup/rollup-win32-x64-msvc": "4.56.0",
+        "@rollup/rollup-android-arm-eabi": "4.57.1",
+        "@rollup/rollup-android-arm64": "4.57.1",
+        "@rollup/rollup-darwin-arm64": "4.57.1",
+        "@rollup/rollup-darwin-x64": "4.57.1",
+        "@rollup/rollup-freebsd-arm64": "4.57.1",
+        "@rollup/rollup-freebsd-x64": "4.57.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.57.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.57.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.57.1",
+        "@rollup/rollup-linux-arm64-musl": "4.57.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.57.1",
+        "@rollup/rollup-linux-loong64-musl": "4.57.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.57.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.57.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.57.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.57.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-gnu": "4.57.1",
+        "@rollup/rollup-linux-x64-musl": "4.57.1",
+        "@rollup/rollup-openbsd-x64": "4.57.1",
+        "@rollup/rollup-openharmony-arm64": "4.57.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.57.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.57.1",
+        "@rollup/rollup-win32-x64-gnu": "4.57.1",
+        "@rollup/rollup-win32-x64-msvc": "4.57.1",
         "fsevents": "~2.3.2"
       }
     },
@@ -20792,7 +20880,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
       "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "xmlchars": "^2.2.0"
@@ -21057,6 +21145,7 @@
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
       "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@socket.io/component-emitter": "~3.1.0",
         "debug": "~4.4.1",
@@ -21241,9 +21330,9 @@
       "license": "MIT"
     },
     "node_modules/string-width": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
-      "integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.1.tgz",
+      "integrity": "sha512-KpqHIdDL9KwYk22wEOg/VIqYbrnLeSApsKT/bSj6Ez7pn3CftUiLAv2Lccpq1ALcpLV9UX1Ppn92npZWu2w/aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21416,7 +21505,7 @@
       "version": "3.2.4",
       "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/synckit": {
@@ -21464,7 +21553,8 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
       "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
       "devOptional": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tapable": {
       "version": "2.3.0",
@@ -21484,6 +21574,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/text-encoding-utf-8/-/text-encoding-utf-8-1.0.2.tgz",
       "integrity": "sha512-8bw4MY9WjdsD2aMtO0OzOCY3pXGYNx2d2FfHRVUKkiCPDWjKuOlhLVASS+pD7VkLTVjW268LYJHwsnPFlBpbAg=="
+    },
+    "node_modules/thread-stream": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
+      "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -21531,7 +21630,7 @@
       "version": "7.0.19",
       "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
       "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tldts-core": "^7.0.19"
@@ -21544,7 +21643,7 @@
       "version": "7.0.19",
       "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
       "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/to-buffer": {
@@ -21624,7 +21723,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
       "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "tldts": "^7.0.5"
@@ -21637,7 +21736,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
       "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "punycode": "^2.3.1"
@@ -21821,6 +21920,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -21860,9 +21960,9 @@
       "license": "MIT"
     },
     "node_modules/undici-types": {
-      "version": "7.19.1",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.1.tgz",
-      "integrity": "sha512-z2f4eae6/P3L9bogRUfLEZfRRxyrH4ssRq8s2/NOOgXEwwM5w0hsaj+mtDJPN7sBXQQNlagCzYUfjHywUiTETw==",
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
       "license": "MIT"
     },
     "node_modules/unified": {
@@ -22147,26 +22247,24 @@
       }
     },
     "node_modules/use-intl": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.7.0.tgz",
-      "integrity": "sha512-jyd8nSErVRRsSlUa+SDobKHo9IiWs5fjcPl9VBUnzUyEQpVM5mwJCgw8eUiylhvBpLQzUGox1KN0XlRivSID9A==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/use-intl/-/use-intl-4.8.1.tgz",
+      "integrity": "sha512-wH85ro36JAw9NrtogpEsqHghD21Ul6/zAKxTqHktnO6WTQzqhbcfPkO5iXu3YOnJBA8Anm7IvWSTqSzRE+2PsA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/amannn"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
-        "@formatjs/fast-memoize": "^2.2.0",
+        "@formatjs/fast-memoize": "^3.1.0",
         "@schummar/icu-type-parser": "1.21.5",
-        "intl-messageformat": "^10.5.14"
+        "icu-minify": "^4.8.1",
+        "intl-messageformat": "^11.1.0"
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0 || >=19.0.0-rc <19.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/use-intl/node_modules/@formatjs/fast-memoize": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.7.tgz",
-      "integrity": "sha512-Yabmi9nSvyOMrlSeGGWDiH7rf3a7sIwplbvo/dlz9WCIjzIQAfy1RMf4S0X3yG724n5Ghu2GmEl5NJIV6O9sZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.8.0"
       }
     },
     "node_modules/use-sidecar": {
@@ -22196,6 +22294,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
       "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -22206,6 +22305,7 @@
       "integrity": "sha512-Z6czzLq4u8fPOyx7TU6X3dvUZVvoJmxSQ+IcrlmagKhilxlhZgxPK6C5Jqbkw1IDUmFTM+cz9QDnnLTwDz/2gQ==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "node-gyp-build": "^4.3.0"
       },
@@ -22260,6 +22360,7 @@
       "resolved": "https://registry.npmjs.org/valtio/-/valtio-2.1.7.tgz",
       "integrity": "sha512-DwJhCDpujuQuKdJ2H84VbTjEJJteaSmqsuUltsfbfdbotVfNeTE4K/qc/Wi57I9x8/2ed4JNdjEna7O6PfavRg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "proxy-compare": "^3.0.1"
       },
@@ -22339,9 +22440,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.45.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.45.0.tgz",
-      "integrity": "sha512-iVA9qrAgRdtpWa80lCZ6Jri6XzmLOwwA1wagX2HnKejKeliFLpON0KOdyfqvcy+gUpBVP59LBxP2aKiL3aj8fg==",
+      "version": "2.45.1",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.45.1.tgz",
+      "integrity": "sha512-LN6Pp7vSfv50LgwhkfSbIXftAM5J89lP9x8TeDa8QM7o41IxlHrDh0F9X+FfnCWtsz11pEVV5sn+yBUoOHNqYA==",
       "funding": [
         {
           "type": "github",
@@ -22349,6 +22450,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@noble/curves": "1.9.1",
         "@noble/hashes": "1.8.0",
@@ -22383,16 +22485,40 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/viem/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+    "node_modules/viem/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
+    "node_modules/viem/node_modules/ox": {
+      "version": "0.11.3",
+      "resolved": "https://registry.npmjs.org/ox/-/ox-0.11.3.tgz",
+      "integrity": "sha512-1bWYGk/xZel3xro3l8WGg6eq4YEKlaqvyMtVhfMFpbJzK2F6rj4EDRtqDCWVEJMkzcmEi9uW2QxsqELokOlarw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/wevm"
+        }
+      ],
       "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
+      "dependencies": {
+        "@adraffy/ens-normalize": "^1.11.0",
+        "@noble/ciphers": "^1.3.0",
+        "@noble/curves": "1.9.1",
+        "@noble/hashes": "^1.8.0",
+        "@scure/bip32": "^1.7.0",
+        "@scure/bip39": "^1.6.0",
+        "abitype": "^1.2.3",
+        "eventemitter3": "5.0.1"
       },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+      "peerDependencies": {
+        "typescript": ">=5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
     "node_modules/viem/node_modules/ws": {
@@ -22422,6 +22548,7 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -22495,6 +22622,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -22511,6 +22639,7 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -22589,6 +22718,7 @@
       "integrity": "sha512-CydUvFOQKD928UzZhTp4pr2vWz1L+H99t7Pkln2QSPdvmURT0MoC4wUccfCnuEaihNsu9aYYyk+bep8rlfkUXw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^4.4.0",
         "eslint-scope": "^8.2.0",
@@ -22611,7 +22741,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
       "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "xml-name-validator": "^5.0.0"
@@ -22624,7 +22754,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
       "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18"
@@ -22635,6 +22765,7 @@
       "resolved": "https://registry.npmjs.org/wagmi/-/wagmi-2.19.5.tgz",
       "integrity": "sha512-RQUfKMv6U+EcSNNGiPbdkDtJwtuFxZWLmvDiQmjjBgkuPulUwDJsKhi7gjynzJdsx2yDqhHCXkKsbbfbIsHfcQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@wagmi/connectors": "6.2.0",
         "@wagmi/core": "2.22.1",
@@ -22670,6 +22801,18 @@
         "preact": "10.24.2",
         "viem": "^2.31.7",
         "zustand": "5.0.3"
+      }
+    },
+    "node_modules/wagmi/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/wagmi/node_modules/@wagmi/connectors": {
@@ -22767,6 +22910,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/wagmi/node_modules/eventemitter3": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
+      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
+      "license": "MIT"
+    },
     "node_modules/wagmi/node_modules/ox": {
       "version": "0.6.9",
       "resolved": "https://registry.npmjs.org/ox/-/ox-0.6.9.tgz",
@@ -22813,6 +22962,7 @@
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
       "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
@@ -22856,7 +23006,7 @@
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
       "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
-      "devOptional": true,
+      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=20"
@@ -22866,7 +23016,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
       "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -22876,7 +23026,7 @@
       "version": "15.1.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
       "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tr46": "^6.0.0",
@@ -23023,6 +23173,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
       "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },
@@ -23053,7 +23204,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
@@ -23090,7 +23241,7 @@
       "version": "2.8.2",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
       "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
@@ -23272,6 +23423,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "fumadocs-ui": "^16.4.9",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.562.0",
-    "next": "^16.1.4",
+    "next": "^16.1.6",
     "next-intl": "^4.4.0",
     "next-themes": "^0.4.6",
     "postgres": "^3.4.8",

--- a/src/app/[locale]/(platform)/(home)/loading.tsx
+++ b/src/app/[locale]/(platform)/(home)/loading.tsx
@@ -4,17 +4,15 @@ import { Skeleton } from '@/components/ui/skeleton'
 export default function Loading() {
   return (
     <>
-      <div className="z-10 border-b bg-background/95 backdrop-blur supports-backdrop-filter:bg-background/60">
-        <div className="container py-4">
-          <div className="scrollbar-hide flex items-center gap-2 overflow-x-auto">
-            <Skeleton className="h-9 w-[75%] shrink-0 rounded md:w-44" />
-            <Skeleton className="size-9 shrink-0 rounded" />
-            <Skeleton className="size-9 shrink-0 rounded" />
-          </div>
+      <div className="container py-4">
+        <div className="flex items-center gap-3">
+          <Skeleton className="h-9 w-[75%] shrink-0 rounded md:w-56" />
+          <Skeleton className="size-9 shrink-0 rounded" />
+          <Skeleton className="size-9 shrink-0 rounded" />
         </div>
       </div>
 
-      <main className="container grid gap-4 py-4">
+      <main className="container grid gap-4">
         <EventsGridSkeleton />
       </main>
     </>

--- a/src/app/[locale]/(platform)/(home)/page.tsx
+++ b/src/app/[locale]/(platform)/(home)/page.tsx
@@ -1,10 +1,14 @@
 'use cache'
 
 import type { Event } from '@/types'
+import { setRequestLocale } from 'next-intl/server'
 import HomeClient from '@/app/[locale]/(platform)/(home)/_components/HomeClient'
 import { EventRepository } from '@/lib/db/queries/event'
 
-export default async function HomePage(_: PageProps<'/[locale]'>) {
+export default async function HomePage({ params }: PageProps<'/[locale]'>) {
+  const { locale } = await params
+  setRequestLocale(locale)
+
   let initialEvents: Event[] = []
 
   try {

--- a/src/app/[locale]/(platform)/[username]/page.tsx
+++ b/src/app/[locale]/(platform)/[username]/page.tsx
@@ -1,6 +1,7 @@
 'use cache'
 
 import type { Metadata } from 'next'
+import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import PublicProfileHeroCards from '@/app/[locale]/(platform)/[username]/_components/PublicProfileHeroCards'
 import PublicProfileTabs from '@/app/[locale]/(platform)/[username]/_components/PublicProfileTabs'
@@ -20,7 +21,9 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/[usernam
 }
 
 export default async function ProfilePage({ params }: PageProps<'/[locale]/[username]'>) {
-  const { username } = await params
+  const { locale, username } = await params
+  setRequestLocale(locale)
+
   const { data: profile } = await UserRepository.getProfileByUsernameOrProxyAddress(username)
   if (!profile) {
     notFound()

--- a/src/app/[locale]/admin/affiliate/page.tsx
+++ b/src/app/[locale]/admin/affiliate/page.tsx
@@ -1,5 +1,6 @@
 'use cache'
 
+import { setRequestLocale } from 'next-intl/server'
 import AdminAffiliateOverview from '@/app/[locale]/admin/affiliate/_components/AdminAffiliateOverview'
 import AdminAffiliateSettingsForm from '@/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm'
 import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotalsByToken } from '@/lib/data-api/fees'
@@ -36,7 +37,10 @@ interface RowSummary {
   total_affiliate_fees: number
 }
 
-export default async function AdminSettingsPage(_: PageProps<'/[locale]/admin/affiliate'>) {
+export default async function AdminSettingsPage({ params }: PageProps<'/[locale]/admin/affiliate'>) {
+  const { locale } = await params
+  setRequestLocale(locale)
+
   const [
     { data: allSettings },
     { data: overviewData },

--- a/src/app/[locale]/admin/locales/page.tsx
+++ b/src/app/[locale]/admin/locales/page.tsx
@@ -1,11 +1,15 @@
 'use cache'
 
+import { setRequestLocale } from 'next-intl/server'
 import AdminLocalesSettingsForm from '@/app/[locale]/admin/locales/_components/AdminLocalesSettingsForm'
 import { getEnabledLocalesFromSettings } from '@/i18n/locale-settings'
 import { SUPPORTED_LOCALES } from '@/i18n/locales'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 
-export default async function AdminLocalesSettingsPage(_: PageProps<'/[locale]/admin/locales'>) {
+export default async function AdminLocalesSettingsPage({ params }: PageProps<'/[locale]/admin/locales'>) {
+  const { locale } = await params
+  setRequestLocale(locale)
+
   const { data: allSettings } = await SettingsRepository.getSettings()
   const enabledLocales = getEnabledLocalesFromSettings(allSettings ?? undefined)
 

--- a/src/app/[locale]/admin/market-context/page.tsx
+++ b/src/app/[locale]/admin/market-context/page.tsx
@@ -1,12 +1,16 @@
 'use cache'
 
+import { setRequestLocale } from 'next-intl/server'
 import AdminMarketContextSettingsForm from '@/app/[locale]/admin/market-context/_components/AdminMarketContextSettingsForm'
 import { parseMarketContextSettings } from '@/lib/ai/market-context-config'
 import { MARKET_CONTEXT_VARIABLES } from '@/lib/ai/market-context-template'
 import { fetchOpenRouterModels } from '@/lib/ai/openrouter'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 
-export default async function AdminMarketContextSettingsPage(_: PageProps<'/[locale]/admin/market-context'>) {
+export default async function AdminMarketContextSettingsPage({ params }: PageProps<'/[locale]/admin/market-context'>) {
+  const { locale } = await params
+  setRequestLocale(locale)
+
   const { data: allSettings } = await SettingsRepository.getSettings()
   const parsedSettings = parseMarketContextSettings(allSettings ?? undefined)
   const defaultPrompt = parsedSettings.prompt

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -40,17 +40,17 @@ export default async function LocaleLayout({ params, children }: LayoutProps<'/[
   if (!hasLocale(routing.locales, locale)) {
     notFound()
   }
+  setRequestLocale(locale)
+
   const enabledLocales = await loadEnabledLocales()
   if (!enabledLocales.includes(locale)) {
     notFound()
   }
 
-  setRequestLocale(locale)
-
   return (
     <html lang={locale} className={`${openSauceOne.variable}`} suppressHydrationWarning>
       <body className="flex min-h-screen flex-col font-sans antialiased">
-        <NextIntlClientProvider>
+        <NextIntlClientProvider locale={locale}>
           {IS_TEST_MODE && <TestModeBanner />}
           {children}
         </NextIntlClientProvider>

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -141,6 +141,7 @@ export const auth = betterAuth({
   }),
   appName: process.env.NEXT_PUBLIC_SITE_NAME,
   secret: process.env.BETTER_AUTH_SECRET,
+  baseURL: process.env.SITE_URL,
   advanced: {
     database: {
       generateId: false,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect language on cached pages by setting the request locale early, ensuring consistent translations and formatting across the app.

- **Bug Fixes**
  - Call setRequestLocale(locale) on cached routes: home, public profile, admin affiliate, admin locales, and admin market context.
  - Move setRequestLocale in [locale]/layout before checks and pass locale to NextIntlClientProvider.
  - Add baseURL to auth config to generate correct URLs.
  - Small cleanup to the home loading UI.

- **Dependencies**
  - Bump Next from 16.1.4 to 16.1.6.

<sup>Written for commit 5f9062e16ac8b5acca88e16b0b6509a7c99e932b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

