### PR TITLE
fix: prevent home toolbar hydration mismatch

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/FilterToolbar.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/FilterToolbar.tsx
@@ -73,6 +73,7 @@ export default function FilterToolbar({ filters, onFiltersChange }: FilterToolba
   const { open } = useAppKit()
   const { isConnected } = useAppKitAccount()
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
+  const [isNavigationTagsReady, setIsNavigationTagsReady] = useState(false)
   const [filterSettings, setFilterSettings] = useState<FilterSettings>(() => createDefaultFilters({
     status: filters.status,
     hideSports: filters.hideSports,
@@ -97,6 +98,10 @@ export default function FilterToolbar({ filters, onFiltersChange }: FilterToolba
     || filterSettings.hideCrypto !== BASE_FILTER_SETTINGS.hideCrypto
     || filterSettings.hideEarnings !== BASE_FILTER_SETTINGS.hideEarnings
   ), [filterSettings])
+
+  useEffect(() => {
+    setIsNavigationTagsReady(true)
+  }, [])
 
   useEffect(() => {
     setFilterSettings((prev) => {
@@ -217,7 +222,11 @@ export default function FilterToolbar({ filters, onFiltersChange }: FilterToolba
 
         <Separator orientation="vertical" className="order-4 hidden shrink-0 md:order-2 md:flex" />
 
-        <div id="navigation-tags" className="order-3 max-w-full min-w-0 flex-1 overflow-hidden md:order-3" />
+        <div
+          id="navigation-tags"
+          data-teleport-ready={isNavigationTagsReady ? 'true' : 'false'}
+          className="order-3 max-w-full min-w-0 flex-1 overflow-hidden md:order-3"
+        />
       </div>
 
       {isSettingsOpen && (

--- a/src/app/[locale]/(platform)/_components/NavigationTab.tsx
+++ b/src/app/[locale]/(platform)/_components/NavigationTab.tsx
@@ -372,7 +372,7 @@ export default function NavigationTab({ tag, childParentMap, tabIndex }: Navigat
       )}
 
       {isActive && (
-        <Teleport to="#navigation-tags">
+        <Teleport to="#navigation-tags" requireReadyAttribute="data-teleport-ready">
           <div className="relative w-full max-w-full">
             <div
               ref={scrollContainerRef}

--- a/src/components/Teleport.tsx
+++ b/src/components/Teleport.tsx
@@ -7,24 +7,40 @@ import { createPortal } from 'react-dom'
 interface TeleportProps {
   to: string
   children: ReactNode
+  requireReadyAttribute?: string
 }
 
-export function Teleport({ to, children }: TeleportProps) {
+export function Teleport({ to, children, requireReadyAttribute }: TeleportProps) {
   const [container, setContainer] = useState<HTMLElement | null>(null)
 
   useEffect(() => {
     function resolveContainer() {
       const target = document.querySelector(to) as HTMLElement | null
+      if (!target) {
+        setContainer(prev => (prev === null ? prev : null))
+        return
+      }
+
+      if (requireReadyAttribute && target.getAttribute(requireReadyAttribute) !== 'true') {
+        setContainer(prev => (prev === null ? prev : null))
+        return
+      }
+
       setContainer(prev => (prev === target ? prev : target))
     }
 
     resolveContainer()
 
     const observer = new MutationObserver(resolveContainer)
-    observer.observe(document.documentElement, { childList: true, subtree: true })
+    observer.observe(document.documentElement, {
+      childList: true,
+      subtree: true,
+      attributes: Boolean(requireReadyAttribute),
+      attributeFilter: requireReadyAttribute ? [requireReadyAttribute] : undefined,
+    })
 
     return () => observer.disconnect()
-  }, [to])
+  }, [to, requireReadyAttribute])
 
   if (!container) {
     return null

--- a/tests/unit/Teleport.test.tsx
+++ b/tests/unit/Teleport.test.tsx
@@ -52,4 +52,23 @@ describe('teleport', () => {
 
     expect(document.querySelector('#teleport-sticky-target')).not.toBeNull()
   })
+
+  it('waits for target readiness attribute before rendering content', async () => {
+    document.body.innerHTML = '<div id="teleport-ready-target" data-teleport-ready="false"></div>'
+
+    render(
+      <Teleport to="#teleport-ready-target" requireReadyAttribute="data-teleport-ready">
+        <span>Ready-gated content</span>
+      </Teleport>,
+    )
+
+    expect(screen.queryByText('Ready-gated content')).not.toBeInTheDocument()
+
+    const target = document.querySelector('#teleport-ready-target')
+    target?.setAttribute('data-teleport-ready', 'true')
+
+    await waitFor(() => {
+      expect(screen.getByText('Ready-gated content')).toBeInTheDocument()
+    })
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prevents hydration mismatch in the Home toolbar by only teleporting navigation tags after the target container signals readiness. This removes hydration warnings and avoids flicker.

- **Bug Fixes**
  - Added requireReadyAttribute to Teleport to wait for a specific DOM attribute before rendering; observes DOM and attribute changes.
  - FilterToolbar sets data-teleport-ready="true" on #navigation-tags after mount.
  - NavigationTab uses Teleport with requireReadyAttribute="data-teleport-ready".
  - Added unit test to verify readiness-gated teleport behavior.

<sup>Written for commit 31ad10771780c630dd4838c0faac100118905259. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

