### PR TITLE
fix: missing icon suffix

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
@@ -1,5 +1,5 @@
 import type { Market, Outcome } from '@/types'
-import { Check, X } from 'lucide-react'
+import { CheckIcon, XIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { OUTCOME_INDEX } from '@/lib/constants'
@@ -48,8 +48,8 @@ export default function EventCardSingleMarketActions({
                   : `bg-no`}`}
                 >
                   {isYesOutcome
-                    ? <Check className="size-3 text-background" strokeWidth={2.5} />
-                    : <X className="size-3 text-background" strokeWidth={2.5} />}
+                    ? <CheckIcon className="size-3 text-background" strokeWidth={2.5} />
+                    : <XIcon className="size-3 text-background" strokeWidth={2.5} />}
                 </span>
               </div>
             )

--- a/src/app/[locale]/(platform)/_components/WalletModal.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletModal.tsx
@@ -3,19 +3,19 @@
 import type { ChangeEventHandler, FormEventHandler } from 'react'
 import type { LiFiWalletTokenItem } from '@/hooks/useLiFiWalletTokens'
 import {
-  ArrowLeft,
-  ArrowRight,
-  Check,
-  ChevronLeft,
-  ChevronRight,
-  CircleDollarSign,
-  Copy,
-  CreditCard,
-  ExternalLink,
-  Fuel,
-  Info,
-  Loader2,
-  Wallet,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+  CheckIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  CircleDollarSignIcon,
+  CopyIcon,
+  CreditCardIcon,
+  ExternalLinkIcon,
+  FuelIcon,
+  InfoIcon,
+  Loader2Icon,
+  WalletIcon,
 } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import Image from 'next/image'
@@ -154,7 +154,7 @@ function WalletAddressCard({
           <p className="ml-2 text-xs font-bold break-all">{walletAddress}</p>
         </div>
         <span className="inline-flex size-8 items-center justify-center">
-          {copied ? <Check className="size-4 text-primary" /> : <Copy className="size-4 text-muted-foreground" />}
+          {copied ? <CheckIcon className="size-4 text-primary" /> : <CopyIcon className="size-4 text-muted-foreground" />}
         </span>
       </div>
     </div>
@@ -325,7 +325,7 @@ function WalletSendForm({
           className="flex items-center gap-2 text-sm text-muted-foreground transition hover:text-foreground"
           onClick={onBack}
         >
-          <ArrowLeft className="size-4" />
+          <ArrowLeftIcon className="size-4" />
           Back
         </button>
       )}
@@ -351,7 +351,7 @@ function WalletSendForm({
                 disabled={!connectedWalletAddress}
                 className="absolute inset-y-2 right-2 text-xs"
               >
-                <Wallet className="size-3.5 shrink-0" />
+                <WalletIcon className="size-3.5 shrink-0" />
                 <span>use connected</span>
               </Button>
             )}
@@ -485,7 +485,7 @@ function WalletSendForm({
             <span>Transaction breakdown</span>
             <span className="flex items-center gap-1">
               {!isBreakdownOpen && <span>0.00%</span>}
-              <ChevronRight
+              <ChevronRightIcon
                 className={`size-4 transition ${isBreakdownOpen ? 'rotate-90' : ''}`}
               />
             </span>
@@ -498,7 +498,7 @@ function WalletSendForm({
                     <TooltipTrigger asChild>
                       <div className="flex items-center gap-2">
                         <span>Network cost</span>
-                        <Info className="size-4" />
+                        <InfoIcon className="size-4" />
                       </div>
                     </TooltipTrigger>
                     <TooltipContent>
@@ -519,7 +519,7 @@ function WalletSendForm({
                     </TooltipContent>
                   </Tooltip>
                   <div className="flex items-center gap-1">
-                    <Fuel className="size-4" />
+                    <FuelIcon className="size-4" />
                     <span>$0.00</span>
                   </div>
                 </div>
@@ -528,7 +528,7 @@ function WalletSendForm({
                     <TooltipTrigger asChild>
                       <div className="flex items-center gap-2">
                         <span>Price impact</span>
-                        <Info className="size-4" />
+                        <InfoIcon className="size-4" />
                       </div>
                     </TooltipTrigger>
                     <TooltipContent>
@@ -555,7 +555,7 @@ function WalletSendForm({
                     <TooltipTrigger asChild>
                       <div className="flex items-center gap-2">
                         <span>Max slippage</span>
-                        <Info className="size-4" />
+                        <InfoIcon className="size-4" />
                       </div>
                     </TooltipTrigger>
                     <TooltipContent>
@@ -573,7 +573,7 @@ function WalletSendForm({
           <div className="rounded-lg bg-muted/60 p-4">
             <div className="flex items-start gap-3 text-xs text-foreground">
               <div className="mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-destructive">
-                <Info className="size-4 text-background" />
+                <InfoIcon className="size-4 text-background" />
               </div>
               <div className="space-y-1">
                 <p className="font-semibold">USDCe is not widely supported by most exchanges</p>
@@ -637,7 +637,7 @@ function WalletFundMenu({
       >
         <div className="flex items-center gap-3">
           <div className="flex size-12 items-center justify-center text-foreground">
-            <Wallet className="size-6" />
+            <WalletIcon className="size-6" />
           </div>
           <div className="space-y-1">
             <p className="text-sm font-semibold text-foreground">
@@ -652,7 +652,7 @@ function WalletFundMenu({
                         ml-2 inline-flex size-4 items-center justify-center rounded-full text-muted-foreground
                       `}
                       >
-                        <Info className="size-3" />
+                        <InfoIcon className="size-3" />
                       </span>
                     </TooltipTrigger>
                     <TooltipContent>
@@ -702,7 +702,7 @@ function WalletFundMenu({
       >
         <div className="flex items-center gap-3">
           <div className="flex size-12 items-center justify-center text-foreground">
-            <CreditCard className="size-6" />
+            <CreditCardIcon className="size-6" />
           </div>
           <div>
             <p className="text-sm font-semibold">Buy Crypto</p>
@@ -744,7 +744,7 @@ function WalletFundMenu({
       >
         <div className="flex items-center gap-3">
           <div className="flex size-12 items-center justify-center text-foreground">
-            <CircleDollarSign className="size-6" />
+            <CircleDollarSignIcon className="size-6" />
           </div>
           <div>
             <p className="text-sm font-semibold">Transfer Funds</p>
@@ -1090,7 +1090,7 @@ function WalletAmountStep({
               <p className="text-sm font-semibold text-foreground">{selectedTokenSymbol ?? 'Token'}</p>
             </div>
           </div>
-          <ArrowRight className="size-4 text-muted-foreground" />
+          <ArrowRightIcon className="size-4 text-muted-foreground" />
           <div className="flex items-center gap-3">
             <div className="relative">
               <Image
@@ -1285,7 +1285,7 @@ function WalletConfirmStep({
             <div className="flex items-center justify-between text-muted-foreground">
               <span>Source</span>
               <span className="flex items-center gap-2 font-semibold text-foreground">
-                <Wallet className="size-4" />
+                <WalletIcon className="size-4" />
                 Wallet (...
                 {eoaSuffix}
                 )
@@ -1401,7 +1401,7 @@ function WalletConfirmStep({
               : (
                   <>
                     {!isBreakdownOpen && <span>{gasUsdDisplay ? `$${gasUsdDisplay}` : '—'}</span>}
-                    <ChevronRight className={`size-3 transition ${isBreakdownOpen ? 'rotate-90' : ''}`} />
+                    <ChevronRightIcon className={`size-3 transition ${isBreakdownOpen ? 'rotate-90' : ''}`} />
                   </>
                 )}
           </span>
@@ -1413,7 +1413,7 @@ function WalletConfirmStep({
                 Network cost
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <Info className="size-3" />
+                    <InfoIcon className="size-3" />
                   </TooltipTrigger>
                   <TooltipContent>
                     <div className="space-y-1 text-xs text-foreground">
@@ -1434,7 +1434,7 @@ function WalletConfirmStep({
                 </Tooltip>
               </span>
               <span className="flex items-center gap-2">
-                <Fuel className="size-3" />
+                <FuelIcon className="size-3" />
                 {gasUsdDisplay ? `$${gasUsdDisplay}` : '—'}
               </span>
             </div>
@@ -1473,7 +1473,7 @@ function WalletConfirmStep({
           }
         }}
       >
-        {(isLoadingQuote || isSubmitting || isExecuting) && <Loader2 className="size-4 animate-spin" />}
+        {(isLoadingQuote || isSubmitting || isExecuting) && <Loader2Icon className="size-4 animate-spin" />}
         {isSubmitting && 'Confirm transaction in your wallet'}
         {!isSubmitting && status === 'quote' && 'Preparing your quote...'}
         {!isSubmitting && status === 'gas' && 'Estimating gas...'}
@@ -1519,7 +1519,7 @@ function WalletSuccessStep({
         <div className="relative flex items-center justify-center">
           <div className="absolute size-20 rounded-full bg-emerald-500/25 blur-md" />
           <div className="relative flex size-14 items-center justify-center rounded-full bg-emerald-500">
-            <Check className="size-7 text-background" />
+            <CheckIcon className="size-7 text-background" />
           </div>
         </div>
         <div className="space-y-1">
@@ -1550,7 +1550,7 @@ function WalletSuccessStep({
             <div className="flex items-center justify-between text-muted-foreground">
               <span>Source</span>
               <span className="flex items-center gap-2 font-semibold text-foreground">
-                <Wallet className="size-4" />
+                <WalletIcon className="size-4" />
                 Wallet (...
                 {eoaSuffix}
                 )
@@ -1562,7 +1562,7 @@ function WalletSuccessStep({
                     className="inline-flex"
                     aria-label="View wallet on Polygonscan"
                   >
-                    <ExternalLink className="size-3" />
+                    <ExternalLinkIcon className="size-3" />
                   </a>
                 )}
               </span>
@@ -1594,7 +1594,7 @@ function WalletSuccessStep({
                     className="inline-flex"
                     aria-label="View wallet on Polygonscan"
                   >
-                    <ExternalLink className="size-3" />
+                    <ExternalLinkIcon className="size-3" />
                   </a>
                 )}
               </span>
@@ -1656,7 +1656,7 @@ function WalletSuccessStep({
 
       {supportUrl && (
         <div className="flex items-center gap-2 rounded-lg bg-muted/50 p-3 text-xs text-foreground">
-          <Info className="size-4 text-muted-foreground" />
+          <InfoIcon className="size-4 text-muted-foreground" />
           <span>
             Experiencing problems?
             {' '}
@@ -1860,7 +1860,7 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
                       `}
                       onClick={() => onViewChange('fund')}
                     >
-                      <ChevronLeft />
+                      <ChevronLeftIcon />
                     </button>
                   )
                 : (
@@ -1921,7 +1921,7 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
                     `}
                     onClick={() => onViewChange('fund')}
                   >
-                    <ChevronLeft />
+                    <ChevronLeftIcon />
                   </button>
                 )
               : (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventConvertPositionsDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventConvertPositionsDialog.tsx
@@ -2,7 +2,7 @@
 
 import type { SafeTransactionRequestPayload } from '@/lib/safe/transactions'
 import { useQueryClient } from '@tanstack/react-query'
-import { BadgeCheck, Loader2, LockKeyhole, MoveDown, MoveLeft } from 'lucide-react'
+import { BadgeCheckIcon, Loader2Icon, LockKeyholeIcon, MoveDownIcon, MoveLeftIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useEffect, useId, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
@@ -499,7 +499,7 @@ export default function EventConvertPositionsDialog({
 
           <div className="relative z-10 -mt-2 -mb-2 flex items-center justify-center text-muted-foreground">
             <div className="rounded-md border-8 border-muted/60 bg-background p-1">
-              <MoveDown className="size-4" />
+              <MoveDownIcon className="size-4" />
             </div>
           </div>
 
@@ -537,7 +537,7 @@ export default function EventConvertPositionsDialog({
                       font-semibold text-yes
                     `}
                     >
-                      <LockKeyhole className="size-3" />
+                      <LockKeyholeIcon className="size-3" />
                       {t('Yes')}
                     </span>
                   </div>
@@ -567,8 +567,8 @@ export default function EventConvertPositionsDialog({
         disabled={!canSubmit}
         onClick={handleSubmit}
       >
-        {submitState === 'signing' && <Loader2 className="size-4 animate-spin" />}
-        {submitState === 'submitting' && <Loader2 className="size-4 animate-spin" />}
+        {submitState === 'signing' && <Loader2Icon className="size-4 animate-spin" />}
+        {submitState === 'submitting' && <Loader2Icon className="size-4 animate-spin" />}
         {submitState === 'signing'
           ? 'Awaiting signature'
           : submitState === 'submitting'
@@ -591,7 +591,7 @@ export default function EventConvertPositionsDialog({
       `}
       onClick={() => setStep('select')}
     >
-      <MoveLeft className="size-4" />
+      <MoveLeftIcon className="size-4" />
       Review
     </button>
   )
@@ -650,7 +650,7 @@ export default function EventConvertPositionsDialog({
 function ConvertSuccessIcon() {
   return (
     <span className="flex size-6 items-center justify-center rounded-full bg-yes/20 text-yes">
-      <BadgeCheck className="size-4" />
+      <BadgeCheckIcon className="size-4" />
     </span>
   )
 }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
@@ -3,7 +3,7 @@
 import type { InfiniteData } from '@tanstack/react-query'
 import type { Event, UserOpenOrder } from '@/types'
 import { useQueryClient } from '@tanstack/react-query'
-import { ChevronDown, ChevronUp, XIcon } from 'lucide-react'
+import { ChevronDownIcon, ChevronUpIcon, XIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
@@ -120,7 +120,7 @@ function SortHeaderButton({
 }) {
   const isActive = sortState?.column === column
   const direction = isActive ? sortState?.direction : null
-  const Icon = direction === 'asc' ? ChevronUp : ChevronDown
+  const Icon = direction === 'asc' ? ChevronUpIcon : ChevronDownIcon
 
   return (
     <button

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -6,7 +6,7 @@ import type { OrderBookSummariesResponse } from '@/app/[locale]/(platform)/event
 import type { DataApiActivity } from '@/lib/data-api/user'
 import type { Event, UserPosition } from '@/types'
 import { useQuery } from '@tanstack/react-query'
-import { Check, ChevronDown, LockKeyhole, RefreshCwIcon, SquareArrowOutUpRight, X } from 'lucide-react'
+import { CheckIcon, ChevronDownIcon, LockKeyholeIcon, RefreshCwIcon, SquareArrowOutUpRightIcon, XIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import Image from 'next/image'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -620,7 +620,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
               data-state={showResolvedMarkets ? 'open' : 'closed'}
             >
               <span>{showResolvedMarkets ? t('Hide resolved') : t('View resolved')}</span>
-              <ChevronDown
+              <ChevronDownIcon
                 className="size-6 transition-transform duration-150 group-data-[state=open]:rotate-180"
               />
             </button>
@@ -792,8 +792,8 @@ function ResolvedMarketRow({
                   )}
                   >
                     {isYesOutcome
-                      ? <Check className="size-3 text-background" strokeWidth={2.5} />
-                      : <X className="size-3 text-background" strokeWidth={2.5} />}
+                      ? <CheckIcon className="size-3 text-background" strokeWidth={2.5} />
+                      : <XIcon className="size-3 text-background" strokeWidth={2.5} />}
                   </span>
                 </span>
               )
@@ -843,7 +843,7 @@ function OtherOutcomeRow({ shares, showMarketIcon }: { shares: number, showMarke
             `,
           )}
           >
-            <LockKeyhole className="size-3 text-yes" />
+            <LockKeyholeIcon className="size-3 text-yes" />
             <span className="tabular-nums">{sharesLabel}</span>
             <span>{t('Yes')}</span>
           </span>
@@ -1141,7 +1141,7 @@ export function ResolvedResolutionPanel({
         <div className="absolute top-3 bottom-3 left-2.5 w-1 bg-primary" aria-hidden="true" />
         <div className="flex items-center gap-3">
           <span className="relative flex size-6 items-center justify-center rounded-full bg-primary">
-            <Check className="size-3.5 text-primary-foreground" />
+            <CheckIcon className="size-3.5 text-primary-foreground" />
           </span>
           <span className="text-sm font-medium text-foreground">
             {t('Outcome proposed:')}
@@ -1151,13 +1151,13 @@ export function ResolvedResolutionPanel({
         </div>
         <div className="flex items-center gap-3">
           <span className="relative flex size-6 items-center justify-center rounded-full bg-primary">
-            <Check className="size-3.5 text-primary-foreground" />
+            <CheckIcon className="size-3.5 text-primary-foreground" />
           </span>
           <span className="text-sm font-medium text-foreground">{t('No dispute')}</span>
         </div>
         <div className="flex items-center gap-3">
           <span className="relative flex size-6 items-center justify-center rounded-full bg-primary">
-            <Check className="size-3.5 text-primary-foreground" />
+            <CheckIcon className="size-3.5 text-primary-foreground" />
           </span>
           <span className="text-sm font-medium text-foreground">
             {t('Final outcome:')}
@@ -1175,7 +1175,7 @@ export function ResolvedResolutionPanel({
           className="inline-flex items-center gap-2 text-sm font-semibold text-foreground hover:underline"
         >
           {t('View details')}
-          <SquareArrowOutUpRight className="size-4" />
+          <SquareArrowOutUpRightIcon className="size-4" />
         </a>
       )}
     </div>

--- a/src/app/[locale]/(platform)/portfolio/_components/PendingDepositBanner.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PendingDepositBanner.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { SafeOperationType } from '@/lib/safe/transactions'
-import { ArrowDownToLine, CheckIcon, Loader2Icon } from 'lucide-react'
+import { ArrowDownToLineIcon, CheckIcon, Loader2Icon } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { toast } from 'sonner'
 import { hashTypedData } from 'viem'
@@ -184,7 +184,7 @@ export default function PendingDepositBanner() {
         onClick={() => setOpen(true)}
       >
         <span className="text-sm font-semibold">Confirm pending deposit</span>
-        <ArrowDownToLine className="size-4" />
+        <ArrowDownToLineIcon className="size-4" />
       </Button>
 
       <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioWalletActions.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioWalletActions.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { ArrowDownToLine, ArrowUpToLine } from 'lucide-react'
+import { ArrowDownToLineIcon, ArrowUpToLineIcon } from 'lucide-react'
 import { useTradingOnboarding } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -15,11 +15,11 @@ export default function PortfolioWalletActions({ className }: PortfolioWalletAct
   return (
     <div className={cn('flex flex-col gap-3 sm:flex-row', className)}>
       <Button className="h-11 flex-1" onClick={startDepositFlow}>
-        <ArrowDownToLine className="size-4" />
+        <ArrowDownToLineIcon className="size-4" />
         Deposit
       </Button>
       <Button variant="outline" className="h-11 flex-1" onClick={startWithdrawFlow}>
-        <ArrowUpToLine className="size-4" />
+        <ArrowUpToLineIcon className="size-4" />
         Withdraw
       </Button>
     </div>

--- a/src/app/[locale]/admin/(users)/_components/columns.tsx
+++ b/src/app/[locale]/admin/(users)/_components/columns.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ColumnDef } from '@tanstack/react-table'
-import { ArrowUpDown, MailIcon } from 'lucide-react'
+import { ArrowUpDownIcon, MailIcon } from 'lucide-react'
 import ProfileLink from '@/components/ProfileLink'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -58,7 +58,7 @@ export const columns: ColumnDef<AdminUserRow>[] = [
           className="h-auto p-0 text-xs font-medium text-muted-foreground uppercase hover:text-foreground"
         >
           User
-          <ArrowUpDown className="ml-2 size-4" />
+          <ArrowUpDownIcon className="ml-2 size-4" />
         </Button>
       )
     },
@@ -93,7 +93,7 @@ export const columns: ColumnDef<AdminUserRow>[] = [
           className="h-auto p-0 text-xs font-medium text-muted-foreground uppercase hover:text-foreground"
         >
           Email
-          <ArrowUpDown className="ml-2 size-4" />
+          <ArrowUpDownIcon className="ml-2 size-4" />
         </Button>
       )
     },
@@ -170,7 +170,7 @@ export const columns: ColumnDef<AdminUserRow>[] = [
             className="h-auto p-0 text-xs font-medium text-muted-foreground uppercase hover:text-foreground"
           >
             Created
-            <ArrowUpDown className="ml-2 size-4" />
+            <ArrowUpDownIcon className="ml-2 size-4" />
           </Button>
         </div>
       )

--- a/src/app/[locale]/admin/categories/_components/columns.tsx
+++ b/src/app/[locale]/admin/categories/_components/columns.tsx
@@ -1,6 +1,6 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import type { AdminCategoryRow } from '@/app/[locale]/admin/categories/_hooks/useAdminCategories'
-import { ArrowUpDown } from 'lucide-react'
+import { ArrowUpDownIcon } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Switch } from '@/components/ui/switch'
@@ -34,7 +34,7 @@ export function createCategoryColumns({
           className="h-auto p-0 text-xs font-medium text-muted-foreground uppercase hover:text-foreground"
         >
           Category
-          <ArrowUpDown className="ml-2 size-4" />
+          <ArrowUpDownIcon className="ml-2 size-4" />
         </Button>
       ),
       cell: ({ row }) => {
@@ -93,7 +93,7 @@ export function createCategoryColumns({
           className="h-auto p-0 text-xs font-medium text-muted-foreground uppercase hover:text-foreground"
         >
           Active Markets
-          <ArrowUpDown className="ml-2 size-4" />
+          <ArrowUpDownIcon className="ml-2 size-4" />
         </Button>
       ),
       cell: ({ row }) => (

--- a/src/app/[locale]/admin/create-event/_components/AdminCreateEventForm.tsx
+++ b/src/app/[locale]/admin/create-event/_components/AdminCreateEventForm.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { ChangeEvent, FormEvent } from 'react'
-import { AlertCircle, Calendar, CheckCircle2, Image, Loader2, Plus, Tag, Trash2 } from 'lucide-react'
+import { AlertCircleIcon, CalendarIcon, CheckCircle2Icon, ImageIcon, Loader2Icon, PlusIcon, TagIcon, Trash2Icon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
@@ -534,7 +534,7 @@ export default function AdminCreateEventForm() {
       <Card className="bg-background">
         <CardHeader className="pt-8 pb-6">
           <CardTitle className="flex items-center gap-2">
-            <Calendar className="size-5" />
+            <CalendarIcon className="size-5" />
             Event Information
           </CardTitle>
           <CardDescription>
@@ -653,7 +653,7 @@ export default function AdminCreateEventForm() {
       <Card className="bg-background">
         <CardHeader className="pt-8 pb-6">
           <CardTitle className="flex items-center gap-2">
-            <Tag className="size-5" />
+            <TagIcon className="size-5" />
             Event Tags
           </CardTitle>
           <CardDescription>
@@ -706,12 +706,12 @@ export default function AdminCreateEventForm() {
                     onClick={() => removeTag(index)}
                     disabled={form.tags.length <= 1}
                   >
-                    <Trash2 className="size-4" />
+                    <Trash2Icon className="size-4" />
                   </Button>
                 </div>
               ))}
               <Button type="button" variant="outline" onClick={addTag}>
-                <Plus className="mr-2 size-4" />
+                <PlusIcon className="mr-2 size-4" />
                 Add Custom Tag
               </Button>
             </div>
@@ -722,7 +722,7 @@ export default function AdminCreateEventForm() {
       <Card className="bg-background">
         <CardHeader className="pt-8 pb-6">
           <CardTitle className="flex items-center gap-2">
-            <Image className="size-5" />
+            <ImageIcon className="size-5" />
             Prediction Markets
           </CardTitle>
           <CardDescription>
@@ -749,7 +749,7 @@ export default function AdminCreateEventForm() {
                     onClick={() => removeMarket(marketIndex)}
                     disabled={form.markets.length <= 1}
                   >
-                    <Trash2 className="mr-2 size-4" />
+                    <Trash2Icon className="mr-2 size-4" />
                     Remove
                   </Button>
                 </div>
@@ -821,7 +821,7 @@ export default function AdminCreateEventForm() {
             ))}
 
             <Button type="button" variant="outline" onClick={addMarket}>
-              <Plus className="mr-2 size-4" />
+              <PlusIcon className="mr-2 size-4" />
               Add Market
             </Button>
           </div>
@@ -833,7 +833,7 @@ export default function AdminCreateEventForm() {
       <Card className="bg-background">
         <CardContent className="pt-8 pb-8">
           <div className="flex items-start gap-3">
-            <AlertCircle className="mt-0.5 size-5 text-no" />
+            <AlertCircleIcon className="mt-0.5 size-5 text-no" />
             <div className="space-y-2">
               <h4 className="font-semibold">Development Status - Not Ready for Production</h4>
               <ul className="space-y-1 text-sm text-muted-foreground">
@@ -879,13 +879,13 @@ export default function AdminCreateEventForm() {
           {isLoading
             ? (
                 <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  <Loader2Icon className="mr-2 size-4 animate-spin" />
                   Validating...
                 </>
               )
             : (
                 <>
-                  <CheckCircle2 className="mr-2 size-4" />
+                  <CheckCircle2Icon className="mr-2 size-4" />
                   Validate Event Data
                 </>
               )}

--- a/src/app/[locale]/docs/_components/ErrorDisplay.tsx
+++ b/src/app/[locale]/docs/_components/ErrorDisplay.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { AffiliateDataError } from '@/lib/affiliate-data'
-import { RefreshCw } from 'lucide-react'
+import { RefreshCwIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 
 interface ErrorDisplayProps {
@@ -37,7 +37,7 @@ export function ErrorDisplay({ fallbackValue, className = '', showRefresh = true
           className="h-auto p-1 text-xs text-muted-foreground hover:text-foreground"
           title="Refresh to retry"
         >
-          <RefreshCw className="size-3" />
+          <RefreshCwIcon className="size-3" />
         </Button>
       )}
     </span>
@@ -73,7 +73,7 @@ export function ErrorDisplayBlock({
             onClick={handleRefresh}
             className="text-xs"
           >
-            <RefreshCw className="mr-1 size-3" />
+            <RefreshCwIcon className="mr-1 size-3" />
             Refresh Page
           </Button>
         </div>

--- a/src/components/HeaderPortfolio.tsx
+++ b/src/components/HeaderPortfolio.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown } from 'lucide-react'
+import { ArrowDownIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
@@ -58,7 +58,7 @@ export default function HeaderPortfolio() {
             <span>{t('Cash')}</span>
             {hasPendingDeposit && (
               <span className="inline-flex size-4 items-center justify-center rounded-full bg-primary">
-                <ArrowDown className="size-3 text-background" />
+                <ArrowDownIcon className="size-3 text-background" />
               </span>
             )}
           </div>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updated all lucide-react icon imports to the new "*Icon" names to fix missing icons after the library change. Restores icons across the app with no logic changes.

- **Bug Fixes**
  - Replaced old icon imports/usages with "*Icon" variants in wallet, events, portfolio, admin, docs, and header components.
  - Fixed missing UI indicators (chevrons, checks, info, arrows) and related build/runtime errors.
  - No behavioral changes; visuals match previous icons.

<sup>Written for commit 89404e1a219ed88698887f0fc7cf1161b94ba2ee. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

