### PR TITLE
fix: include resolved-active events and correct sync market ordering

### DIFF
--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -725,7 +725,7 @@ async function updateEventStatusesFromMarketsBatch(eventIds: string[]) {
       .from('markets')
       .select('event_id,is_active,is_resolved')
       .in('event_id', uniqueEventIds)
-      .order('id', { ascending: true })
+      .order('condition_id', { ascending: true })
       .range(marketRowsOffset, marketRowsOffset + marketRowsPageSize - 1)
 
     if (marketRowsError) {

--- a/src/app/api/sync/resolution/route.ts
+++ b/src/app/api/sync/resolution/route.ts
@@ -718,7 +718,7 @@ async function updateEventStatusesFromMarketsBatch(eventIds: string[]) {
       .from('markets')
       .select('event_id,is_active,is_resolved')
       .in('event_id', uniqueEventIds)
-      .order('id', { ascending: true })
+      .order('condition_id', { ascending: true })
       .range(marketRowsOffset, marketRowsOffset + marketRowsPageSize - 1)
 
     if (marketRowsError) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expands the resolved filter to include events still marked active but with all markets resolved. Also orders market syncs by condition_id to ensure consistent status updates.

- **Bug Fixes**
  - Event query: when filtering by resolved, also include active events with all markets resolved.
  - Sync routes: order markets by condition_id instead of id during status sync.

<sup>Written for commit 87e0e53670bbfcec56369896bd58eb02da040189. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

