### PR TITLE
refactor: use custom hooks for EventShare, EventContent, EventMarkets

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
@@ -214,22 +214,213 @@ function useWindowViewport() {
   )
 }
 
-function EventOrderQuerySync({ event, marketSlug, isMobile }: EventOrderQuerySyncProps) {
-  const searchParams = useSearchParams()
-  const setMarket = useOrder(state => state.setMarket)
-  const setOutcome = useOrder(state => state.setOutcome)
-  const setSide = useOrder(state => state.setSide)
-  const setType = useOrder(state => state.setType)
-  const setAmount = useOrder(state => state.setAmount)
-  const setLimitShares = useOrder(state => state.setLimitShares)
-  const setIsMobileOrderPanelOpen = useOrder(state => state.setIsMobileOrderPanelOpen)
-  const appliedOrderParamsRef = useRef<string | null>(null)
-  const resolvedQueryState = useMemo(
-    () => resolveEventOrderQueryState(event, marketSlug, searchParams),
-    [event, marketSlug, searchParams],
-  )
+function useHasResolvedMobileBreakpoint() {
+  const [hasResolvedMobileBreakpoint, setHasResolvedMobileBreakpoint] = useState(false)
 
-  useEffect(() => {
+  useEffect(function resolveMobileBreakpointOnMount() {
+    let isActive = true
+
+    queueMicrotask(function markBreakpointResolved() {
+      if (isActive) {
+        setHasResolvedMobileBreakpoint(true)
+      }
+    })
+
+    return function cancelBreakpointResolution() {
+      isActive = false
+    }
+  }, [])
+
+  return hasResolvedMobileBreakpoint
+}
+
+function useSyncUserToClientStore(user: User | null) {
+  const prevUserIdRef = useRef<string | null>(null)
+
+  useEffect(function syncServerUserToClientStore() {
+    if (user?.id) {
+      prevUserIdRef.current = user.id
+      useUser.setState(user)
+      return
+    }
+
+    if (!user && prevUserIdRef.current) {
+      prevUserIdRef.current = null
+      useUser.setState(null)
+    }
+  }, [user])
+}
+
+function useSetEventInOrderStore(event: Event) {
+  const setEvent = useOrder(state => state.setEvent)
+
+  useEffect(function writeEventToOrderStore() {
+    setEvent(event)
+  }, [event, setEvent])
+}
+
+function useOrderBootstrapMarketSelection({
+  event,
+  marketSlug,
+  orderBootstrapTargetMarket,
+  currentEventId,
+  currentMarketId,
+  setMarket,
+  setOutcome,
+}: {
+  event: Event
+  marketSlug: string | undefined
+  orderBootstrapTargetMarket: Event['markets'][number] | null
+  currentEventId: string | undefined
+  currentMarketId: string | undefined
+  setMarket: (market: Event['markets'][number]) => void
+  setOutcome: (outcome: Event['markets'][number]['outcomes'][number]) => void
+}) {
+  const appliedMarketSlugRef = useRef<string | null>(null)
+  const appliedEventIdRef = useRef<string | null>(null)
+
+  useEffect(function bootstrapOrderMarketSelection() {
+    if (!orderBootstrapTargetMarket) {
+      return
+    }
+
+    const shouldApplyMarket = marketSlug
+      ? appliedMarketSlugRef.current !== marketSlug
+      || appliedEventIdRef.current !== event.id
+      || !currentMarketId
+      : currentEventId !== event.id
+        || !currentMarketId
+
+    if (!shouldApplyMarket) {
+      return
+    }
+
+    const currentOrderState = useOrder.getState()
+    const nextSelection = resolveEventOrderBootstrapSelection({
+      event,
+      targetMarket: orderBootstrapTargetMarket,
+      preserveSnapshotMarket: !marketSlug,
+      snapshot: {
+        eventId: currentOrderState.event?.id,
+        market: currentOrderState.market,
+        outcome: currentOrderState.outcome,
+      },
+    })
+
+    setMarket(nextSelection.market)
+    if (nextSelection.outcome) {
+      setOutcome(nextSelection.outcome)
+    }
+    appliedMarketSlugRef.current = marketSlug ?? null
+    appliedEventIdRef.current = event.id
+  }, [currentEventId, currentMarketId, event, marketSlug, orderBootstrapTargetMarket, setMarket, setOutcome])
+}
+
+function useInitialMarketAndOutcome({
+  event,
+  marketSlug,
+}: {
+  event: Event
+  marketSlug: string | undefined
+}) {
+  const initialMarket = useMemo(function resolveInitialMarket() {
+    if (marketSlug) {
+      return event.markets.find(market => market.slug === marketSlug) ?? resolveDefaultMarket(event.markets) ?? null
+    }
+    return resolveDefaultMarket(event.markets) ?? null
+  }, [event.markets, marketSlug])
+
+  const initialOutcome = useMemo(function resolveInitialOutcome() {
+    if (!initialMarket) {
+      return null
+    }
+    return initialMarket.outcomes[0] ?? null
+  }, [initialMarket])
+
+  return { initialMarket, initialOutcome }
+}
+
+function useSelectedMarketInfo({
+  event,
+  currentMarketId,
+  initialMarket,
+}: {
+  event: Event
+  currentMarketId: string | undefined
+  initialMarket: Event['markets'][number] | null
+}) {
+  const selectedMarket = useMemo(function resolveSelectedMarket() {
+    if (!currentMarketId) {
+      return initialMarket
+    }
+    return event.markets.find(market => market.condition_id === currentMarketId) ?? initialMarket
+  }, [currentMarketId, event.markets, initialMarket])
+
+  const selectedMarketTimelineOutcome = useMemo(function resolveSelectedMarketTimelineOutcome() {
+    return selectedMarket && isMarketResolved(selectedMarket)
+      ? toResolutionTimelineOutcome(resolveEventResolvedOutcomeIndex(event, selectedMarket))
+      : null
+  }, [event, selectedMarket])
+
+  return { selectedMarket, selectedMarketTimelineOutcome }
+}
+
+function useBackToTopBounds({
+  isMobile,
+  scrollY,
+  viewportWidth,
+  contentRef,
+  eventMarketsRef,
+}: {
+  isMobile: boolean
+  scrollY: number
+  viewportWidth: number
+  contentRef: React.RefObject<HTMLDivElement | null>
+  eventMarketsRef: React.RefObject<HTMLDivElement | null>
+}) {
+  return useMemo(function computeBackToTopBounds() {
+    if (isMobile || !contentRef.current || !eventMarketsRef.current) {
+      return null
+    }
+
+    const eventMarketsTop = eventMarketsRef.current.getBoundingClientRect().top + scrollY
+    if (scrollY < eventMarketsTop - 80) {
+      return null
+    }
+
+    const rect = contentRef.current.getBoundingClientRect()
+    const boundedWidth = viewportWidth > 0 ? Math.min(rect.width, viewportWidth) : rect.width
+    return {
+      left: rect.left,
+      width: boundedWidth,
+    }
+  }, [contentRef, eventMarketsRef, isMobile, scrollY, viewportWidth])
+}
+
+function useAppliedOrderQuerySync({
+  resolvedQueryState,
+  isMobile,
+  setMarket,
+  setOutcome,
+  setSide,
+  setType,
+  setAmount,
+  setLimitShares,
+  setIsMobileOrderPanelOpen,
+}: {
+  resolvedQueryState: ResolvedEventOrderQueryState | null
+  isMobile: boolean
+  setMarket: (market: Event['markets'][number]) => void
+  setOutcome: (outcome: Event['markets'][number]['outcomes'][number]) => void
+  setSide: (side: typeof ORDER_SIDE.BUY | typeof ORDER_SIDE.SELL) => void
+  setType: (type: typeof ORDER_TYPE.MARKET | typeof ORDER_TYPE.LIMIT) => void
+  setAmount: (value: string) => void
+  setLimitShares: (value: string) => void
+  setIsMobileOrderPanelOpen: (value: boolean) => void
+}) {
+  const appliedOrderParamsRef = useRef<string | null>(null)
+
+  useEffect(function applyOrderQueryParamsToStore() {
     if (!resolvedQueryState) {
       return
     }
@@ -281,6 +472,33 @@ function EventOrderQuerySync({ event, marketSlug, isMobile }: EventOrderQuerySyn
     setSide,
     setType,
   ])
+}
+
+function EventOrderQuerySync({ event, marketSlug, isMobile }: EventOrderQuerySyncProps) {
+  const searchParams = useSearchParams()
+  const setMarket = useOrder(state => state.setMarket)
+  const setOutcome = useOrder(state => state.setOutcome)
+  const setSide = useOrder(state => state.setSide)
+  const setType = useOrder(state => state.setType)
+  const setAmount = useOrder(state => state.setAmount)
+  const setLimitShares = useOrder(state => state.setLimitShares)
+  const setIsMobileOrderPanelOpen = useOrder(state => state.setIsMobileOrderPanelOpen)
+  const resolvedQueryState = useMemo(
+    () => resolveEventOrderQueryState(event, marketSlug, searchParams),
+    [event, marketSlug, searchParams],
+  )
+
+  useAppliedOrderQuerySync({
+    resolvedQueryState,
+    isMobile,
+    setMarket,
+    setOutcome,
+    setSide,
+    setType,
+    setAmount,
+    setLimitShares,
+    setIsMobileOrderPanelOpen,
+  })
 
   return null
 }
@@ -295,18 +513,14 @@ export default function EventContent({
   liveChartConfig = null,
 }: EventContentProps) {
   const t = useExtracted()
-  const setEvent = useOrder(state => state.setEvent)
   const setMarket = useOrder(state => state.setMarket)
   const setOutcome = useOrder(state => state.setOutcome)
   const currentEventId = useOrder(state => state.event?.id)
   const currentMarketId = useOrder(state => state.market?.condition_id)
   const isMobile = useIsMobile()
   const clientUser = useUser()
-  const prevUserIdRef = useRef<string | null>(null)
   const contentRef = useRef<HTMLDivElement | null>(null)
   const eventMarketsRef = useRef<HTMLDivElement | null>(null)
-  const appliedMarketSlugRef = useRef<string | null>(null)
-  const appliedEventIdRef = useRef<string | null>(null)
   const windowViewport = useWindowViewport()
   const scrollY = windowViewport.scrollY
   const viewportWidth = windowViewport.viewportWidth
@@ -317,120 +531,37 @@ export default function EventContent({
     () => resolveBootstrapTargetMarket(event, marketSlug),
     [event, marketSlug],
   )
-  const initialMarket = useMemo(() => {
-    if (marketSlug) {
-      return event.markets.find(market => market.slug === marketSlug) ?? resolveDefaultMarket(event.markets) ?? null
-    }
-    return resolveDefaultMarket(event.markets) ?? null
-  }, [event.markets, marketSlug])
-  const initialOutcome = useMemo(() => {
-    if (!initialMarket) {
-      return null
-    }
-    return initialMarket.outcomes[0] ?? null
-  }, [initialMarket])
-  const [hasResolvedMobileBreakpoint, setHasResolvedMobileBreakpoint] = useState(false)
-  const selectedMarket = useMemo(() => {
-    if (!currentMarketId) {
-      return initialMarket
-    }
-    return event.markets.find(market => market.condition_id === currentMarketId) ?? initialMarket
-  }, [currentMarketId, event.markets, initialMarket])
-  const selectedMarketTimelineOutcome = useMemo(
-    () => selectedMarket && isMarketResolved(selectedMarket)
-      ? toResolutionTimelineOutcome(resolveEventResolvedOutcomeIndex(event, selectedMarket))
-      : null,
-    [event, selectedMarket],
-  )
+  const { initialMarket, initialOutcome } = useInitialMarketAndOutcome({ event, marketSlug })
+  const hasResolvedMobileBreakpoint = useHasResolvedMobileBreakpoint()
+  const { selectedMarket, selectedMarketTimelineOutcome } = useSelectedMarketInfo({
+    event,
+    currentMarketId,
+    initialMarket,
+  })
   const singleMarket = event.markets[0]
   const isSingleMarketResolved = isMarketResolved(singleMarket)
   const usesLiveSeriesChart = Boolean(liveChartConfig && shouldUseLiveSeriesChart(event, liveChartConfig))
   const shouldRenderMobileRelated = hasResolvedMobileBreakpoint && isMobile
   const shouldRenderDesktopRelated = hasResolvedMobileBreakpoint && !isMobile
-  const backToTopBounds = useMemo(() => {
-    if (isMobile || !contentRef.current || !eventMarketsRef.current) {
-      return null
-    }
+  const backToTopBounds = useBackToTopBounds({
+    isMobile,
+    scrollY,
+    viewportWidth,
+    contentRef,
+    eventMarketsRef,
+  })
 
-    const eventMarketsTop = eventMarketsRef.current.getBoundingClientRect().top + scrollY
-    if (scrollY < eventMarketsTop - 80) {
-      return null
-    }
-
-    const rect = contentRef.current.getBoundingClientRect()
-    const boundedWidth = viewportWidth > 0 ? Math.min(rect.width, viewportWidth) : rect.width
-    return {
-      left: rect.left,
-      width: boundedWidth,
-    }
-  }, [isMobile, scrollY, viewportWidth])
-
-  useEffect(() => {
-    let isActive = true
-
-    queueMicrotask(() => {
-      if (isActive) {
-        setHasResolvedMobileBreakpoint(true)
-      }
-    })
-
-    return () => {
-      isActive = false
-    }
-  }, [])
-
-  useEffect(() => {
-    if (user?.id) {
-      prevUserIdRef.current = user.id
-      useUser.setState(user)
-      return
-    }
-
-    if (!user && prevUserIdRef.current) {
-      prevUserIdRef.current = null
-      useUser.setState(null)
-    }
-  }, [user])
-
-  useEffect(() => {
-    setEvent(event)
-  }, [event, setEvent])
-
-  useEffect(() => {
-    if (!orderBootstrapTargetMarket) {
-      return
-    }
-
-    const shouldApplyMarket = marketSlug
-      ? appliedMarketSlugRef.current !== marketSlug
-      || appliedEventIdRef.current !== event.id
-      || !currentMarketId
-      : currentEventId !== event.id
-        || !currentMarketId
-
-    if (!shouldApplyMarket) {
-      return
-    }
-
-    const currentOrderState = useOrder.getState()
-    const nextSelection = resolveEventOrderBootstrapSelection({
-      event,
-      targetMarket: orderBootstrapTargetMarket,
-      preserveSnapshotMarket: !marketSlug,
-      snapshot: {
-        eventId: currentOrderState.event?.id,
-        market: currentOrderState.market,
-        outcome: currentOrderState.outcome,
-      },
-    })
-
-    setMarket(nextSelection.market)
-    if (nextSelection.outcome) {
-      setOutcome(nextSelection.outcome)
-    }
-    appliedMarketSlugRef.current = marketSlug ?? null
-    appliedEventIdRef.current = event.id
-  }, [currentEventId, currentMarketId, event, marketSlug, orderBootstrapTargetMarket, setMarket, setOutcome])
+  useSyncUserToClientStore(user)
+  useSetEventInOrderStore(event)
+  useOrderBootstrapMarketSelection({
+    event,
+    marketSlug,
+    orderBootstrapTargetMarket,
+    currentEventId,
+    currentMarketId,
+    setMarket,
+    setOutcome,
+  })
 
   function handleBackToTop() {
     window.scrollTo({ top: 0, behavior: 'smooth' })

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
@@ -323,14 +323,14 @@ function useInitialMarketAndOutcome({
   event: Event
   marketSlug: string | undefined
 }) {
-  const initialMarket = useMemo(function resolveInitialMarket() {
+  const initialMarket = useMemo(() => {
     if (marketSlug) {
       return event.markets.find(market => market.slug === marketSlug) ?? resolveDefaultMarket(event.markets) ?? null
     }
     return resolveDefaultMarket(event.markets) ?? null
   }, [event.markets, marketSlug])
 
-  const initialOutcome = useMemo(function resolveInitialOutcome() {
+  const initialOutcome = useMemo(() => {
     if (!initialMarket) {
       return null
     }
@@ -349,14 +349,14 @@ function useSelectedMarketInfo({
   currentMarketId: string | undefined
   initialMarket: Event['markets'][number] | null
 }) {
-  const selectedMarket = useMemo(function resolveSelectedMarket() {
+  const selectedMarket = useMemo(() => {
     if (!currentMarketId) {
       return initialMarket
     }
     return event.markets.find(market => market.condition_id === currentMarketId) ?? initialMarket
   }, [currentMarketId, event.markets, initialMarket])
 
-  const selectedMarketTimelineOutcome = useMemo(function resolveSelectedMarketTimelineOutcome() {
+  const selectedMarketTimelineOutcome = useMemo(() => {
     return selectedMarket && isMarketResolved(selectedMarket)
       ? toResolutionTimelineOutcome(resolveEventResolvedOutcomeIndex(event, selectedMarket))
       : null
@@ -378,7 +378,7 @@ function useBackToTopBounds({
   contentRef: React.RefObject<HTMLDivElement | null>
   eventMarketsRef: React.RefObject<HTMLDivElement | null>
 }) {
-  return useMemo(function computeBackToTopBounds() {
+  return useMemo(() => {
     if (isMobile || !contentRef.current || !eventMarketsRef.current) {
       return null
     }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -86,62 +86,21 @@ export function resolveWinningOutcomeIndex(market: Event['markets'][number]) {
   return resolveUniqueBinaryWinningOutcomeIndexFromPayoutNumerators(market.condition?.payout_numerators)
 }
 
-interface CashOutModalPayload {
-  market: Event['markets'][number]
-  outcomeLabel: string
-  outcomeIndex: typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO
-  shares: number
-  filledShares: number
-  avgPriceCents: number | null
-  receiveAmount: number | null
-  sellBids: NormalizedBookLevel[]
-}
+function useTweetMarketResolution({
+  event,
+  currentTimestamp,
+}: {
+  event: Event
+  currentTimestamp: number | null
+}) {
+  const isTweetMarketEvent = useMemo(function detectTweetMarketEvent() {
+    return isTweetMarketsEvent(event)
+  }, [event])
 
-export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
-  const t = useExtracted()
-  const currentTimestamp = useCurrentTimestamp({ intervalMs: 60_000 })
-  const normalizeOutcomeLabel = useOutcomeLabel()
-  const selectedMarketId = useOrder(state => state.market?.condition_id)
-  const selectedOutcome = useOrder(state => state.outcome)
-  const setMarket = useOrder(state => state.setMarket)
-  const setOutcome = useOrder(state => state.setOutcome)
-  const setSide = useOrder(state => state.setSide)
-  const setType = useOrder(state => state.setType)
-  const setIsMobileOrderPanelOpen = useOrder(state => state.setIsMobileOrderPanelOpen)
-  const setAmount = useOrder(state => state.setAmount)
-  const inputRef = useOrder(state => state.inputRef)
-  const user = useUser()
-  const isSingleMarket = useIsSingleMarket()
-  const isNegRiskEnabled = Boolean(event.enable_neg_risk || event.neg_risk)
-  const isNegRiskAugmented = Boolean(event.neg_risk_augmented)
-  const isTweetMarketEvent = useMemo(
-    () => isTweetMarketsEvent(event),
-    [event],
-  )
-  const { rows: marketRows, hasChanceData } = useEventMarketRows(event)
   const xtrackerTweetCountQuery = useXTrackerTweetCount(event, isTweetMarketEvent)
-  const {
-    expandedMarketId,
-    toggleMarket,
-    expandMarket,
-    selectDetailTab,
-    getSelectedDetailTab,
-  } = useMarketDetailController(event.id)
-  const reviewConditionIds = useMemo(() => {
-    if (currentTimestamp == null) {
-      return new Set<string>()
-    }
-
-    const ids = new Set<string>()
-    event.markets.forEach((market) => {
-      if (isResolutionReviewActive(market, { nowMs: currentTimestamp })) {
-        ids.add(market.condition_id)
-      }
-    })
-    return ids
-  }, [currentTimestamp, event.markets])
   const xtrackerTotalCount = xtrackerTweetCountQuery.data?.totalCount ?? null
-  const isTweetMarketFinal = useMemo(() => {
+
+  const isTweetMarketFinal = useMemo(function detectTweetMarketFinal() {
     if (currentTimestamp == null) {
       return false
     }
@@ -158,7 +117,8 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
     const parsedEndMs = Date.parse(event.end_date)
     return Number.isFinite(parsedEndMs) && currentTimestamp >= parsedEndMs
   }, [currentTimestamp, event.end_date, xtrackerTweetCountQuery.data?.trackingEndMs])
-  const resolveResolvedOutcomeIndex = useCallback((market: Event['markets'][number]) => {
+
+  const resolveResolvedOutcomeIndex = useCallback(function resolveResolvedOutcomeIndex(market: Event['markets'][number]) {
     if (!isMarketResolved(market)) {
       return null
     }
@@ -169,21 +129,37 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
       totalCount: xtrackerTotalCount,
     })
   }, [event, isTweetMarketEvent, isTweetMarketFinal, xtrackerTotalCount])
-  const chanceRefreshQueryKeys = useMemo(
-    () => [
-      ['event-price-history', event.id] as const,
-      ['event-market-quotes'] as const,
-    ],
-    [event.id],
-  )
-  const [showResolvedMarkets, setShowResolvedMarkets] = useState(false)
-  const {
-    isFetching: isPriceHistoryFetching,
-  } = useChanceRefresh({ queryKeys: chanceRefreshQueryKeys })
-  const eventTokenIds = useMemo(() => {
+
+  return { resolveResolvedOutcomeIndex }
+}
+
+function useReviewConditionIds({
+  markets,
+  currentTimestamp,
+}: {
+  markets: Event['markets']
+  currentTimestamp: number | null
+}) {
+  return useMemo(function buildReviewConditionIds() {
+    if (currentTimestamp == null) {
+      return new Set<string>()
+    }
+
+    const ids = new Set<string>()
+    markets.forEach((market) => {
+      if (isResolutionReviewActive(market, { nowMs: currentTimestamp })) {
+        ids.add(market.condition_id)
+      }
+    })
+    return ids
+  }, [currentTimestamp, markets])
+}
+
+function useEventTokenIds(markets: Event['markets']) {
+  return useMemo(function buildEventTokenIds() {
     const ids = new Set<string>()
 
-    event.markets.forEach((market) => {
+    markets.forEach((market) => {
       market.outcomes.forEach((currentOutcome) => {
         if (currentOutcome.token_id) {
           ids.add(currentOutcome.token_id)
@@ -192,20 +168,185 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
     })
 
     return Array.from(ids)
-  }, [event.markets])
-  const shouldEnableOrderBookPolling = !isSingleMarket
-  const orderBookQuery = useOrderBookSummaries(eventTokenIds, { enabled: shouldEnableOrderBookPolling })
-  const orderBookSummaries = orderBookQuery.data
-  const isOrderBookLoading = orderBookQuery.isLoading
-  const shouldShowOrderBookLoader = !shouldEnableOrderBookPolling || (isOrderBookLoading && !orderBookSummaries)
-  const ownerAddress = useMemo(() => {
+  }, [markets])
+}
+
+function useOwnerAddress(user: { proxy_wallet_address?: string | null, proxy_wallet_status?: string | null } | null) {
+  return useMemo(function resolveOwnerAddress() {
     if (user && user.proxy_wallet_address && user.proxy_wallet_status === 'deployed') {
       return user.proxy_wallet_address as `0x${string}`
     }
     return '' as `0x${string}`
   }, [user])
-  const { sharesByCondition } = useUserShareBalances({ event, ownerAddress })
+}
+
+function useCashOutFlow({
+  isMobile,
+  orderBookSummaries,
+  orderBookQuery,
+  setType,
+  setSide,
+  setMarket,
+  setOutcome,
+  setAmount,
+  setIsMobileOrderPanelOpen,
+}: {
+  isMobile: boolean
+  orderBookSummaries: OrderBookSummariesResponse | undefined
+  orderBookQuery: { refetch: () => Promise<{ data?: OrderBookSummariesResponse }> }
+  setType: (type: typeof ORDER_TYPE.MARKET | typeof ORDER_TYPE.LIMIT) => void
+  setSide: (side: typeof ORDER_SIDE.BUY | typeof ORDER_SIDE.SELL) => void
+  setMarket: (market: Event['markets'][number]) => void
+  setOutcome: (outcome: Event['markets'][number]['outcomes'][number]) => void
+  setAmount: (value: string) => void
+  setIsMobileOrderPanelOpen: (value: boolean) => void
+}) {
   const [cashOutPayload, setCashOutPayload] = useState<CashOutModalPayload | null>(null)
+
+  const handleCashOut = useCallback(async function handleCashOut(
+    market: Event['markets'][number],
+    tag: MarketPositionTag,
+  ) {
+    const outcome = market.outcomes.find(item => item.outcome_index === tag.outcomeIndex)
+      ?? market.outcomes[tag.outcomeIndex]
+    if (!outcome) {
+      return
+    }
+
+    const tokenId = outcome.token_id ? String(outcome.token_id) : null
+    let summary = tokenId ? orderBookSummaries?.[tokenId] : undefined
+    if (!summary && tokenId) {
+      try {
+        const result = await orderBookQuery.refetch()
+        summary = result.data?.[tokenId]
+      }
+      catch {
+        summary = undefined
+      }
+    }
+    const bids = normalizeBookLevels(summary?.bids, 'bid')
+    const asks = normalizeBookLevels(summary?.asks, 'ask')
+    const fill = calculateMarketFill(ORDER_SIDE.SELL, tag.shares, bids, asks)
+
+    setType(ORDER_TYPE.MARKET)
+    setSide(ORDER_SIDE.SELL)
+    setMarket(market)
+    setOutcome(outcome)
+    setAmount(formatAmountInputValue(tag.shares, { roundingMode: 'floor' }))
+    if (isMobile) {
+      setIsMobileOrderPanelOpen(true)
+    }
+
+    setCashOutPayload({
+      market,
+      outcomeLabel: tag.label,
+      outcomeIndex: tag.outcomeIndex,
+      shares: tag.shares,
+      filledShares: fill.filledShares,
+      avgPriceCents: fill.avgPriceCents,
+      receiveAmount: fill.totalCost > 0 ? fill.totalCost : null,
+      sellBids: bids,
+    })
+  }, [isMobile, orderBookQuery, orderBookSummaries, setAmount, setIsMobileOrderPanelOpen, setMarket, setOutcome, setSide, setType])
+
+  const handleCashOutModalChange = useCallback(function handleCashOutModalChange(open: boolean) {
+    if (!open) {
+      setCashOutPayload(null)
+    }
+  }, [])
+
+  const handleCashOutSubmit = useCallback(function handleCashOutSubmit(sharesToSell: number) {
+    if (!(sharesToSell > 0)) {
+      return
+    }
+    setAmount(formatAmountInputValue(sharesToSell, { roundingMode: 'floor' }))
+    setCashOutPayload(null)
+    const form = document.getElementById('event-order-form') as HTMLFormElement | null
+    form?.requestSubmit()
+  }, [setAmount])
+
+  const dismissCashOut = useCallback(function dismissCashOut() {
+    setCashOutPayload(null)
+  }, [])
+
+  return { cashOutPayload, handleCashOut, handleCashOutModalChange, handleCashOutSubmit, dismissCashOut }
+}
+
+function useMarketInteractionHandlers({
+  selectedOutcome,
+  toggleMarket,
+  expandMarket,
+  setMarket,
+  setOutcome,
+  setSide,
+  setIsMobileOrderPanelOpen,
+  inputRef,
+}: {
+  selectedOutcome: Event['markets'][number]['outcomes'][number] | null | undefined
+  toggleMarket: (conditionId: string) => void
+  expandMarket: (conditionId: string) => void
+  setMarket: (market: Event['markets'][number]) => void
+  setOutcome: (outcome: Event['markets'][number]['outcomes'][number]) => void
+  setSide: (side: typeof ORDER_SIDE.BUY | typeof ORDER_SIDE.SELL) => void
+  setIsMobileOrderPanelOpen: (value: boolean) => void
+  inputRef: React.RefObject<HTMLInputElement | null> | null | undefined
+}) {
+  const handleToggle = useCallback(function handleToggle(market: Event['markets'][number]) {
+    toggleMarket(market.condition_id)
+    setMarket(market)
+    setSide(ORDER_SIDE.BUY)
+
+    if (!selectedOutcome || selectedOutcome.condition_id !== market.condition_id) {
+      const defaultOutcome = market.outcomes[0]
+      if (defaultOutcome) {
+        setOutcome(defaultOutcome)
+      }
+    }
+  }, [toggleMarket, selectedOutcome, setMarket, setOutcome, setSide])
+
+  const handleBuy = useCallback(function handleBuy(
+    market: Event['markets'][number],
+    outcomeIndex: number,
+    source: 'mobile' | 'desktop',
+  ) {
+    expandMarket(market.condition_id)
+    setMarket(market)
+    const outcome = market.outcomes[outcomeIndex]
+    if (outcome) {
+      setOutcome(outcome)
+    }
+    setSide(ORDER_SIDE.BUY)
+
+    if (source === 'mobile') {
+      setIsMobileOrderPanelOpen(true)
+    }
+    else {
+      inputRef?.current?.focus()
+    }
+  }, [expandMarket, inputRef, setIsMobileOrderPanelOpen, setMarket, setOutcome, setSide])
+
+  return { handleToggle, handleBuy }
+}
+
+function useEventUserPositionsData({
+  event,
+  ownerAddress,
+  sharesByCondition,
+  isNegRiskEnabled,
+  isNegRiskAugmented,
+  userId,
+  normalizeOutcomeLabel,
+  t,
+}: {
+  event: Event
+  ownerAddress: `0x${string}`
+  sharesByCondition: SharesByCondition
+  isNegRiskEnabled: boolean
+  isNegRiskAugmented: boolean
+  userId: string | undefined
+  normalizeOutcomeLabel: (value: string | null | undefined) => string
+  t: ReturnType<typeof useExtracted>
+}) {
   const { data: userPositions } = useQuery<UserPosition[]>({
     queryKey: ['event-user-positions', ownerAddress, event.id],
     enabled: Boolean(ownerAddress),
@@ -221,6 +362,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
         signal,
       }),
   })
+
   const { data: otherBalances } = useQuery({
     queryKey: ['event-other-balance', ownerAddress, event.slug],
     enabled: Boolean(ownerAddress && isNegRiskAugmented && userPositions),
@@ -233,7 +375,8 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
         signal,
       }),
   })
-  const otherShares = useMemo(() => {
+
+  const otherShares = useMemo(function sumOtherShares() {
     if (!otherBalances?.length) {
       return 0
     }
@@ -242,13 +385,14 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
       return total + (Number.isFinite(size) ? size : 0)
     }, 0)
   }, [otherBalances])
-  const shouldShowOtherRow = isNegRiskAugmented && otherShares > 0
+
   const { data: eventOpenOrdersData } = useUserOpenOrdersQuery({
-    userId: user?.id,
+    userId,
     eventSlug: event.slug,
-    enabled: Boolean(user?.id),
+    enabled: Boolean(userId),
   })
-  const mergedEventUserPositions = useMemo(() => {
+
+  const mergedEventUserPositions = useMemo(function mergeUserPositionsWithTokenBalances() {
     const basePositions = userPositions ?? []
     const deltas = event.markets.flatMap((market) => {
       const tokenShares = sharesByCondition[market.condition_id]
@@ -307,7 +451,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
     return applyPositionDeltasToUserPositions(basePositions, deltas) ?? basePositions
   }, [event.markets, event.slug, sharesByCondition, userPositions])
 
-  const openOrdersCountByCondition = useMemo(() => {
+  const openOrdersCountByCondition = useMemo(function countOpenOrdersByCondition() {
     const pages = eventOpenOrdersData?.pages ?? []
     return pages.reduce<Record<string, number>>((acc, page) => {
       page.data.forEach((order) => {
@@ -320,7 +464,8 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
       return acc
     }, {})
   }, [eventOpenOrdersData?.pages])
-  const positionTagsByCondition = useMemo(() => {
+
+  const positionTagsByCondition = useMemo(function buildPositionTagsByCondition() {
     if (!mergedEventUserPositions.length) {
       return {}
     }
@@ -400,7 +545,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
     }, {})
   }, [event.markets, mergedEventUserPositions, normalizeOutcomeLabel, t])
 
-  const convertOptions = useMemo(() => {
+  const convertOptions = useMemo(function buildConvertOptions() {
     if (!isNegRiskEnabled || !mergedEventUserPositions.length) {
       return []
     }
@@ -449,7 +594,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
     )
   }, [event.markets, isNegRiskEnabled, mergedEventUserPositions])
 
-  const eventOutcomes = useMemo(() => {
+  const eventOutcomes = useMemo(function buildEventOutcomes() {
     return event.markets.map(market => ({
       conditionId: market.condition_id,
       questionId: market.question_id,
@@ -458,101 +603,24 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
     }))
   }, [event.markets])
 
-  const handleCashOut = useCallback(async (market: Event['markets'][number], tag: MarketPositionTag) => {
-    const outcome = market.outcomes.find(item => item.outcome_index === tag.outcomeIndex)
-      ?? market.outcomes[tag.outcomeIndex]
-    if (!outcome) {
-      return
-    }
+  return {
+    otherShares,
+    openOrdersCountByCondition,
+    positionTagsByCondition,
+    convertOptions,
+    eventOutcomes,
+  }
+}
 
-    const tokenId = outcome.token_id ? String(outcome.token_id) : null
-    let summary = tokenId ? orderBookSummaries?.[tokenId] : undefined
-    if (!summary && tokenId) {
-      try {
-        const result = await orderBookQuery.refetch()
-        summary = result.data?.[tokenId]
-      }
-      catch {
-        summary = undefined
-      }
-    }
-    const bids = normalizeBookLevels(summary?.bids, 'bid')
-    const asks = normalizeBookLevels(summary?.asks, 'ask')
-    const fill = calculateMarketFill(ORDER_SIDE.SELL, tag.shares, bids, asks)
-
-    setType(ORDER_TYPE.MARKET)
-    setSide(ORDER_SIDE.SELL)
-    setMarket(market)
-    setOutcome(outcome)
-    setAmount(formatAmountInputValue(tag.shares, { roundingMode: 'floor' }))
-    if (isMobile) {
-      setIsMobileOrderPanelOpen(true)
-    }
-
-    setCashOutPayload({
-      market,
-      outcomeLabel: tag.label,
-      outcomeIndex: tag.outcomeIndex,
-      shares: tag.shares,
-      filledShares: fill.filledShares,
-      avgPriceCents: fill.avgPriceCents,
-      receiveAmount: fill.totalCost > 0 ? fill.totalCost : null,
-      sellBids: bids,
-    })
-  }, [isMobile, orderBookQuery, orderBookSummaries, setAmount, setIsMobileOrderPanelOpen, setMarket, setOutcome, setSide, setType])
-
-  const handleCashOutModalChange = useCallback((open: boolean) => {
-    if (!open) {
-      setCashOutPayload(null)
-    }
-  }, [])
-
-  const handleCashOutSubmit = useCallback((sharesToSell: number) => {
-    if (!(sharesToSell > 0)) {
-      return
-    }
-    setAmount(formatAmountInputValue(sharesToSell, { roundingMode: 'floor' }))
-    setCashOutPayload(null)
-    const form = document.getElementById('event-order-form') as HTMLFormElement | null
-    form?.requestSubmit()
-  }, [setAmount])
-
-  const chanceHighlightVersion = hasChanceData
-    ? (isPriceHistoryFetching ? 'fetching' : 'ready')
-    : 'idle'
-
-  const handleToggle = useCallback((market: Event['markets'][number]) => {
-    toggleMarket(market.condition_id)
-    setMarket(market)
-    setSide(ORDER_SIDE.BUY)
-
-    if (!selectedOutcome || selectedOutcome.condition_id !== market.condition_id) {
-      const defaultOutcome = market.outcomes[0]
-      if (defaultOutcome) {
-        setOutcome(defaultOutcome)
-      }
-    }
-  }, [toggleMarket, selectedOutcome, setMarket, setOutcome, setSide])
-
-  const handleBuy = useCallback((market: Event['markets'][number], outcomeIndex: number, source: 'mobile' | 'desktop') => {
-    expandMarket(market.condition_id)
-    setMarket(market)
-    const outcome = market.outcomes[outcomeIndex]
-    if (outcome) {
-      setOutcome(outcome)
-    }
-    setSide(ORDER_SIDE.BUY)
-
-    if (source === 'mobile') {
-      setIsMobileOrderPanelOpen(true)
-    }
-    else {
-      inputRef?.current?.focus()
-    }
-  }, [expandMarket, inputRef, setIsMobileOrderPanelOpen, setMarket, setOutcome, setSide])
-
-  const pricedMarketRows = useMemo(
-    () => marketRows.map(row => ({
+function useMarketRowsByResolution({
+  marketRows,
+  orderBookSummaries,
+}: {
+  marketRows: EventMarketRow[]
+  orderBookSummaries: OrderBookSummariesResponse | undefined
+}) {
+  const pricedMarketRows = useMemo(function buildPricedMarketRows() {
+    return marketRows.map(row => ({
       ...row,
       yesPriceValue: resolveOutcomeUnitPrice(row.market, OUTCOME_INDEX.YES, {
         orderBookSummaries,
@@ -562,10 +630,10 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
         orderBookSummaries,
         side: ORDER_SIDE.BUY,
       }),
-    })),
-    [marketRows, orderBookSummaries],
-  )
-  const { activeDisplayRows, resolvedDisplayRows } = useMemo(() => {
+    }))
+  }, [marketRows, orderBookSummaries])
+
+  const { activeDisplayRows, resolvedDisplayRows } = useMemo(function splitRowsByResolution() {
     const activeRows: EventMarketRow[] = []
     const resolvedRows: EventMarketRow[] = []
 
@@ -580,7 +648,8 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
 
     return { activeDisplayRows: activeRows, resolvedDisplayRows: resolvedRows }
   }, [pricedMarketRows])
-  const sortedResolvedDisplayRows = useMemo(() => {
+
+  const sortedResolvedDisplayRows = useMemo(function sortResolvedRowsByEndTime() {
     if (!resolvedDisplayRows.length) {
       return resolvedDisplayRows
     }
@@ -599,6 +668,111 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
       })
       .map(item => item.row)
   }, [resolvedDisplayRows])
+
+  return { pricedMarketRows, activeDisplayRows, sortedResolvedDisplayRows }
+}
+
+interface CashOutModalPayload {
+  market: Event['markets'][number]
+  outcomeLabel: string
+  outcomeIndex: typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO
+  shares: number
+  filledShares: number
+  avgPriceCents: number | null
+  receiveAmount: number | null
+  sellBids: NormalizedBookLevel[]
+}
+
+export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
+  const t = useExtracted()
+  const currentTimestamp = useCurrentTimestamp({ intervalMs: 60_000 })
+  const normalizeOutcomeLabel = useOutcomeLabel()
+  const selectedMarketId = useOrder(state => state.market?.condition_id)
+  const selectedOutcome = useOrder(state => state.outcome)
+  const setMarket = useOrder(state => state.setMarket)
+  const setOutcome = useOrder(state => state.setOutcome)
+  const setSide = useOrder(state => state.setSide)
+  const setType = useOrder(state => state.setType)
+  const setIsMobileOrderPanelOpen = useOrder(state => state.setIsMobileOrderPanelOpen)
+  const setAmount = useOrder(state => state.setAmount)
+  const inputRef = useOrder(state => state.inputRef)
+  const user = useUser()
+  const isSingleMarket = useIsSingleMarket()
+  const isNegRiskEnabled = Boolean(event.enable_neg_risk || event.neg_risk)
+  const isNegRiskAugmented = Boolean(event.neg_risk_augmented)
+  const { rows: marketRows, hasChanceData } = useEventMarketRows(event)
+  const {
+    expandedMarketId,
+    toggleMarket,
+    expandMarket,
+    selectDetailTab,
+    getSelectedDetailTab,
+  } = useMarketDetailController(event.id)
+  const reviewConditionIds = useReviewConditionIds({ markets: event.markets, currentTimestamp })
+  const { resolveResolvedOutcomeIndex } = useTweetMarketResolution({ event, currentTimestamp })
+  const chanceRefreshQueryKeys = useMemo(
+    () => [
+      ['event-price-history', event.id] as const,
+      ['event-market-quotes'] as const,
+    ],
+    [event.id],
+  )
+  const { isFetching: isPriceHistoryFetching } = useChanceRefresh({ queryKeys: chanceRefreshQueryKeys })
+  const [showResolvedMarkets, setShowResolvedMarkets] = useState(false)
+  const eventTokenIds = useEventTokenIds(event.markets)
+  const shouldEnableOrderBookPolling = !isSingleMarket
+  const orderBookQuery = useOrderBookSummaries(eventTokenIds, { enabled: shouldEnableOrderBookPolling })
+  const orderBookSummaries = orderBookQuery.data
+  const isOrderBookLoading = orderBookQuery.isLoading
+  const shouldShowOrderBookLoader = !shouldEnableOrderBookPolling || (isOrderBookLoading && !orderBookSummaries)
+  const ownerAddress = useOwnerAddress(user)
+  const { sharesByCondition } = useUserShareBalances({ event, ownerAddress })
+  const {
+    otherShares,
+    openOrdersCountByCondition,
+    positionTagsByCondition,
+    convertOptions,
+    eventOutcomes,
+  } = useEventUserPositionsData({
+    event,
+    ownerAddress,
+    sharesByCondition,
+    isNegRiskEnabled,
+    isNegRiskAugmented,
+    userId: user?.id,
+    normalizeOutcomeLabel,
+    t,
+  })
+  const shouldShowOtherRow = isNegRiskAugmented && otherShares > 0
+  const { cashOutPayload, handleCashOut, handleCashOutModalChange, handleCashOutSubmit, dismissCashOut } = useCashOutFlow({
+    isMobile,
+    orderBookSummaries,
+    orderBookQuery,
+    setType,
+    setSide,
+    setMarket,
+    setOutcome,
+    setAmount,
+    setIsMobileOrderPanelOpen,
+  })
+  const { handleToggle, handleBuy } = useMarketInteractionHandlers({
+    selectedOutcome,
+    toggleMarket,
+    expandMarket,
+    setMarket,
+    setOutcome,
+    setSide,
+    setIsMobileOrderPanelOpen,
+    inputRef,
+  })
+  const chanceHighlightVersion = hasChanceData
+    ? (isPriceHistoryFetching ? 'fetching' : 'ready')
+    : 'idle'
+
+  const { pricedMarketRows, activeDisplayRows, sortedResolvedDisplayRows } = useMarketRowsByResolution({
+    marketRows,
+    orderBookSummaries,
+  })
   const showResolvedInline = pricedMarketRows.length > 0
     && pricedMarketRows.every(row => isMarketResolved(row.market))
   const primaryMarketRows = showResolvedInline ? sortedResolvedDisplayRows : activeDisplayRows
@@ -813,7 +987,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
           onCashOut={handleCashOutSubmit}
           onEditOrder={(sharesToSell) => {
             setAmount(formatAmountInputValue(sharesToSell, { roundingMode: 'floor' }))
-            setCashOutPayload(null)
+            dismissCashOut()
           }}
         />
       )}
@@ -1117,7 +1291,7 @@ function MarketDetailTabs({
     [market.condition, siteName],
   )
 
-  useEffect(() => {
+  useEffect(function syncSelectedTabWithController() {
     if (selectedTab !== controlledTab) {
       select(selectedTab)
     }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -93,14 +93,11 @@ function useTweetMarketResolution({
   event: Event
   currentTimestamp: number | null
 }) {
-  const isTweetMarketEvent = useMemo(function detectTweetMarketEvent() {
-    return isTweetMarketsEvent(event)
-  }, [event])
-
+  const isTweetMarketEvent = useMemo(() => isTweetMarketsEvent(event), [event])
   const xtrackerTweetCountQuery = useXTrackerTweetCount(event, isTweetMarketEvent)
   const xtrackerTotalCount = xtrackerTweetCountQuery.data?.totalCount ?? null
 
-  const isTweetMarketFinal = useMemo(function detectTweetMarketFinal() {
+  const isTweetMarketFinal = useMemo(() => {
     if (currentTimestamp == null) {
       return false
     }
@@ -140,7 +137,7 @@ function useReviewConditionIds({
   markets: Event['markets']
   currentTimestamp: number | null
 }) {
-  return useMemo(function buildReviewConditionIds() {
+  return useMemo(() => {
     if (currentTimestamp == null) {
       return new Set<string>()
     }
@@ -156,7 +153,7 @@ function useReviewConditionIds({
 }
 
 function useEventTokenIds(markets: Event['markets']) {
-  return useMemo(function buildEventTokenIds() {
+  return useMemo(() => {
     const ids = new Set<string>()
 
     markets.forEach((market) => {
@@ -172,7 +169,7 @@ function useEventTokenIds(markets: Event['markets']) {
 }
 
 function useOwnerAddress(user: { proxy_wallet_address?: string | null, proxy_wallet_status?: string | null } | null) {
-  return useMemo(function resolveOwnerAddress() {
+  return useMemo(() => {
     if (user && user.proxy_wallet_address && user.proxy_wallet_status === 'deployed') {
       return user.proxy_wallet_address as `0x${string}`
     }
@@ -376,7 +373,7 @@ function useEventUserPositionsData({
       }),
   })
 
-  const otherShares = useMemo(function sumOtherShares() {
+  const otherShares = useMemo(() => {
     if (!otherBalances?.length) {
       return 0
     }
@@ -392,7 +389,7 @@ function useEventUserPositionsData({
     enabled: Boolean(userId),
   })
 
-  const mergedEventUserPositions = useMemo(function mergeUserPositionsWithTokenBalances() {
+  const mergedEventUserPositions = useMemo(() => {
     const basePositions = userPositions ?? []
     const deltas = event.markets.flatMap((market) => {
       const tokenShares = sharesByCondition[market.condition_id]
@@ -451,7 +448,7 @@ function useEventUserPositionsData({
     return applyPositionDeltasToUserPositions(basePositions, deltas) ?? basePositions
   }, [event.markets, event.slug, sharesByCondition, userPositions])
 
-  const openOrdersCountByCondition = useMemo(function countOpenOrdersByCondition() {
+  const openOrdersCountByCondition = useMemo(() => {
     const pages = eventOpenOrdersData?.pages ?? []
     return pages.reduce<Record<string, number>>((acc, page) => {
       page.data.forEach((order) => {
@@ -465,7 +462,7 @@ function useEventUserPositionsData({
     }, {})
   }, [eventOpenOrdersData?.pages])
 
-  const positionTagsByCondition = useMemo(function buildPositionTagsByCondition() {
+  const positionTagsByCondition = useMemo(() => {
     if (!mergedEventUserPositions.length) {
       return {}
     }
@@ -545,7 +542,7 @@ function useEventUserPositionsData({
     }, {})
   }, [event.markets, mergedEventUserPositions, normalizeOutcomeLabel, t])
 
-  const convertOptions = useMemo(function buildConvertOptions() {
+  const convertOptions = useMemo(() => {
     if (!isNegRiskEnabled || !mergedEventUserPositions.length) {
       return []
     }
@@ -594,7 +591,7 @@ function useEventUserPositionsData({
     )
   }, [event.markets, isNegRiskEnabled, mergedEventUserPositions])
 
-  const eventOutcomes = useMemo(function buildEventOutcomes() {
+  const eventOutcomes = useMemo(() => {
     return event.markets.map(market => ({
       conditionId: market.condition_id,
       questionId: market.question_id,
@@ -619,7 +616,7 @@ function useMarketRowsByResolution({
   marketRows: EventMarketRow[]
   orderBookSummaries: OrderBookSummariesResponse | undefined
 }) {
-  const pricedMarketRows = useMemo(function buildPricedMarketRows() {
+  const pricedMarketRows = useMemo(() => {
     return marketRows.map(row => ({
       ...row,
       yesPriceValue: resolveOutcomeUnitPrice(row.market, OUTCOME_INDEX.YES, {
@@ -633,7 +630,7 @@ function useMarketRowsByResolution({
     }))
   }, [marketRows, orderBookSummaries])
 
-  const { activeDisplayRows, resolvedDisplayRows } = useMemo(function splitRowsByResolution() {
+  const { activeDisplayRows, resolvedDisplayRows } = useMemo(() => {
     const activeRows: EventMarketRow[] = []
     const resolvedRows: EventMarketRow[] = []
 
@@ -649,7 +646,7 @@ function useMarketRowsByResolution({
     return { activeDisplayRows: activeRows, resolvedDisplayRows: resolvedRows }
   }, [pricedMarketRows])
 
-  const sortedResolvedDisplayRows = useMemo(function sortResolvedRowsByEndTime() {
+  const sortedResolvedDisplayRows = useMemo(() => {
     if (!resolvedDisplayRows.length) {
       return resolvedDisplayRows
     }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -118,7 +118,7 @@ function useTweetMarketResolution({
     return Number.isFinite(parsedEndMs) && currentTimestamp >= parsedEndMs
   }, [currentTimestamp, event.end_date, xtrackerTweetCountQuery.data?.trackingEndMs])
 
-  const resolveResolvedOutcomeIndex = useCallback(function resolveResolvedOutcomeIndex(market: Event['markets'][number]) {
+  const resolveResolvedOutcomeIndex = useCallback((market: Event['markets'][number]) => {
     if (!isMarketResolved(market)) {
       return null
     }
@@ -249,13 +249,13 @@ function useCashOutFlow({
     })
   }, [isMobile, orderBookQuery, orderBookSummaries, setAmount, setIsMobileOrderPanelOpen, setMarket, setOutcome, setSide, setType])
 
-  const handleCashOutModalChange = useCallback(function handleCashOutModalChange(open: boolean) {
+  const handleCashOutModalChange = useCallback((open: boolean) => {
     if (!open) {
       setCashOutPayload(null)
     }
   }, [])
 
-  const handleCashOutSubmit = useCallback(function handleCashOutSubmit(sharesToSell: number) {
+  const handleCashOutSubmit = useCallback((sharesToSell: number) => {
     if (!(sharesToSell > 0)) {
       return
     }
@@ -265,7 +265,7 @@ function useCashOutFlow({
     form?.requestSubmit()
   }, [setAmount])
 
-  const dismissCashOut = useCallback(function dismissCashOut() {
+  const dismissCashOut = useCallback(() => {
     setCashOutPayload(null)
   }, [])
 
@@ -291,7 +291,7 @@ function useMarketInteractionHandlers({
   setIsMobileOrderPanelOpen: (value: boolean) => void
   inputRef: React.RefObject<HTMLInputElement | null> | null | undefined
 }) {
-  const handleToggle = useCallback(function handleToggle(market: Event['markets'][number]) {
+  const handleToggle = useCallback((market: Event['markets'][number]) => {
     toggleMarket(market.condition_id)
     setMarket(market)
     setSide(ORDER_SIDE.BUY)
@@ -304,11 +304,11 @@ function useMarketInteractionHandlers({
     }
   }, [toggleMarket, selectedOutcome, setMarket, setOutcome, setSide])
 
-  const handleBuy = useCallback(function handleBuy(
+  const handleBuy = useCallback((
     market: Event['markets'][number],
     outcomeIndex: number,
     source: 'mobile' | 'desktop',
-  ) {
+  ) => {
     expandMarket(market.condition_id)
     setMarket(market)
     const outcome = market.outcomes[outcomeIndex]

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventShare.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventShare.tsx
@@ -137,7 +137,7 @@ function useAffiliateToastData({
     affiliateToastDataRequestRef.current = null
   }, [affiliateCode])
 
-  const ensureAffiliateToastData = useCallback(async function ensureAffiliateToastData(): Promise<AffiliateToastData> {
+  const ensureAffiliateToastData = useCallback(async (): Promise<AffiliateToastData> => {
     if (!affiliateCode) {
       return {
         affiliateSharePercent: null,
@@ -189,7 +189,7 @@ function useAffiliateToastData({
     void ensureAffiliateToastData()
   }
 
-  const showAffiliateToast = useCallback(async function showAffiliateToast() {
+  const showAffiliateToast = useCallback(async () => {
     const toastData = await ensureAffiliateToastData()
 
     maybeShowAffiliateToast({

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventShare.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventShare.tsx
@@ -1,4 +1,3 @@
-import type { RefObject } from 'react'
 import type { Event } from '@/types'
 import { CheckIcon, ShareIcon } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
@@ -46,25 +45,52 @@ function parseAffiliateToastData(result: Awaited<ReturnType<typeof fetchAffiliat
   }
 }
 
-export default function EventShare({ event }: EventShareProps) {
-  const site = useSiteIdentity()
-  const [shareSuccess, setShareSuccess] = useState(false)
+const MENU_CLOSE_DELAY_MS = 120
+const COPY_FEEDBACK_DURATION_MS = 1600
+
+function useCopyFeedback() {
   const [copiedKey, setCopiedKey] = useState<string | null>(null)
-  const [affiliateSharePercent, setAffiliateSharePercent] = useState<number | null>(null)
-  const [tradeFeePercent, setTradeFeePercent] = useState<number | null>(null)
-  const [hasResolvedAffiliateToastData, setHasResolvedAffiliateToastData] = useState(false)
-  const [shareMenuOpen, setShareMenuOpen] = useState(false)
   const copyTimeoutRef = useRef<number | null>(null)
+
+  useEffect(function clearCopyTimeoutOnUnmount() {
+    return function clearCopyTimeout() {
+      if (copyTimeoutRef.current) {
+        window.clearTimeout(copyTimeoutRef.current)
+      }
+    }
+  }, [])
+
+  function markKeyAsCopied(key: string) {
+    setCopiedKey(key)
+    if (copyTimeoutRef.current) {
+      window.clearTimeout(copyTimeoutRef.current)
+    }
+    copyTimeoutRef.current = window.setTimeout(setCopiedKey, COPY_FEEDBACK_DURATION_MS, null)
+  }
+
+  return { copiedKey, markKeyAsCopied }
+}
+
+function useShareMenuHover() {
+  const [shareMenuOpen, setShareMenuOpen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const affiliateToastDataRequestRef = useRef<Promise<AffiliateToastData> | null>(null)
-  const user = useUser()
-  const affiliateCode = user?.affiliate_code?.trim() ?? ''
-  const isMultiMarket = event.total_markets_count > 1
-  const eventPath = resolveEventPagePath(event)
 
-  function relatedTargetIsWithin(ref: RefObject<HTMLElement | null>, relatedTarget: EventTarget | null) {
-    const current = ref.current
+  function clearCloseTimeout() {
+    if (closeTimeoutRef.current) {
+      clearTimeout(closeTimeoutRef.current)
+      closeTimeoutRef.current = null
+    }
+  }
+
+  useEffect(function clearCloseTimeoutOnUnmount() {
+    return function clearMenuCloseTimeout() {
+      clearCloseTimeout()
+    }
+  }, [])
+
+  function relatedTargetIsInsideWrapper(relatedTarget: EventTarget | null) {
+    const current = wrapperRef.current
     if (!current) {
       return false
     }
@@ -77,47 +103,41 @@ export default function EventShare({ event }: EventShareProps) {
     return current.contains(relatedTarget)
   }
 
-  function clearCloseTimeout() {
-    if (closeTimeoutRef.current) {
-      clearTimeout(closeTimeoutRef.current)
-      closeTimeoutRef.current = null
-    }
-  }
-
-  function handleWrapperPointerEnter() {
-    clearCloseTimeout()
-    setShareMenuOpen(true)
-    prefetchAffiliateToastData()
-  }
-
-  function handleWrapperPointerLeave(event: React.PointerEvent) {
-    if (relatedTargetIsWithin(wrapperRef, event.relatedTarget)) {
-      return
-    }
-
-    clearCloseTimeout()
-    closeTimeoutRef.current = setTimeout(() => {
-      setShareMenuOpen(false)
-    }, 120)
-  }
-
-  useEffect(() => {
-    return () => {
-      if (copyTimeoutRef.current) {
-        window.clearTimeout(copyTimeoutRef.current)
-      }
+  return {
+    shareMenuOpen,
+    setShareMenuOpen,
+    wrapperRef,
+    clearCloseTimeout,
+    scheduleClose() {
       clearCloseTimeout()
-    }
-  }, [])
+      closeTimeoutRef.current = setTimeout(function closeMenuAfterDelay() {
+        setShareMenuOpen(false)
+      }, MENU_CLOSE_DELAY_MS)
+    },
+    relatedTargetIsInsideWrapper,
+  }
+}
 
-  useEffect(() => {
+function useAffiliateToastData({
+  affiliateCode,
+  siteName,
+}: {
+  affiliateCode: string
+  siteName: string
+}) {
+  const [affiliateSharePercent, setAffiliateSharePercent] = useState<number | null>(null)
+  const [tradeFeePercent, setTradeFeePercent] = useState<number | null>(null)
+  const [hasResolvedAffiliateToastData, setHasResolvedAffiliateToastData] = useState(false)
+  const affiliateToastDataRequestRef = useRef<Promise<AffiliateToastData> | null>(null)
+
+  useEffect(function resetAffiliateDataOnCodeChange() {
     setAffiliateSharePercent(null)
     setTradeFeePercent(null)
     setHasResolvedAffiliateToastData(false)
     affiliateToastDataRequestRef.current = null
   }, [affiliateCode])
 
-  const ensureAffiliateToastData = useCallback(async (): Promise<AffiliateToastData> => {
+  const ensureAffiliateToastData = useCallback(async function ensureAffiliateToastData(): Promise<AffiliateToastData> {
     if (!affiliateCode) {
       return {
         affiliateSharePercent: null,
@@ -169,19 +189,23 @@ export default function EventShare({ event }: EventShareProps) {
     void ensureAffiliateToastData()
   }
 
-  const showAffiliateToast = useCallback(async () => {
+  const showAffiliateToast = useCallback(async function showAffiliateToast() {
     const toastData = await ensureAffiliateToastData()
 
     maybeShowAffiliateToast({
       affiliateCode,
       affiliateSharePercent: toastData.affiliateSharePercent,
       tradeFeePercent: toastData.tradeFeePercent,
-      siteName: site.name,
+      siteName,
       context: 'link',
     })
-  }, [affiliateCode, ensureAffiliateToastData, site.name])
+  }, [affiliateCode, ensureAffiliateToastData, siteName])
 
-  const debugPayload = useMemo(() => {
+  return { prefetchAffiliateToastData, showAffiliateToast }
+}
+
+function useDebugCopy(event: Event) {
+  const debugPayload = useMemo(function buildDebugPayload() {
     return {
       event: {
         id: event.id,
@@ -204,7 +228,7 @@ export default function EventShare({ event }: EventShareProps) {
     }
   }, [event.id, event.markets, event.slug, event.title])
 
-  const handleDebugCopy = useCallback(async () => {
+  const handleDebugCopy = useCallback(async function handleDebugCopy() {
     try {
       await navigator.clipboard.writeText(JSON.stringify(debugPayload, null, 2))
     }
@@ -213,24 +237,69 @@ export default function EventShare({ event }: EventShareProps) {
     }
   }, [debugPayload])
 
-  const maybeHandleDebugCopy = useCallback((event: React.MouseEvent | React.PointerEvent) => {
-    if (!event.altKey) {
+  const maybeHandleDebugCopy = useCallback(function maybeHandleDebugCopy(
+    triggerEvent: React.MouseEvent | React.PointerEvent,
+  ) {
+    if (!triggerEvent.altKey) {
       return false
     }
 
-    event.preventDefault()
-    event.stopPropagation()
+    triggerEvent.preventDefault()
+    triggerEvent.stopPropagation()
     void handleDebugCopy()
     return true
   }, [handleDebugCopy])
 
-  const buildShareUrl = useCallback((path: string) => {
+  return { maybeHandleDebugCopy }
+}
+
+function useShareUrlBuilder(affiliateCode: string) {
+  return useCallback(function buildShareUrl(path: string) {
     const url = new URL(path, window.location.origin)
     if (affiliateCode) {
       url.searchParams.set('r', affiliateCode)
     }
     return url.toString()
   }, [affiliateCode])
+}
+
+export default function EventShare({ event }: EventShareProps) {
+  const site = useSiteIdentity()
+  const user = useUser()
+  const affiliateCode = user?.affiliate_code?.trim() ?? ''
+  const isMultiMarket = event.total_markets_count > 1
+  const eventPath = resolveEventPagePath(event)
+
+  const [shareSuccess, setShareSuccess] = useState(false)
+  const { copiedKey, markKeyAsCopied } = useCopyFeedback()
+  const {
+    shareMenuOpen,
+    setShareMenuOpen,
+    wrapperRef,
+    clearCloseTimeout,
+    scheduleClose,
+    relatedTargetIsInsideWrapper,
+  } = useShareMenuHover()
+  const { prefetchAffiliateToastData, showAffiliateToast } = useAffiliateToastData({
+    affiliateCode,
+    siteName: site.name,
+  })
+  const { maybeHandleDebugCopy } = useDebugCopy(event)
+  const buildShareUrl = useShareUrlBuilder(affiliateCode)
+
+  function handleWrapperPointerEnter() {
+    clearCloseTimeout()
+    setShareMenuOpen(true)
+    prefetchAffiliateToastData()
+  }
+
+  function handleWrapperPointerLeave(pointerEvent: React.PointerEvent) {
+    if (relatedTargetIsInsideWrapper(pointerEvent.relatedTarget)) {
+      return
+    }
+
+    scheduleClose()
+  }
 
   async function handleShare() {
     try {
@@ -249,11 +318,7 @@ export default function EventShare({ event }: EventShareProps) {
     try {
       const url = buildShareUrl(path)
       await navigator.clipboard.writeText(url)
-      setCopiedKey(key)
-      if (copyTimeoutRef.current) {
-        window.clearTimeout(copyTimeoutRef.current)
-      }
-      copyTimeoutRef.current = window.setTimeout(setCopiedKey, 1600, null)
+      markKeyAsCopied(key)
       await showAffiliateToast()
     }
     catch (error) {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventShare.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventShare.tsx
@@ -237,9 +237,9 @@ function useDebugCopy(event: Event) {
     }
   }, [debugPayload])
 
-  const maybeHandleDebugCopy = useCallback(function maybeHandleDebugCopy(
+  const maybeHandleDebugCopy = useCallback((
     triggerEvent: React.MouseEvent | React.PointerEvent,
-  ) {
+  ) => {
     if (!triggerEvent.altKey) {
       return false
     }
@@ -254,7 +254,7 @@ function useDebugCopy(event: Event) {
 }
 
 function useShareUrlBuilder(affiliateCode: string) {
-  return useCallback(function buildShareUrl(path: string) {
+  return useCallback((path: string) => {
     const url = new URL(path, window.location.origin)
     if (affiliateCode) {
       url.searchParams.set('r', affiliateCode)


### PR DESCRIPTION
## Summary

Applies [#855](https://github.com/kuestcom/prediction-market/issues/855) to the three heavy content files on the event page: `EventMarkets` (1268 LOC), `EventContent` (588 LOC), `EventShare` (367 LOC). Extracts file-local custom hooks and names every affected `useEffect`.

Follow-up to [#866](https://github.com/kuestcom/prediction-market/pull/866), [#867](https://github.com/kuestcom/prediction-market/pull/867), [#868](https://github.com/kuestcom/prediction-market/pull/868).

## Files changed (3)

| File | `use-encapsulation/prefer-custom-hooks` | Effects named |
|---|---|---|
| `EventShare` | 18 → 1 (94%) | 3 |
| `EventContent` | 19 → 4 (79%) | 5 |
| `EventMarkets` | 30 → 9 (70%) | 1 (inside `MarketDetailTabs`) |

**Total: 67 → 14 (79% reduction, 53 eliminated), 9 effects all named (zero unnamed).**

## Extracted hooks (all file-local)

### `EventShare`
- `useCopyFeedback` — `copiedKey` state + named cleanup for copy timeout
- `useShareMenuHover` — `shareMenuOpen` + hover timeout + pointer-enter/leave handlers
- `useAffiliateToastData` — 3 affiliate states + reset effect + `ensureAffiliateToastData` + `showAffiliateToast`
- `useDebugCopy` — `debugPayload` memo + alt-click debug copy handlers
- `useShareUrlBuilder` — affiliate-aware URL builder

### `EventContent`
- `useHasResolvedMobileBreakpoint` — deferred mobile gate with named effect
- `useSyncUserToClientStore` — server user → zustand client sync
- `useSetEventInOrderStore` — write event to order store
- `useOrderBootstrapMarketSelection` — bootstrap market/outcome on mount/slug change
- `useInitialMarketAndOutcome` — 2 memos for initial selection
- `useSelectedMarketInfo` — selected market + timeline outcome
- `useBackToTopBounds` — scroll-aware back-to-top positioning
- `useAppliedOrderQuerySync` — URL query → order store sync (in `EventOrderQuerySync` sub-component)

### `EventMarkets`
- `useTweetMarketResolution` — tweet/resolved outcome derivation (3 memos + 1 callback)
- `useReviewConditionIds` — resolution review status set
- `useEventTokenIds` — token ID aggregation across markets
- `useOwnerAddress` — proxy-wallet-aware owner address
- `useCashOutFlow` — cash-out state + 4 named handlers
- `useMarketInteractionHandlers` — toggle + buy handlers
- `useEventUserPositionsData` — positions query + other-balances query + open-orders count + position tags + convert options + event outcomes
- `useMarketRowsByResolution` — priced rows + active/resolved split + resolved sort

## Kept inline (per your "2–3 sec rule")

Remaining 14 warnings are library/context hooks (`useUser`, `useOrder`, `useQuery`, `useUserOpenOrdersQuery`, `useIsMobile`, `useCurrentTimestamp`, `useOutcomeLabel`, `useIsSingleMarket`) and trivial single-line `useMemo` / `useState` derivations (query keys, content/markets refs, UMA URL memos). Each is readable in under 3 seconds.

## Test plan

- [x] `npm test` — 487/487 pass
- [x] `npm run build` — clean
- [x] `tsc --noEmit` on touched files — 0 errors
- [x] Pre-push hook re-ran full suite on push
- [x] Manual UX smoke: event header + sticky scroll, share menu hover + copy + affiliate toast, alt-click debug copy, multi-market switching + cash-out flow, resolved market rendering + resolution timeline tab, open-orders/positions/history tabs, back-to-top button

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored the event page to move heavy inline logic into file-local custom hooks for `EventShare`, `EventContent`, and `EventMarkets`, reducing complexity with no behavior changes. Improves readability, isolates side effects, and keeps all `useEffect` bodies named.

- **Refactors**
  - EventShare: added hooks for copy feedback, hover open/close with delayed close, affiliate toast prefetch/show, debug copy, and affiliate-aware URL building.
  - EventContent: added hooks for mobile breakpoint resolution, server user → client store sync, event write to the order store, market/outcome bootstrap + initial selection, selected market/timeline outcome, back-to-top bounds, and URL query → order store sync.
  - EventMarkets: added hooks for tweet market resolution, review condition IDs, token ID aggregation, owner address resolution, cash-out flow (state + handlers), market interaction handlers, user positions/open-orders aggregation, and pricing/splitting/sorting market rows; named the tab sync effect.
  - Consistency: removed named function expressions from `useCallback` wrappers and converted all `useMemo` implementations to arrow functions.
  - Results: reduced custom-hook warnings from 67 to 14 (~79%); components are slimmer with unchanged UX (cash-out, affiliate toasts, mobile/desktop rendering, resolved-market ordering).

<sup>Written for commit ebd3d699085ded1ee1a48f682803b49a875ffd62. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

