### PR TITLE
style: standardize classnames with cn usage

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCard.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCard.tsx
@@ -29,6 +29,7 @@ import { buildChanceByMarket } from '@/lib/market-chance'
 import { buildOrderPayload, submitOrder } from '@/lib/orders'
 import { signOrderPayload } from '@/lib/orders/signing'
 import { validateOrder } from '@/lib/orders/validation'
+import { cn } from '@/lib/utils'
 import { isUserRejectedRequestError, normalizeAddress } from '@/lib/wallet'
 import { useUser } from '@/stores/useUser'
 
@@ -276,20 +277,18 @@ export default function EventCard({ event, priceOverridesByMarket = EMPTY_PRICE_
   return (
     <Card
       className={
-        `
-          flex h-45 cursor-pointer flex-col transition-all
+        cn(`
+          flex h-45 cursor-pointer flex-col overflow-hidden transition-all
           hover:-translate-y-0.5 hover:bg-(--card-hover) hover:shadow-lg
-          ${isInTradingMode ? 'ring-2 ring-primary/20' : ''}
-          overflow-hidden
-        `
+        `, { 'ring-2 ring-primary/20': isInTradingMode })
       }
     >
       <CardContent
         className={
-          `
+          cn(`
             flex h-full flex-col px-3 pt-3
             ${isResolvedEvent ? 'pb-3' : 'pb-1'}
-          `
+          `)
         }
       >
         <EventCardHeader
@@ -326,11 +325,11 @@ export default function EventCard({ event, priceOverridesByMarket = EMPTY_PRICE_
             : (
                 <div
                   className={
-                    isResolvedEvent && isSingleMarket
+                    cn(isResolvedEvent && isSingleMarket
                       ? 'mt-6'
                       : isResolvedEvent && !isSingleMarket
                         ? 'mt-1'
-                        : 'mt-auto'
+                        : 'mt-auto')
                   }
                 >
                   {!isSingleMarket && (

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardHeader.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardHeader.tsx
@@ -5,6 +5,7 @@ import Image from 'next/image'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { Link } from '@/i18n/navigation'
 import { OUTCOME_INDEX } from '@/lib/constants'
+import { cn } from '@/lib/utils'
 
 function normalizeOutcomeText(value: string | null | undefined) {
   return value?.trim().toLowerCase() ?? ''
@@ -129,13 +130,13 @@ export default function EventCardHeader({
                       strokeWidth="5"
                       strokeLinecap="round"
                       className={
-                        `transition-all duration-300 ${
+                        cn(`transition-all duration-300 ${
                           roundedPrimaryDisplayChance < 40
                             ? 'text-no'
                             : roundedPrimaryDisplayChance === 50
                               ? 'text-slate-400'
                               : 'text-yes'
-                        }`
+                        }`)
                       }
                       strokeDasharray={`${(roundedPrimaryDisplayChance / 100) * 94.25} 94.25`}
                       strokeDashoffset="0"

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
@@ -4,6 +4,7 @@ import { Button } from '@/components/ui/button'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { Link } from '@/i18n/navigation'
 import { OUTCOME_INDEX } from '@/lib/constants'
+import { cn } from '@/lib/utils'
 
 interface EventCardMarketsListProps {
   event: Event
@@ -70,9 +71,9 @@ export default function EventCardMarketsList({
                     resolvedOutcome
                       ? (
                           <span className="inline-flex items-center gap-2 text-sm font-semibold text-foreground">
-                            <span className={`flex size-4 items-center justify-center rounded-full ${isYesOutcome
+                            <span className={cn(`flex size-4 items-center justify-center rounded-full ${isYesOutcome
                               ? `bg-yes`
-                              : `bg-no`}`}
+                              : `bg-no`}`)}
                             >
                               {isYesOutcome
                                 ? <CheckIcon className="size-3 text-background" strokeWidth={2.5} />

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
@@ -3,6 +3,7 @@ import { CheckIcon, XIcon } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { OUTCOME_INDEX } from '@/lib/constants'
+import { cn } from '@/lib/utils'
 
 interface EventCardSingleMarketActionsProps {
   yesOutcome: Outcome
@@ -43,9 +44,9 @@ export default function EventCardSingleMarketActions({
               `}
               >
                 <span className="min-w-8 text-right">{resolvedLabel}</span>
-                <span className={`flex size-4 items-center justify-center rounded-full ${isYesOutcome
+                <span className={cn(`flex size-4 items-center justify-center rounded-full ${isYesOutcome
                   ? 'bg-yes'
-                  : `bg-no`}`}
+                  : `bg-no`}`)}
                 >
                   {isYesOutcome
                     ? <CheckIcon className="size-3 text-background" strokeWidth={2.5} />

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardTradePanel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardTradePanel.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { MAX_AMOUNT_INPUT, sanitizeNumericInput } from '@/lib/amount-input'
 import { formatAmountInputValue } from '@/lib/formatters'
+import { cn } from '@/lib/utils'
 
 interface EventCardTradePanelProps {
   activeOutcome: SelectedOutcome
@@ -87,12 +88,12 @@ export default function EventCardTradePanel({
       <div className="grid grid-cols-5 gap-4">
         <div
           className={
-            `
+            cn(`
               relative col-span-3 flex items-center gap-0 rounded-md border px-2 py-2.5 transition-colors
               ${amountNumber > availableBalance ? 'border-red-500' : 'border-border/70'}
               bg-background
               focus-within:border-border focus-within:ring-0
-            `
+            `)
           }
         >
           <DollarSignIcon className="size-3 text-foreground" />

--- a/src/app/[locale]/(platform)/(home)/_components/FilterToolbar.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/FilterToolbar.tsx
@@ -275,7 +275,7 @@ function SettingsToggle({ isActive, isOpen, onToggle }: SettingsToggleProps) {
           hover:bg-transparent hover:text-muted-foreground
           md:size-9
         `,
-        (isOpen || isActive) && 'bg-muted/70 text-foreground hover:bg-muted/70 hover:text-foreground',
+        { 'bg-muted/70 text-foreground hover:bg-muted/70 hover:text-foreground': isOpen || isActive },
       )}
       title={t('Open filters')}
       aria-label={t('Open filters')}

--- a/src/app/[locale]/(platform)/[username]/_components/PublicActivityError.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicActivityError.tsx
@@ -37,7 +37,7 @@ export default function PublicActivityError({
                   className="flex items-center gap-2"
                   disabled={isLoading}
                 >
-                  <RefreshCwIcon className={cn('size-3', isLoading && 'animate-spin')} />
+                  <RefreshCwIcon className={cn('size-3', { 'animate-spin': isLoading })} />
                   {isLoading ? 'Retrying...' : 'Try again'}
                 </Button>
                 {retryCount > 2 && (

--- a/src/app/[locale]/(platform)/[username]/_components/PublicActivityFeedList.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicActivityFeedList.tsx
@@ -207,7 +207,7 @@ export default function PublicActivityFeedList({ userAddress }: PublicActivityFe
                         className="flex items-center gap-2"
                         disabled={isLoadingMore}
                       >
-                        <RefreshCwIcon className={cn('size-3', isLoadingMore && 'animate-spin')} />
+                        <RefreshCwIcon className={cn('size-3', { 'animate-spin': isLoadingMore })} />
                         {isLoadingMore ? 'Retrying...' : 'Try again'}
                       </Button>
                       {retryCount > 2 && (

--- a/src/app/[locale]/(platform)/[username]/_components/PublicPositionItem.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicPositionItem.tsx
@@ -4,6 +4,7 @@ import type { Route } from 'next'
 import Image from 'next/image'
 import { Link } from '@/i18n/navigation'
 import { formatCurrency, formatSharesLabel, formatTimeAgo } from '@/lib/formatters'
+import { cn } from '@/lib/utils'
 
 export interface PublicPosition {
   id: string
@@ -68,13 +69,13 @@ export default function PublicPositionItem({ item }: PositionItemProps) {
           </h4>
 
           <div className="flex flex-col gap-1 text-xs sm:flex-row sm:items-center sm:gap-2">
-            <span className={`
+            <span className={cn(`
               inline-flex w-fit rounded-md px-2 py-1 text-xs font-medium
               ${item.status === 'active'
       ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300'
       : 'bg-gray-100 text-gray-800 dark:bg-gray-900/30 dark:text-gray-300'
     }
-            `}
+            `)}
             >
               {item.status === 'active' ? 'Active' : 'Closed'}
             </span>

--- a/src/app/[locale]/(platform)/[username]/_components/PublicPositionItemSkeleton.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicPositionItemSkeleton.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
 
 interface PositionItemSkeletonProps {
   isInfiniteScroll?: boolean
@@ -8,12 +9,11 @@ interface PositionItemSkeletonProps {
 
 export default function PublicPositionItemSkeleton({ isInfiniteScroll = false }: PositionItemSkeletonProps) {
   return (
-    <div className={`
+    <div className={cn(`
       flex items-center gap-3 border-b border-border px-3 py-4 transition-colors
       last:border-b-0
       sm:gap-4 sm:px-5
-      ${isInfiniteScroll ? 'animate-pulse' : ''}
-    `}
+    `, { 'animate-pulse': isInfiniteScroll })}
     >
       <div className="flex min-w-0 flex-1 items-center gap-2 sm:gap-3">
 

--- a/src/app/[locale]/(platform)/[username]/_components/PublicPositionsError.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicPositionsError.tsx
@@ -51,7 +51,7 @@ export default function PublicPositionsError({
                     className="flex items-center gap-2"
                     disabled={isLoading}
                   >
-                    <RefreshCwIcon className={cn('size-3', isLoading && 'animate-spin')} />
+                    <RefreshCwIcon className={cn('size-3', { 'animate-spin': isLoading })} />
                     {isLoading ? 'Retrying...' : 'Try again'}
                   </Button>
                 )}

--- a/src/app/[locale]/(platform)/[username]/_components/PublicPositionsInfiniteScrollError.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicPositionsInfiniteScrollError.tsx
@@ -50,7 +50,7 @@ export default function PublicPositionsInfiniteScrollError({
                   className="flex items-center gap-2"
                   disabled={isLoadingMore}
                 >
-                  <RefreshCwIcon className={cn('size-3', isLoadingMore && 'animate-spin')} />
+                  <RefreshCwIcon className={cn('size-3', { 'animate-spin': isLoadingMore })} />
                   {isLoadingMore ? 'Retrying...' : 'Try again'}
                 </Button>
               )}

--- a/src/app/[locale]/(platform)/[username]/_components/PublicPositionsTable.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicPositionsTable.tsx
@@ -38,7 +38,7 @@ function SortHeaderButton({
           transition-colors
           hover:bg-muted/70 hover:shadow-sm
         `,
-        isActive && 'text-foreground',
+        { 'text-foreground': isActive },
       )}
     >
       <span>{label}</span>

--- a/src/app/[locale]/(platform)/[username]/_components/PublicProfileTabs.tsx
+++ b/src/app/[locale]/(platform)/[username]/_components/PublicProfileTabs.tsx
@@ -70,7 +70,7 @@ export default function PublicProfileTabs({ userAddress }: PublicProfileTabsProp
         <div
           className={cn(
             'pointer-events-none absolute bottom-0 h-0.5 bg-primary',
-            isInitialized && 'transition-all duration-300 ease-out',
+            { 'transition-all duration-300 ease-out': isInitialized },
           )}
           style={{
             left: `${indicatorStyle.left}px`,

--- a/src/app/[locale]/(platform)/_components/HeaderHowItWorks.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderHowItWorks.tsx
@@ -121,7 +121,7 @@ export default function HeaderHowItWorks() {
       </DialogTrigger>
 
       {showMobileBanner && (
-        <div className="fixed right-0 bottom-0 left-0 z-40 border-t bg-background sm:hidden" data-testid="how-it-works-mobile-banner">
+        <div className="fixed inset-x-0 bottom-0 z-40 border-t bg-background sm:hidden" data-testid="how-it-works-mobile-banner">
           <div className="container flex items-center justify-between gap-2 py-3">
             <DialogTrigger asChild>
               <Button
@@ -171,7 +171,7 @@ export default function HeaderHowItWorks() {
                 key={step.title}
                 className={cn(
                   'h-1.5 w-8 rounded-full bg-muted transition-colors',
-                  index === activeStep && 'bg-primary',
+                  { 'bg-primary': index === activeStep },
                 )}
               />
             ))}

--- a/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
@@ -7,6 +7,7 @@ import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { getAvatarPlaceholderStyle } from '@/lib/avatar'
+import { cn } from '@/lib/utils'
 import {
   isLocalOrderFillNotification,
   useNotificationList,
@@ -149,17 +150,17 @@ export default function HeaderNotifications() {
                 const isLocalOrderFill = isLocalOrderFillNotification(notification)
                 const linkIcon = (
                   <ExternalLinkIcon
-                    className={`size-3 text-muted-foreground ${hasLink ? '' : 'opacity-0'}`}
+                    className={cn('size-3 text-muted-foreground', { 'opacity-0': !(hasLink) })}
                   />
                 )
 
                 return (
                   <div
                     key={notification.id}
-                    className={`
+                    className={cn(`
                       flex items-start gap-3 p-3 transition-colors hover:bg-accent/50
                       ${isLocalOrderFill ? 'cursor-pointer' : 'cursor-default'}
-                    `}
+                    `)}
                     role={isLocalOrderFill ? 'button' : undefined}
                     tabIndex={isLocalOrderFill ? 0 : undefined}
                     onClick={isLocalOrderFill ? () => handleLocalOrderFillClick(notification) : undefined}

--- a/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
@@ -7,6 +7,7 @@ import { SearchResults } from '@/app/[locale]/(platform)/_components/SearchResul
 import { Input } from '@/components/ui/input'
 import { useSearch } from '@/hooks/useSearch'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
+import { cn } from '@/lib/utils'
 
 export default function HeaderSearch() {
   const searchRef = useRef<HTMLDivElement>(null)
@@ -74,14 +75,16 @@ export default function HeaderSearch() {
         placeholder={`${t('Search')} ${sitename}`}
         value={query}
         onChange={e => handleQueryChange(e.target.value)}
-        className={`
-          h-12 w-full pr-12 pl-11 shadow-none transition-colors lg:h-10
-          ${inputBorderClass}
-          ${inputBaseClass}
-          ${showDropdown ? 'rounded-b-none' : ''}
-          ${inputHoverClass}
-          focus-visible:border-border ${inputFocusClass} focus-visible:ring-0 focus-visible:ring-offset-0
-        `}
+        className={cn(
+          'h-12 w-full pr-12 pl-11 shadow-none transition-colors lg:h-10',
+          inputBorderClass,
+          inputBaseClass,
+          { 'rounded-b-none': showDropdown },
+          inputHoverClass,
+          'focus-visible:border-border',
+          inputFocusClass,
+          'focus-visible:ring-0 focus-visible:ring-offset-0',
+        )}
       />
       {query.length > 0
         ? (

--- a/src/app/[locale]/(platform)/_components/NavigationTab.tsx
+++ b/src/app/[locale]/(platform)/_components/NavigationTab.tsx
@@ -339,13 +339,13 @@ export default function NavigationTab({ tag, childParentMap, tabIndex }: Navigat
       {tag.slug === 'mentions' && (
         <Link
           href="/mentions"
-          className={`
-            inline-flex h-full items-center justify-center rounded-md py-1 whitespace-nowrap ${mainTabPadding}
-            ${
-        isActive
-          ? 'border-primary font-semibold text-foreground'
-          : 'border-transparent text-muted-foreground hover:text-foreground'
-        }`}
+          className={cn(
+            'inline-flex h-full items-center justify-center rounded-md py-1 whitespace-nowrap',
+            mainTabPadding,
+            isActive
+              ? 'border-primary font-semibold text-foreground'
+              : 'border-transparent text-muted-foreground hover:text-foreground',
+          )}
         >
           <span>{tag.name}</span>
         </Link>
@@ -356,14 +356,14 @@ export default function NavigationTab({ tag, childParentMap, tabIndex }: Navigat
           <Link
             href={'/' as Route}
             onClick={() => handleTagClick(tag.slug)}
-            className={`
-              inline-flex h-full items-center justify-center rounded-md py-1 whitespace-nowrap ${mainTabPadding}
-              ${tag.slug === 'trending' ? 'gap-2' : ''}
-              ${
-        isActive
-          ? 'border-primary font-semibold text-foreground'
-          : 'border-transparent text-muted-foreground hover:text-foreground'
-        }`}
+            className={cn(
+              'inline-flex h-full items-center justify-center rounded-md py-1 whitespace-nowrap',
+              mainTabPadding,
+              { 'gap-2': tag.slug === 'trending' },
+              isActive
+                ? 'border-primary font-semibold text-foreground'
+                : 'border-transparent text-muted-foreground hover:text-foreground',
+            )}
           >
             {tag.slug === 'trending' && <TrendingUpIcon className="size-4" />}
             <span>{tag.name}</span>
@@ -398,7 +398,7 @@ export default function NavigationTab({ tag, childParentMap, tabIndex }: Navigat
               <div
                 className={cn(
                   'pointer-events-none absolute inset-y-0 rounded-sm bg-primary/30',
-                  indicatorReady && 'transition-all duration-300 ease-out',
+                  { 'transition-all duration-300 ease-out': indicatorReady },
                 )}
                 style={{
                   left: `${indicatorStyle.left}px`,

--- a/src/app/[locale]/(platform)/_components/ProfileOverviewCard.tsx
+++ b/src/app/[locale]/(platform)/_components/ProfileOverviewCard.tsx
@@ -250,7 +250,7 @@ export default function ProfileOverviewCard({
                           key={stat.label}
                           className={cn(
                             'flex h-full flex-col rounded-lg bg-background/40 p-2 shadow-sm',
-                            index > 0 && 'border-l',
+                            { 'border-l': index > 0 },
                           )}
                         >
                           <p className="text-sm font-medium text-muted-foreground">

--- a/src/app/[locale]/(platform)/_components/SearchTabs.tsx
+++ b/src/app/[locale]/(platform)/_components/SearchTabs.tsx
@@ -97,7 +97,7 @@ export function SearchTabs({
         <div
           className={cn(
             'absolute bottom-0 h-0.5 bg-primary',
-            isInitialized && 'transition-all duration-300 ease-out',
+            { 'transition-all duration-300 ease-out': isInitialized },
           )}
           style={{
             left: `${indicatorStyle.left}px`,

--- a/src/app/[locale]/(platform)/_components/TradingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingDialogs.tsx
@@ -253,7 +253,7 @@ function TradingRequirementStep({
           : (
               <Button
                 size="sm"
-                className={cn('min-w-27.5', isLoading && 'pointer-events-none opacity-80')}
+                className={cn('min-w-27.5', { 'pointer-events-none opacity-80': isLoading })}
                 disabled={Boolean(disabled) || isLoading}
                 onClick={onAction}
               >

--- a/src/app/[locale]/(platform)/_components/WalletModal.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletModal.tsx
@@ -39,6 +39,7 @@ import { formatDisplayAmount, getAmountSizeClass, MAX_AMOUNT_INPUT, sanitizeNume
 import { POLYGON_SCAN_BASE } from '@/lib/constants'
 import { formatAmountInputValue } from '@/lib/formatters'
 import { IS_TEST_MODE } from '@/lib/network'
+import { cn } from '@/lib/utils'
 
 const MELD_PAYMENT_METHODS = [
   'apple_pay',
@@ -342,7 +343,7 @@ function WalletSendForm({
               value={sendTo}
               onChange={onChangeSendTo}
               placeholder="0x..."
-              className={`${showConnectedWalletButton ? 'pr-28' : ''} h-12 text-sm placeholder:text-sm`}
+              className={cn('h-12 text-sm placeholder:text-sm', { 'pr-28': showConnectedWalletButton })}
               required
             />
             {showConnectedWalletButton && (
@@ -488,7 +489,7 @@ function WalletSendForm({
             <span className="flex items-center gap-1">
               {!isBreakdownOpen && <span>0.00%</span>}
               <ChevronRightIcon
-                className={`size-4 transition ${isBreakdownOpen ? 'rotate-90' : ''}`}
+                className={cn('size-4 transition', { 'rotate-90': isBreakdownOpen })}
               />
             </span>
           </button>
@@ -895,11 +896,14 @@ function WalletTokenList({
                     onSelect(item.id)
                   }
                 }}
-                className={`
-                  flex w-full items-center justify-between rounded-lg px-3 py-1.5 text-left transition
-                  ${isSelected ? 'border border-foreground/20' : 'border border-transparent'}
-                  ${isDisabled ? 'cursor-not-allowed opacity-50' : isSelected ? '' : 'hover:bg-muted/50'}
-                `}
+                className={cn(
+                  'flex w-full items-center justify-between rounded-lg px-3 py-1.5 text-left transition',
+                  isSelected ? 'border border-foreground/20' : 'border border-transparent',
+                  {
+                    'cursor-not-allowed opacity-50': isDisabled,
+                    'hover:bg-muted/50': !isDisabled && !isSelected,
+                  },
+                )}
               >
                 <div className="flex items-center gap-3">
                   <Tooltip>
@@ -1092,10 +1096,7 @@ function WalletAmountStep({
           <button
             key={label}
             type="button"
-            className={`
-              rounded-md bg-muted/60 px-4 py-2 text-sm text-foreground transition hover:bg-muted
-              ${!hasAvailableTokenAmount ? 'cursor-not-allowed opacity-50' : ''}
-            `}
+            className={cn('rounded-md bg-muted/60 px-4 py-2 text-sm text-foreground transition hover:bg-muted', { 'cursor-not-allowed opacity-50': !hasAvailableTokenAmount })}
             disabled={!hasAvailableTokenAmount}
             onClick={() => handleQuickFill(label)}
           >
@@ -1448,7 +1449,7 @@ function WalletConfirmStep({
               : (
                   <>
                     {!isBreakdownOpen && <span>{gasUsdDisplay ? `$${gasUsdDisplay}` : '—'}</span>}
-                    <ChevronRightIcon className={`size-3 transition ${isBreakdownOpen ? 'rotate-90' : ''}`} />
+                    <ChevronRightIcon className={cn('size-3 transition', { 'rotate-90': isBreakdownOpen })} />
                   </>
                 )}
           </span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/ConnectionStatusIndicator.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/ConnectionStatusIndicator.tsx
@@ -22,9 +22,9 @@ export default function ConnectionStatusIndicator({
           <span
             className={cn(
               'relative inline-flex size-2 rounded-full',
-              status === 'live' && 'bg-yes',
-              status === 'connecting' && 'bg-amber-500',
-              status === 'offline' && 'bg-muted-foreground/40',
+              { 'bg-yes': status === 'live' },
+              { 'bg-amber-500': status === 'connecting' },
+              { 'bg-muted-foreground/40': status === 'offline' },
             )}
           />
         </span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventBookmark.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventBookmark.tsx
@@ -68,7 +68,7 @@ export default function EventBookmark({ event }: EventBookmarkProps) {
       className={cn(
         headerIconButtonClass,
         'size-auto p-0',
-        isPending && 'opacity-50',
+        { 'opacity-50': isPending },
       )}
     >
       <BookmarkIcon className={cn({ 'fill-current text-primary': isBookmarked })} />

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -45,6 +45,7 @@ import { useWindowSize } from '@/hooks/useWindowSize'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { formatSharePriceLabel } from '@/lib/formatters'
 import { resolveDisplayPrice } from '@/lib/market-chance'
+import { cn } from '@/lib/utils'
 import { useIsSingleMarket } from '@/stores/useOrder'
 import { loadStoredChartSettings, storeChartSettings } from '../_utils/chartSettingsStorage'
 import EventChartControls, { defaultChartSettings } from './EventChartControls'
@@ -829,7 +830,7 @@ function EventChartComponent({ event, isMobile, seriesEvents = [] }: EventChartP
                     {tradeFlowItems.map(item => (
                       <span
                         key={item.id}
-                        className={`${item.outcome === 'yes' ? 'text-yes' : 'text-no'} animate-trade-flow-rise`}
+                        className={cn(`${item.outcome === 'yes' ? 'text-yes' : 'text-no'} animate-trade-flow-rise`)}
                         style={tradeFlowTextStrokeStyle}
                       >
                         +

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartHeader.tsx
@@ -171,7 +171,7 @@ export default function EventChartHeader({
                   `}
                 >
                   <span>Past</span>
-                  <ChevronDownIcon className={cn('size-4 transition-transform', isPastMenuOpen && 'rotate-180')} />
+                  <ChevronDownIcon className={cn('size-4 transition-transform', { 'rotate-180': isPastMenuOpen })} />
                 </button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="max-h-72 min-w-44 overflow-y-auto p-1">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
@@ -24,6 +24,7 @@ import { Teleport } from '@/components/Teleport'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { ORDER_SIDE, ORDER_TYPE } from '@/lib/constants'
 import { formatAmountInputValue } from '@/lib/formatters'
+import { cn } from '@/lib/utils'
 import { useOrder, useSyncLimitPriceWithOutcome } from '@/stores/useOrder'
 import { useUser } from '@/stores/useUser'
 import EventChart from './EventChart'
@@ -273,10 +274,10 @@ export default function EventContent({
     <EventMarketChannelProvider markets={event.markets}>
       <EventOutcomeChanceProvider eventId={event.id}>
         <OrderLimitPriceSync />
-        <div className={shouldHideChart ? 'grid gap-2' : 'grid gap-3'} ref={contentRef}>
+        <div className={cn(shouldHideChart ? 'grid gap-2' : 'grid gap-3')} ref={contentRef}>
           <EventHeader event={event} />
 
-          <div className={shouldHideChart ? 'w-full' : 'min-h-96 w-full'}>
+          <div className={cn(shouldHideChart ? 'w-full' : 'min-h-96 w-full')}>
             <EventChart event={event} isMobile={isMobile} seriesEvents={seriesEvents} />
           </div>
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventConvertPositionsDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventConvertPositionsDialog.tsx
@@ -398,7 +398,7 @@ export default function EventConvertPositionsDialog({
                 htmlFor={checkboxId}
                 className={cn(
                   `flex items-center gap-3 px-3 py-2.5 text-sm transition-colors`,
-                  index < options.length - 1 && 'border-b',
+                  { 'border-b': index < options.length - 1 },
                   selectedIds.has(option.id) ? 'opacity-100' : 'opacity-80',
                 )}
               >

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
@@ -25,7 +25,7 @@ export default function EventHeader({ event }: EventHeaderProps) {
     <div
       className={cn(
         'relative z-10 -mx-4 flex items-center gap-3 px-4 transition-all ease-in-out',
-        scrolled ? 'sticky top-26 translate-y-1 bg-background py-3 pr-6 md:translate-y-3 lg:top-28 lg:translate-y-1' : '',
+        { 'sticky top-26 translate-y-1 bg-background py-3 pr-6 md:translate-y-3 lg:top-28 lg:translate-y-1': scrolled },
       )}
     >
       {scrolled && (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChance.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChance.tsx
@@ -44,7 +44,7 @@ export default function EventMarketChance({
     <div
       className={cn(
         'flex flex-col items-end gap-1',
-        layout === 'desktop' && 'flex-row items-center gap-2',
+        { 'flex-row items-center gap-2': layout === 'desktop' },
       )}
     >
       <div className="flex items-center justify-end gap-1.5">
@@ -81,12 +81,12 @@ export default function EventMarketChance({
           className={cn(
             'flex items-center justify-end gap-0.5 text-xs font-semibold',
             chanceChangeColorClass,
-            !chanceMeta.shouldShowChanceChange && 'invisible',
-            layout === 'desktop' && 'w-[5.5ch]',
+            { invisible: !chanceMeta.shouldShowChanceChange },
+            { 'w-[5.5ch]': layout === 'desktop' },
           )}
         >
           <TriangleIcon
-            className={cn('size-3 fill-current', chanceMeta.isChanceChangePositive ? '' : 'rotate-180')}
+            className={cn('size-3 fill-current', { 'rotate-180': !chanceMeta.isChanceChangePositive })}
             fill="currentColor"
           />
           <span className="inline-block tabular-nums">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
@@ -190,7 +190,7 @@ export default function EventMarketContext({ event }: EventMarketContextProps) {
                   focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
                   focus-visible:ring-offset-background focus-visible:outline-none
                 `,
-                isContentExpanded ? 'rounded-b-none' : '',
+                { 'rounded-b-none': isContentExpanded },
               )}
               disabled={isPending || !state.market}
             >
@@ -208,19 +208,16 @@ export default function EventMarketContext({ event }: EventMarketContextProps) {
           )}
 
       <div
-        className={`
+        className={cn(`
           grid overflow-hidden transition-all duration-500 ease-in-out
           ${isContentExpanded
       ? 'pointer-events-auto grid-rows-[1fr] opacity-100'
       : 'pointer-events-none grid-rows-[0fr] opacity-0'}
-        `}
+        `)}
         aria-hidden={!isContentExpanded}
       >
         <div
-          className={`
-            min-h-0 overflow-hidden
-            ${isContentExpanded ? 'border-t border-border/30' : ''}
-          `}
+          className={cn('min-h-0 overflow-hidden', { 'border-t border-border/30': isContentExpanded })}
         >
           <div className="space-y-3 p-3">
             {error && (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
@@ -119,7 +119,7 @@ export default function EventMarketHistory({ market }: EventMarketHistoryProps) 
             <h3 className="text-base font-medium">{t('History')}</h3>
           </div>
         )}
-        <div className={cn(isSingleMarket ? 'border-t' : '', 'p-4')}>
+        <div className={cn({ 'border-t': isSingleMarket }, 'p-4')}>
           <AlertBanner
             title={t('Failed to load activity')}
             description={(
@@ -243,14 +243,14 @@ export default function EventMarketHistory({ market }: EventMarketHistoryProps) 
       </div>
 
       {isFetchingNextPage && (
-        <div className={cn(isSingleMarket ? 'border-t' : '', `px-4 py-3 text-center text-xs text-muted-foreground`)}>
+        <div className={cn({ 'border-t': isSingleMarket }, `px-4 py-3 text-center text-xs text-muted-foreground`)}>
           <Loader2Icon className="mr-2 inline size-4 animate-spin align-middle" />
           {t('Loading more history...')}
         </div>
       )}
 
       {infiniteScrollError && (
-        <div className={cn(isSingleMarket ? 'border-t' : '', 'px-4 py-3')}>
+        <div className={cn({ 'border-t': isSingleMarket }, 'px-4 py-3')}>
           <AlertBanner
             title={t('Failed to load more activity')}
             description={(

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
@@ -127,9 +127,9 @@ function SortHeaderButton({
       type="button"
       className={cn(
         'group flex w-full items-center gap-2 whitespace-nowrap uppercase transition-colors',
-        alignment === 'center' && 'justify-center',
-        alignment === 'right' && 'justify-end',
-        alignment === 'left' && 'justify-start',
+        { 'justify-center': alignment === 'center' },
+        { 'justify-end': alignment === 'right' },
+        { 'justify-start': alignment === 'left' },
       )}
       onClick={() => onSort(column)}
     >
@@ -577,13 +577,13 @@ export default function EventMarketOpenOrders({ market, eventSlug }: EventMarket
       </div>
 
       {hasOrders && isFetchingNextPage && (
-        <div className={cn(isSingleMarket ? 'border-t' : '', `px-4 py-3 text-center text-xs text-muted-foreground`)}>
+        <div className={cn({ 'border-t': isSingleMarket }, `px-4 py-3 text-center text-xs text-muted-foreground`)}>
           {t('Loading more open orders...')}
         </div>
       )}
 
       {infiniteScrollError && (
-        <div className={cn(isSingleMarket ? 'border-t' : '', 'px-4 py-3')}>
+        <div className={cn({ 'border-t': isSingleMarket }, 'px-4 py-3')}>
           <AlertBanner
             title={t('Could not load more open orders')}
             description={(

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -1070,7 +1070,7 @@ function MarketDetailTabs({
               <RefreshCwIcon
                 className={cn(
                   'size-3',
-                  (orderBookData.isLoading || orderBookData.isRefetching) && 'animate-spin',
+                  { 'animate-spin': orderBookData.isLoading || orderBookData.isRefetching },
                 )}
               />
             </button>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBookRow.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBookRow.tsx
@@ -69,7 +69,7 @@ export default function EventOrderBookRow({
                     className={cn(
                       'group inline-flex size-5 items-center justify-center text-base transition-colors',
                       userOrder.side === 'ask' ? 'text-no' : 'text-yes',
-                      isCancelling && 'cursor-not-allowed opacity-60',
+                      { 'cursor-not-allowed opacity-60': isCancelling },
                     )}
                   >
                     {isCancelling
@@ -137,11 +137,11 @@ export default function EventOrderBookRow({
       {showBadge && (
         <span
           className={
-            `
+            cn(`
               absolute top-1/2 left-2 -translate-y-1/2 rounded-sm px-1.5 py-0.5 text-2xs font-semibold uppercase
               sm:left-3
               ${showBadge === 'ask' ? 'bg-no text-white' : 'bg-yes text-white'}
-            `
+            `)
           }
         >
           {showBadge === 'ask' ? t('Asks') : t('Bids')}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
@@ -142,7 +142,7 @@ export default function EventOrderPanelBuySellTabs({
                 dark:focus-visible:bg-transparent!
                 dark:active:bg-transparent!
               `,
-              side === ORDER_SIDE.BUY && 'border-foreground text-foreground',
+              { 'border-foreground text-foreground': side === ORDER_SIDE.BUY },
             )}
             onClick={() => handleSideChange(ORDER_SIDE.BUY)}
           >
@@ -163,7 +163,7 @@ export default function EventOrderPanelBuySellTabs({
                 dark:focus-visible:bg-transparent!
                 dark:active:bg-transparent!
               `,
-              side === ORDER_SIDE.SELL && 'border-foreground text-foreground',
+              { 'border-foreground text-foreground': side === ORDER_SIDE.SELL },
             )}
             onClick={() => handleSideChange(ORDER_SIDE.SELL)}
           >
@@ -181,7 +181,7 @@ export default function EventOrderPanelBuySellTabs({
                   transition-colors duration-200
                   focus:outline-none
                   focus-visible:ring-0 focus-visible:ring-offset-0 focus-visible:outline-none
-                `, typeMenuOpen && 'text-foreground')}
+                `, { 'text-foreground': typeMenuOpen })}
                 aria-haspopup="menu"
                 aria-expanded={typeMenuOpen}
               >
@@ -193,7 +193,7 @@ export default function EventOrderPanelBuySellTabs({
                       group-hover:rotate-180
                       group-data-[state=open]:rotate-180
                     `,
-                    typeMenuOpen && 'text-foreground',
+                    { 'text-foreground': typeMenuOpen },
                   )}
                 />
               </button>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelEarnings.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelEarnings.tsx
@@ -90,10 +90,10 @@ export default function EventOrderPanelEarnings({
   )
 
   return (
-    <div className={`${isMobile ? 'mb-4 text-center' : 'mb-4'}`}>
+    <div className={cn(`${isMobile ? 'mb-4 text-center' : 'mb-4'}`)}>
       {!isMobile && <hr className="mb-3 border" />}
       <div className={cn('flex', isMobile ? 'flex-col' : 'items-center justify-between')}>
-        <div className={isMobile ? 'mb-1' : ''}>
+        <div className={cn({ 'mb-1': isMobile })}>
           <div className={cn(
             'flex items-center gap-1 font-bold text-foreground',
             isMobile ? 'justify-center text-lg' : 'text-sm',
@@ -109,7 +109,7 @@ export default function EventOrderPanelEarnings({
                       alt=""
                       width={20}
                       height={14}
-                      className={isMobile ? 'h-5 w-8' : 'ml-1 h-4 w-6'}
+                      className={cn(isMobile ? 'h-5 w-8' : 'ml-1 h-4 w-6')}
                     />
                   </span>
                 </TooltipTrigger>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput.tsx
@@ -120,7 +120,7 @@ export default function EventOrderPanelInput({
           variant="outline"
           className={cn(
             'text-xs',
-            isDisabled && 'cursor-not-allowed opacity-50',
+            { 'cursor-not-allowed opacity-50': isDisabled },
           )}
           disabled={isDisabled}
           onClick={() => {
@@ -197,7 +197,7 @@ export default function EventOrderPanelInput({
                         [&::-webkit-outer-spin-button]:appearance-none
                       `,
                       amountSizeClass,
-                      shouldShake && 'animate-order-shake',
+                      { 'animate-order-shake': shouldShake },
                     )}
                     placeholder={side === ORDER_SIDE.SELL ? '0' : '$0'}
                     value={inputValue}
@@ -256,7 +256,7 @@ export default function EventOrderPanelInput({
                       [&::-webkit-outer-spin-button]:appearance-none
                     `,
                     amountSizeClass,
-                    shouldShake && 'animate-order-shake',
+                    { 'animate-order-shake': shouldShake },
                   )}
                   placeholder={side === ORDER_SIDE.SELL ? '0' : '$0'}
                   value={inputValue}
@@ -280,7 +280,7 @@ export default function EventOrderPanelInput({
           variant="outline"
           className={cn(
             'text-xs',
-            side === ORDER_SIDE.SELL && availableShares <= 0 && 'cursor-not-allowed opacity-50',
+            { 'cursor-not-allowed opacity-50': side === ORDER_SIDE.SELL && availableShares <= 0 },
           )}
           disabled={side === ORDER_SIDE.SELL && availableShares <= 0}
           onClick={() => {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
@@ -281,7 +281,7 @@ export default function EventOrderPanelLimitControls({
           <span
             className={cn(
               'text-lg font-medium text-foreground',
-              shouldShakeShares && 'animate-order-shake',
+              { 'animate-order-shake': shouldShakeShares },
             )}
           >
             {t('Shares')}
@@ -296,7 +296,7 @@ export default function EventOrderPanelLimitControls({
               className={cn(
                 'h-10 bg-transparent! text-right font-bold',
                 limitSharesSizeClass,
-                shouldShakeShares && 'animate-order-shake',
+                { 'animate-order-shake': shouldShakeShares },
               )}
             />
           </div>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
@@ -202,7 +202,7 @@ export default function EventRules({ event }: EventRulesProps) {
 
   const resolverBlock = (
     <div className="rounded-lg border p-3">
-      <div className={hasResolutionSourceUrl ? 'flex items-center' : 'flex items-center justify-between'}>
+      <div className={cn(hasResolutionSourceUrl ? 'flex items-center' : 'flex items-center justify-between')}>
         {resolverDetails}
         {!hasResolutionSourceUrl && (
           proposeUrl
@@ -288,19 +288,16 @@ export default function EventRules({ event }: EventRulesProps) {
       </button>
 
       <div
-        className={`
+        className={cn(`
           grid overflow-hidden transition-all duration-500 ease-in-out
           ${isExpanded
       ? 'pointer-events-auto grid-rows-[1fr] opacity-100'
       : 'pointer-events-none grid-rows-[0fr] opacity-0'}
-        `}
+        `)}
         aria-hidden={!isExpanded}
       >
         <div
-          className={`
-            min-h-0 overflow-hidden
-            ${isExpanded ? 'border-t border-border/30' : ''}
-          `}
+          className={cn('min-h-0 overflow-hidden', { 'border-t border-border/30': isExpanded })}
         >
           <div className="space-y-2 p-3">
             {formattedRules && (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventSingleMarketOrderBook.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventSingleMarketOrderBook.tsx
@@ -154,7 +154,7 @@ export default function EventSingleMarketOrderBook({ market, eventSlug }: EventS
         <div
           className={cn(
             'overflow-hidden',
-            isExpanded && 'border-t border-border/30',
+            { 'border-t border-border/30': isExpanded },
           )}
         >
           <div
@@ -192,7 +192,7 @@ export default function EventSingleMarketOrderBook({ market, eventSlug }: EventS
                 <RefreshCwIcon
                   className={cn(
                     'size-3',
-                    (isOrderBookLoading || isOrderBookRefetching) && 'animate-spin',
+                    { 'animate-spin': isOrderBookLoading || isOrderBookRefetching },
                   )}
                 />
               </button>
@@ -223,7 +223,7 @@ function OutcomeToggle({ label, selected, onClick }: OutcomeToggleProps) {
       type="button"
       onClick={onClick}
       className={cn(
-        `-mb-0.5 border-b-2 border-transparent pt-1 pb-2 text-sm font-semibold transition-colors`,
+        `-mb-0.5 border-b-3 border-transparent pt-1 pb-2 text-sm font-semibold transition-colors`,
         selected
           ? 'border-primary text-foreground'
           : 'text-muted-foreground hover:text-foreground',

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventTabSelector.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventTabSelector.tsx
@@ -81,7 +81,7 @@ export default function EventTabSelector({
         <div
           className={cn(
             'absolute bottom-0 h-0.5 bg-primary',
-            isInitialized && 'transition-all duration-300 ease-out',
+            { 'transition-all duration-300 ease-out': isInitialized },
           )}
           style={{
             left: `${indicatorStyle.left}px`,

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
@@ -493,9 +493,9 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
                         isActive
                           ? 'bg-muted text-foreground'
                           : 'bg-background text-muted-foreground hover:bg-muted/40',
-                        !isLast && 'border-r border-border',
-                        isFirst && 'rounded-l-lg',
-                        isLast && 'rounded-r-lg',
+                        { 'border-r border-border': !isLast },
+                        { 'rounded-l-lg': isFirst },
+                        { 'rounded-r-lg': isLast },
                       )}
                     >
                       {option.label}

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioSummaryCard.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioSummaryCard.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton'
 import { useBalance } from '@/hooks/useBalance'
 import { useClientMounted } from '@/hooks/useClientMounted'
 import { usePortfolioValue } from '@/hooks/usePortfolioValue'
+import { cn } from '@/lib/utils'
 
 export default function PortfolioSummaryCard() {
   const dailyChange = 0.00
@@ -71,7 +72,7 @@ export default function PortfolioSummaryCard() {
         </div>
 
         <div className="mb-6">
-          <div className={`flex items-center gap-1 text-sm ${isPositive ? 'text-yes' : 'text-no'}`}>
+          <div className={cn(`flex items-center gap-1 text-sm ${isPositive ? 'text-yes' : 'text-no'}`)}>
             <span>
               $
               {dailyChange.toFixed(2)}

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioTabs.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioTabs.tsx
@@ -124,7 +124,7 @@ export default function PortfolioTabs({ userAddress }: PortfolioTabsProps) {
         <div
           className={cn(
             'pointer-events-none absolute bottom-0 h-0.5 bg-primary',
-            isInitialized && 'transition-all duration-300 ease-out',
+            { 'transition-all duration-300 ease-out': isInitialized },
           )}
           style={{
             left: `${indicatorStyle.left}px`,

--- a/src/app/[locale]/(platform)/settings/_components/SettingsSidebar.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsSidebar.tsx
@@ -6,6 +6,7 @@ import { BadgePercentIcon, BellIcon, CoinsIcon, FingerprintIcon, UserIcon } from
 import { useExtracted } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Link, usePathname } from '@/i18n/navigation'
+import { cn } from '@/lib/utils'
 
 interface MenuItem {
   id: string
@@ -35,7 +36,7 @@ export default function SettingsSidebar() {
             key={item.id}
             type="button"
             variant="ghost"
-            className={`h-11 justify-start text-foreground ${active === item.id ? 'bg-accent hover:bg-accent' : ''}`}
+            className={cn('h-11 justify-start text-foreground', { 'bg-accent hover:bg-accent': active === item.id })}
             asChild
           >
             <Link href={item.href}>

--- a/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
+++ b/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
@@ -295,7 +295,7 @@ export default function AdminGeneralSettingsForm({
                       border border-dashed border-border bg-muted/20 text-muted-foreground transition
                       hover:border-primary/60
                     `,
-                    isPending ? 'cursor-not-allowed opacity-60 hover:border-border hover:bg-muted/20' : '',
+                    { 'cursor-not-allowed opacity-60 hover:border-border hover:bg-muted/20': isPending },
                   )}
                 >
                   <span className={`
@@ -530,7 +530,7 @@ export default function AdminGeneralSettingsForm({
                 title={t('Refresh models')}
                 aria-label={t('Refresh models')}
               >
-                <RefreshCwIcon className={`size-4 ${isRefreshingOpenRouterModels ? 'animate-spin' : ''}`} />
+                <RefreshCwIcon className={cn('size-4', { 'animate-spin': isRefreshingOpenRouterModels })} />
               </Button>
             </div>
             <p className="text-xs text-muted-foreground">

--- a/src/app/[locale]/admin/_components/AdminSidebar.tsx
+++ b/src/app/[locale]/admin/_components/AdminSidebar.tsx
@@ -6,6 +6,7 @@ import { BadgePercentIcon, LanguagesIcon, SettingsIcon, SwatchBookIcon, TagsIcon
 import { useExtracted } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Link, usePathname } from '@/i18n/navigation'
+import { cn } from '@/lib/utils'
 
 interface AdminMenuItem {
   id: string
@@ -37,7 +38,7 @@ export default function AdminSidebar() {
             key={item.id}
             type="button"
             variant="ghost"
-            className={`h-11 justify-start text-foreground ${active === item.id ? 'bg-accent hover:bg-accent' : ''}`}
+            className={cn('h-11 justify-start text-foreground', { 'bg-accent hover:bg-accent': active === item.id })}
             asChild
           >
             <Link href={item.href}>

--- a/src/app/[locale]/admin/market-context/_components/AdminMarketContextSettingsForm.tsx
+++ b/src/app/[locale]/admin/market-context/_components/AdminMarketContextSettingsForm.tsx
@@ -14,6 +14,7 @@ import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { Link } from '@/i18n/navigation'
+import { cn } from '@/lib/utils'
 
 const initialState = {
   error: null,
@@ -181,7 +182,7 @@ export default function AdminMarketContextSettingsForm({
             value={promptValue}
             onChange={event => setPromptValue(event.target.value)}
             disabled={isPending}
-            className={isPromptHighlighted ? 'bg-primary/5 ring-2 ring-primary/35 transition-colors' : undefined}
+            className={cn({ 'bg-primary/5 ring-2 ring-primary/35 transition-colors': isPromptHighlighted })}
           />
           <p className="text-sm text-muted-foreground">
             {t('Use the variables below to blend live market data into the instructions. They will be replaced before the request is sent.')}
@@ -207,10 +208,7 @@ export default function AdminMarketContextSettingsForm({
                   <tr key={variable.key} className="group border-b transition-colors last:border-b-0 hover:bg-muted/50">
                     <td className="px-4 py-2 font-mono text-sm">
                       <span
-                        className={`
-                          inline-flex items-center gap-2 text-nowrap transition-transform duration-200
-                          ${liftedVariableKey === variable.key ? '-translate-y-0.5' : ''}
-                        `}
+                        className={cn('inline-flex items-center gap-2 text-nowrap transition-transform duration-200', { '-translate-y-0.5': liftedVariableKey === variable.key })}
                       >
                         <span>
                           [
@@ -225,12 +223,11 @@ export default function AdminMarketContextSettingsForm({
                               disabled={isPending}
                               onClick={() => handleInsertVariable(variable.key)}
                               aria-label={`Add [${variable.key}] variable`}
-                              className={`
+                              className={cn(`
                                 size-5 rounded-full bg-primary p-0 text-background shadow-none transition-transform
                                 duration-200
                                 hover:bg-primary/90
-                                ${liftedVariableKey === variable.key ? '-translate-y-0.5' : ''}
-                              `}
+                              `, { '-translate-y-0.5': liftedVariableKey === variable.key })}
                             >
                               <PlusIcon className="size-2.5" />
                             </Button>

--- a/src/app/[locale]/admin/theme/_components/AdminThemeSettingsForm.tsx
+++ b/src/app/[locale]/admin/theme/_components/AdminThemeSettingsForm.tsx
@@ -661,7 +661,7 @@ function ThemeTokenMatrix({
                       focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
                       focus-visible:ring-offset-background focus-visible:outline-none
                     `,
-                    isOpen ? 'border-b border-border/40' : '',
+                    { 'border-b border-border/40': isOpen },
                   )}
                 >
                   <span className="leading-tight">
@@ -674,7 +674,7 @@ function ThemeTokenMatrix({
                           : t('Chart palette')}
                   </span>
                   <ChevronDown
-                    className={`size-5 text-muted-foreground transition-transform ${isOpen ? 'rotate-180' : ''}`}
+                    className={cn('size-5 text-muted-foreground transition-transform', { 'rotate-180': isOpen })}
                   />
                 </button>
                 {isOpen && (

--- a/src/components/ProfileLink.tsx
+++ b/src/components/ProfileLink.tsx
@@ -234,7 +234,7 @@ export default function ProfileLink({
               : children
                 ? 'items-start'
                 : `items-center`,
-          isInline || isStacked ? null : 'py-2',
+          { 'py-2': !(isInline || isStacked) },
           containerClassName,
         )}
       >

--- a/src/components/ProfileLinkSkeleton.tsx
+++ b/src/components/ProfileLinkSkeleton.tsx
@@ -36,7 +36,7 @@ export default function ProfileLinkSkeleton({
       <div
         className={cn(
           'flex min-w-0 flex-1 items-center gap-3',
-          showTrailing ? 'justify-between' : '',
+          { 'justify-between': showTrailing },
         )}
       >
         <div className="flex min-w-0 flex-1 items-center gap-2">

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -3,6 +3,7 @@ import * as React from 'react'
 import { useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
 
 export function NumberInput({
   value,
@@ -137,7 +138,7 @@ export function NumberInput({
           style={{ width: `${inputSize}ch` }}
         />
         <span
-          className={`text-lg font-bold ${hasValue ? 'text-foreground' : 'text-muted-foreground'}`}
+          className={cn(`text-lg font-bold ${hasValue ? 'text-foreground' : 'text-muted-foreground'}`)}
         >
           ¢
         </span>

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -113,7 +113,6 @@ function SelectContent({
               data-[position=popper]:h-(--radix-select-trigger-height) data-[position=popper]:w-full
               data-[position=popper]:min-w-(--radix-select-trigger-width)
             `,
-            position === 'popper' && '',
           )}
         >
           {children}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized Tailwind class handling across the app by adopting cn() for conditional classes. This improves readability, consistency, and reduces styling bugs; no functional changes expected.

- **Refactors**
  - Replaced string-interpolated className expressions with cn() in platform, event, admin, and shared UI components.
  - Switched to object-based conditionals (e.g., { 'animate-spin': isLoading }) and removed no-op/duplicate classes.
  - Normalized transition and focus classes for tabs, dropdowns, and buttons.

- **UI Polish**
  - Fixed mobile “How it works” banner positioning (inset-x-0 bottom-0) and unified animated tab indicators.
  - Consistent conditional borders (e.g., border-t in single-market views) and disabled/opacity states.
  - Minor visual tweaks: thicker active underline in order book tabs (border-b-3) and safer overflow handling on cards.

<sup>Written for commit b7c39c8fa6700054bc86919bd521a0348e895d87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

