### PR TITLE
style: sidebar icons

### DIFF
--- a/src/app/[locale]/(platform)/settings/_components/SettingsSidebar.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsSidebar.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import type { LucideIcon } from 'lucide-react'
 import type { Route } from 'next'
+import { BadgePercentIcon, BellIcon, CoinsIcon, FingerprintIcon, UserIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Link, usePathname } from '@/i18n/navigation'
@@ -9,17 +11,18 @@ interface MenuItem {
   id: string
   label: string
   href: Route
+  icon: LucideIcon
 }
 
 export default function SettingsSidebar() {
   const t = useExtracted()
   const pathname = usePathname()
   const menuItems: MenuItem[] = [
-    { id: 'profile', label: t('Profile'), href: '/settings' as Route },
-    { id: 'notifications', label: t('Notifications'), href: '/settings/notifications' as Route },
-    { id: 'trading', label: t('Trading'), href: '/settings/trading' as Route },
-    { id: 'affiliate', label: t('Affiliate'), href: '/settings/affiliate' as Route },
-    { id: 'two-factor', label: t('Two-Factor Auth'), href: '/settings/two-factor' as Route },
+    { id: 'profile', label: t('Profile'), href: '/settings' as Route, icon: UserIcon },
+    { id: 'notifications', label: t('Notifications'), href: '/settings/notifications' as Route, icon: BellIcon },
+    { id: 'trading', label: t('Trading'), href: '/settings/trading' as Route, icon: CoinsIcon },
+    { id: 'affiliate', label: t('Affiliate'), href: '/settings/affiliate' as Route, icon: BadgePercentIcon },
+    { id: 'two-factor', label: t('Two-Factor Auth'), href: '/settings/two-factor' as Route, icon: FingerprintIcon },
   ]
   const activeItem = menuItems.find(item => pathname === item.href)
   const active = activeItem?.id ?? 'profile'
@@ -31,11 +34,14 @@ export default function SettingsSidebar() {
           <Button
             key={item.id}
             type="button"
-            variant={active === item.id ? 'outline' : 'ghost'}
-            className="justify-start text-muted-foreground"
+            variant="ghost"
+            className={`h-11 justify-start text-foreground ${active === item.id ? 'bg-accent hover:bg-accent' : ''}`}
             asChild
           >
-            <Link href={item.href}>{item.label}</Link>
+            <Link href={item.href}>
+              <item.icon className="size-5 text-muted-foreground" />
+              {item.label}
+            </Link>
           </Button>
         ))}
       </nav>

--- a/src/app/[locale]/(platform)/settings/layout.tsx
+++ b/src/app/[locale]/(platform)/settings/layout.tsx
@@ -19,7 +19,7 @@ export default async function SettingsLayout({ params, children }: LayoutProps<'
   return (
     <main className="container py-8">
       <div className="mx-auto max-w-6xl">
-        <div className="grid gap-8 lg:grid-cols-[240px_1fr] lg:gap-16">
+        <div className="grid gap-8 lg:grid-cols-[200px_1fr] lg:gap-16">
           <SettingsSidebar />
           {children}
         </div>

--- a/src/app/[locale]/admin/_components/AdminSidebar.tsx
+++ b/src/app/[locale]/admin/_components/AdminSidebar.tsx
@@ -1,6 +1,8 @@
 'use client'
 
+import type { LucideIcon } from 'lucide-react'
 import type { Route } from 'next'
+import { BadgePercentIcon, ChartColumnIcon, LanguagesIcon, SettingsIcon, SwatchBookIcon, TagsIcon, UsersIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Link, usePathname } from '@/i18n/navigation'
@@ -9,18 +11,19 @@ interface AdminMenuItem {
   id: string
   label: string
   href: Route
+  icon: LucideIcon
 }
 
 export default function AdminSidebar() {
   const t = useExtracted()
   const adminMenuItems: AdminMenuItem[] = [
-    { id: 'general', label: t('General'), href: '/admin' as Route },
-    { id: 'theme', label: t('Theme'), href: '/admin/theme' as Route },
-    { id: 'categories', label: t('Categories'), href: '/admin/categories' as Route },
-    { id: 'market-context', label: t('Market Context'), href: '/admin/market-context' as Route },
-    { id: 'affiliate', label: t('Affiliate'), href: '/admin/affiliate' as Route },
-    { id: 'users', label: t('Users'), href: '/admin/users' as Route },
-    { id: 'locales', label: t('Locales'), href: '/admin/locales' as Route },
+    { id: 'general', label: t('General'), href: '/admin' as Route, icon: SettingsIcon },
+    { id: 'theme', label: t('Theme'), href: '/admin/theme' as Route, icon: SwatchBookIcon },
+    { id: 'categories', label: t('Categories'), href: '/admin/categories' as Route, icon: TagsIcon },
+    { id: 'market-context', label: t('Market Context'), href: '/admin/market-context' as Route, icon: ChartColumnIcon },
+    { id: 'affiliate', label: t('Affiliate'), href: '/admin/affiliate' as Route, icon: BadgePercentIcon },
+    { id: 'users', label: t('Users'), href: '/admin/users' as Route, icon: UsersIcon },
+    { id: 'locales', label: t('Locales'), href: '/admin/locales' as Route, icon: LanguagesIcon },
   ]
   const pathname = usePathname()
   const activeItem = adminMenuItems.find(item => pathname === item.href)
@@ -33,11 +36,14 @@ export default function AdminSidebar() {
           <Button
             key={item.id}
             type="button"
-            variant={active === item.id ? 'outline' : 'ghost'}
-            className="justify-start text-muted-foreground"
+            variant="ghost"
+            className={`h-11 justify-start text-foreground ${active === item.id ? 'bg-accent hover:bg-accent' : ''}`}
             asChild
           >
-            <Link href={item.href}>{item.label}</Link>
+            <Link href={item.href}>
+              <item.icon className="size-5 text-muted-foreground" />
+              {item.label}
+            </Link>
           </Button>
         ))}
       </nav>

--- a/src/app/[locale]/admin/layout.tsx
+++ b/src/app/[locale]/admin/layout.tsx
@@ -18,7 +18,7 @@ export default async function AdminLayout({ params, children }: LayoutProps<'/[l
     <AppProviders>
       <AdminHeader />
       <main className="container py-8">
-        <div className="grid gap-8 lg:grid-cols-[240px_1fr] lg:gap-16">
+        <div className="grid gap-8 lg:grid-cols-[200px_1fr] lg:gap-16">
           <AdminSidebar />
           <div className="space-y-8">
             {children}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added Lucide icons to Settings and Admin sidebars and refined styles for a cleaner, more compact nav. Also reduced sidebar column width to 200px in both layouts.

- **New Features**
  - Icons for each menu item in both sidebars (Lucide).
  - Unified ghost buttons with active highlight (bg-accent) and 44px height.
  - Sidebar grid column reduced from 240px to 200px.

<sup>Written for commit 0beb10e6c582817d8c5af7023d997ef528b6a295. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

