### PR TITLE
refactor: use custom hooks for event page content components

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
@@ -25,6 +25,14 @@ interface EventActivityProps {
   event: Event
 }
 
+function resolveActivityRowKey(activity: ActivityOrder, index: number) {
+  return [
+    activity.id,
+    activity.created_at,
+    index,
+  ].join(':')
+}
+
 function getEventTokenIds(event: Event) {
   const tokenIds = new Set<string>()
 
@@ -407,7 +415,7 @@ export default function EventActivity({ event }: EventActivityProps) {
       {!loading && activities.length > 0 && (
         <div className="overflow-hidden">
           <div className="divide-y divide-border/80">
-            {activities.map((activity) => {
+            {activities.map((activity, index) => {
               const timeAgoLabel = formatTimeAgo(activity.created_at)
               const txUrl = activity.tx_hash ? `${POLYGON_SCAN_BASE}/tx/${activity.tx_hash}` : null
               const priceLabel = formatSharePriceLabel(Number(activity.price))
@@ -428,7 +436,7 @@ export default function EventActivity({ event }: EventActivityProps) {
 
               return (
                 <div
-                  key={activity.id}
+                  key={resolveActivityRowKey(activity, index)}
                 >
                   <ProfileLink
                     user={{

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
@@ -25,11 +25,14 @@ interface EventActivityProps {
   event: Event
 }
 
-function resolveActivityRowKey(activity: ActivityOrder, index: number) {
+function resolveActivityRowKey(activity: ActivityOrder) {
   return [
     activity.id,
     activity.created_at,
-    index,
+    activity.tx_hash ?? 'no-tx',
+    activity.user.id,
+    activity.market.condition_id ?? 'no-market',
+    activity.side,
   ].join(':')
 }
 
@@ -415,7 +418,7 @@ export default function EventActivity({ event }: EventActivityProps) {
       {!loading && activities.length > 0 && (
         <div className="overflow-hidden">
           <div className="divide-y divide-border/80">
-            {activities.map((activity, index) => {
+            {activities.map((activity) => {
               const timeAgoLabel = formatTimeAgo(activity.created_at)
               const txUrl = activity.tx_hash ? `${POLYGON_SCAN_BASE}/tx/${activity.tx_hash}` : null
               const priceLabel = formatSharePriceLabel(Number(activity.price))
@@ -436,7 +439,7 @@ export default function EventActivity({ event }: EventActivityProps) {
 
               return (
                 <div
-                  key={resolveActivityRowKey(activity, index)}
+                  key={resolveActivityRowKey(activity)}
                 >
                   <ProfileLink
                     user={{

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
@@ -207,7 +207,7 @@ function useRealtimeActivityRefresh({
     }
   }, [hasMarkets, refreshLatestActivity])
 
-  const handleMarketChannelMessage = useCallback(function handleMarketChannelMessage(payload: any) {
+  const handleMarketChannelMessage = useCallback((payload: any) => {
     if (!hasMarkets || tokenIds.length === 0) {
       return
     }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
@@ -39,102 +39,93 @@ function getEventTokenIds(event: Event) {
   return Array.from(tokenIds)
 }
 
-export default function EventActivity({ event }: EventActivityProps) {
-  const t = useExtracted()
-  const [minAmountFilter, setMinAmountFilter] = useState('none')
-  const [infiniteScrollError, setInfiniteScrollError] = useState<string | null>(null)
-  const queryClient = useQueryClient()
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
-  const isPollingRef = useRef(false)
-  const lastWsRefreshAtRef = useRef(0)
-  const wsRefreshThrottleMs = 2000
-  const normalizeOutcomeLabel = useOutcomeLabel()
-  const isSportsEvent = Boolean(event.sports_sport_slug?.trim())
+const WS_REFRESH_THROTTLE_MS = 2000
+const ACTIVITY_POLL_INTERVAL_MS = 60_000
 
-  useEffect(() => {
-    queueMicrotask(() => setInfiniteScrollError(null))
-  }, [minAmountFilter])
+function useClearInfiniteScrollErrorOnFilterChange({
+  minAmountFilter,
+  setInfiniteScrollError,
+}: {
+  minAmountFilter: string
+  setInfiniteScrollError: (value: string | null) => void
+}) {
+  useEffect(function clearInfiniteScrollErrorOnFilterChange() {
+    queueMicrotask(function clearErrorNow() {
+      setInfiniteScrollError(null)
+    })
+  }, [minAmountFilter, setInfiniteScrollError])
+}
 
-  const marketIds = useMemo(
-    () => event.markets.map(market => market.condition_id).filter(Boolean),
-    [event.markets],
-  )
-  const marketKey = useMemo(() => marketIds.join(','), [marketIds])
-  const hasMarkets = marketIds.length > 0
-  const tokenIds = useMemo(
-    () => {
-      return getEventTokenIds(event)
-    },
-    [event],
-  )
-
-  const queryKey = useMemo(
-    () => ['event-activity', event.slug, marketKey, minAmountFilter],
-    [event.slug, marketKey, minAmountFilter],
-  )
-
-  const {
-    status,
-    data,
-    isFetchingNextPage,
-    fetchNextPage,
-    hasNextPage,
-    refetch,
-  } = useInfiniteQuery({
-    queryKey,
-    queryFn: ({ pageParam = 0, signal }) =>
-      fetchEventTrades({
-        marketIds,
-        pageParam,
-        minAmountFilter,
-        signal,
-      }),
-    getNextPageParam: (lastPage, allPages) => {
-      if (lastPage.length === EVENT_ACTIVITY_PAGE_SIZE) {
-        return allPages.reduce((total, page) => total + page.length, 0)
-      }
-
-      return undefined
-    },
-    initialPageParam: 0,
-    staleTime: 1000 * 60 * 5,
-    gcTime: 1000 * 60 * 10,
-    enabled: hasMarkets,
-  })
-
-  const activities: ActivityOrder[] = data?.pages.flat() ?? []
-  const loading = hasMarkets && status === 'pending'
-  const hasInitialError = hasMarkets && status === 'error'
-
-  useEffect(() => {
-    const node = loadMoreRef.current
+function useInfiniteScrollSentinel({
+  sentinelRef,
+  hasMarkets,
+  hasNextPage,
+  isFetchingNextPage,
+  loading,
+  hasError,
+  fetchNextPage,
+  setInfiniteScrollError,
+  errorMessage,
+}: {
+  sentinelRef: React.RefObject<HTMLDivElement | null>
+  hasMarkets: boolean
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  loading: boolean
+  hasError: boolean
+  fetchNextPage: () => Promise<unknown>
+  setInfiniteScrollError: (value: string | null) => void
+  errorMessage: string
+}) {
+  useEffect(function observeInfiniteScrollSentinel() {
+    const node = sentinelRef.current
     if (!node || !hasMarkets) {
       return
     }
 
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0]
-        if (
-          entry?.isIntersecting
-          && hasNextPage
-          && !isFetchingNextPage
-          && !loading
-          && !infiniteScrollError
-        ) {
-          fetchNextPage().catch((error) => {
-            setInfiniteScrollError(error.message || t('Failed to load more activity'))
-          })
-        }
-      },
-      { rootMargin: '200px 0px' },
-    )
+    const observer = new IntersectionObserver(function handleSentinelIntersection(entries) {
+      const entry = entries[0]
+      if (
+        entry?.isIntersecting
+        && hasNextPage
+        && !isFetchingNextPage
+        && !loading
+        && !hasError
+      ) {
+        fetchNextPage().catch((error) => {
+          setInfiniteScrollError(error.message || errorMessage)
+        })
+      }
+    }, { rootMargin: '200px 0px' })
 
     observer.observe(node)
-    return () => observer.disconnect()
-  }, [activities.length, fetchNextPage, hasMarkets, hasNextPage, infiniteScrollError, isFetchingNextPage, loading, t])
+    return function unobserveInfiniteScrollSentinel() {
+      observer.disconnect()
+    }
+  }, [errorMessage, fetchNextPage, hasError, hasMarkets, hasNextPage, isFetchingNextPage, loading, sentinelRef, setInfiniteScrollError])
+}
 
-  const refreshLatestActivity = useCallback(async () => {
+function useRealtimeActivityRefresh({
+  hasMarkets,
+  loading,
+  marketIds,
+  tokenIds,
+  minAmountFilter,
+  queryClient,
+  queryKey,
+}: {
+  hasMarkets: boolean
+  loading: boolean
+  marketIds: string[]
+  tokenIds: string[]
+  minAmountFilter: string
+  queryClient: ReturnType<typeof useQueryClient>
+  queryKey: readonly unknown[]
+}) {
+  const isPollingRef = useRef(false)
+  const lastWsRefreshAtRef = useRef(0)
+
+  const refreshLatestActivity = useCallback(async function refreshLatestActivity() {
     if (!hasMarkets || loading || isPollingRef.current) {
       return
     }
@@ -188,22 +179,24 @@ export default function EventActivity({ event }: EventActivityProps) {
     }
   }, [hasMarkets, loading, marketIds, minAmountFilter, queryClient, queryKey])
 
-  useEffect(() => {
+  useEffect(function pollActivityWhilePageVisible() {
     if (!hasMarkets) {
       return
     }
 
-    const interval = window.setInterval(() => {
+    const interval = window.setInterval(function refreshIfVisible() {
       if (document.hidden) {
         return
       }
       void refreshLatestActivity()
-    }, 60_000)
+    }, ACTIVITY_POLL_INTERVAL_MS)
 
-    return () => window.clearInterval(interval)
+    return function stopActivityPolling() {
+      window.clearInterval(interval)
+    }
   }, [hasMarkets, refreshLatestActivity])
 
-  const handleMarketChannelMessage = useCallback((payload: any) => {
+  const handleMarketChannelMessage = useCallback(function handleMarketChannelMessage(payload: any) {
     if (!hasMarkets || tokenIds.length === 0) {
       return
     }
@@ -218,7 +211,7 @@ export default function EventActivity({ event }: EventActivityProps) {
       return
     }
     const now = Date.now()
-    if (now - lastWsRefreshAtRef.current < wsRefreshThrottleMs) {
+    if (now - lastWsRefreshAtRef.current < WS_REFRESH_THROTTLE_MS) {
       return
     }
     lastWsRefreshAtRef.current = now
@@ -226,6 +219,94 @@ export default function EventActivity({ event }: EventActivityProps) {
   }, [hasMarkets, refreshLatestActivity, tokenIds])
 
   useMarketChannelSubscription(handleMarketChannelMessage)
+}
+
+export default function EventActivity({ event }: EventActivityProps) {
+  const t = useExtracted()
+  const [minAmountFilter, setMinAmountFilter] = useState('none')
+  const [infiniteScrollError, setInfiniteScrollError] = useState<string | null>(null)
+  const queryClient = useQueryClient()
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const normalizeOutcomeLabel = useOutcomeLabel()
+  const isSportsEvent = Boolean(event.sports_sport_slug?.trim())
+
+  useClearInfiniteScrollErrorOnFilterChange({
+    minAmountFilter,
+    setInfiniteScrollError,
+  })
+
+  const marketIds = useMemo(
+    () => event.markets.map(market => market.condition_id).filter(Boolean),
+    [event.markets],
+  )
+  const marketKey = useMemo(() => marketIds.join(','), [marketIds])
+  const hasMarkets = marketIds.length > 0
+  const tokenIds = useMemo(
+    () => {
+      return getEventTokenIds(event)
+    },
+    [event],
+  )
+
+  const queryKey = useMemo(
+    () => ['event-activity', event.slug, marketKey, minAmountFilter],
+    [event.slug, marketKey, minAmountFilter],
+  )
+
+  const {
+    status,
+    data,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey,
+    queryFn: ({ pageParam = 0, signal }) =>
+      fetchEventTrades({
+        marketIds,
+        pageParam,
+        minAmountFilter,
+        signal,
+      }),
+    getNextPageParam: (lastPage, allPages) => {
+      if (lastPage.length === EVENT_ACTIVITY_PAGE_SIZE) {
+        return allPages.reduce((total, page) => total + page.length, 0)
+      }
+
+      return undefined
+    },
+    initialPageParam: 0,
+    staleTime: 1000 * 60 * 5,
+    gcTime: 1000 * 60 * 10,
+    enabled: hasMarkets,
+  })
+
+  const activities: ActivityOrder[] = data?.pages.flat() ?? []
+  const loading = hasMarkets && status === 'pending'
+  const hasInitialError = hasMarkets && status === 'error'
+
+  useInfiniteScrollSentinel({
+    sentinelRef: loadMoreRef,
+    hasMarkets,
+    hasNextPage,
+    isFetchingNextPage,
+    loading,
+    hasError: Boolean(infiniteScrollError),
+    fetchNextPage,
+    setInfiniteScrollError,
+    errorMessage: t('Failed to load more activity'),
+  })
+
+  useRealtimeActivityRefresh({
+    hasMarkets,
+    loading,
+    marketIds,
+    tokenIds,
+    minAmountFilter,
+    queryClient,
+    queryKey,
+  })
 
   function formatTotalValue(totalValueMicro: number) {
     const totalValue = totalValueMicro / MICRO_UNIT

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventBookmark.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventBookmark.tsx
@@ -10,8 +10,6 @@ import { useAppKit } from '@/hooks/useAppKit'
 import { cn } from '@/lib/utils'
 import { useUser } from '@/stores/useUser'
 
-const headerIconButtonClass = 'size-10 rounded-sm border border-transparent bg-transparent text-foreground transition-colors hover:bg-muted/80 focus-visible:ring-1 focus-visible:ring-ring md:size-9'
-
 interface EventBookmarkProps {
   event: Event
   refreshStatusOnMount?: boolean
@@ -81,7 +79,7 @@ function updateEventsQueryData(
 
   let hasChanges = false
   const nextPages = currentData.pages.map((page) => {
-    const nextPage = page.flatMap((entry) => {
+    return page.flatMap((entry) => {
       if (entry.id !== event.id) {
         return [entry]
       }
@@ -94,8 +92,6 @@ function updateEventsQueryData(
 
       return [{ ...entry, is_bookmarked: nextBookmarkedState }]
     })
-
-    return nextPage
   })
 
   if (!hasChanges) {
@@ -260,8 +256,12 @@ export default function EventBookmark({
       aria-pressed={isBookmarked}
       title={isBookmarked ? 'Remove Bookmark' : 'Bookmark'}
       className={cn(
-        headerIconButtonClass,
-        'size-auto p-0',
+        `
+          size-auto rounded-sm border border-transparent bg-transparent p-0 text-foreground transition-colors
+          hover:bg-muted/80
+          focus-visible:ring-1 focus-visible:ring-ring
+          md:size-9
+        `,
         { 'opacity-50': isSubmitting },
       )}
     >

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventBookmark.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventBookmark.tsx
@@ -120,10 +120,13 @@ function createBookmarkOverrideState(
   }
 }
 
-export default function EventBookmark({
+function useBookmarkState({
   event,
-  refreshStatusOnMount = true,
-}: EventBookmarkProps) {
+  refreshStatusOnMount,
+}: {
+  event: Event
+  refreshStatusOnMount: boolean
+}) {
   const { open } = useAppKit()
   const user = useUser()
   const queryClient = useQueryClient()
@@ -208,14 +211,14 @@ export default function EventBookmark({
     }
   }
 
-  useEffect(() => {
+  useEffect(function refreshInitialBookmarkStatus() {
     if (!refreshStatusOnMount || !user?.id) {
       return
     }
 
     let isActive = true
 
-    void (async () => {
+    void (async function fetchInitialBookmarkStatus() {
       const response = await getBookmarkStatusAction(event.id)
       if (!isActive || response.error || typeof response.data !== 'boolean') {
         return
@@ -223,10 +226,22 @@ export default function EventBookmark({
       setBookmarkOverride(createBookmarkOverrideState(event.id, event.is_bookmarked, response.data))
     })()
 
-    return () => {
+    return function cancelInitialBookmarkFetch() {
       isActive = false
     }
   }, [event.id, event.is_bookmarked, refreshStatusOnMount, user?.id])
+
+  return { isBookmarked, isSubmitting, handleBookmark }
+}
+
+export default function EventBookmark({
+  event,
+  refreshStatusOnMount = true,
+}: EventBookmarkProps) {
+  const { isBookmarked, isSubmitting, handleBookmark } = useBookmarkState({
+    event,
+    refreshStatusOnMount,
+  })
 
   return (
     <Button

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
@@ -38,6 +38,64 @@ interface CommentItemProps {
   retryLoadReplies: (commentId: string) => void
 }
 
+function useCommentItemHandlers({
+  comment,
+  user,
+  replyingTo,
+  onSetReplyingTo,
+  onSetReplyText,
+  onLikeToggle,
+  onDelete,
+}: {
+  comment: Comment
+  user: any
+  replyingTo: string | null
+  onSetReplyingTo: (id: string | null) => void
+  onSetReplyText: (text: string) => void
+  onLikeToggle: (commentId: string) => void
+  onDelete: (commentId: string) => void
+}) {
+  const { open } = useAppKit()
+
+  const handleReplyClick = useCallback(function handleReplyClick() {
+    if (!user) {
+      queueMicrotask(() => open())
+      return
+    }
+    const shouldOpen = replyingTo !== comment.id
+    onSetReplyingTo(shouldOpen ? comment.id : null)
+    if (shouldOpen) {
+      onSetReplyText('')
+    }
+  }, [user, comment, replyingTo, onSetReplyingTo, onSetReplyText, open])
+
+  const handleLikeToggle = useCallback(function handleLikeToggle() {
+    onLikeToggle(comment.id)
+  }, [comment.id, onLikeToggle])
+
+  const handleDelete = useCallback(function handleDelete() {
+    onDelete(comment.id)
+  }, [comment.id, onDelete])
+
+  const handleReplyAdded = useCallback(function handleReplyAdded() {
+    onSetReplyingTo(null)
+    onSetReplyText('')
+  }, [onSetReplyingTo, onSetReplyText])
+
+  const handleReplyCancel = useCallback(function handleReplyCancel() {
+    onSetReplyingTo(null)
+    onSetReplyText('')
+  }, [onSetReplyingTo, onSetReplyText])
+
+  return {
+    handleReplyClick,
+    handleLikeToggle,
+    handleDelete,
+    handleReplyAdded,
+    handleReplyCancel,
+  }
+}
+
 export default function EventCommentItem({
   comment,
   user,
@@ -61,39 +119,23 @@ export default function EventCommentItem({
   loadRepliesError,
   retryLoadReplies,
 }: CommentItemProps) {
-  const { open } = useAppKit()
   const { displayName, profileSlug } = resolveCommentUserIdentity(comment)
   const t = useExtracted()
-
-  const handleReplyClick = useCallback(() => {
-    if (!user) {
-      queueMicrotask(() => open())
-      return
-    }
-    const shouldOpen = replyingTo !== comment.id
-    onSetReplyingTo(shouldOpen ? comment.id : null)
-    if (shouldOpen) {
-      onSetReplyText('')
-    }
-  }, [user, comment, replyingTo, onSetReplyingTo, onSetReplyText, open])
-
-  const handleLikeToggle = useCallback(() => {
-    onLikeToggle(comment.id)
-  }, [comment.id, onLikeToggle])
-
-  const handleDelete = useCallback(() => {
-    onDelete(comment.id)
-  }, [comment.id, onDelete])
-
-  const handleReplyAdded = useCallback(() => {
-    onSetReplyingTo(null)
-    onSetReplyText('')
-  }, [onSetReplyingTo, onSetReplyText])
-
-  const handleReplyCancel = useCallback(() => {
-    onSetReplyingTo(null)
-    onSetReplyText('')
-  }, [onSetReplyingTo, onSetReplyText])
+  const {
+    handleReplyClick,
+    handleLikeToggle,
+    handleDelete,
+    handleReplyAdded,
+    handleReplyCancel,
+  } = useCommentItemHandlers({
+    comment,
+    user,
+    replyingTo,
+    onSetReplyingTo,
+    onSetReplyText,
+    onLikeToggle,
+    onDelete,
+  })
 
   return (
     <div className="comment-item">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
@@ -57,7 +57,7 @@ function useCommentItemHandlers({
 }) {
   const { open } = useAppKit()
 
-  const handleReplyClick = useCallback(function handleReplyClick() {
+  const handleReplyClick = useCallback(() => {
     if (!user) {
       queueMicrotask(() => open())
       return
@@ -69,20 +69,20 @@ function useCommentItemHandlers({
     }
   }, [user, comment, replyingTo, onSetReplyingTo, onSetReplyText, open])
 
-  const handleLikeToggle = useCallback(function handleLikeToggle() {
+  const handleLikeToggle = useCallback(() => {
     onLikeToggle(comment.id)
   }, [comment.id, onLikeToggle])
 
-  const handleDelete = useCallback(function handleDelete() {
+  const handleDelete = useCallback(() => {
     onDelete(comment.id)
   }, [comment.id, onDelete])
 
-  const handleReplyAdded = useCallback(function handleReplyAdded() {
+  const handleReplyAdded = useCallback(() => {
     onSetReplyingTo(null)
     onSetReplyText('')
   }, [onSetReplyingTo, onSetReplyText])
 
-  const handleReplyCancel = useCallback(function handleReplyCancel() {
+  const handleReplyCancel = useCallback(() => {
     onSetReplyingTo(null)
     onSetReplyText('')
   }, [onSetReplyingTo, onSetReplyText])

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
@@ -55,7 +55,7 @@ function useCommentReplyItemHandlers({
 }) {
   const { open } = useAppKit()
 
-  const handleReplyClick = useCallback(function handleReplyClick() {
+  const handleReplyClick = useCallback(() => {
     if (!user) {
       queueMicrotask(() => open())
       return
@@ -67,20 +67,20 @@ function useCommentReplyItemHandlers({
     }
   }, [user, reply, replyingTo, onSetReplyingTo, onSetReplyText, open])
 
-  const handleLikeToggle = useCallback(function handleLikeToggle() {
+  const handleLikeToggle = useCallback(() => {
     onLikeToggle(commentId, reply.id)
   }, [commentId, reply.id, onLikeToggle])
 
-  const handleDelete = useCallback(function handleDelete() {
+  const handleDelete = useCallback(() => {
     onDelete(commentId, reply.id)
   }, [commentId, reply.id, onDelete])
 
-  const handleReplyAdded = useCallback(function handleReplyAdded() {
+  const handleReplyAdded = useCallback(() => {
     onSetReplyingTo(null)
     onSetReplyText('')
   }, [onSetReplyingTo, onSetReplyText])
 
-  const handleReplyCancel = useCallback(function handleReplyCancel() {
+  const handleReplyCancel = useCallback(() => {
     onSetReplyingTo(null)
     onSetReplyText('')
   }, [onSetReplyingTo, onSetReplyText])

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
@@ -34,6 +34,66 @@ interface ReplyItemProps {
   isTogglingLikeForComment: (commentId: string) => boolean
 }
 
+function useCommentReplyItemHandlers({
+  reply,
+  commentId,
+  user,
+  replyingTo,
+  onSetReplyingTo,
+  onSetReplyText,
+  onLikeToggle,
+  onDelete,
+}: {
+  reply: Comment
+  commentId: string
+  user: any
+  replyingTo: string | null
+  onSetReplyingTo: (id: string | null) => void
+  onSetReplyText: (text: string) => void
+  onLikeToggle: (commentId: string, replyId: string) => void
+  onDelete: (commentId: string, replyId: string) => void
+}) {
+  const { open } = useAppKit()
+
+  const handleReplyClick = useCallback(function handleReplyClick() {
+    if (!user) {
+      queueMicrotask(() => open())
+      return
+    }
+    const shouldOpen = replyingTo !== reply.id
+    onSetReplyingTo(shouldOpen ? reply.id : null)
+    if (shouldOpen) {
+      onSetReplyText('')
+    }
+  }, [user, reply, replyingTo, onSetReplyingTo, onSetReplyText, open])
+
+  const handleLikeToggle = useCallback(function handleLikeToggle() {
+    onLikeToggle(commentId, reply.id)
+  }, [commentId, reply.id, onLikeToggle])
+
+  const handleDelete = useCallback(function handleDelete() {
+    onDelete(commentId, reply.id)
+  }, [commentId, reply.id, onDelete])
+
+  const handleReplyAdded = useCallback(function handleReplyAdded() {
+    onSetReplyingTo(null)
+    onSetReplyText('')
+  }, [onSetReplyingTo, onSetReplyText])
+
+  const handleReplyCancel = useCallback(function handleReplyCancel() {
+    onSetReplyingTo(null)
+    onSetReplyText('')
+  }, [onSetReplyingTo, onSetReplyText])
+
+  return {
+    handleReplyClick,
+    handleLikeToggle,
+    handleDelete,
+    handleReplyAdded,
+    handleReplyCancel,
+  }
+}
+
 export default function EventCommentReplyItem({
   reply,
   parentDisplayName,
@@ -53,40 +113,25 @@ export default function EventCommentReplyItem({
   isCreatingComment,
   isTogglingLikeForComment,
 }: ReplyItemProps) {
-  const { open } = useAppKit()
   const { displayName, profileSlug } = resolveCommentUserIdentity(reply)
   const parentHref = parentProfileSlug ? ((buildPublicProfilePath(parentProfileSlug) ?? '#') as any) : ('#' as any)
   const t = useExtracted()
-
-  const handleReplyClick = useCallback(() => {
-    if (!user) {
-      queueMicrotask(() => open())
-      return
-    }
-    const shouldOpen = replyingTo !== reply.id
-    onSetReplyingTo(shouldOpen ? reply.id : null)
-    if (shouldOpen) {
-      onSetReplyText('')
-    }
-  }, [user, reply, replyingTo, onSetReplyingTo, onSetReplyText, open])
-
-  const handleLikeToggle = useCallback(() => {
-    onLikeToggle(commentId, reply.id)
-  }, [commentId, reply.id, onLikeToggle])
-
-  const handleDelete = useCallback(() => {
-    onDelete(commentId, reply.id)
-  }, [commentId, reply.id, onDelete])
-
-  const handleReplyAdded = useCallback(() => {
-    onSetReplyingTo(null)
-    onSetReplyText('')
-  }, [onSetReplyingTo, onSetReplyText])
-
-  const handleReplyCancel = useCallback(() => {
-    onSetReplyingTo(null)
-    onSetReplyText('')
-  }, [onSetReplyingTo, onSetReplyText])
+  const {
+    handleReplyClick,
+    handleLikeToggle,
+    handleDelete,
+    handleReplyAdded,
+    handleReplyCancel,
+  } = useCommentReplyItemHandlers({
+    reply,
+    commentId,
+    user,
+    replyingTo,
+    onSetReplyingTo,
+    onSetReplyText,
+    onLikeToggle,
+    onDelete,
+  })
 
   return (
     <>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
@@ -31,7 +31,7 @@ interface InfiniteScrollErrorState {
 }
 
 function useMarketsByConditionId(markets: Event['markets']) {
-  return useMemo(function buildMarketsByConditionIdMap() {
+  return useMemo(() => {
     const map = new Map<string, Event['markets'][number]>()
     markets.forEach((market) => {
       if (market?.condition_id) {
@@ -43,7 +43,7 @@ function useMarketsByConditionId(markets: Event['markets']) {
 }
 
 function useExpandedCommentIds(comments: Array<{ id: string, recent_replies?: Array<unknown> | null }>) {
-  return useMemo(function buildExpandedCommentsSet() {
+  return useMemo(() => {
     return new Set(
       comments
         .filter(comment => (comment.recent_replies?.length ?? 0) > 3)

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
@@ -30,24 +30,172 @@ interface InfiniteScrollErrorState {
   message: string
 }
 
-export default function EventComments({ event, user }: EventCommentsProps) {
-  const [replyingTo, setReplyingTo] = useState<string | null>(null)
-  const [replyText, setReplyText] = useState('')
-  const [infiniteScrollError, setInfiniteScrollError] = useState<InfiniteScrollErrorState | null>(null)
-  const [sortBy, setSortBy] = useState<'newest' | 'most_liked'>('newest')
-  const [holdersOnly, setHoldersOnly] = useState(false)
-  const holdersCheckboxId = useId()
-  const isSportsEvent = Boolean(event.sports_sport_slug?.trim())
-  const marketsByConditionId = useMemo(() => {
+function useMarketsByConditionId(markets: Event['markets']) {
+  return useMemo(function buildMarketsByConditionIdMap() {
     const map = new Map<string, Event['markets'][number]>()
-    event.markets.forEach((market) => {
+    markets.forEach((market) => {
       if (market?.condition_id) {
         map.set(market.condition_id, market)
       }
     })
     return map
-  }, [event.markets])
+  }, [markets])
+}
 
+function useExpandedCommentIds(comments: Array<{ id: string, recent_replies?: Array<unknown> | null }>) {
+  return useMemo(function buildExpandedCommentsSet() {
+    return new Set(
+      comments
+        .filter(comment => (comment.recent_replies?.length ?? 0) > 3)
+        .map(comment => comment.id),
+    )
+  }, [comments])
+}
+
+function useCommentActionHandlers({
+  loadMoreReplies,
+  toggleCommentLike,
+  deleteReply,
+  toggleReplyLike,
+  deleteComment,
+  refetch,
+  setInfiniteScrollError,
+  setSortBy,
+  setHoldersOnly,
+}: {
+  loadMoreReplies: (commentId: string) => void
+  toggleCommentLike: (commentId: string) => void
+  deleteReply: (commentId: string, replyId: string) => void
+  toggleReplyLike: (replyId: string) => void
+  deleteComment: (commentId: string) => void
+  refetch: () => Promise<unknown>
+  setInfiniteScrollError: (value: InfiniteScrollErrorState | null) => void
+  setSortBy: (value: 'newest' | 'most_liked') => void
+  setHoldersOnly: (value: boolean) => void
+}) {
+  const handleRepliesLoaded = useCallback(function loadRepliesForComment(commentId: string) {
+    loadMoreReplies(commentId)
+  }, [loadMoreReplies])
+
+  const handleLikeToggled = useCallback(function toggleLikeForComment(commentId: string) {
+    toggleCommentLike(commentId)
+  }, [toggleCommentLike])
+
+  const handleDeleteReply = useCallback(function removeReplyFromComment(commentId: string, replyId: string) {
+    deleteReply(commentId, replyId)
+  }, [deleteReply])
+
+  const handleUpdateReply = useCallback(function toggleLikeForReply(_: string, replyId: string) {
+    toggleReplyLike(replyId)
+  }, [toggleReplyLike])
+
+  const handleDeleteComment = useCallback(function removeComment(commentId: string) {
+    deleteComment(commentId)
+  }, [deleteComment])
+
+  const handleRefetch = useCallback(function refetchAllComments() {
+    setInfiniteScrollError(null)
+    void refetch()
+  }, [refetch, setInfiniteScrollError])
+
+  const handleCommentAdded = useCallback(function refetchAfterCommentAdded() {
+    setInfiniteScrollError(null)
+    void refetch()
+  }, [refetch, setInfiniteScrollError])
+
+  const handleSortChange = useCallback(function changeCommentSort(value: string) {
+    setInfiniteScrollError(null)
+    setSortBy(value as 'newest' | 'most_liked')
+  }, [setInfiniteScrollError, setSortBy])
+
+  const handleHoldersOnlyChange = useCallback(function toggleHoldersOnlyFilter(checked: boolean | 'indeterminate') {
+    setInfiniteScrollError(null)
+    setHoldersOnly(Boolean(checked))
+  }, [setInfiniteScrollError, setHoldersOnly])
+
+  return {
+    handleRepliesLoaded,
+    handleLikeToggled,
+    handleDeleteReply,
+    handleUpdateReply,
+    handleDeleteComment,
+    handleRefetch,
+    handleCommentAdded,
+    handleSortChange,
+    handleHoldersOnlyChange,
+  }
+}
+
+function useInfiniteCommentsScroll({
+  fetchNextPage,
+  hasNextPage,
+  isFetchingNextPage,
+  isInitialized,
+  contextKey,
+}: {
+  fetchNextPage: () => Promise<unknown>
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  isInitialized: boolean
+  contextKey: string
+}) {
+  const [infiniteScrollError, setInfiniteScrollError] = useState<InfiniteScrollErrorState | null>(null)
+  const visibleInfiniteScrollError = infiniteScrollError?.contextKey === contextKey
+    ? infiniteScrollError.message
+    : null
+
+  const handleFetchNextPage = useCallback(async function fetchNextCommentsPage() {
+    setInfiniteScrollError(null)
+
+    try {
+      await fetchNextPage()
+    }
+    catch (error) {
+      setInfiniteScrollError({
+        contextKey,
+        message: error instanceof Error ? error.message : 'Failed to load more comments',
+      })
+    }
+  }, [fetchNextPage, contextKey])
+
+  useEffect(function loadMoreCommentsOnScrollNearBottom() {
+    function handleWindowScroll() {
+      const scrollTop = window.pageYOffset || document.documentElement.scrollTop
+      const windowHeight = window.innerHeight
+      const documentHeight = document.documentElement.scrollHeight
+
+      if (scrollTop + windowHeight >= documentHeight - 1000) {
+        if (hasNextPage && !isFetchingNextPage && isInitialized && !visibleInfiniteScrollError) {
+          void handleFetchNextPage()
+        }
+      }
+    }
+
+    window.addEventListener('scroll', handleWindowScroll)
+    return function detachInfiniteCommentsScrollListener() {
+      window.removeEventListener('scroll', handleWindowScroll)
+    }
+  }, [handleFetchNextPage, hasNextPage, isFetchingNextPage, isInitialized, visibleInfiniteScrollError])
+
+  const retryInfiniteScroll = useCallback(function retryInfiniteScrollFetch() {
+    void handleFetchNextPage()
+  }, [handleFetchNextPage])
+
+  return {
+    setInfiniteScrollError,
+    visibleInfiniteScrollError,
+    retryInfiniteScroll,
+  }
+}
+
+export default function EventComments({ event, user }: EventCommentsProps) {
+  const [replyingTo, setReplyingTo] = useState<string | null>(null)
+  const [replyText, setReplyText] = useState('')
+  const [sortBy, setSortBy] = useState<'newest' | 'most_liked'>('newest')
+  const [holdersOnly, setHoldersOnly] = useState(false)
+  const holdersCheckboxId = useId()
+  const isSportsEvent = Boolean(event.sports_sport_slug?.trim())
+  const marketsByConditionId = useMarketsByConditionId(event.markets)
   const t = useExtracted()
 
   const {
@@ -73,91 +221,41 @@ export default function EventComments({ event, user }: EventCommentsProps) {
   } = useInfiniteComments(event.slug, sortBy, user, holdersOnly)
   const isInitialized = status === 'success'
   const infiniteScrollContextKey = `${sortBy}:${holdersOnly}:${comments.length}`
-  const visibleInfiniteScrollError = infiniteScrollError?.contextKey === infiniteScrollContextKey
-    ? infiniteScrollError.message
-    : null
-  const expandedComments = useMemo(() => {
-    return new Set(
-      comments
-        .filter(comment => (comment.recent_replies?.length ?? 0) > 3)
-        .map(comment => comment.id),
-    )
-  }, [comments])
 
-  const handleFetchNextPage = useCallback(async () => {
-    setInfiniteScrollError(null)
+  const {
+    setInfiniteScrollError,
+    visibleInfiniteScrollError,
+    retryInfiniteScroll,
+  } = useInfiniteCommentsScroll({
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    isInitialized,
+    contextKey: infiniteScrollContextKey,
+  })
+  const expandedComments = useExpandedCommentIds(comments)
 
-    try {
-      await fetchNextPage()
-    }
-    catch (error) {
-      setInfiniteScrollError({
-        contextKey: infiniteScrollContextKey,
-        message: error instanceof Error ? error.message : 'Failed to load more comments',
-      })
-    }
-  }, [fetchNextPage, infiniteScrollContextKey])
-
-  useEffect(() => {
-    function handleScroll() {
-      const scrollTop = window.pageYOffset || document.documentElement.scrollTop
-      const windowHeight = window.innerHeight
-      const documentHeight = document.documentElement.scrollHeight
-
-      if (scrollTop + windowHeight >= documentHeight - 1000) {
-        if (hasNextPage && !isFetchingNextPage && isInitialized && !visibleInfiniteScrollError) {
-          void handleFetchNextPage()
-        }
-      }
-    }
-
-    window.addEventListener('scroll', handleScroll)
-    return () => window.removeEventListener('scroll', handleScroll)
-  }, [handleFetchNextPage, hasNextPage, isFetchingNextPage, isInitialized, visibleInfiniteScrollError])
-
-  const handleRepliesLoaded = useCallback((commentId: string) => {
-    loadMoreReplies(commentId)
-  }, [loadMoreReplies])
-
-  const handleLikeToggled = useCallback((commentId: string) => {
-    toggleCommentLike(commentId)
-  }, [toggleCommentLike])
-
-  const handleDeleteReply = useCallback((commentId: string, replyId: string) => {
-    deleteReply(commentId, replyId)
-  }, [deleteReply])
-
-  const handleUpdateReply = useCallback((_: string, replyId: string) => {
-    toggleReplyLike(replyId)
-  }, [toggleReplyLike])
-
-  const handleDeleteComment = useCallback((commentId: string) => {
-    deleteComment(commentId)
-  }, [deleteComment])
-
-  const retryInfiniteScroll = useCallback(() => {
-    void handleFetchNextPage()
-  }, [handleFetchNextPage])
-
-  const handleRefetch = useCallback(() => {
-    setInfiniteScrollError(null)
-    void refetch()
-  }, [refetch])
-
-  const handleCommentAdded = useCallback(() => {
-    setInfiniteScrollError(null)
-    void refetch()
-  }, [refetch])
-
-  const handleSortChange = useCallback((value: string) => {
-    setInfiniteScrollError(null)
-    setSortBy(value as 'newest' | 'most_liked')
-  }, [])
-
-  const handleHoldersOnlyChange = useCallback((checked: boolean | 'indeterminate') => {
-    setInfiniteScrollError(null)
-    setHoldersOnly(Boolean(checked))
-  }, [])
+  const {
+    handleRepliesLoaded,
+    handleLikeToggled,
+    handleDeleteReply,
+    handleUpdateReply,
+    handleDeleteComment,
+    handleRefetch,
+    handleCommentAdded,
+    handleSortChange,
+    handleHoldersOnlyChange,
+  } = useCommentActionHandlers({
+    loadMoreReplies,
+    toggleCommentLike,
+    deleteReply,
+    toggleReplyLike,
+    deleteComment,
+    refetch,
+    setInfiniteScrollError,
+    setSortBy,
+    setHoldersOnly,
+  })
 
   if (error) {
     return (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
@@ -73,42 +73,42 @@ function useCommentActionHandlers({
   setSortBy: (value: 'newest' | 'most_liked') => void
   setHoldersOnly: (value: boolean) => void
 }) {
-  const handleRepliesLoaded = useCallback(function loadRepliesForComment(commentId: string) {
+  const handleRepliesLoaded = useCallback((commentId: string) => {
     loadMoreReplies(commentId)
   }, [loadMoreReplies])
 
-  const handleLikeToggled = useCallback(function toggleLikeForComment(commentId: string) {
+  const handleLikeToggled = useCallback((commentId: string) => {
     toggleCommentLike(commentId)
   }, [toggleCommentLike])
 
-  const handleDeleteReply = useCallback(function removeReplyFromComment(commentId: string, replyId: string) {
+  const handleDeleteReply = useCallback((commentId: string, replyId: string) => {
     deleteReply(commentId, replyId)
   }, [deleteReply])
 
-  const handleUpdateReply = useCallback(function toggleLikeForReply(_: string, replyId: string) {
+  const handleUpdateReply = useCallback((_: string, replyId: string) => {
     toggleReplyLike(replyId)
   }, [toggleReplyLike])
 
-  const handleDeleteComment = useCallback(function removeComment(commentId: string) {
+  const handleDeleteComment = useCallback((commentId: string) => {
     deleteComment(commentId)
   }, [deleteComment])
 
-  const handleRefetch = useCallback(function refetchAllComments() {
+  const handleRefetch = useCallback(() => {
     setInfiniteScrollError(null)
     void refetch()
   }, [refetch, setInfiniteScrollError])
 
-  const handleCommentAdded = useCallback(function refetchAfterCommentAdded() {
+  const handleCommentAdded = useCallback(() => {
     setInfiniteScrollError(null)
     void refetch()
   }, [refetch, setInfiniteScrollError])
 
-  const handleSortChange = useCallback(function changeCommentSort(value: string) {
+  const handleSortChange = useCallback((value: string) => {
     setInfiniteScrollError(null)
     setSortBy(value as 'newest' | 'most_liked')
   }, [setInfiniteScrollError, setSortBy])
 
-  const handleHoldersOnlyChange = useCallback(function toggleHoldersOnlyFilter(checked: boolean | 'indeterminate') {
+  const handleHoldersOnlyChange = useCallback((checked: boolean | 'indeterminate') => {
     setInfiniteScrollError(null)
     setHoldersOnly(Boolean(checked))
   }, [setInfiniteScrollError, setHoldersOnly])
@@ -177,7 +177,7 @@ function useInfiniteCommentsScroll({
     }
   }, [handleFetchNextPage, hasNextPage, isFetchingNextPage, isInitialized, visibleInfiniteScrollError])
 
-  const retryInfiniteScroll = useCallback(function retryInfiniteScrollFetch() {
+  const retryInfiniteScroll = useCallback(() => {
     void handleFetchNextPage()
   }, [handleFetchNextPage])
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
@@ -85,6 +85,23 @@ function resolveEventHeaderTaxonomy({
   }
 }
 
+function useScrollPastThreshold(threshold: number) {
+  const [scrolled, setScrolled] = useState(false)
+
+  useEffect(function trackScrollPastThreshold() {
+    function handleWindowScroll() {
+      setScrolled(window.scrollY > threshold)
+    }
+
+    window.addEventListener('scroll', handleWindowScroll)
+    return function removeWindowScrollListener() {
+      window.removeEventListener('scroll', handleWindowScroll)
+    }
+  }, [threshold])
+
+  return scrolled
+}
+
 function EventHeaderTaxonomyItem({
   href,
   label,
@@ -111,7 +128,7 @@ function EventHeaderTaxonomyItem({
 }
 
 export default function EventHeader({ event }: EventHeaderProps) {
-  const [scrolled, setScrolled] = useState(false)
+  const scrolled = useScrollPastThreshold(20)
   const { childParentMap, tags } = usePlatformNavigationData()
   const taxonomy = useMemo(
     () => resolveEventHeaderTaxonomy({
@@ -121,15 +138,6 @@ export default function EventHeader({ event }: EventHeaderProps) {
     }),
     [childParentMap, event, tags],
   )
-
-  useEffect(() => {
-    function onScroll() {
-      setScrolled(window.scrollY > 20)
-    }
-
-    window.addEventListener('scroll', onScroll)
-    return () => window.removeEventListener('scroll', onScroll)
-  }, [])
 
   return (
     <div

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
@@ -21,6 +21,57 @@ interface EventMarketHistoryProps {
   market: Event['markets'][number]
 }
 
+function useClearInfiniteScrollErrorOnMarketChange({
+  conditionId,
+  setInfiniteScrollError,
+}: {
+  conditionId: string | undefined
+  setInfiniteScrollError: (value: string | null) => void
+}) {
+  useEffect(function clearInfiniteScrollErrorOnMarketChange() {
+    queueMicrotask(function clearErrorNow() {
+      setInfiniteScrollError(null)
+    })
+  }, [conditionId, setInfiniteScrollError])
+}
+
+function useInfiniteScrollSentinel({
+  sentinelRef,
+  hasNextPage,
+  isFetchingNextPage,
+  hasError,
+  fetchNextPage,
+  setInfiniteScrollError,
+}: {
+  sentinelRef: React.RefObject<HTMLDivElement | null>
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  hasError: boolean
+  fetchNextPage: () => Promise<unknown>
+  setInfiniteScrollError: (value: string | null) => void
+}) {
+  useEffect(function observeInfiniteScrollSentinel() {
+    const node = sentinelRef.current
+    if (!node) {
+      return
+    }
+
+    const observer = new IntersectionObserver(function handleSentinelIntersection(entries) {
+      const entry = entries[0]
+      if (entry?.isIntersecting && hasNextPage && !isFetchingNextPage && !hasError) {
+        fetchNextPage().catch((error) => {
+          setInfiniteScrollError(error.message || 'Failed to load more activity')
+        })
+      }
+    }, { rootMargin: '200px 0px' })
+
+    observer.observe(node)
+    return function unobserveInfiniteScrollSentinel() {
+      observer.disconnect()
+    }
+  }, [hasError, hasNextPage, isFetchingNextPage, fetchNextPage, sentinelRef, setInfiniteScrollError])
+}
+
 export default function EventMarketHistory({ market }: EventMarketHistoryProps) {
   const t = useExtracted()
   const locale = useLocale()
@@ -31,9 +82,10 @@ export default function EventMarketHistory({ market }: EventMarketHistoryProps) 
   const userAddress = getUserPublicAddress(user)
   const normalizeOutcomeLabel = useOutcomeLabel()
 
-  useEffect(() => {
-    queueMicrotask(() => setInfiniteScrollError(null))
-  }, [market.condition_id])
+  useClearInfiniteScrollErrorOnMarketChange({
+    conditionId: market.condition_id,
+    setInfiniteScrollError,
+  })
 
   const {
     status,
@@ -74,32 +126,14 @@ export default function EventMarketHistory({ market }: EventMarketHistoryProps) 
   const isLoadingInitial = status === 'pending'
   const hasInitialError = status === 'error'
 
-  useEffect(() => {
-    const node = loadMoreRef.current
-    if (!node) {
-      return
-    }
-
-    const observer = new IntersectionObserver(
-      (entries) => {
-        const entry = entries[0]
-        if (
-          entry?.isIntersecting
-          && hasNextPage
-          && !isFetchingNextPage
-          && !infiniteScrollError
-        ) {
-          fetchNextPage().catch((error) => {
-            setInfiniteScrollError(error.message || 'Failed to load more activity')
-          })
-        }
-      },
-      { rootMargin: '200px 0px' },
-    )
-
-    observer.observe(node)
-    return () => observer.disconnect()
-  }, [fetchNextPage, hasNextPage, infiniteScrollError, isFetchingNextPage])
+  useInfiniteScrollSentinel({
+    sentinelRef: loadMoreRef,
+    hasNextPage,
+    isFetchingNextPage,
+    hasError: Boolean(infiniteScrollError),
+    fetchNextPage,
+    setInfiniteScrollError,
+  })
 
   function retryInfiniteScroll() {
     setInfiniteScrollError(null)

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRelated.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRelated.tsx
@@ -86,13 +86,125 @@ function useRelatedEvents(params: UseRelatedEventsParams) {
   })
 }
 
+function useTabIndicator({
+  activeIndex,
+  tagItemsLength,
+  buttonsWrapperRef,
+  buttonRef,
+}: {
+  activeIndex: number
+  tagItemsLength: number
+  buttonsWrapperRef: React.RefObject<HTMLDivElement | null>
+  buttonRef: React.RefObject<(HTMLButtonElement | null)[]>
+}) {
+  const [backgroundStyle, setBackgroundStyle] = useState<BackgroundStyle>(INITIAL_BACKGROUND_STYLE)
+
+  const updateBackgroundPosition = useCallback(function updateBackgroundPosition() {
+    if (activeIndex === -1) {
+      setBackgroundStyle({ ...INITIAL_BACKGROUND_STYLE })
+      return
+    }
+
+    const activeButton = buttonRef.current[activeIndex]
+    const container = buttonsWrapperRef.current
+
+    if (!activeButton || !container) {
+      return
+    }
+
+    requestAnimationFrame(function applyButtonRect() {
+      const buttonRect = activeButton.getBoundingClientRect()
+      const containerRect = container.getBoundingClientRect()
+
+      setBackgroundStyle({
+        left: buttonRect.left - containerRect.left,
+        width: buttonRect.width,
+        height: buttonRect.height,
+        top: buttonRect.top - containerRect.top,
+        isInitialized: true,
+      })
+    })
+  }, [activeIndex, buttonRef, buttonsWrapperRef])
+
+  useEffect(function syncButtonRefArrayLength() {
+    buttonRef.current = Array.from({ length: tagItemsLength }).map((_, index) => buttonRef.current[index] ?? null)
+  }, [buttonRef, tagItemsLength])
+
+  useLayoutEffect(function repositionTabIndicatorOnChange() {
+    updateBackgroundPosition()
+  }, [updateBackgroundPosition, tagItemsLength, activeIndex])
+
+  return { backgroundStyle, updateBackgroundPosition }
+}
+
+function useHorizontalScrollShadows(scrollContainerRef: React.RefObject<HTMLDivElement | null>) {
+  const [showLeftShadow, setShowLeftShadow] = useState(false)
+  const [showRightShadow, setShowRightShadow] = useState(false)
+
+  const updateScrollShadows = useCallback(function updateScrollShadows() {
+    const container = scrollContainerRef.current
+    if (!container) {
+      setShowLeftShadow(false)
+      setShowRightShadow(false)
+      return
+    }
+
+    const { scrollLeft, scrollWidth, clientWidth } = container
+    const maxScrollLeft = scrollWidth - clientWidth
+
+    setShowLeftShadow(scrollLeft > 4)
+    setShowRightShadow(scrollLeft < maxScrollLeft - 4)
+  }, [scrollContainerRef])
+
+  return { showLeftShadow, showRightShadow, updateScrollShadows }
+}
+
+function useRelatedTabsScrollListeners({
+  scrollContainerRef,
+  tagItemsLength,
+  updateBackgroundPosition,
+  updateScrollShadows,
+}: {
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>
+  tagItemsLength: number
+  updateBackgroundPosition: () => void
+  updateScrollShadows: () => void
+}) {
+  useEffect(function attachTabScrollAndResizeListeners() {
+    const container = scrollContainerRef.current
+    if (!container) {
+      return
+    }
+
+    let resizeTimeout: ReturnType<typeof setTimeout>
+    function handleResize() {
+      clearTimeout(resizeTimeout)
+      resizeTimeout = setTimeout(function applyResizeUpdate() {
+        updateBackgroundPosition()
+        updateScrollShadows()
+      }, 16)
+    }
+
+    function handleContainerScroll() {
+      updateScrollShadows()
+      updateBackgroundPosition()
+    }
+
+    container.addEventListener('scroll', handleContainerScroll)
+    window.addEventListener('resize', handleResize)
+
+    return function detachTabScrollAndResizeListeners() {
+      container.removeEventListener('scroll', handleContainerScroll)
+      window.removeEventListener('resize', handleResize)
+      clearTimeout(resizeTimeout)
+    }
+  }, [scrollContainerRef, tagItemsLength, updateBackgroundPosition, updateScrollShadows])
+}
+
 export default function EventRelated({ event }: EventRelatedProps) {
   const t = useExtracted()
   const locale = useLocale()
   const [activeTagByEvent, setActiveTagByEvent] = useState<Record<string, string>>({})
-  const [backgroundStyle, setBackgroundStyle] = useState<BackgroundStyle>(INITIAL_BACKGROUND_STYLE)
-  const [showLeftShadow, setShowLeftShadow] = useState(false)
-  const [showRightShadow, setShowRightShadow] = useState(false)
   const activeTag = activeTagByEvent[event.slug] ?? 'all'
 
   const { data: events = [], isLoading: loading, error } = useRelatedEvents({
@@ -101,18 +213,6 @@ export default function EventRelated({ event }: EventRelatedProps) {
     locale,
   })
 
-  function resetBackgroundStyle() {
-    setBackgroundStyle({ ...INITIAL_BACKGROUND_STYLE })
-  }
-
-  function applyBackgroundStyle(style: BackgroundStyle) {
-    setBackgroundStyle(style)
-  }
-
-  function updateScrollShadowState(left: boolean, right: boolean) {
-    setShowLeftShadow(left)
-    setShowRightShadow(right)
-  }
   const scrollContainerRef = useRef<HTMLDivElement>(null)
   const buttonsWrapperRef = useRef<HTMLDivElement>(null)
   const buttonRef = useRef<(HTMLButtonElement | null)[]>([])
@@ -149,87 +249,21 @@ export default function EventRelated({ event }: EventRelatedProps) {
     [activeTag, tagItems],
   )
 
-  useEffect(() => {
-    buttonRef.current = Array.from({ length: tagItems.length }).map((_, index) => buttonRef.current[index] ?? null)
-  }, [tagItems.length])
+  const { backgroundStyle, updateBackgroundPosition } = useTabIndicator({
+    activeIndex,
+    tagItemsLength: tagItems.length,
+    buttonsWrapperRef,
+    buttonRef,
+  })
 
-  const updateBackgroundPosition = useCallback(() => {
-    if (activeIndex === -1) {
-      resetBackgroundStyle()
-      return
-    }
+  const { showLeftShadow, showRightShadow, updateScrollShadows } = useHorizontalScrollShadows(scrollContainerRef)
 
-    const activeButton = buttonRef.current[activeIndex]
-    const container = buttonsWrapperRef.current
-
-    if (!activeButton || !container) {
-      return
-    }
-
-    requestAnimationFrame(() => {
-      const buttonRect = activeButton.getBoundingClientRect()
-      const containerRect = container.getBoundingClientRect()
-
-      const left = buttonRect.left - containerRect.left
-      const top = buttonRect.top - containerRect.top
-
-      applyBackgroundStyle({
-        left,
-        width: buttonRect.width,
-        height: buttonRect.height,
-        top,
-        isInitialized: true,
-      })
-    })
-  }, [activeIndex])
-
-  const updateScrollShadows = useCallback(() => {
-    const container = scrollContainerRef.current
-    if (!container) {
-      updateScrollShadowState(false, false)
-      return
-    }
-
-    const { scrollLeft, scrollWidth, clientWidth } = container
-    const maxScrollLeft = scrollWidth - clientWidth
-
-    updateScrollShadowState(scrollLeft > 4, scrollLeft < maxScrollLeft - 4)
-  }, [])
-
-  useLayoutEffect(() => {
-    updateBackgroundPosition()
-  }, [updateBackgroundPosition, tagItems.length, activeIndex])
-
-  useEffect(() => {
-    const container = scrollContainerRef.current
-
-    if (!container) {
-      return
-    }
-
-    let resizeTimeout: NodeJS.Timeout
-    function handleResize() {
-      clearTimeout(resizeTimeout)
-      resizeTimeout = setTimeout(() => {
-        updateBackgroundPosition()
-        updateScrollShadows()
-      }, 16)
-    }
-
-    function handleScroll() {
-      updateScrollShadows()
-      updateBackgroundPosition()
-    }
-
-    container.addEventListener('scroll', handleScroll)
-    window.addEventListener('resize', handleResize)
-
-    return () => {
-      container.removeEventListener('scroll', handleScroll)
-      window.removeEventListener('resize', handleResize)
-      clearTimeout(resizeTimeout)
-    }
-  }, [updateBackgroundPosition, updateScrollShadows, tagItems.length])
+  useRelatedTabsScrollListeners({
+    scrollContainerRef,
+    tagItemsLength: tagItems.length,
+    updateBackgroundPosition,
+    updateScrollShadows,
+  })
 
   function handleTagClick(slug: string, index: number) {
     setActiveTagByEvent((current) => {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRelated.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRelated.tsx
@@ -99,7 +99,7 @@ function useTabIndicator({
 }) {
   const [backgroundStyle, setBackgroundStyle] = useState<BackgroundStyle>(INITIAL_BACKGROUND_STYLE)
 
-  const updateBackgroundPosition = useCallback(function updateBackgroundPosition() {
+  const updateBackgroundPosition = useCallback(() => {
     if (activeIndex === -1) {
       setBackgroundStyle({ ...INITIAL_BACKGROUND_STYLE })
       return
@@ -141,7 +141,7 @@ function useHorizontalScrollShadows(scrollContainerRef: React.RefObject<HTMLDivE
   const [showLeftShadow, setShowLeftShadow] = useState(false)
   const [showRightShadow, setShowRightShadow] = useState(false)
 
-  const updateScrollShadows = useCallback(function updateScrollShadows() {
+  const updateScrollShadows = useCallback(() => {
     const container = scrollContainerRef.current
     if (!container) {
       setShowLeftShadow(false)

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -245,7 +245,7 @@ export function formatTimeAgo(dateInput: string | number | Date) {
   }
 
   const now = new Date()
-  const diffInSeconds = Math.floor((now.getTime() - date.getTime()) / 1000)
+  const diffInSeconds = Math.max(0, Math.floor((now.getTime() - date.getTime()) / 1000))
 
   if (diffInSeconds < 60) {
     return `${diffInSeconds}s ago`

--- a/tests/unit/formattersMoney.test.ts
+++ b/tests/unit/formattersMoney.test.ts
@@ -71,6 +71,11 @@ describe('money/price formatters', () => {
     expect(formatTimeAgo(new Date(Date.now()).toISOString())).toMatch(/s ago$/)
   })
 
+  it('formatTimeAgo clamps near-future timestamps to 0s ago', () => {
+    const futureDate = new Date(Date.now() + 500).toISOString()
+    expect(formatTimeAgo(futureDate)).toBe('0s ago')
+  })
+
   it('truncateAddress shortens and handles empty', () => {
     expect(truncateAddress('')).toBe('')
     expect(truncateAddress('0x1234567890abcdef')).toBe('0x12…abcdef')


### PR DESCRIPTION
## Summary

Applies [#855](https://github.com/kuestcom/prediction-market/issues/855) to the event page's content + comments cluster. Extracts file-local custom hooks and names every affected `useEffect`.

Follow-up to [#866](https://github.com/kuestcom/prediction-market/pull/866) (order panel periphery) and [#867](https://github.com/kuestcom/prediction-market/pull/867) (EventOrderPanelForm).

## Files changed (8)

| File | `use-encapsulation/prefer-custom-hooks` | Effects named |
|---|---|---|
| `EventHeader` | 3 → 1 | 1 (`trackScrollPastThreshold`) |
| `EventBookmark` | 3 → 0 | 1 (`refreshInitialBookmarkStatus`) |
| `EventCommentItem` | 5 → 0 | — |
| `EventCommentReplyItem` | 5 → 0 | — |
| `EventMarketHistory` | 5 → 3 | 2 |
| `EventActivity` | 14 → 7 | 3 |
| `EventRelated` | 14 → 7 | 3 (incl. 1 `useLayoutEffect`) |
| `EventComments` | 20 → 5 | 1 (`loadMoreCommentsOnScrollNearBottom`) |

**Total: 69 → 23 (46 eliminated, 66% reduction), 11 effects named (0 unnamed).**

## Extracted hooks (all file-local)

**`EventHeader`**
- `useScrollPastThreshold(threshold)` — sticky-header scroll toggle with named effect + named cleanup

**`EventBookmark`**
- `useBookmarkState({ event, refreshStatusOnMount })` — override state + submission + initial-status fetch effect

**`EventCommentItem` / `EventCommentReplyItem`**
- `useCommentItemHandlers` / `useCommentReplyItemHandlers` — 5 named `useCallback` wrappers each for reply/like/delete

**`EventMarketHistory`**
- `useClearInfiniteScrollErrorOnMarketChange`, `useInfiniteScrollSentinel` — shared infinite-scroll pattern

**`EventActivity`**
- `useClearInfiniteScrollErrorOnFilterChange`, `useInfiniteScrollSentinel`, `useRealtimeActivityRefresh` (60s polling + WebSocket throttled refresh)

**`EventRelated`**
- `useTabIndicator` (sliding background + `useLayoutEffect`), `useHorizontalScrollShadows` (left/right fade), `useRelatedTabsScrollListeners` (scroll + resize listeners)

**`EventComments`**
- `useMarketsByConditionId`, `useExpandedCommentIds`, `useInfiniteCommentsScroll`, `useCommentActionHandlers` (bundles 9 thin callback wrappers)

## Kept inline (per your "2–3 sec rule")

Remaining 23 warnings are trivial `useState` (filter strings, toggle flags, reply input), `useId`, `useRef` (DOM refs), and 1-line `useMemo` derivations (query keys, tag lists, flatMap/filter). `EventFaq.tsx` (3 violations) was **not touched** — 2 `useState` + 1 `useMemo` for accordion items, each readable in under 3 seconds.

## Test plan

- [x] `npm test` — 487/487 pass
- [x] `npm run build` — clean
- [x] `tsc --noEmit` — 0 errors on touched files
- [x] Pre-push hook re-ran suite on push
- [x] Manual UX smoke: header sticky on scroll, bookmark toggle, comment reply/like/delete flows, activity feed real-time updates + infinite scroll, related-events tab sliding indicator + horizontal scroll shadows, market history pagination

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the event page content and comments to use file-local custom hooks. Cuts effects by 66% (69 → 23), keeps remaining effects named, standardizes callbacks and `useMemo` to arrow functions, and streamlines infinite scroll, polling, and WS refresh (aligns with #855).

- **Refactors**
  - Header: `useScrollPastThreshold` for sticky header toggle.
  - Bookmark: `useBookmarkState` for initial status fetch, override, and submit; removed a redundant local variable.
  - Comments: `useInfiniteCommentsScroll`, `useCommentActionHandlers`, `useExpandedCommentIds`, `useMarketsByConditionId`; extracted comment/reply handler hooks.
  - Activity/History: shared `useInfiniteScrollSentinel`; clear errors on filter/market change; `useRealtimeActivityRefresh` adds 60s polling and 2s WS throttle.
  - Related: `useTabIndicator`, `useHorizontalScrollShadows`, `useRelatedTabsScrollListeners` for smoother tab UI and scrolling.
  - Callbacks/Memo: dropped named function expressions in `useCallback` wrappers; converted named `useMemo` functions to arrow functions; named `useEffect` bodies remain.

- **Bug Fixes**
  - Activity: stable, unique row keys via `resolveActivityRowKey(activity)` (no index) to prevent duplicate key collisions.
  - Formatters: `formatTimeAgo` clamps near-future timestamps to show `0s ago`, fixing incorrect "seconds ago" diffs for just-posted comments.

<sup>Written for commit fdfb8bd05edca70890fbe403f9f7c111c116abc9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

