### PR TITLE
feat: generate market context using current selected locale

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_actions/generate-market-context.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_actions/generate-market-context.ts
@@ -1,5 +1,6 @@
 'use server'
 
+import { getLocale } from 'next-intl/server'
 import { z } from 'zod'
 import { generateMarketContext } from '@/lib/ai/market-context'
 import { loadMarketContextSettings } from '@/lib/ai/market-context-config'
@@ -40,7 +41,8 @@ export async function generateMarketContextAction(input: GenerateMarketContextIn
       return { error: 'No markets available for this event.' }
     }
 
-    const context = await generateMarketContext(event, market, settings)
+    const locale = await getLocale()
+    const context = await generateMarketContext(event, market, settings, locale)
     return { context }
   }
   catch (error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Generate market context in the user’s selected locale. Adds locale normalization and a system prompt instruction so responses are localized with a safe fallback.

- **New Features**
  - Read current locale via next-intl and pass it to the generator.
  - Normalize locale to supported set (e.g., en-US -> en); fall back to default when unknown.
  - Inject locale instruction into the system message for localized output.
  - generateMarketContext now accepts an optional locale argument.

<sup>Written for commit 682114a5d4bc1def3d31fb8c346da230226742d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

