### PR TITLE
fix: migrate guard

### DIFF
--- a/src/app/api/sync/resolution/route.ts
+++ b/src/app/api/sync/resolution/route.ts
@@ -112,9 +112,6 @@ async function tryAcquireSyncLock(): Promise<boolean> {
     .limit(1)
 
   if (claimError) {
-    if (isMissingColumnError(claimError, 'status')) {
-      return tryAcquireLegacySyncLock()
-    }
     throw new Error(`Failed to claim sync lock: ${claimError.message}`)
   }
 
@@ -137,50 +134,6 @@ async function tryAcquireSyncLock(): Promise<boolean> {
   }
 
   throw new Error(`Failed to initialize sync lock: ${insertError.message}`)
-}
-
-function isMissingColumnError(error: { message?: string } | null | undefined, column: string): boolean {
-  const message = error?.message ?? ''
-  return message.includes(`column subgraph_syncs.${column} does not exist`)
-}
-
-async function tryAcquireLegacySyncLock(): Promise<boolean> {
-  const legacyPayload = {
-    service_name: 'resolution_sync',
-    subgraph_name: 'resolution',
-    error_message: null,
-  }
-
-  // Legacy fallback: keep the sync progressing even when status-based lock columns are not visible.
-  const { data: updatedRows, error: updateError } = await supabaseAdmin
-    .from('subgraph_syncs')
-    .update(legacyPayload)
-    .eq('service_name', 'resolution_sync')
-    .eq('subgraph_name', 'resolution')
-    .select('id')
-    .limit(1)
-
-  if (updateError) {
-    throw new Error(`Failed to claim legacy sync lock: ${updateError.message}`)
-  }
-
-  if ((updatedRows?.length ?? 0) > 0) {
-    return true
-  }
-
-  const { error: insertError } = await supabaseAdmin
-    .from('subgraph_syncs')
-    .insert(legacyPayload)
-
-  if (!insertError) {
-    return true
-  }
-
-  if (insertError.code === '23505') {
-    return false
-  }
-
-  throw new Error(`Failed to initialize legacy sync lock: ${insertError.message}`)
 }
 
 async function updateSyncStatus(
@@ -209,9 +162,6 @@ async function updateSyncStatus(
     })
 
   if (error) {
-    if (isMissingColumnError(error, 'status')) {
-      return
-    }
     console.error(`Failed to update sync status to ${status}:`, error)
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure migrations always run and only gate cron setup behind required env vars. Also prefer POSTGRES_MIGRATION_URL for migration connection string and improve skip checks.

- **Bug Fixes**
  - Move VERCEL_PROJECT_PRODUCTION_URL/CRON_SECRET guard to only wrap cron setup; migrations no longer blocked.
  - Prefer POSTGRES_MIGRATION_URL over POSTGRES_URL_NON_POOLING/POSTGRES_URL.
  - Update shouldSkip to return { skip, missing } and improve missing-env logging.

<sup>Written for commit 6d7332e0690b5b8f45e2898510523684c5e9d069. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

