### PR TITLE
docs: add creator field to sports websocket docs

### DIFF
--- a/docs/api-reference/wss/sports.mdx
+++ b/docs/api-reference/wss/sports.mdx
@@ -30,6 +30,22 @@ Send any variant of `PING` (`ping`, `PiNg`, `PING`). The server replies with `PO
 - `symbol` is used for one symbol; `symbols` supports arrays.
 - `filters` may be sent as a JSON object or JSON string.
 - One connection can subscribe to multiple topics.
+- `activity` (`orders_matched`) payload now includes `creator` (market creator wallet).
+
+## Activity payload example
+
+```json
+{
+  "topic": "activity",
+  "type": "orders_matched",
+  "payload": {
+    "proxyWallet": "0xe25b9180f5687aa85bd94ee309bb72a464320f1b",
+    "creator": "0x8f2a6db31d2f3f3c8e4f9e74d5f5f9d2a7b0c123",
+    "transactionHash": "0xdeadbeef",
+    "eventSlug": "x-banned-in-uk-by-march-31"
+  }
+}
+```
 
 ## WebSocket Playground
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added documentation for the `creator` field in the sports WebSocket `activity` (`orders_matched`) payload so clients can read the market creator wallet. Includes a brief note in the tips and a JSON example showing `creator`.

<sup>Written for commit b1ff3705bfe3b0c1428a2ec5381b9fa3e945ad5f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

