### PR TITLE
feat: use referral volume totals from blockchain and explain commission

### DIFF
--- a/src/app/[locale]/(platform)/settings/_components/SettingsAffiliateContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsAffiliateContent.tsx
@@ -1,9 +1,10 @@
 'use client'
 
 import type { AffiliateData } from '@/types'
-import { CheckIcon, CopyIcon } from 'lucide-react'
+import { CheckIcon, CopyIcon, InfoIcon } from 'lucide-react'
 import ProfileLink from '@/components/ProfileLink'
 import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useClipboard } from '@/hooks/useClipboard'
 import { formatCurrency, formatPercent } from '@/lib/formatters'
 
@@ -49,7 +50,27 @@ export default function SettingsAffiliateContent({ affiliateData }: SettingsAffi
             </div>
           </div>
           <div className="shrink-0 text-left sm:text-right">
-            <div className="text-lg font-medium text-primary">{formatPercent(affiliateData.commissionPercent)}</div>
+            <div className="flex items-center justify-start gap-1 text-lg font-medium text-primary sm:justify-end">
+              <span>{formatPercent(affiliateData.commissionPercent)}</span>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <button
+                    type="button"
+                    className={`
+                      inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors
+                      hover:text-foreground
+                      focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none
+                    `}
+                    aria-label="Commission info"
+                  >
+                    <InfoIcon className="size-3" aria-hidden />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="max-w-64 text-left">
+                  Commission is taken from the trading fee at execution, not from volume. The exchange base fee comes out first.
+                </TooltipContent>
+              </Tooltip>
+            </div>
             <div className="text-sm text-muted-foreground">Commission</div>
           </div>
         </div>

--- a/src/app/[locale]/(platform)/settings/affiliate/page.tsx
+++ b/src/app/[locale]/(platform)/settings/affiliate/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import { setRequestLocale } from 'next-intl/server'
 import SettingsAffiliateContent from '@/app/[locale]/(platform)/settings/_components/SettingsAffiliateContent'
-import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotals } from '@/lib/data-api/fees'
+import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotals, sumFeeVolumes } from '@/lib/data-api/fees'
 import { AffiliateRepository } from '@/lib/db/queries/affiliate'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { UserRepository } from '@/lib/db/queries/user'
@@ -42,10 +42,13 @@ export default async function AffiliateSettingsPage({ params }: PageProps<'/[loc
   ])
   const affiliateSettings = allSettings?.affiliate
   let totalAffiliateFees = 0
+  let referredVolume = 0
 
   if (feeTotals) {
     const usdcTotal = sumFeeTotals(feeTotals)
+    const volumeTotal = sumFeeVolumes(feeTotals)
     totalAffiliateFees = baseUnitsToNumber(usdcTotal, 6)
+    referredVolume = baseUnitsToNumber(volumeTotal, 6)
   }
 
   const tradeFeeBps = Number.parseInt(affiliateSettings?.trade_fee_bps?.value || '100', 10)
