### PR TITLE
fix: refetch events when client timestamp hydrates from null

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
@@ -20,7 +20,8 @@ export default async function HomeContent({
   const resolvedLocale = locale as SupportedLocale
   const initialTagSlug = initialTag ?? 'trending'
   const initialMainTagSlug = initialMainTag ?? initialTagSlug
-  let initialCurrentTimestamp: number | null = null
+  const serverCurrentTimestamp = Date.now()
+  let initialCurrentTimestamp: number | null = serverCurrentTimestamp
 
   let initialEvents: Event[] = []
 
@@ -32,9 +33,10 @@ export default async function HomeContent({
       userId: '',
       bookmarked: false,
       locale: resolvedLocale,
+      currentTimestamp: serverCurrentTimestamp,
     })
 
-    initialCurrentTimestamp = currentTimestamp ?? null
+    initialCurrentTimestamp = currentTimestamp ?? serverCurrentTimestamp
 
     if (error) {
       console.warn('Failed to fetch initial events for static generation:', error)

--- a/src/app/[locale]/(platform)/(home)/_components/HydratedEventsGrid.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HydratedEventsGrid.tsx
@@ -164,8 +164,7 @@ export default function HydratedEventsGrid({
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const canRetryLoadMoreAfterErrorRef = useRef(true)
   const user = useUser()
-  const userCacheKey = user?.id ?? 'guest'
-  const queryUserScope = userCacheKey
+  const queryUserScope = user?.id ?? 'guest'
   const currentTimestamp = useCurrentTimestamp({
     initialTimestamp: initialCurrentTimestamp,
     intervalMs: HOME_FEED_REFRESH_INTERVAL_MS,
@@ -329,6 +328,11 @@ export default function HydratedEventsGrid({
         key: queryRunKey,
         timestamp: resolvedCurrentTimestamp,
       }
+
+      if (!isFetching && !isFetchingNextPage) {
+        void refetch()
+      }
+
       return
     }
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -13,6 +13,7 @@ import { formatCurrency } from '@/lib/formatters'
 import { cn } from '@/lib/utils'
 import { createWebSocketReconnectController } from '@/lib/websocket-reconnect'
 import {
+  resolveLiveSeriesDeltaDisplayDigits,
   resolveLiveSeriesPriceDisplayDigits,
   resolveLiveSeriesTopicPriceDigits,
 } from '../_utils/liveSeriesPricePrecision'
@@ -1215,10 +1216,10 @@ function EventLiveSeriesChartContent({
     precisionReferencePrice,
   )
   const headerPriceDisplayDigits = Math.max(2, priceDisplayDigits)
-  const deltaDisplayDigits = priceDisplayDigits >= 4 ? 4 : 0
   const delta = currentPrice != null && resolvedBaselinePrice != null
     ? currentPrice - resolvedBaselinePrice
     : null
+  const deltaDisplayDigits = resolveLiveSeriesDeltaDisplayDigits(priceDisplayDigits, delta)
   const rawAxisValues = useMemo(() => {
     const values = axisSourceData
       .map(point => point[SERIES_KEY])

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesPricePrecision.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesPricePrecision.ts
@@ -27,3 +27,19 @@ export function resolveLiveSeriesPriceDisplayDigits(
 
   return resolveAdaptiveCryptoPriceDigits(referencePrice)
 }
+
+export function resolveLiveSeriesDeltaDisplayDigits(
+  priceDisplayDigits: number,
+  delta?: number | null,
+) {
+  const normalizedDigits = Number.isFinite(priceDisplayDigits)
+    ? Math.max(0, Math.floor(priceDisplayDigits))
+    : 2
+
+  const absDelta = Math.abs(Number(delta))
+  if (Number.isFinite(absDelta) && absDelta > 1) {
+    return 0
+  }
+
+  return Math.max(2, normalizedDigits)
+}

--- a/tests/unit/EventLiveSeriesChartPrecision.test.ts
+++ b/tests/unit/EventLiveSeriesChartPrecision.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { resolveLiveSeriesPriceDisplayDigits } from '@/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesPricePrecision'
+import {
+  resolveLiveSeriesDeltaDisplayDigits,
+  resolveLiveSeriesPriceDisplayDigits,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/liveSeriesPricePrecision'
 
 describe('resolveLiveSeriesPriceDisplayDigits', () => {
   it('keeps equity prices at 2 digits when decimals are enabled', () => {
@@ -29,5 +32,27 @@ describe('resolveLiveSeriesPriceDisplayDigits', () => {
 
   it('normalizes topic casing and spacing', () => {
     expect(resolveLiveSeriesPriceDisplayDigits('  CRYPTO_PRICES_CHAINLINK  ', true, 1.2)).toBe(4)
+  })
+})
+
+describe('resolveLiveSeriesDeltaDisplayDigits', () => {
+  it('shows cents when base price digits are hidden', () => {
+    expect(resolveLiveSeriesDeltaDisplayDigits(0, 0.66)).toBe(2)
+  })
+
+  it('keeps 2-digit deltas for 2-digit prices', () => {
+    expect(resolveLiveSeriesDeltaDisplayDigits(2, 0.66)).toBe(2)
+  })
+
+  it('keeps 4-digit deltas for low-price crypto series', () => {
+    expect(resolveLiveSeriesDeltaDisplayDigits(4, 0.0066)).toBe(4)
+  })
+
+  it('hides decimals for positive deltas above one dollar', () => {
+    expect(resolveLiveSeriesDeltaDisplayDigits(2, 1.01)).toBe(0)
+  })
+
+  it('hides decimals for negative deltas above one dollar in absolute value', () => {
+    expect(resolveLiveSeriesDeltaDisplayDigits(2, -1.25)).toBe(0)
   })
 })

--- a/tests/unit/HydratedEventsGrid.test.tsx
+++ b/tests/unit/HydratedEventsGrid.test.tsx
@@ -244,4 +244,45 @@ describe('hydratedEventsGrid', () => {
 
     expect(mocks.refetch).not.toHaveBeenCalled()
   })
+
+  it('refetches once when the client timestamp hydrates from null', async () => {
+    const filters = {
+      tag: 'trending',
+      mainTag: 'trending',
+      search: '',
+      bookmarked: false,
+      frequency: 'all',
+      status: 'active',
+      hideSports: false,
+      hideCrypto: false,
+      hideEarnings: false,
+    } as const
+
+    const hydratedTimestamp = Date.parse('2026-03-16T12:00:00.000Z')
+    mocks.useCurrentTimestamp.mockReturnValueOnce(null).mockReturnValue(hydratedTimestamp)
+
+    const { rerender } = render(
+      <HydratedEventsGrid
+        filters={filters}
+        initialEvents={[]}
+        initialCurrentTimestamp={null}
+        routeMainTag="trending"
+        routeTag="trending"
+      />,
+    )
+
+    await act(async () => {
+      rerender(
+        <HydratedEventsGrid
+          filters={filters}
+          initialEvents={[]}
+          initialCurrentTimestamp={null}
+          routeMainTag="trending"
+          routeTag="trending"
+        />,
+      )
+    })
+
+    expect(mocks.refetch).toHaveBeenCalledTimes(1)
+  })
 })

--- a/tests/unit/homeContent.test.ts
+++ b/tests/unit/homeContent.test.ts
@@ -37,6 +37,7 @@ describe('homeContent', () => {
       tag: 'ai',
       mainTag: 'tech',
       locale: 'en',
+      currentTimestamp: expect.any(Number),
     }))
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stale home feed after hydration by refetching once when the client timestamp initializes, and uses the server time for SSR event selection. Also hides chart delta decimals when the absolute change exceeds $1 for clearer display.

- **Bug Fixes**
  - Trigger a single refetch when the timestamp hydrates and no fetch is in progress.
  - Pass the server timestamp to SSR home events selection and include it in the request.
  - Add `resolveLiveSeriesDeltaDisplayDigits` to control delta precision and tests covering the new behavior.

<sup>Written for commit 676347859866a265d26fd9ac0aa24a1997397356. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

