### PR TITLE
fix: make volume sync cursor-based and timeout-resilient

### DIFF
--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -264,8 +264,8 @@ async function createSyncEventsCron(sql, siteUrl, cronSecret) {
 async function createSyncVolumeCron(sql, siteUrl, cronSecret) {
   await createSyncCron(sql, {
     jobName: 'sync-volume',
-    schedule: '* * * * *',
-    endpointPath: '/api/sync/volume?limit=120',
+    schedule: '*/10 * * * *',
+    endpointPath: '/api/sync/volume?limit=150',
     siteUrl,
     cronSecret,
     timeoutMilliseconds: 20000,

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -29,11 +29,15 @@ function buildSyncCronSql({
   endpointPath,
   siteUrl,
   cronSecret,
+  timeoutMilliseconds = 20000,
 }) {
   const endpointUrl = joinSiteUrlPath(siteUrl, endpointPath)
   const escapedJobName = escapeSqlLiteral(jobName)
   const escapedSchedule = escapeSqlLiteral(schedule)
   const escapedEndpointUrl = escapeSqlLiteral(endpointUrl)
+  const normalizedTimeout = Number.isFinite(Number(timeoutMilliseconds))
+    ? Math.max(1000, Math.trunc(Number(timeoutMilliseconds)))
+    : 20000
   const escapedHeaders = escapeSqlLiteral(JSON.stringify({
     'Content-Type': 'application/json',
     'Authorization': `Bearer ${cronSecret}`,
@@ -46,7 +50,8 @@ function buildSyncCronSql({
     cmd text := $c$
       SELECT net.http_get(
         url := '${escapedEndpointUrl}',
-        headers := '${escapedHeaders}'
+        headers := '${escapedHeaders}',
+        timeout_milliseconds := ${normalizedTimeout}
       );
     $c$;
   BEGIN
@@ -259,10 +264,11 @@ async function createSyncEventsCron(sql, siteUrl, cronSecret) {
 async function createSyncVolumeCron(sql, siteUrl, cronSecret) {
   await createSyncCron(sql, {
     jobName: 'sync-volume',
-    schedule: '16,46 * * * *',
-    endpointPath: '/api/sync/volume',
+    schedule: '* * * * *',
+    endpointPath: '/api/sync/volume?limit=120',
     siteUrl,
     cronSecret,
+    timeoutMilliseconds: 20000,
   })
 }
 

--- a/src/app/api/sync/volume/helpers.ts
+++ b/src/app/api/sync/volume/helpers.ts
@@ -1,6 +1,6 @@
 export const VOLUME_BATCH_SIZE = 100
 export const VOLUME_REQUEST_TIMEOUT_MS = 10_000
-export const DEFAULT_VOLUME_SYNC_LIMIT = 120
+export const DEFAULT_VOLUME_SYNC_LIMIT = 150
 export const MAX_VOLUME_SYNC_LIMIT = 500
 export const SYNC_TIME_LIMIT_MS = 250_000
 

--- a/src/app/api/sync/volume/helpers.ts
+++ b/src/app/api/sync/volume/helpers.ts
@@ -1,6 +1,6 @@
 export const VOLUME_BATCH_SIZE = 100
 export const VOLUME_REQUEST_TIMEOUT_MS = 10_000
-export const DEFAULT_VOLUME_SYNC_LIMIT = 200
+export const DEFAULT_VOLUME_SYNC_LIMIT = 120
 export const MAX_VOLUME_SYNC_LIMIT = 500
 export const SYNC_TIME_LIMIT_MS = 250_000
 

--- a/src/app/api/sync/volume/route.ts
+++ b/src/app/api/sync/volume/route.ts
@@ -45,8 +45,10 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthenticated.' }, { status: 401 })
   }
 
+  let lockAcquired = false
+
   try {
-    const lockAcquired = await tryAcquireSyncLock()
+    lockAcquired = await tryAcquireSyncLock()
     if (!lockAcquired) {
       return NextResponse.json({
         success: false,
@@ -60,7 +62,9 @@ export async function GET(request: Request) {
     return NextResponse.json({ success: true, ...stats })
   }
   catch (error: any) {
-    await updateSyncStatus('error', error?.message ?? 'Unknown error')
+    if (lockAcquired) {
+      await updateSyncStatus('error', error?.message ?? 'Unknown error')
+    }
     console.error('volume-sync failed', error)
     return NextResponse.json(
       { success: false, error: error?.message ?? 'Unknown error' },

--- a/src/app/api/sync/volume/route.ts
+++ b/src/app/api/sync/volume/route.ts
@@ -1,5 +1,5 @@
 import type { VolumeResponseItem, VolumeWorkItem } from '@/app/api/sync/volume/helpers'
-import { and, asc, eq, inArray } from 'drizzle-orm'
+import { and, asc, eq, gt, inArray, lt, ne, or } from 'drizzle-orm'
 import { NextResponse } from 'next/server'
 import {
   chunkVolumeWork,
@@ -13,12 +13,15 @@ import {
   VOLUME_REQUEST_TIMEOUT_MS,
 } from '@/app/api/sync/volume/helpers'
 import { isCronAuthorized } from '@/lib/auth-cron'
-import { markets, outcomes } from '@/lib/db/schema'
+import { markets, outcomes, subgraph_syncs } from '@/lib/db/schema'
 import { db } from '@/lib/drizzle'
 
 export const maxDuration = 300
 
 const CLOB_URL = process.env.CLOB_URL!
+const SYNC_RUNNING_STALE_MS = 15 * 60 * 1000
+const VOLUME_SYNC_SERVICE = 'volume_sync'
+const VOLUME_SYNC_SUBGRAPH = 'volume'
 
 interface VolumeSyncStats {
   scanned: number
@@ -26,6 +29,8 @@ interface VolumeSyncStats {
   skipped: number
   errors: { context: string, error: string }[]
   timeLimitReached: boolean
+  nextCursor: string | null
+  wrappedAround: boolean
 }
 
 interface OutcomeRow {
@@ -41,10 +46,21 @@ export async function GET(request: Request) {
   }
 
   try {
+    const lockAcquired = await tryAcquireSyncLock()
+    if (!lockAcquired) {
+      return NextResponse.json({
+        success: false,
+        message: 'Sync already running',
+        skipped: true,
+      }, { status: 409 })
+    }
+
     const stats = await syncMarketVolumes(request)
+    await updateSyncStatus('completed', null, stats.updated, stats.nextCursor)
     return NextResponse.json({ success: true, ...stats })
   }
   catch (error: any) {
+    await updateSyncStatus('error', error?.message ?? 'Unknown error')
     console.error('volume-sync failed', error)
     return NextResponse.json(
       { success: false, error: error?.message ?? 'Unknown error' },
@@ -60,15 +76,19 @@ async function syncMarketVolumes(request: Request): Promise<VolumeSyncStats> {
     DEFAULT_VOLUME_SYNC_LIMIT,
     MAX_VOLUME_SYNC_LIMIT,
   )
+  const cursorOverride = normalizeCursorParam(url.searchParams.get('cursor'))
+  const currentCursor = cursorOverride ?? await getStoredCursor()
   const startedAt = Date.now()
 
-  const worklist = await buildVolumeWorklist(limit)
+  const worklist = await buildVolumeWorklist(limit, currentCursor)
   const stats: VolumeSyncStats = {
     scanned: worklist.scanned,
     updated: 0,
     skipped: worklist.skipped,
     errors: [...worklist.errors],
     timeLimitReached: false,
+    nextCursor: worklist.nextCursor,
+    wrappedAround: worklist.wrappedAround,
   }
 
   if (worklist.items.length === 0) {
@@ -146,25 +166,31 @@ async function syncMarketVolumes(request: Request): Promise<VolumeSyncStats> {
   return stats
 }
 
-async function buildVolumeWorklist(limit: number): Promise<{
+function normalizeCursorParam(value: string | null): string | null {
+  if (!value) {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return trimmed || null
+}
+
+async function buildVolumeWorklist(limit: number, cursor: string | null): Promise<{
   items: VolumeWorkItem[]
   scanned: number
   skipped: number
   errors: { context: string, error: string }[]
+  nextCursor: string | null
+  wrappedAround: boolean
 }> {
-  const marketRows = await db
-    .select({
-      condition_id: markets.condition_id,
-      volume_24h: markets.volume_24h,
-      volume: markets.volume,
-    })
-    .from(markets)
-    .where(and(
-      eq(markets.is_active, true),
-      eq(markets.is_resolved, false),
-    ))
-    .orderBy(asc(markets.updated_at))
-    .limit(limit)
+  let wrappedAround = false
+  let marketRows = await fetchMarketRows(limit, cursor)
+  if (marketRows.length === 0 && cursor) {
+    marketRows = await fetchMarketRows(limit, null)
+    wrappedAround = true
+  }
+
+  const nextCursor = marketRows.at(-1)?.condition_id ?? null
   const conditionIds = marketRows.map(market => market.condition_id)
 
   let outcomesMap = new Map<string, string[]>()
@@ -208,7 +234,31 @@ async function buildVolumeWorklist(limit: number): Promise<{
     scanned: marketRows.length,
     skipped,
     errors,
+    nextCursor,
+    wrappedAround,
   }
+}
+
+async function fetchMarketRows(limit: number, cursor: string | null) {
+  const basePredicate = and(
+    eq(markets.is_active, true),
+    eq(markets.is_resolved, false),
+  )
+
+  const predicate = cursor
+    ? and(basePredicate, gt(markets.condition_id, cursor))
+    : basePredicate
+
+  return db
+    .select({
+      condition_id: markets.condition_id,
+      volume_24h: markets.volume_24h,
+      volume: markets.volume,
+    })
+    .from(markets)
+    .where(predicate)
+    .orderBy(asc(markets.condition_id))
+    .limit(limit)
 }
 
 function buildOutcomeMap(outcomes: OutcomeRow[]): Map<string, string[]> {
@@ -276,4 +326,113 @@ async function updateMarketVolume(conditionId: string, totalVolume: string, volu
       volume_24h: volume24h,
     })
     .where(eq(markets.condition_id, conditionId))
+}
+
+async function getStoredCursor(): Promise<string | null> {
+  const rows = await db
+    .select({
+      cursor_id: subgraph_syncs.cursor_id,
+    })
+    .from(subgraph_syncs)
+    .where(and(
+      eq(subgraph_syncs.service_name, VOLUME_SYNC_SERVICE),
+      eq(subgraph_syncs.subgraph_name, VOLUME_SYNC_SUBGRAPH),
+    ))
+    .limit(1)
+
+  if (rows.length === 0) {
+    throw new Error('Missing sync state row for volume_sync/volume. Run the latest database migrations.')
+  }
+
+  return rows[0]?.cursor_id ?? null
+}
+
+async function tryAcquireSyncLock(): Promise<boolean> {
+  const staleThreshold = new Date(Date.now() - SYNC_RUNNING_STALE_MS)
+  const runningPayload = {
+    service_name: VOLUME_SYNC_SERVICE,
+    subgraph_name: VOLUME_SYNC_SUBGRAPH,
+    status: 'running' as const,
+    error_message: null,
+  }
+
+  try {
+    const claimedRows = await db
+      .update(subgraph_syncs)
+      .set(runningPayload)
+      .where(and(
+        eq(subgraph_syncs.service_name, VOLUME_SYNC_SERVICE),
+        eq(subgraph_syncs.subgraph_name, VOLUME_SYNC_SUBGRAPH),
+        or(
+          ne(subgraph_syncs.status, 'running'),
+          lt(subgraph_syncs.updated_at, staleThreshold),
+        ),
+      ))
+      .returning({ id: subgraph_syncs.id })
+
+    if (claimedRows.length > 0) {
+      return true
+    }
+
+    const existingRows = await db
+      .select({ id: subgraph_syncs.id })
+      .from(subgraph_syncs)
+      .where(and(
+        eq(subgraph_syncs.service_name, VOLUME_SYNC_SERVICE),
+        eq(subgraph_syncs.subgraph_name, VOLUME_SYNC_SUBGRAPH),
+      ))
+      .limit(1)
+
+    if (existingRows.length > 0) {
+      return false
+    }
+
+    throw new Error('Missing sync state row for volume_sync/volume. Run the latest database migrations.')
+  }
+  catch (error: any) {
+    throw new Error(`Failed to claim sync lock: ${error?.message ?? String(error)}`)
+  }
+}
+
+async function updateSyncStatus(
+  status: 'running' | 'completed' | 'error',
+  errorMessage?: string | null,
+  totalProcessed?: number,
+  cursorId?: string | null,
+) {
+  const updateData: any = {
+    service_name: VOLUME_SYNC_SERVICE,
+    subgraph_name: VOLUME_SYNC_SUBGRAPH,
+    status,
+  }
+
+  if (errorMessage !== undefined) {
+    updateData.error_message = errorMessage
+  }
+
+  if (totalProcessed !== undefined) {
+    updateData.total_processed = totalProcessed
+  }
+
+  if (cursorId !== undefined) {
+    updateData.cursor_id = cursorId
+  }
+
+  try {
+    const updatedRows = await db
+      .update(subgraph_syncs)
+      .set(updateData)
+      .where(and(
+        eq(subgraph_syncs.service_name, VOLUME_SYNC_SERVICE),
+        eq(subgraph_syncs.subgraph_name, VOLUME_SYNC_SUBGRAPH),
+      ))
+      .returning({ id: subgraph_syncs.id })
+
+    if (updatedRows.length === 0) {
+      console.error('Failed to update sync status: missing sync state row for volume_sync/volume')
+    }
+  }
+  catch (error: any) {
+    console.error(`Failed to update sync status to ${status}:`, error)
+  }
 }

--- a/src/lib/db/migrations/2026_04_13_002_volume_sync_cursor.sql
+++ b/src/lib/db/migrations/2026_04_13_002_volume_sync_cursor.sql
@@ -1,0 +1,16 @@
+INSERT INTO subgraph_syncs (service_name, subgraph_name, status, total_processed, error_message, cursor_id)
+VALUES
+  ('volume_sync', 'volume', 'idle', 0, NULL, NULL)
+ON CONFLICT (service_name, subgraph_name) DO NOTHING;
+
+UPDATE subgraph_syncs
+SET
+  status = 'idle',
+  error_message = NULL,
+  updated_at = NOW()
+WHERE (service_name, subgraph_name) IN (
+  ('volume_sync', 'volume')
+);
+
+CREATE INDEX IF NOT EXISTS idx_markets_active_resolved_condition_id
+  ON markets (is_active, is_resolved, condition_id);


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make volume sync cursor-based and resumable with a lock and request timeouts to avoid overlap and handle slow networks. Cron now runs every 10 minutes with a tighter batch size to keep each run fast.

- **New Features**
  - Cursor-based scanning on `markets.condition_id`; wraps around after the end and persists `nextCursor`.
  - Persists `cursor_id`, status, and totals in `subgraph_syncs`; supports `?cursor=` override.
  - Concurrency lock with 15‑min stale recovery; returns 409 if a run is active and avoids releasing the lock on pre‑lock failures.
  - Cron runs every 10 minutes: `/api/sync/volume?limit=150` with `timeout_milliseconds: 20000`.
  - Default limit set to 150 for faster, timeout-safe runs.

- **Migration**
  - Adds `subgraph_syncs` row for `volume_sync`/`volume`.
  - Creates `idx_markets_active_resolved_condition_id` to support cursor queries.
  - Run database migrations before deploying; the API expects the sync state row.

<sup>Written for commit 60b62da795d90e67a9c505606e404f559ba79648. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

