### PR TITLE
refactor: store affiliate by code only

### DIFF
--- a/src/app/[locale]/(platform)/r/[code]/route.ts
+++ b/src/app/[locale]/(platform)/r/[code]/route.ts
@@ -25,8 +25,7 @@ export async function GET(request: Request, context: { params: Promise<{ code: s
   }
 
   const cookieValue = JSON.stringify({
-    code: affiliate.affiliate_code,
-    affiliateUserId: affiliate.id,
+    affiliateCode: affiliate.affiliate_code,
     timestamp: Date.now(),
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Store only the affiliate code in the referral cookie and resolve the affiliate user ID at auth time. This simplifies the cookie and avoids storing user IDs client-side.

- **Refactors**
  - Cookie now stores affiliateCode and timestamp; removed affiliateUserId.
  - Parse with type checks; invalid cookies are ignored.
  - On auth, look up affiliate by code, skip self/missing, record referral, then clear cookie.

- **Migration**
  - Old cookies using code/affiliateUserId are ignored and won’t record referrals. New referrals will set affiliateCode.

<sup>Written for commit ffa1faf9bc0cd5568398b35604725e30524d1b74. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

