### PR TITLE
fix: align leaderboard pnl with portfolio timeframe values

### DIFF
--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
@@ -232,7 +232,7 @@ async function hydrateEntriesWithPortfolioPnl(
     return entries
   }
 
-  if (filters.category !== 'overall' || filters.order !== 'profit') {
+  if (filters.category !== 'overall') {
     return entries
   }
 

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
@@ -52,9 +52,16 @@ interface BiggestWinEntry {
 
 const DATA_API_URL = process.env.DATA_URL!
 const LEADERBOARD_API_URL = DATA_API_URL.endsWith('/v1') ? DATA_API_URL : `${DATA_API_URL}/v1`
+const USER_PNL_API_URL = process.env.USER_PNL_URL
 const PAGE_SIZE = 20
 const BIGGEST_WINS_CACHE = new Map<string, BiggestWinEntry[]>()
 const BIGGEST_WINS_IN_FLIGHT = new Map<string, Promise<BiggestWinEntry[]>>()
+const USER_TIMEFRAME_PNL_CACHE = new Map<string, number>()
+
+interface UserPnlPoint {
+  t?: number
+  p?: number
+}
 
 async function fetchBiggestWins(category: string, period: string) {
   const params = new URLSearchParams({
@@ -175,6 +182,128 @@ function buildLeaderboardScopeKey(filters: LeaderboardFilters, searchQuery: stri
   return `${buildFiltersKey(filters)}:${searchQuery}`
 }
 
+function normalizeWalletAddress(value?: string) {
+  return (value ?? '').trim().toLowerCase()
+}
+
+function resolveUserPnlTimeframe(period: LeaderboardFilters['period']) {
+  switch (period) {
+    case 'today':
+      return { interval: '1d', fidelity: '1h', relative: true }
+    case 'weekly':
+      return { interval: '1w', fidelity: '3h', relative: true }
+    case 'monthly':
+      return { interval: '1m', fidelity: '18h', relative: true }
+    case 'all':
+      return { interval: 'all', fidelity: '12h', relative: false }
+    default:
+      return { interval: '1d', fidelity: '1h', relative: true }
+  }
+}
+
+async function fetchUserTimeframePnl(
+  userAddress: string,
+  period: LeaderboardFilters['period'],
+  signal: AbortSignal,
+): Promise<number | null> {
+  const normalizedAddress = normalizeWalletAddress(userAddress)
+  if (!normalizedAddress || !USER_PNL_API_URL) {
+    return null
+  }
+
+  const cacheKey = `${period}:${normalizedAddress}`
+  const cached = USER_TIMEFRAME_PNL_CACHE.get(cacheKey)
+  if (typeof cached === 'number' && Number.isFinite(cached)) {
+    return cached
+  }
+
+  const timeframe = resolveUserPnlTimeframe(period)
+  const params = new URLSearchParams({
+    user_address: normalizedAddress,
+    interval: timeframe.interval,
+    fidelity: timeframe.fidelity,
+  })
+  const endpoint = new URL('/user-pnl', USER_PNL_API_URL)
+  const response = await fetch(`${endpoint.toString()}?${params.toString()}`, { signal })
+  if (!response.ok) {
+    return null
+  }
+
+  const payload = await response.json() as UserPnlPoint[]
+  if (!Array.isArray(payload) || payload.length === 0) {
+    USER_TIMEFRAME_PNL_CACHE.set(cacheKey, 0)
+    return 0
+  }
+
+  const points = payload
+    .map(point => (typeof point.p === 'number' && Number.isFinite(point.p) ? point.p : null))
+    .filter((value): value is number => value !== null)
+
+  if (points.length === 0) {
+    USER_TIMEFRAME_PNL_CACHE.set(cacheKey, 0)
+    return 0
+  }
+
+  const start = points[0]
+  const end = points[points.length - 1]
+  const value = timeframe.relative ? end - start : end
+  USER_TIMEFRAME_PNL_CACHE.set(cacheKey, value)
+  return value
+}
+
+async function hydrateEntriesWithPortfolioPnl(
+  entries: LeaderboardEntry[],
+  filters: LeaderboardFilters,
+  signal: AbortSignal,
+): Promise<LeaderboardEntry[]> {
+  if (entries.length === 0) {
+    return entries
+  }
+
+  if (filters.category !== 'overall' || !USER_PNL_API_URL) {
+    return entries
+  }
+
+  const addresses = Array.from(
+    new Set(
+      entries
+        .map(entry => normalizeWalletAddress(entry.proxyWallet))
+        .filter(address => address.length > 0),
+    ),
+  )
+
+  if (addresses.length === 0) {
+    return entries
+  }
+
+  const values = await Promise.all(
+    addresses.map(async (address) => {
+      const pnl = await fetchUserTimeframePnl(address, filters.period, signal).catch(() => null)
+      return [address, pnl] as const
+    }),
+  )
+
+  const pnlByAddress = new Map<string, number>()
+  for (const [address, pnl] of values) {
+    if (typeof pnl === 'number' && Number.isFinite(pnl)) {
+      pnlByAddress.set(address, pnl)
+    }
+  }
+
+  if (pnlByAddress.size === 0) {
+    return entries
+  }
+
+  return entries.map((entry) => {
+    const address = normalizeWalletAddress(entry.proxyWallet)
+    const pnl = pnlByAddress.get(address)
+    if (typeof pnl !== 'number') {
+      return entry
+    }
+    return { ...entry, pnl }
+  })
+}
+
 export default function LeaderboardClient({ initialFilters }: { initialFilters: LeaderboardFilters }) {
   const router = useRouter()
   const user = useUser()
@@ -236,8 +365,13 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
         }
         return response.json()
       })
-      .then((result) => {
-        setEntries(normalizeLeaderboardResponse(result))
+      .then(async (result) => {
+        const normalized = normalizeLeaderboardResponse(result)
+        const hydrated = await hydrateEntriesWithPortfolioPnl(normalized, filters, controller.signal)
+        if (controller.signal.aborted) {
+          return
+        }
+        setEntries(hydrated)
       })
       .catch((_error) => {
         if (controller.signal.aborted) {
@@ -278,9 +412,18 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
         }
         return response.json()
       })
-      .then((result) => {
+      .then(async (result) => {
         const [entry] = normalizeLeaderboardResponse(result)
-        setUserEntry(entry ?? null)
+        if (!entry) {
+          setUserEntry(null)
+          return
+        }
+
+        const [hydrated] = await hydrateEntriesWithPortfolioPnl([entry], filters, controller.signal)
+        if (controller.signal.aborted) {
+          return
+        }
+        setUserEntry(hydrated ?? entry)
       })
       .catch((_error) => {
         if (controller.signal.aborted) {

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
@@ -52,15 +52,12 @@ interface BiggestWinEntry {
 
 const DATA_API_URL = process.env.DATA_URL!
 const LEADERBOARD_API_URL = DATA_API_URL.endsWith('/v1') ? DATA_API_URL : `${DATA_API_URL}/v1`
-const USER_PNL_API_URL = process.env.USER_PNL_URL
 const PAGE_SIZE = 20
 const BIGGEST_WINS_CACHE = new Map<string, BiggestWinEntry[]>()
 const BIGGEST_WINS_IN_FLIGHT = new Map<string, Promise<BiggestWinEntry[]>>()
-const USER_TIMEFRAME_PNL_CACHE = new Map<string, number>()
 
-interface UserPnlPoint {
-  t?: number
-  p?: number
+interface TimeframePnlBatchResponse {
+  values?: Record<string, number>
 }
 
 async function fetchBiggestWins(category: string, period: string) {
@@ -186,69 +183,44 @@ function normalizeWalletAddress(value?: string) {
   return (value ?? '').trim().toLowerCase()
 }
 
-function resolveUserPnlTimeframe(period: LeaderboardFilters['period']) {
-  switch (period) {
-    case 'today':
-      return { interval: '1d', fidelity: '1h', relative: true }
-    case 'weekly':
-      return { interval: '1w', fidelity: '3h', relative: true }
-    case 'monthly':
-      return { interval: '1m', fidelity: '18h', relative: true }
-    case 'all':
-      return { interval: 'all', fidelity: '12h', relative: false }
-    default:
-      return { interval: '1d', fidelity: '1h', relative: true }
-  }
-}
-
-async function fetchUserTimeframePnl(
-  userAddress: string,
+async function fetchTimeframePnlBatch(
+  userAddresses: string[],
   period: LeaderboardFilters['period'],
   signal: AbortSignal,
-): Promise<number | null> {
-  const normalizedAddress = normalizeWalletAddress(userAddress)
-  if (!normalizedAddress || !USER_PNL_API_URL) {
-    return null
-  }
-
-  const cacheKey = `${period}:${normalizedAddress}`
-  const cached = USER_TIMEFRAME_PNL_CACHE.get(cacheKey)
-  if (typeof cached === 'number' && Number.isFinite(cached)) {
-    return cached
-  }
-
-  const timeframe = resolveUserPnlTimeframe(period)
-  const params = new URLSearchParams({
-    user_address: normalizedAddress,
-    interval: timeframe.interval,
-    fidelity: timeframe.fidelity,
+): Promise<Map<string, number>> {
+  const response = await fetch('/api/leaderboard/timeframe-pnl', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      period,
+      addresses: userAddresses,
+    }),
+    signal,
   })
-  const endpoint = new URL('/user-pnl', USER_PNL_API_URL)
-  const response = await fetch(`${endpoint.toString()}?${params.toString()}`, { signal })
+
   if (!response.ok) {
-    return null
+    return new Map()
   }
 
-  const payload = await response.json() as UserPnlPoint[]
-  if (!Array.isArray(payload) || payload.length === 0) {
-    USER_TIMEFRAME_PNL_CACHE.set(cacheKey, 0)
-    return 0
+  const payload = await response.json() as TimeframePnlBatchResponse
+  if (!payload || typeof payload !== 'object' || !payload.values || typeof payload.values !== 'object') {
+    return new Map()
   }
 
-  const points = payload
-    .map(point => (typeof point.p === 'number' && Number.isFinite(point.p) ? point.p : null))
-    .filter((value): value is number => value !== null)
-
-  if (points.length === 0) {
-    USER_TIMEFRAME_PNL_CACHE.set(cacheKey, 0)
-    return 0
+  const values = new Map<string, number>()
+  for (const [address, rawValue] of Object.entries(payload.values)) {
+    const normalizedAddress = normalizeWalletAddress(address)
+    if (!normalizedAddress) {
+      continue
+    }
+    if (typeof rawValue === 'number' && Number.isFinite(rawValue)) {
+      values.set(normalizedAddress, rawValue)
+    }
   }
 
-  const start = points[0]
-  const end = points[points.length - 1]
-  const value = timeframe.relative ? end - start : end
-  USER_TIMEFRAME_PNL_CACHE.set(cacheKey, value)
-  return value
+  return values
 }
 
 async function hydrateEntriesWithPortfolioPnl(
@@ -260,7 +232,7 @@ async function hydrateEntriesWithPortfolioPnl(
     return entries
   }
 
-  if (filters.category !== 'overall' || !USER_PNL_API_URL) {
+  if (filters.category !== 'overall' || filters.order !== 'profit') {
     return entries
   }
 
@@ -276,19 +248,7 @@ async function hydrateEntriesWithPortfolioPnl(
     return entries
   }
 
-  const values = await Promise.all(
-    addresses.map(async (address) => {
-      const pnl = await fetchUserTimeframePnl(address, filters.period, signal).catch(() => null)
-      return [address, pnl] as const
-    }),
-  )
-
-  const pnlByAddress = new Map<string, number>()
-  for (const [address, pnl] of values) {
-    if (typeof pnl === 'number' && Number.isFinite(pnl)) {
-      pnlByAddress.set(address, pnl)
-    }
-  }
+  const pnlByAddress = await fetchTimeframePnlBatch(addresses, filters.period, signal).catch(() => new Map())
 
   if (pnlByAddress.size === 0) {
     return entries

--- a/src/app/api/leaderboard/timeframe-pnl/route.ts
+++ b/src/app/api/leaderboard/timeframe-pnl/route.ts
@@ -1,0 +1,234 @@
+import { NextResponse } from 'next/server'
+import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
+import { normalizeAddress } from '@/lib/wallet'
+
+const USER_PNL_API_URL = process.env.USER_PNL_URL
+const MAX_ADDRESSES = 50
+const UPSTREAM_CONCURRENCY = 6
+const CACHE_TTL_MS = 60_000
+const CACHE_MAX_ENTRIES = 5_000
+
+type TimePeriod = 'today' | 'weekly' | 'monthly' | 'all'
+
+interface UserPnlPoint {
+  p?: number
+}
+
+interface CacheEntry {
+  value: number
+  expiresAt: number
+}
+
+const TIMEFRAME_PNL_CACHE = new Map<string, CacheEntry>()
+const TIMEFRAME_PNL_IN_FLIGHT = new Map<string, Promise<number | null>>()
+
+function resolvePeriodConfig(period: TimePeriod) {
+  switch (period) {
+    case 'today':
+      return { interval: '1d', fidelity: '1h', relative: true }
+    case 'weekly':
+      return { interval: '1w', fidelity: '3h', relative: true }
+    case 'monthly':
+      return { interval: '1m', fidelity: '18h', relative: true }
+    case 'all':
+      return { interval: 'all', fidelity: '12h', relative: false }
+    default:
+      return { interval: '1d', fidelity: '1h', relative: true }
+  }
+}
+
+function normalizePeriod(value: unknown): TimePeriod | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const normalized = value.trim().toLowerCase()
+  if (normalized === 'today' || normalized === 'weekly' || normalized === 'monthly' || normalized === 'all') {
+    return normalized
+  }
+
+  return null
+}
+
+function normalizeAddresses(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const unique = new Set<string>()
+  for (const item of value) {
+    const normalized = normalizeAddress(typeof item === 'string' ? item : null)?.toLowerCase()
+    if (!normalized) {
+      continue
+    }
+    unique.add(normalized)
+    if (unique.size >= MAX_ADDRESSES) {
+      break
+    }
+  }
+
+  return Array.from(unique)
+}
+
+function toCacheKey(period: TimePeriod, address: string) {
+  return `${period}:${address}`
+}
+
+function trimCache() {
+  while (TIMEFRAME_PNL_CACHE.size > CACHE_MAX_ENTRIES) {
+    const oldest = TIMEFRAME_PNL_CACHE.keys().next().value
+    if (!oldest) {
+      break
+    }
+    TIMEFRAME_PNL_CACHE.delete(oldest)
+  }
+}
+
+function getCachedValue(period: TimePeriod, address: string, now: number): number | null {
+  const key = toCacheKey(period, address)
+  const cached = TIMEFRAME_PNL_CACHE.get(key)
+  if (!cached) {
+    return null
+  }
+
+  if (cached.expiresAt <= now) {
+    TIMEFRAME_PNL_CACHE.delete(key)
+    return null
+  }
+
+  return cached.value
+}
+
+function setCachedValue(period: TimePeriod, address: string, value: number, now: number) {
+  const key = toCacheKey(period, address)
+  TIMEFRAME_PNL_CACHE.set(key, {
+    value,
+    expiresAt: now + CACHE_TTL_MS,
+  })
+  trimCache()
+}
+
+function parseUserPnlValue(payload: unknown, relative: boolean): number {
+  if (!Array.isArray(payload) || payload.length === 0) {
+    return 0
+  }
+
+  const points = (payload as UserPnlPoint[])
+    .map(point => (typeof point.p === 'number' && Number.isFinite(point.p) ? point.p : null))
+    .filter((value): value is number => value !== null)
+
+  if (points.length === 0) {
+    return 0
+  }
+
+  const start = points[0]
+  const end = points[points.length - 1]
+  return relative ? end - start : end
+}
+
+async function fetchUserTimeframePnl(
+  period: TimePeriod,
+  address: string,
+  signal: AbortSignal,
+): Promise<number | null> {
+  if (!USER_PNL_API_URL) {
+    return null
+  }
+
+  const now = Date.now()
+  const cached = getCachedValue(period, address, now)
+  if (typeof cached === 'number' && Number.isFinite(cached)) {
+    return cached
+  }
+
+  const key = toCacheKey(period, address)
+  const inFlight = TIMEFRAME_PNL_IN_FLIGHT.get(key)
+  if (inFlight) {
+    return inFlight
+  }
+
+  const request = (async () => {
+    const { interval, fidelity, relative } = resolvePeriodConfig(period)
+    const params = new URLSearchParams({
+      user_address: address,
+      interval,
+      fidelity,
+    })
+
+    const endpoint = new URL('/user-pnl', USER_PNL_API_URL)
+    const response = await fetch(`${endpoint.toString()}?${params.toString()}`, {
+      signal,
+      cache: 'no-store',
+    })
+
+    if (!response.ok) {
+      return null
+    }
+
+    const payload = await response.json()
+    const value = parseUserPnlValue(payload, relative)
+    if (Number.isFinite(value)) {
+      setCachedValue(period, address, value, Date.now())
+      return value
+    }
+
+    return null
+  })()
+    .finally(() => {
+      TIMEFRAME_PNL_IN_FLIGHT.delete(key)
+    })
+
+  TIMEFRAME_PNL_IN_FLIGHT.set(key, request)
+  return request
+}
+
+async function fetchBatchPnlValues(
+  period: TimePeriod,
+  addresses: string[],
+  signal: AbortSignal,
+): Promise<Record<string, number>> {
+  const values: Record<string, number> = {}
+  if (addresses.length === 0) {
+    return values
+  }
+
+  const queue = [...addresses]
+  const workers = Array.from({ length: Math.min(UPSTREAM_CONCURRENCY, queue.length) }, async () => {
+    while (queue.length > 0) {
+      const nextAddress = queue.shift()
+      if (!nextAddress) {
+        return
+      }
+
+      const value = await fetchUserTimeframePnl(period, nextAddress, signal).catch(() => null)
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        values[nextAddress] = value
+      }
+    }
+  })
+
+  await Promise.all(workers)
+  return values
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => null) as { period?: unknown, addresses?: unknown } | null
+    const period = normalizePeriod(body?.period)
+    if (!period) {
+      return NextResponse.json({ error: 'Invalid period.' }, { status: 400 })
+    }
+
+    const addresses = normalizeAddresses(body?.addresses)
+    if (addresses.length === 0) {
+      return NextResponse.json({ values: {} })
+    }
+
+    const values = await fetchBatchPnlValues(period, addresses, request.signal)
+    return NextResponse.json({ values })
+  }
+  catch (error) {
+    console.error('Failed to load leaderboard timeframe pnl:', error)
+    return NextResponse.json({ error: DEFAULT_ERROR_MESSAGE }, { status: 500 })
+  }
+}

--- a/src/app/api/leaderboard/timeframe-pnl/route.ts
+++ b/src/app/api/leaderboard/timeframe-pnl/route.ts
@@ -19,8 +19,14 @@ interface CacheEntry {
   expiresAt: number
 }
 
+interface InFlightEntry {
+  controller: AbortController
+  consumers: number
+  promise: Promise<number | null>
+}
+
 const TIMEFRAME_PNL_CACHE = new Map<string, CacheEntry>()
-const TIMEFRAME_PNL_IN_FLIGHT = new Map<string, Promise<number | null>>()
+const TIMEFRAME_PNL_IN_FLIGHT = new Map<string, InFlightEntry>()
 
 function resolvePeriodConfig(period: TimePeriod) {
   switch (period) {
@@ -130,23 +136,46 @@ function abortError() {
   return new DOMException('The operation was aborted.', 'AbortError')
 }
 
-async function withAbortSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+function releaseInFlightConsumer(entry: InFlightEntry) {
+  entry.consumers = Math.max(0, entry.consumers - 1)
+  if (entry.consumers === 0) {
+    entry.controller.abort()
+  }
+}
+
+async function waitForInFlightEntry(
+  key: string,
+  entry: InFlightEntry,
+  signal: AbortSignal,
+): Promise<number | null> {
   if (signal.aborted) {
+    if (entry.consumers === 0) {
+      entry.controller.abort()
+    }
     throw abortError()
   }
 
-  return await new Promise<T>((resolve, reject) => {
-    const onAbort = () => {
+  entry.consumers += 1
+
+  return await new Promise<number | null>((resolve, reject) => {
+    let settled = false
+
+    function cleanup() {
+      if (settled) {
+        return
+      }
+      settled = true
+      signal.removeEventListener('abort', onAbort)
+      releaseInFlightConsumer(entry)
+    }
+
+    function onAbort() {
       cleanup()
       reject(abortError())
     }
 
-    const cleanup = () => {
-      signal.removeEventListener('abort', onAbort)
-    }
-
     signal.addEventListener('abort', onAbort, { once: true })
-    promise
+    entry.promise
       .then((value) => {
         cleanup()
         resolve(value)
@@ -161,6 +190,7 @@ async function withAbortSignal<T>(promise: Promise<T>, signal: AbortSignal): Pro
 async function fetchUserTimeframePnl(
   period: TimePeriod,
   address: string,
+  signal: AbortSignal,
 ): Promise<number | null> {
   if (!USER_PNL_API_URL) {
     return null
@@ -175,10 +205,17 @@ async function fetchUserTimeframePnl(
   const key = toCacheKey(period, address)
   const inFlight = TIMEFRAME_PNL_IN_FLIGHT.get(key)
   if (inFlight) {
-    return inFlight
+    return await waitForInFlightEntry(key, inFlight, signal)
   }
 
-  const request = (async () => {
+  const controller = new AbortController()
+  const entry: InFlightEntry = {
+    controller,
+    consumers: 0,
+    promise: Promise.resolve(null),
+  }
+
+  entry.promise = (async () => {
     const { interval, fidelity, relative } = resolvePeriodConfig(period)
     const params = new URLSearchParams({
       user_address: address,
@@ -188,6 +225,7 @@ async function fetchUserTimeframePnl(
 
     const endpoint = new URL('/user-pnl', USER_PNL_API_URL)
     const response = await fetch(`${endpoint.toString()}?${params.toString()}`, {
+      signal: controller.signal,
       cache: 'no-store',
     })
 
@@ -197,7 +235,7 @@ async function fetchUserTimeframePnl(
 
     const payload = await response.json()
     const value = parseUserPnlValue(payload, relative)
-    if (Number.isFinite(value)) {
+    if (typeof value === 'number' && Number.isFinite(value)) {
       setCachedValue(period, address, value, Date.now())
       return value
     }
@@ -208,8 +246,8 @@ async function fetchUserTimeframePnl(
       TIMEFRAME_PNL_IN_FLIGHT.delete(key)
     })
 
-  TIMEFRAME_PNL_IN_FLIGHT.set(key, request)
-  return request
+  TIMEFRAME_PNL_IN_FLIGHT.set(key, entry)
+  return await waitForInFlightEntry(key, entry, signal)
 }
 
 async function fetchBatchPnlValues(
@@ -234,8 +272,7 @@ async function fetchBatchPnlValues(
         return
       }
 
-      const sharedLookup = fetchUserTimeframePnl(period, nextAddress)
-      const value = await withAbortSignal(sharedLookup, signal).catch(() => null)
+      const value = await fetchUserTimeframePnl(period, nextAddress, signal).catch(() => null)
       if (typeof value === 'number' && Number.isFinite(value)) {
         values[nextAddress] = value
       }

--- a/src/app/api/leaderboard/timeframe-pnl/route.ts
+++ b/src/app/api/leaderboard/timeframe-pnl/route.ts
@@ -204,8 +204,12 @@ async function fetchUserTimeframePnl(
 
   const key = toCacheKey(period, address)
   const inFlight = TIMEFRAME_PNL_IN_FLIGHT.get(key)
-  if (inFlight) {
+  if (inFlight && !inFlight.controller.signal.aborted) {
     return await waitForInFlightEntry(key, inFlight, signal)
+  }
+
+  if (inFlight?.controller.signal.aborted) {
+    TIMEFRAME_PNL_IN_FLIGHT.delete(key)
   }
 
   const controller = new AbortController()

--- a/src/app/api/leaderboard/timeframe-pnl/route.ts
+++ b/src/app/api/leaderboard/timeframe-pnl/route.ts
@@ -247,7 +247,9 @@ async function fetchUserTimeframePnl(
     return null
   })()
     .finally(() => {
-      TIMEFRAME_PNL_IN_FLIGHT.delete(key)
+      if (TIMEFRAME_PNL_IN_FLIGHT.get(key) === entry) {
+        TIMEFRAME_PNL_IN_FLIGHT.delete(key)
+      }
     })
 
   TIMEFRAME_PNL_IN_FLIGHT.set(key, entry)

--- a/src/app/api/leaderboard/timeframe-pnl/route.ts
+++ b/src/app/api/leaderboard/timeframe-pnl/route.ts
@@ -108,9 +108,9 @@ function setCachedValue(period: TimePeriod, address: string, value: number, now:
   trimCache()
 }
 
-function parseUserPnlValue(payload: unknown, relative: boolean): number {
+function parseUserPnlValue(payload: unknown, relative: boolean): number | null {
   if (!Array.isArray(payload) || payload.length === 0) {
-    return 0
+    return null
   }
 
   const points = (payload as UserPnlPoint[])
@@ -118,7 +118,7 @@ function parseUserPnlValue(payload: unknown, relative: boolean): number {
     .filter((value): value is number => value !== null)
 
   if (points.length === 0) {
-    return 0
+    return null
   }
 
   const start = points[0]
@@ -126,10 +126,41 @@ function parseUserPnlValue(payload: unknown, relative: boolean): number {
   return relative ? end - start : end
 }
 
+function abortError() {
+  return new DOMException('The operation was aborted.', 'AbortError')
+}
+
+async function withAbortSignal<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) {
+    throw abortError()
+  }
+
+  return await new Promise<T>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup()
+      reject(abortError())
+    }
+
+    const cleanup = () => {
+      signal.removeEventListener('abort', onAbort)
+    }
+
+    signal.addEventListener('abort', onAbort, { once: true })
+    promise
+      .then((value) => {
+        cleanup()
+        resolve(value)
+      })
+      .catch((error) => {
+        cleanup()
+        reject(error)
+      })
+  })
+}
+
 async function fetchUserTimeframePnl(
   period: TimePeriod,
   address: string,
-  signal: AbortSignal,
 ): Promise<number | null> {
   if (!USER_PNL_API_URL) {
     return null
@@ -157,7 +188,6 @@ async function fetchUserTimeframePnl(
 
     const endpoint = new URL('/user-pnl', USER_PNL_API_URL)
     const response = await fetch(`${endpoint.toString()}?${params.toString()}`, {
-      signal,
       cache: 'no-store',
     })
 
@@ -195,12 +225,17 @@ async function fetchBatchPnlValues(
   const queue = [...addresses]
   const workers = Array.from({ length: Math.min(UPSTREAM_CONCURRENCY, queue.length) }, async () => {
     while (queue.length > 0) {
+      if (signal.aborted) {
+        return
+      }
+
       const nextAddress = queue.shift()
       if (!nextAddress) {
         return
       }
 
-      const value = await fetchUserTimeframePnl(period, nextAddress, signal).catch(() => null)
+      const sharedLookup = fetchUserTimeframePnl(period, nextAddress)
+      const value = await withAbortSignal(sharedLookup, signal).catch(() => null)
       if (typeof value === 'number' && Number.isFinite(value)) {
         values[nextAddress] = value
       }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the mismatch between leaderboard PnL and the portfolio chart by aligning calculations to the selected timeframe and batching hydration via a new API. Leaderboard rows (including the current user) now use period-aligned portfolio PnL so numbers match across views.

- **Bug Fixes**
  - Map periods to portfolio intervals and compute relative vs absolute PnL server-side.
  - Batch-fetch timeframe PnL via `POST /api/leaderboard/timeframe-pnl`; override `pnl` for `overall`.
  - Add caching and coalescing; normalize addresses; enforce batch/concurrency limits; validate payloads; preserve active in-flight entries and cancel only when unused; avoid reusing aborted lookups.

<sup>Written for commit de18080f8b028beaea0e6c7b7b2e970cdf57b728. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

