### PR TITLE
fix: record affiliate only on creation

### DIFF
--- a/src/lib/db/queries/user.ts
+++ b/src/lib/db/queries/user.ts
@@ -1,6 +1,6 @@
 import type { MarketOrderType, ProxyWalletStatus, User } from '@/types'
 import { asc, count, desc, eq, ilike, inArray, or, sql } from 'drizzle-orm'
-import { cookies, headers } from 'next/headers'
+import { headers } from 'next/headers'
 import { auth } from '@/lib/auth'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { AffiliateRepository } from '@/lib/db/queries/affiliate'
@@ -172,30 +172,6 @@ export const UserRepository = {
         }
         catch (error) {
           console.error('Failed to ensure affiliate code', error)
-        }
-      }
-
-      if (!user.referred_by_user_id) {
-        try {
-          const cookieStore = await cookies()
-          const referralCookie = cookieStore.get('platform_affiliate')
-
-          if (referralCookie?.value) {
-            const parsed = JSON.parse(referralCookie.value) as {
-              affiliateUserId?: string
-              timestamp?: number
-            }
-
-            if (parsed?.affiliateUserId && parsed.affiliateUserId !== user.id) {
-              await AffiliateRepository.recordReferral({
-                user_id: user.id,
-                affiliate_user_id: parsed.affiliateUserId,
-              })
-            }
-          }
-        }
-        catch (error) {
-          console.error('Failed to record affiliate referral', error)
         }
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Record affiliate referrals only when a new user account is created, moving logic to an auth creation hook and removing duplicate checks in user queries. This prevents duplicate or invalid referrals and clears the cookie after success.

- **Bug Fixes**
  - Record referral in auth databaseHooks (user.create.after) using AffiliateRepository.
  - Parse and validate cookie safely: requires affiliateUserId, not self, timestamp not in future and within 30 days.
  - Clear platform_affiliate cookie on success and log failures; removed referral logic from UserRepository and unused cookies import.

<sup>Written for commit 718b5ffc381e05a9847e4cae360a11e1a317728f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

