### PR TITLE
refactor: prerender only 'en' locale

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -40,7 +40,7 @@ export const viewport: Viewport = {
 }
 
 export async function generateStaticParams() {
-  return routing.locales.map(locale => ({ locale }))
+  return [{ locale: 'en' }]
 }
 
 export default async function LocaleLayout({ params, children }: LayoutProps<'/[locale]'>) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prerender only the 'en' locale by returning a single static param in generateStaticParams. This reduces build time and output; other locales are no longer statically generated.

- **Migration**
  - If you need other locales pre-rendered, add them back to generateStaticParams; otherwise they render at runtime (or 404 if disabled).

<sup>Written for commit 41fc58b6ed368fa5e933a201db95feb9a7fa4b15. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

