### PR TITLE
fix: rebase pnl chart series to timeframe start

### DIFF
--- a/src/app/[locale]/(platform)/[username]/_components/PublicProfileHeroCards.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicProfileHeroCards.tsx
@@ -100,7 +100,18 @@ function ProfitLossCard({
           .map(point => ({ date: point.date as Date, value: point.value as number }))
           .sort((a, b) => a.date.getTime() - b.date.getTime())
 
-        setPnlSeries(normalized)
+        if (normalized.length === 0) {
+          setPnlSeries([])
+          return
+        }
+
+        const base = normalized[0].value
+        const rebased = normalized.map(point => ({
+          ...point,
+          value: point.value - base,
+        }))
+
+        setPnlSeries(rebased)
       })
       .catch((error) => {
         if (error?.name !== 'AbortError') {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rebased the PnL chart to the first point of the selected timeframe so it shows change from the start, not absolute values. This removes misleading offsets and aligns the zero baseline with the timeframe start.

- **Bug Fixes**
  - Subtract the first point’s value from all points to rebase the series.
  - Return an empty series when no data exists to avoid invalid state.

<sup>Written for commit f9fc5c282700ffa22260687c11900f0d3ca82ba4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