@@ -65,7 +68,7 @@ export default async function AffiliateSettingsPage({ params }: PageProps<'/[loc
         stats: {
           total_referrals: Number(statsData?.total_referrals ?? 0),
           active_referrals: Number(statsData?.active_referrals ?? 0),
-          volume: Number(statsData?.volume ?? 0),
+          volume: referredVolume,
           total_affiliate_fees: totalAffiliateFees,
         },
         recentReferrals: (referralsData ?? []).map((referral: any) => {

--- a/src/app/[locale]/admin/affiliate/page.tsx
+++ b/src/app/[locale]/admin/affiliate/page.tsx
@@ -1,9 +1,11 @@
 'use cache'
 
+import { InfoIcon } from 'lucide-react'
 import { setRequestLocale } from 'next-intl/server'
 import AdminAffiliateOverview from '@/app/[locale]/admin/affiliate/_components/AdminAffiliateOverview'
 import AdminAffiliateSettingsForm from '@/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm'
-import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotals } from '@/lib/data-api/fees'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { baseUnitsToNumber, fetchFeeReceiverTotals, sumFeeTotals, sumFeeVolumes } from '@/lib/data-api/fees'
 import { AffiliateRepository } from '@/lib/db/queries/affiliate'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { fetchMaxExchangeBaseFeeRate } from '@/lib/exchange'
@@ -76,7 +78,7 @@ export default async function AdminSettingsPage({ params }: PageProps<'/[locale]
   }
 
   const profileMap = new Map<string, AffiliateProfile>(profiles.map(profile => [profile.id, profile]))
-  const feeTotalsByAddress = new Map<string, number>()
+  const feeTotalsByAddress = new Map<string, { fees: number, volume: number }>()
 
   if (profiles.length > 0) {
     const uniqueReceivers = Array.from(
@@ -98,9 +100,13 @@ export default async function AdminSettingsPage({ params }: PageProps<'/[locale]
         return
       }
       const usdcTotal = sumFeeTotals(result.value)
+      const volumeTotal = sumFeeVolumes(result.value)
       feeTotalsByAddress.set(
         uniqueReceivers[idx].toLowerCase(),
-        baseUnitsToNumber(usdcTotal, 6),
+        {
+          fees: baseUnitsToNumber(usdcTotal, 6),
+          volume: baseUnitsToNumber(volumeTotal, 6),
+        },
       )
     })
   }
@@ -109,7 +115,7 @@ export default async function AdminSettingsPage({ params }: PageProps<'/[locale]
     const profile = profileMap.get(item.affiliate_user_id)
 
     const receiverAddress = (profile?.proxy_wallet_address || profile?.address || '').toLowerCase()
-    const onchainFees = receiverAddress ? feeTotalsByAddress.get(receiverAddress) : undefined
+    const onchainData = receiverAddress ? feeTotalsByAddress.get(receiverAddress) : undefined
 
     return {
       id: item.affiliate_user_id,
@@ -119,8 +125,8 @@ export default async function AdminSettingsPage({ params }: PageProps<'/[locale]
       image: profile?.image ? getSupabaseImageUrl(profile.image) : '',
       affiliate_code: profile?.affiliate_code ?? null,
       total_referrals: Number(item.total_referrals ?? 0),
-      volume: Number(item.volume ?? 0),
-      total_affiliate_fees: onchainFees ?? 0,
+      volume: onchainData?.volume ?? 0,
+      total_affiliate_fees: onchainData?.fees ?? 0,
     }
   })
 
@@ -160,9 +166,28 @@ export default async function AdminSettingsPage({ params }: PageProps<'/[locale]
             </div>
             <div className="rounded-lg bg-muted/40 p-4">
               <p className="text-xs text-muted-foreground uppercase">Affiliate fees</p>
-              <p className="mt-1 text-2xl font-semibold">
-                {usdFormatter.format(aggregate.totalAffiliateFees)}
-              </p>
+              <div className="mt-1 flex items-center gap-1 text-2xl font-semibold">
+                <span>{usdFormatter.format(aggregate.totalAffiliateFees)}</span>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      className={`
+                        inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground
+                        transition-colors
+                        hover:text-foreground
+                        focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none
+                      `}
+                      aria-label="Affiliate fee info"
+                    >
+                      <InfoIcon className="size-3" aria-hidden />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top" className="max-w-64 text-left">
+                    Commission is taken from the trading fee at execution, not from volume. The exchange base fee comes out first.
+                  </TooltipContent>
+                </Tooltip>
+              </div>
             </div>
           </div>
         </div>

--- a/src/lib/data-api/fees.ts
+++ b/src/lib/data-api/fees.ts
@@ -3,6 +3,7 @@ export interface FeeReceiverTotal {
   receiver: string
   tokenId: string
   totalAmount: string
+  totalVolume: string
   updatedAt: number
 }
 
@@ -81,6 +82,17 @@ export function sumFeeTotals(totals: FeeReceiverTotal[]): bigint {
   return totals.reduce((acc, total) => {
     try {
       return acc + BigInt(total.totalAmount)
+    }
+    catch {
+      return acc
+    }
+  }, 0n)
+}
+
+export function sumFeeVolumes(totals: FeeReceiverTotal[]): bigint {
+  return totals.reduce((acc, total) => {
+    try {
+      return acc + BigInt(total.totalVolume)
     }
     catch {
       return acc


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch referral volume to on-chain totals and add tooltips that clarify how commission is calculated. Improves accuracy and clarity in Affiliate Settings and Admin.

- **New Features**
  - Use blockchain fee receiver totals to compute referred volume in user Settings and Admin (via sumFeeVolumes).
  - Extend fees API: add totalVolume to FeeReceiverTotal and a sumFeeVolumes helper.
  - Replace stats.volume with on-chain volume in Settings; Admin now reads both on-chain volume and fees per receiver.
  - Add Info tooltips next to commission and affiliate fees explaining commission is taken from the trading fee at execution (after the base fee), not from volume.

<sup>Written for commit 4a080d1797c58e59da7f9b4106299f999efd23b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

