### PR TITLE
fix: dark theme override

### DIFF
--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -318,7 +318,15 @@ export function buildThemeCssText(light: ThemeOverrides, dark: ThemeOverrides, r
     blocks.push(`:root {\n${lightLines.join('\n')}\n}`)
   }
   if (darkLines.length > 0) {
-    blocks.push(`.dark {\n${darkLines.join('\n')}\n}`)
+    blocks.push(
+      `
+.dark,
+[data-theme-mode='dark'],
+.dark[data-theme-preset],
+[data-theme-mode='dark'][data-theme-preset] {
+${darkLines.join('\n')}
+}`.trim(),
+    )
   }
 
   return blocks.join('\n')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure dark theme overrides apply correctly across both class-based and data-attribute dark modes, even when a theme preset is set. This prevents preset-specific dark values from blocking user overrides.

- **Bug Fixes**
  - Expanded dark selectors to include `.dark`, `[data-theme-mode='dark']`, and both with `[data-theme-preset]`.
  - Added tests to verify dark overrides take precedence over preset-specific values (e.g., background).

<sup>Written for commit 6cc218c6e745bacec41b89dc6b30a3c5b5e69acf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

