### PR TITLE
fix: calculate portfolio pnl by selected timeframe

### DIFF
--- a/src/app/[locale]/(platform)/profile/_components/PublicProfileHeroCards.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicProfileHeroCards.tsx
@@ -280,10 +280,11 @@ function ProfitLossCard({
       top: `${(cursorY / innerHeight) * 100}%`,
     }
   }, [clampedCursorX, cursorY, innerHeight, innerWidth])
-  const displayValue = clampedCursorX == null ? endValue : cursorValue
-  const deltaValue = displayValue - startValue
-  const isDeltaPositive = deltaValue > 0
-  const isDeltaNegative = deltaValue < 0
+  const displayAbsoluteValue = clampedCursorX == null ? endValue : cursorValue
+  const displayBaselineValue = activeTimeframe === 'ALL' ? 0 : startValue
+  const displayNetValue = displayAbsoluteValue - displayBaselineValue
+  const isDeltaPositive = displayNetValue > 0
+  const isDeltaNegative = displayNetValue < 0
   const areValuesHidden = usePortfolioValueVisibility(state => state.isHidden)
   const [gainTotal, lossTotal] = useMemo(() => {
     if (!chartData.length) {
@@ -293,6 +294,7 @@ function ProfitLossCard({
     const targetTime = (cursorDate ?? endDate).getTime()
     const firstPoint = chartData[0]
     const firstTime = firstPoint.date.getTime()
+    const baseline = activeTimeframe === 'ALL' ? 0 : firstPoint.value
 
     if (targetTime < firstTime) {
       return [0, 0]
@@ -300,17 +302,16 @@ function ProfitLossCard({
 
     let gain = 0
     let loss = 0
-    let prevValue = 0
+    let prevValue = firstPoint.value
     let prevTime = firstTime
 
-    const initialDelta = firstPoint.value - prevValue
+    const initialDelta = firstPoint.value - baseline
     if (initialDelta >= 0) {
       gain += initialDelta
     }
     else {
       loss += Math.abs(initialDelta)
     }
-    prevValue = firstPoint.value
 
     for (let index = 1; index < chartData.length; index += 1) {
       const point = chartData[index]
@@ -345,7 +346,7 @@ function ProfitLossCard({
     }
 
     return [gain, loss]
-  }, [chartData, cursorDate, endDate])
+  }, [activeTimeframe, chartData, cursorDate, endDate])
   const timeframeLabel = ({
     'ALL': 'All-Time',
     '1D': 'Past Day',
@@ -428,8 +429,8 @@ function ProfitLossCard({
                     ? '****'
                     : (
                         <>
-                          {displayValue < 0 ? '-' : '+'}
-                          {formatCurrency(Math.abs(displayValue))}
+                          {displayNetValue < 0 ? '-' : '+'}
+                          {formatCurrency(Math.abs(displayNetValue))}
                         </>
                       )}
                 </span>
@@ -482,8 +483,8 @@ function ProfitLossCard({
                             ? '****'
                             : (
                                 <>
-                                  {displayValue < 0 ? '-' : '+'}
-                                  {formatCurrency(Math.abs(displayValue))}
+                                  {displayNetValue < 0 ? '-' : '+'}
+                                  {formatCurrency(Math.abs(displayNetValue))}
                                 </>
                               )}
                         </span>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed portfolio PnL to respect the selected timeframe in Public Profile cards. Net PnL now reflects all-time from zero or from the timeframe start, with correct signs.

- **Bug Fixes**
  - Compute net value as (cursor/end value) minus baseline: baseline is 0 for `ALL`, otherwise the timeframe start value; update UI to show the net value with correct +/−.
  - Adjust gain/loss accumulation to start from the first point relative to the baseline and add `activeTimeframe` to memo deps for accurate recalculation.

<sup>Written for commit 0975a78d3ab7b119614d1345905d5d8d6ec8105a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

