### PR TITLE
fix: how it works hidden on mobile

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCard.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCard.tsx
@@ -287,7 +287,7 @@ export default function EventCard({ event, priceOverridesByMarket = EMPTY_PRICE_
         className={
           cn(`
             flex h-full flex-col px-3 pt-3
-            ${isResolvedEvent ? 'pb-3' : 'pb-1'}
+            ${isResolvedEvent ? 'pb-3' : 'pb-3 md:pb-1'}
           `)
         }
       >

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
@@ -44,7 +44,12 @@ export default function EventCardMarketsList({
     : event.markets
 
   return (
-    <div className="mb-1 max-h-16 space-y-2 overflow-y-auto">
+    <div
+      className={cn(
+        'max-h-16 space-y-2 overflow-y-auto',
+        isResolvedEvent ? 'mb-1' : 'mb-2',
+      )}
+    >
       {marketsToRender.map((market) => {
         const resolvedOutcome = isResolvedEvent
           ? market.outcomes.find(outcome => outcome.is_winning_outcome)

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
@@ -68,7 +68,7 @@ export default function EventCardSingleMarketActions({
   }
 
   return (
-    <div className="mt-auto mb-1 grid grid-cols-2 gap-2">
+    <div className="mt-auto mb-2 grid grid-cols-2 gap-2">
       <Button
         type="button"
         onClick={(e) => {

--- a/src/app/[locale]/admin/theme/_components/AdminThemeSettingsForm.tsx
+++ b/src/app/[locale]/admin/theme/_components/AdminThemeSettingsForm.tsx
@@ -34,7 +34,7 @@ const initialState = {
 }
 
 const COLOR_PICKER_FALLBACK = '#000000'
-const DEFAULT_RADIUS_VALUE = '0.625rem'
+const DEFAULT_RADIUS_VALUE = '0.75rem'
 const RADIUS_PRESETS = [
   { id: 'sharp', value: '0' },
   { id: 'soft', value: DEFAULT_RADIUS_VALUE },

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -11,7 +11,7 @@
   --yes-foreground: oklch(62% 0.154 150.069);
   --no: oklch(63.7% 0.237 25.331);
   --no-foreground: oklch(50.5% 0.213 27.518);
-  --radius: 0.625rem;
+  --radius: 0.75rem;
   --background: oklch(1 0 0);
   --foreground: oklch(0.129 0.042 264.695);
   --card: oklch(1 0 0);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the “How it works” being hidden on mobile by adding a bottom banner and a mobile Drawer. The banner is correctly offset when the single-market order panel is open.

- **Bug Fixes**
  - Render mobile banner via createPortal to avoid overlap.
  - Replace mobile dialog with Drawer for a consistent mobile flow.
  - Offset banner on event pages when single-market order panel is open.
  - Show desktop trigger only on lg+ screens.

- **Refactors**
  - Adjust event card spacing (padding/margins) for consistency.
  - Increase default border radius to 0.75rem (Admin and CSS variable).

<sup>Written for commit 4ebf614790833eb99cd67ecd8803ee83467246d3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

