### PR TITLE
fix: display <1% for any chance below 1%

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
@@ -82,8 +82,7 @@ export function buildEventMarketRows(
       : null
     const normalizedChanceValue = normalizedChance ?? 0
     const roundedChance = Math.round(normalizedChanceValue)
-    const roundedThresholdChance = Math.round(normalizedChanceValue * 10) / 10
-    const isSubOnePercent = normalizedChance != null && roundedThresholdChance > 0 && roundedThresholdChance < 1
+    const isSubOnePercent = normalizedChance != null && normalizedChance < 1
     const chanceDisplay = normalizedChance != null
       ? (isSubOnePercent ? '<1%' : `${roundedChance}%`)
       : '—'

--- a/tests/unit/EventMarketRows.test.ts
+++ b/tests/unit/EventMarketRows.test.ts
@@ -91,4 +91,24 @@ describe('buildEventMarketRows', () => {
 
     expect(result.rows.map(row => row.market.condition_id)).toEqual(['m2', 'm1'])
   })
+
+  it('displays <1% for any chance below 1, including zero', () => {
+    const event = createEvent([
+      createMarket({ condition_id: 'm0', title: 'Zero' }),
+      createMarket({ condition_id: 'm095', title: 'Zero Point Ninety Five' }),
+      createMarket({ condition_id: 'm1', title: 'One' }),
+    ])
+
+    const result = buildEventMarketRows(event, {
+      outcomeChances: { m0: 0, m095: 0.95, m1: 1 },
+      outcomeChanceChanges: { m0: 0, m095: 0, m1: 0 },
+      marketYesPrices: {},
+    })
+
+    const byId = Object.fromEntries(result.rows.map(row => [row.market.condition_id, row]))
+
+    expect(byId.m0?.chanceMeta.chanceDisplay).toBe('<1%')
+    expect(byId.m095?.chanceMeta.chanceDisplay).toBe('<1%')
+    expect(byId.m1?.chanceMeta.chanceDisplay).toBe('1%')
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Display '<1%' for any market chance below 1%, including zero. Fixes incorrect rounding that showed '1%' for 0.95% and '0%' for zero.

- **Bug Fixes**
  - Use normalizedChance < 1 to detect sub-1% values.
  - Add unit test for 0, 0.95, and 1 to verify display.

<sup>Written for commit 84cafbbe7c6c1478130a7ca2a4e87a5e6af710c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

