### PR TITLE
feat: sum referrer totals across tokens

### DIFF
--- a/src/app/[locale]/(platform)/settings/affiliate/page.tsx
+++ b/src/app/[locale]/(platform)/settings/affiliate/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { setRequestLocale } from 'next-intl/server'
 import SettingsAffiliateContent from '@/app/[locale]/(platform)/settings/_components/SettingsAffiliateContent'
-import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotalsByToken } from '@/lib/data-api/fees'
+import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotals } from '@/lib/data-api/fees'
 import { AffiliateRepository } from '@/lib/db/queries/affiliate'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { UserRepository } from '@/lib/db/queries/user'
@@ -43,7 +43,7 @@ export default async function AffiliateSettingsPage({ params }: PageProps<'/[loc
   let totalAffiliateFees = 0
 
   if (feeTotals) {
-    const usdcTotal = sumFeeTotalsByToken(feeTotals, '0')
+    const usdcTotal = sumFeeTotals(feeTotals)
     totalAffiliateFees = baseUnitsToNumber(usdcTotal, 6)
   }
 

--- a/src/app/[locale]/admin/affiliate/page.tsx
+++ b/src/app/[locale]/admin/affiliate/page.tsx
@@ -3,7 +3,7 @@
 import { setRequestLocale } from 'next-intl/server'
 import AdminAffiliateOverview from '@/app/[locale]/admin/affiliate/_components/AdminAffiliateOverview'
 import AdminAffiliateSettingsForm from '@/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm'
-import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotalsByToken } from '@/lib/data-api/fees'
+import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotals } from '@/lib/data-api/fees'
 import { AffiliateRepository } from '@/lib/db/queries/affiliate'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { fetchMaxExchangeBaseFeeRate } from '@/lib/exchange'
@@ -97,7 +97,7 @@ export default async function AdminSettingsPage({ params }: PageProps<'/[locale]
         console.warn('Failed to load affiliate fee totals', result.reason)
         return
       }
-      const usdcTotal = sumFeeTotalsByToken(result.value, '0')
+      const usdcTotal = sumFeeTotals(result.value)
       feeTotalsByAddress.set(
         uniqueReceivers[idx].toLowerCase(),
         baseUnitsToNumber(usdcTotal, 6),

--- a/src/lib/data-api/fees.ts
+++ b/src/lib/data-api/fees.ts
@@ -77,6 +77,17 @@ export function sumFeeTotalsByToken(totals: FeeReceiverTotal[], tokenId: string)
   }, 0n)
 }
 
+export function sumFeeTotals(totals: FeeReceiverTotal[]): bigint {
+  return totals.reduce((acc, total) => {
+    try {
+      return acc + BigInt(total.totalAmount)
+    }
+    catch {
+      return acc
+    }
+  }, 0n)
+}
+
 export function baseUnitsToNumber(amount: bigint, decimals = 6): number {
   if (decimals <= 0) {
     return Number(amount)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Affiliate/referrer totals are now summed across all tokens, not just USDC, for both Settings and Admin affiliate pages. This ensures totals reflect all earnings.

- **New Features**
  - Added sumFeeTotals to aggregate FeeReceiverTotal amounts across tokens with BigInt and safe parsing.
  - Updated SettingsAffiliate and AdminAffiliate overview to use sumFeeTotals for displayed totals.

<sup>Written for commit f52c675f211b7f4290b724b77dd25dbf959fc5bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

