### PR TITLE
feat: frequency filter

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventsGrid.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventsGrid.tsx
@@ -118,6 +118,7 @@ async function fetchEvents({
     tag: filters.tag,
     search: filters.search,
     bookmarked: filters.bookmarked.toString(),
+    frequency: filters.frequency,
     status: filters.status,
     offset: pageParam.toString(),
     locale,
@@ -152,6 +153,7 @@ export default function EventsGrid({
   const isDefaultState = filters.tag === 'trending'
     && filters.search === ''
     && !filters.bookmarked
+    && filters.frequency === 'all'
     && filters.status === 'active'
   const shouldUseInitialData = isDefaultState && initialEvents.length > 0
 
@@ -170,6 +172,7 @@ export default function EventsGrid({
       filters.tag,
       filters.search,
       filters.bookmarked,
+      filters.frequency,
       filters.status,
       filters.hideSports,
       filters.hideCrypto,

--- a/src/app/[locale]/(platform)/(home)/_components/FilterToolbar.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/FilterToolbar.tsx
@@ -39,8 +39,8 @@ interface SettingsToggleProps {
 }
 
 type SortOption = '24h-volume' | 'total-volume' | 'liquidity' | 'newest' | 'ending-soon' | 'competitive'
-type FrequencyOption = 'all' | 'daily' | 'weekly' | 'monthly'
-type StatusOption = 'active' | 'resolved'
+type FrequencyOption = FilterState['frequency']
+type StatusOption = FilterState['status']
 
 type FilterCheckboxKey = 'hideSports' | 'hideCrypto' | 'hideEarnings'
 
@@ -75,6 +75,7 @@ export default function FilterToolbar({ filters, onFiltersChange }: FilterToolba
   const [isSettingsOpen, setIsSettingsOpen] = useState(false)
   const [isNavigationTagsReady, setIsNavigationTagsReady] = useState(false)
   const [filterSettings, setFilterSettings] = useState<FilterSettings>(() => createDefaultFilters({
+    frequency: filters.frequency,
     status: filters.status,
     hideSports: filters.hideSports,
     hideCrypto: filters.hideCrypto,
@@ -106,7 +107,8 @@ export default function FilterToolbar({ filters, onFiltersChange }: FilterToolba
   useEffect(() => {
     setFilterSettings((prev) => {
       if (
-        prev.status === filters.status
+        prev.frequency === filters.frequency
+        && prev.status === filters.status
         && prev.hideSports === filters.hideSports
         && prev.hideCrypto === filters.hideCrypto
         && prev.hideEarnings === filters.hideEarnings
@@ -116,13 +118,14 @@ export default function FilterToolbar({ filters, onFiltersChange }: FilterToolba
 
       return {
         ...prev,
+        frequency: filters.frequency,
         status: filters.status,
         hideSports: filters.hideSports,
         hideCrypto: filters.hideCrypto,
         hideEarnings: filters.hideEarnings,
       }
     })
-  }, [filters.hideSports, filters.hideCrypto, filters.hideEarnings, filters.status])
+  }, [filters.frequency, filters.hideSports, filters.hideCrypto, filters.hideEarnings, filters.status])
 
   const handleBookmarkToggle = useCallback(() => {
     onFiltersChange({ bookmarked: !filters.bookmarked })
@@ -157,6 +160,9 @@ export default function FilterToolbar({ filters, onFiltersChange }: FilterToolba
         }
         onFiltersChange(filterUpdates)
       }
+      if ('frequency' in updates && updates.frequency !== undefined && updates.frequency !== prev.frequency) {
+        onFiltersChange({ frequency: updates.frequency })
+      }
       if ('status' in updates && updates.status && updates.status !== prev.status) {
         onFiltersChange({ status: updates.status })
       }
@@ -172,6 +178,7 @@ export default function FilterToolbar({ filters, onFiltersChange }: FilterToolba
     onFiltersChange({
       search: '',
       bookmarked: false,
+      frequency: defaultFilters.frequency,
       status: defaultFilters.status,
       hideSports: defaultFilters.hideSports,
       hideCrypto: defaultFilters.hideCrypto,

--- a/src/app/[locale]/(platform)/_providers/FilterProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/FilterProvider.tsx
@@ -8,6 +8,7 @@ export interface FilterState {
   tag: string
   mainTag: string
   bookmarked: boolean
+  frequency: 'all' | 'daily' | 'weekly' | 'monthly'
   status: 'active' | 'resolved'
   hideSports: boolean
   hideCrypto: boolean
@@ -31,6 +32,7 @@ const DEFAULT_FILTERS: FilterState = {
   tag: 'trending',
   mainTag: 'trending',
   bookmarked: false,
+  frequency: 'all',
   status: 'active',
   hideSports: false,
   hideCrypto: false,

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -9,6 +9,7 @@ export async function GET(request: Request) {
   const tag = searchParams.get('tag') || 'trending'
   const search = searchParams.get('search') || ''
   const bookmarked = searchParams.get('bookmarked') === 'true'
+  const frequency = searchParams.get('frequency') || 'all'
   const status = searchParams.get('status') || 'active'
   const localeParam = searchParams.get('locale') ?? DEFAULT_LOCALE
   const locale = SUPPORTED_LOCALES.includes(localeParam as typeof SUPPORTED_LOCALES[number])
@@ -21,6 +22,10 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Invalid status filter.' }, { status: 400 })
   }
 
+  if (frequency !== 'all' && frequency !== 'daily' && frequency !== 'weekly' && frequency !== 'monthly') {
+    return NextResponse.json({ error: 'Invalid frequency filter.' }, { status: 400 })
+  }
+
   const user = await UserRepository.getCurrentUser()
   const userId = user?.id
 
@@ -30,6 +35,7 @@ export async function GET(request: Request) {
       search,
       userId,
       bookmarked,
+      frequency,
       status,
       offset: clampedOffset,
       locale,

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -226,6 +226,7 @@ interface ListEventsProps {
   search?: string
   userId?: string | undefined
   bookmarked?: boolean
+  frequency?: 'all' | 'daily' | 'weekly' | 'monthly'
   status?: Event['status']
   offset?: number
   locale?: SupportedLocale
@@ -495,6 +496,7 @@ export const EventRepository = {
     search = '',
     userId = '',
     bookmarked = false,
+    frequency = 'all',
     status = 'active',
     offset = 0,
     locale = DEFAULT_LOCALE,
@@ -544,6 +546,11 @@ export const EventRepository = {
             and(...searchTerms.map(term => ilike(loweredTitle, `%${term}%`))),
           )
         }
+      }
+
+      if (frequency !== 'all') {
+        const normalizedSeriesRecurrence = sql<string>`LOWER(TRIM(COALESCE(${events.series_recurrence}, '')))`
+        whereConditions.push(eq(normalizedSeriesRecurrence, frequency))
       }
 
       if (tag && tag !== 'trending' && tag !== 'new') {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added a frequency filter for events (all, daily, weekly, monthly) so users can quickly narrow recurring series. The filter is wired end-to-end across the UI, API, and DB query.

- **New Features**
  - UI: FilterToolbar and FilterProvider support frequency; EventsGrid includes it in fetch and cache keys; default state treats frequency as "all".
  - API/DB: /api/events accepts and validates the frequency param; EventRepository filters by series_recurrence (normalized).

<sup>Written for commit 05dc09e70736b5c5b8e0f8e53f9d96b858929f56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

