### PR TITLE
refactor: use custom hooks for event page chart components

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -158,6 +158,330 @@ const PredictionChart = dynamic<PredictionChartProps>(
   { ssr: false, loading: () => <div className="h-83 w-full" /> },
 )
 
+function useChartSettingsFromStore() {
+  const chartSettings = useSyncExternalStore(
+    subscribeToChartSettings,
+    loadStoredChartSettings,
+    getStoredChartSettingsServerSnapshot,
+  )
+
+  const handleChartSettingsChange = useCallback(function handleChartSettingsChange(nextValue: SetStateAction<ChartSettings>) {
+    const nextSettings = typeof nextValue === 'function'
+      ? nextValue(chartSettings)
+      : nextValue
+
+    storeChartSettings(nextSettings)
+  }, [chartSettings])
+
+  return { chartSettings, handleChartSettingsChange }
+}
+
+function useChartCursorTracking(chartScopeKey: string) {
+  const [cursorState, setCursorState] = useState<{
+    scopeKey: string
+    snapshot: PredictionChartCursorSnapshot | null
+  }>({
+    scopeKey: '',
+    snapshot: null,
+  })
+
+  const cursorSnapshot = cursorState.scopeKey === chartScopeKey
+    ? cursorState.snapshot
+    : null
+
+  const handleCursorDataChange = useCallback(function handleCursorDataChange(snapshot: PredictionChartCursorSnapshot | null) {
+    setCursorState({
+      scopeKey: chartScopeKey,
+      snapshot,
+    })
+  }, [chartScopeKey])
+
+  return { cursorSnapshot, handleCursorDataChange }
+}
+
+function useTweetMarketsDerivations({
+  event,
+  currentTimestampMs,
+  xtrackerData,
+}: {
+  event: Event
+  currentTimestampMs: number
+  xtrackerData: ReturnType<typeof useXTrackerTweetCount>['data']
+}) {
+  const shouldShowTweetMarketsPanel = useMemo(function detectTweetMarketsEvent() {
+    return isTweetMarketsEvent(event)
+  }, [event])
+
+  const tweetCount = useMemo(function resolveStaticTweetCount() {
+    return resolveTweetCount(event)
+  }, [event])
+
+  const tweetCountdownTargetMs = useMemo(function resolveStaticTweetCountdownTarget() {
+    return resolveTweetCountdownTargetMs(event)
+  }, [event])
+
+  const resolvedTweetCount = xtrackerData?.totalCount ?? tweetCount
+
+  const resolvedTweetCountdownTargetMs = useMemo(function resolveTweetCountdownTarget() {
+    const trackingEndMs = xtrackerData?.trackingEndMs
+    if (typeof trackingEndMs === 'number' && Number.isFinite(trackingEndMs) && trackingEndMs > 0) {
+      return trackingEndMs
+    }
+
+    return tweetCountdownTargetMs
+  }, [tweetCountdownTargetMs, xtrackerData?.trackingEndMs])
+
+  const resolvedTweetStartTargetMs = useMemo(function resolveTweetStartTarget() {
+    const trackingStartMs = xtrackerData?.trackingStartMs
+    if (typeof trackingStartMs === 'number' && Number.isFinite(trackingStartMs) && trackingStartMs > 0) {
+      return trackingStartMs
+    }
+
+    return parseTimestampToMs(event.start_date ?? null)
+  }, [event.start_date, xtrackerData?.trackingStartMs])
+
+  const shouldRenderTweetMarketsPanel = shouldShowTweetMarketsPanel
+    && resolvedTweetStartTargetMs != null
+    && currentTimestampMs >= resolvedTweetStartTargetMs
+
+  const isTweetMarketsFinal = Boolean(event.resolved_at || event.status === 'resolved')
+    || (
+      resolvedTweetCountdownTargetMs != null
+      && Number.isFinite(resolvedTweetCountdownTargetMs)
+      && currentTimestampMs >= resolvedTweetCountdownTargetMs
+    )
+
+  return {
+    shouldShowTweetMarketsPanel,
+    shouldRenderTweetMarketsPanel,
+    resolvedTweetCount,
+    resolvedTweetCountdownTargetMs,
+    isTweetMarketsFinal,
+  }
+}
+
+function useMarketSelection({
+  eventId,
+  allMarketIds,
+  defaultMarketIds,
+  maxSeriesCount,
+  isSingleMarket,
+}: {
+  eventId: string
+  allMarketIds: string[]
+  defaultMarketIds: string[]
+  maxSeriesCount: number
+  isSingleMarket: boolean
+}) {
+  const [customMarketSelection, setCustomMarketSelection] = useState<{
+    eventId: string
+    marketIds: string[] | null
+  }>(() => ({
+    eventId,
+    marketIds: null,
+  }))
+
+  const activeCustomMarketIds = customMarketSelection.eventId === eventId
+    ? customMarketSelection.marketIds
+    : null
+
+  const selectedMarketIds = useMemo(function resolveSelectedMarkets() {
+    return isSingleMarket
+      ? defaultMarketIds
+      : resolveSelectedMarketIds(activeCustomMarketIds, allMarketIds, defaultMarketIds)
+  }, [activeCustomMarketIds, allMarketIds, defaultMarketIds, isSingleMarket])
+
+  const handleToggleMarket = useCallback(function handleToggleMarket(marketId: string) {
+    if (isSingleMarket) {
+      return
+    }
+
+    setCustomMarketSelection((prev) => {
+      const currentSelection = resolveSelectedMarketIds(
+        prev.eventId === eventId ? prev.marketIds : null,
+        allMarketIds,
+        defaultMarketIds,
+      )
+      const isSelected = currentSelection.includes(marketId)
+      if (isSelected) {
+        const nextSelection = currentSelection.filter(id => id !== marketId)
+        return nextSelection.length > 0
+          ? { eventId, marketIds: nextSelection }
+          : prev
+      }
+      if (currentSelection.length >= maxSeriesCount) {
+        return prev
+      }
+      const nextSet = new Set(currentSelection)
+      nextSet.add(marketId)
+      return {
+        eventId,
+        marketIds: allMarketIds.filter(id => nextSet.has(id)).slice(0, maxSeriesCount),
+      }
+    })
+  }, [allMarketIds, defaultMarketIds, eventId, isSingleMarket, maxSeriesCount])
+
+  return { selectedMarketIds, handleToggleMarket }
+}
+
+function useChartSeriesBuilders({
+  event,
+  topMarketIds,
+  fallbackMarketIds,
+  allMarketIds,
+  selectedMarketIds,
+  isSingleMarket,
+  showBothOutcomes,
+  activeOutcomeIndex,
+  primaryConditionId,
+  yesSeriesKey,
+  noSeriesKey,
+  yesOutcomeLabel,
+  noOutcomeLabel,
+}: {
+  event: Event
+  topMarketIds: string[]
+  fallbackMarketIds: string[]
+  allMarketIds: string[]
+  selectedMarketIds: string[]
+  isSingleMarket: boolean
+  showBothOutcomes: boolean
+  activeOutcomeIndex: typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO
+  primaryConditionId: string
+  yesSeriesKey: string
+  noSeriesKey: string
+  yesOutcomeLabel: string
+  noOutcomeLabel: string
+}) {
+  const chartSeries = useMemo(function buildTopChartSeries() {
+    return buildChartSeries(event, topMarketIds)
+  }, [event, topMarketIds])
+
+  const fallbackChartSeries = useMemo(function buildFallbackChartSeries() {
+    return buildChartSeries(event, fallbackMarketIds)
+  }, [event, fallbackMarketIds])
+
+  const allSeries = useMemo(function buildAllChartSeries() {
+    return buildChartSeries(event, allMarketIds)
+  }, [event, allMarketIds])
+
+  const selectedSeries = useMemo(function buildSelectedChartSeries() {
+    return buildChartSeries(event, selectedMarketIds)
+  }, [event, selectedMarketIds])
+
+  const selectedColors = useMemo(function buildSelectedSeriesColors() {
+    return Object.fromEntries(selectedSeries.map(series => [series.key, series.color]))
+  }, [selectedSeries])
+
+  const marketOptions = useMemo(function buildMarketOptions() {
+    return allSeries.map(series => ({
+      ...series,
+      color: selectedColors[series.key] ?? '#374151',
+    }))
+  }, [allSeries, selectedColors])
+
+  const baseSeries = useMemo(function resolveBaseSeries() {
+    if (!isSingleMarket) {
+      if (selectedSeries.length > 0) {
+        return selectedSeries
+      }
+      return chartSeries.length > 0 ? chartSeries : fallbackChartSeries
+    }
+    return chartSeries.length > 0 ? chartSeries : fallbackChartSeries
+  }, [chartSeries, fallbackChartSeries, isSingleMarket, selectedSeries])
+
+  const bothOutcomeSeries = useMemo(function buildBothOutcomeSeries() {
+    if (!showBothOutcomes || !primaryConditionId) {
+      return []
+    }
+    return [
+      { key: yesSeriesKey, name: yesOutcomeLabel, color: 'var(--primary)' },
+      { key: noSeriesKey, name: noOutcomeLabel, color: '#FF6600' },
+    ]
+  }, [showBothOutcomes, primaryConditionId, yesSeriesKey, noSeriesKey, yesOutcomeLabel, noOutcomeLabel])
+
+  const effectiveSeries = useMemo(function resolveEffectiveSeries() {
+    if (showBothOutcomes) {
+      return bothOutcomeSeries
+    }
+    if (!isSingleMarket || baseSeries.length === 0) {
+      return baseSeries
+    }
+    const primaryColor = activeOutcomeIndex === OUTCOME_INDEX.NO ? '#FF6600' : 'var(--primary)'
+    return baseSeries.map((seriesItem, index) => (index === 0
+      ? { ...seriesItem, color: primaryColor }
+      : seriesItem))
+  }, [activeOutcomeIndex, baseSeries, isSingleMarket, showBothOutcomes, bothOutcomeSeries])
+
+  return {
+    chartSeries,
+    marketOptions,
+    effectiveSeries,
+  }
+}
+
+function useTradeFlowLabels(outcomeTokenKey: string) {
+  const [tradeFlowState, setTradeFlowState] = useState<{
+    tokenKey: string
+    items: TradeFlowLabelItem[]
+  }>({
+    tokenKey: '',
+    items: [],
+  })
+  const tradeFlowIdRef = useRef(0)
+  const tradeFlowItems = tradeFlowState.tokenKey === outcomeTokenKey
+    ? tradeFlowState.items
+    : []
+  const hasTradeFlowLabels = tradeFlowItems.length > 0
+
+  function appendTradeFlowItem(item: Omit<TradeFlowLabelItem, 'id'>) {
+    const id = String(tradeFlowIdRef.current)
+    tradeFlowIdRef.current += 1
+
+    setTradeFlowState((prev) => {
+      const activeItems = prev.tokenKey === outcomeTokenKey ? prev.items : []
+      const nextItems = trimTradeFlowItems(pruneTradeFlowItems([
+        ...activeItems,
+        { ...item, id },
+      ], item.createdAt))
+
+      return {
+        tokenKey: outcomeTokenKey,
+        items: nextItems,
+      }
+    })
+  }
+
+  useEffect(function pruneExpiredTradeFlowLabels() {
+    if (!outcomeTokenKey || !hasTradeFlowLabels) {
+      return
+    }
+
+    const interval = window.setInterval(function pruneExpiredTradeFlowItems() {
+      const now = Date.now()
+      setTradeFlowState((prev) => {
+        const activeItems = prev.tokenKey === outcomeTokenKey ? prev.items : []
+        const nextItems = pruneTradeFlowItems(activeItems, now)
+
+        if (nextItems.length === activeItems.length && prev.tokenKey === outcomeTokenKey) {
+          return prev
+        }
+
+        return {
+          tokenKey: outcomeTokenKey,
+          items: nextItems,
+        }
+      })
+    }, tradeFlowCleanupIntervalMs)
+
+    return function stopTradeFlowPruning() {
+      window.clearInterval(interval)
+    }
+  }, [hasTradeFlowLabels, outcomeTokenKey])
+
+  return { tradeFlowItems, hasTradeFlowLabels, appendTradeFlowItem }
+}
+
 function getOutcomeTokenIds(market: Market | null) {
   if (!market) {
     return null
@@ -385,88 +709,33 @@ function EventChartComponent({
   const isSingleMarket = useIsSingleMarket()
   const isNegRiskEnabled = Boolean(event.enable_neg_risk || event.neg_risk)
   const shouldHideChart = !isSingleMarket && !isNegRiskEnabled
-  const chartSettings = useSyncExternalStore(
-    subscribeToChartSettings,
-    loadStoredChartSettings,
-    getStoredChartSettingsServerSnapshot,
-  )
+  const { chartSettings, handleChartSettingsChange } = useChartSettingsFromStore()
 
   const [activeTimeRange, setActiveTimeRange] = useState<TimeRange>('ALL')
   const [activeOutcomeIndex, setActiveOutcomeIndex] = useState<
     typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO
   >(OUTCOME_INDEX.YES)
-  const [cursorState, setCursorState] = useState<{
-    scopeKey: string
-    snapshot: PredictionChartCursorSnapshot | null
-  }>({
-    scopeKey: '',
-    snapshot: null,
-  })
-  const [tradeFlowState, setTradeFlowState] = useState<{
-    tokenKey: string
-    items: TradeFlowLabelItem[]
-  }>({
-    tokenKey: '',
-    items: [],
-  })
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
   const [embedDialogOpen, setEmbedDialogOpen] = useState(false)
   const nowMs = useCurrentTimestamp({ intervalMs: 30_000 })
   const currentTimestampMs = nowMs ?? 0
-  const tradeFlowIdRef = useRef(0)
-
-  const handleChartSettingsChange = useCallback((nextValue: SetStateAction<ChartSettings>) => {
-    const nextSettings = typeof nextValue === 'function'
-      ? nextValue(chartSettings)
-      : nextValue
-
-    storeChartSettings(nextSettings)
-  }, [chartSettings])
 
   const showBothOutcomes = isSingleMarket && chartSettings.bothOutcomes
   const eventHistoryEndAt = useMemo(
     () => resolveEventHistoryEndAt(event),
     [event],
   )
-  const shouldShowTweetMarketsPanel = useMemo(
-    () => isTweetMarketsEvent(event),
-    [event],
-  )
-  const tweetCount = useMemo(
-    () => resolveTweetCount(event),
-    [event],
-  )
-  const tweetCountdownTargetMs = useMemo(
-    () => resolveTweetCountdownTargetMs(event),
-    [event],
-  )
-  const xtrackerTweetCountQuery = useXTrackerTweetCount(event, shouldShowTweetMarketsPanel)
-  const resolvedTweetCount = xtrackerTweetCountQuery.data?.totalCount ?? tweetCount
-  const resolvedTweetCountdownTargetMs = useMemo(() => {
-    const trackingEndMs = xtrackerTweetCountQuery.data?.trackingEndMs
-    if (typeof trackingEndMs === 'number' && Number.isFinite(trackingEndMs) && trackingEndMs > 0) {
-      return trackingEndMs
-    }
-
-    return tweetCountdownTargetMs
-  }, [tweetCountdownTargetMs, xtrackerTweetCountQuery.data?.trackingEndMs])
-  const resolvedTweetStartTargetMs = useMemo(() => {
-    const trackingStartMs = xtrackerTweetCountQuery.data?.trackingStartMs
-    if (typeof trackingStartMs === 'number' && Number.isFinite(trackingStartMs) && trackingStartMs > 0) {
-      return trackingStartMs
-    }
-
-    return parseTimestampToMs(event.start_date ?? null)
-  }, [event.start_date, xtrackerTweetCountQuery.data?.trackingStartMs])
-  const shouldRenderTweetMarketsPanel = shouldShowTweetMarketsPanel
-    && resolvedTweetStartTargetMs != null
-    && currentTimestampMs >= resolvedTweetStartTargetMs
-  const isTweetMarketsFinal = Boolean(event.resolved_at || event.status === 'resolved')
-    || (
-      resolvedTweetCountdownTargetMs != null
-      && Number.isFinite(resolvedTweetCountdownTargetMs)
-      && currentTimestampMs >= resolvedTweetCountdownTargetMs
-    )
+  const xtrackerTweetCountQuery = useXTrackerTweetCount(event, isTweetMarketsEvent(event))
+  const {
+    shouldRenderTweetMarketsPanel,
+    resolvedTweetCount,
+    resolvedTweetCountdownTargetMs,
+    isTweetMarketsFinal,
+  } = useTweetMarketsDerivations({
+    event,
+    currentTimestampMs,
+    xtrackerData: xtrackerTweetCountQuery.data,
+  })
 
   const {
     displayChanceByMarket,
@@ -511,103 +780,23 @@ function EventChartComponent({
     () => (topMarketIds.length > 0 ? topMarketIds : fallbackMarketIds),
     [topMarketIds, fallbackMarketIds],
   )
-  const [customMarketSelection, setCustomMarketSelection] = useState<{
-    eventId: string
-    marketIds: string[] | null
-  }>(() => ({
+  const { selectedMarketIds, handleToggleMarket } = useMarketSelection({
     eventId: event.id,
-    marketIds: null,
-  }))
-  const activeCustomMarketIds = customMarketSelection.eventId === event.id
-    ? customMarketSelection.marketIds
-    : null
-  const selectedMarketIds = useMemo(
-    () => (isSingleMarket
-      ? defaultMarketIds
-      : resolveSelectedMarketIds(activeCustomMarketIds, allMarketIds, defaultMarketIds)),
-    [activeCustomMarketIds, allMarketIds, defaultMarketIds, isSingleMarket],
-  )
+    allMarketIds,
+    defaultMarketIds,
+    maxSeriesCount,
+    isSingleMarket,
+  })
 
-  const handleToggleMarket = useCallback((marketId: string) => {
+  const primaryMarket = useMemo(function resolvePrimaryMarket() {
     if (isSingleMarket) {
-      return
+      return event.markets[0]
     }
-
-    setCustomMarketSelection((prev) => {
-      const currentSelection = resolveSelectedMarketIds(
-        prev.eventId === event.id ? prev.marketIds : null,
-        allMarketIds,
-        defaultMarketIds,
-      )
-      const isSelected = currentSelection.includes(marketId)
-      if (isSelected) {
-        const nextSelection = currentSelection.filter(id => id !== marketId)
-        return nextSelection.length > 0
-          ? { eventId: event.id, marketIds: nextSelection }
-          : prev
-      }
-      if (currentSelection.length >= maxSeriesCount) {
-        return prev
-      }
-      const nextSet = new Set(currentSelection)
-      nextSet.add(marketId)
-      return {
-        eventId: event.id,
-        marketIds: allMarketIds.filter(id => nextSet.has(id)).slice(0, maxSeriesCount),
-      }
-    })
-  }, [allMarketIds, defaultMarketIds, event.id, isSingleMarket, maxSeriesCount])
-
-  const chartSeries = useMemo(
-    () => buildChartSeries(event, topMarketIds),
-    [event, topMarketIds],
-  )
-  const fallbackChartSeries = useMemo(
-    () => buildChartSeries(event, fallbackMarketIds),
-    [event, fallbackMarketIds],
-  )
-  const allSeries = useMemo(
-    () => buildChartSeries(event, allMarketIds),
-    [event, allMarketIds],
-  )
-  const selectedSeries = useMemo(
-    () => buildChartSeries(event, selectedMarketIds),
-    [event, selectedMarketIds],
-  )
-  const selectedColors = useMemo(
-    () => Object.fromEntries(selectedSeries.map(series => [series.key, series.color])),
-    [selectedSeries],
-  )
-  const marketOptions = useMemo(
-    () => allSeries.map(series => ({
-      ...series,
-      color: selectedColors[series.key] ?? '#374151',
-    })),
-    [allSeries, selectedColors],
-  )
-
-  const baseSeries = useMemo(() => {
-    if (!isSingleMarket) {
-      if (selectedSeries.length > 0) {
-        return selectedSeries
-      }
-      return chartSeries.length > 0 ? chartSeries : fallbackChartSeries
-    }
-    return chartSeries.length > 0 ? chartSeries : fallbackChartSeries
-  }, [chartSeries, fallbackChartSeries, isSingleMarket, selectedSeries])
-
-  const primaryMarket = useMemo(
-    () => {
-      if (isSingleMarket) {
-        return event.markets[0]
-      }
-      const primaryId = baseSeries[0]?.key
-      return (primaryId
-        ? event.markets.find(market => market.condition_id === primaryId)
-        : null) ?? event.markets[0]
-    },
-    [event.markets, baseSeries, isSingleMarket],
-  )
+    const primaryId = topMarketIds[0] ?? fallbackMarketIds[0]
+    return (primaryId
+      ? event.markets.find(market => market.condition_id === primaryId)
+      : null) ?? event.markets[0]
+  }, [event.markets, topMarketIds, fallbackMarketIds, isSingleMarket])
 
   const primaryConditionId = primaryMarket?.condition_id ?? ''
   const yesSeriesKey = showBothOutcomes && primaryConditionId
@@ -618,31 +807,22 @@ function EventChartComponent({
     : primaryConditionId
   const yesOutcomeLabel = getOutcomeLabelForMarket(primaryMarket, OUTCOME_INDEX.YES)
   const noOutcomeLabel = getOutcomeLabelForMarket(primaryMarket, OUTCOME_INDEX.NO)
-  const bothOutcomeSeries = useMemo(
-    () => {
-      if (!showBothOutcomes || !primaryConditionId) {
-        return []
-      }
-      return [
-        { key: yesSeriesKey, name: yesOutcomeLabel, color: 'var(--primary)' },
-        { key: noSeriesKey, name: noOutcomeLabel, color: '#FF6600' },
-      ]
-    },
-    [showBothOutcomes, primaryConditionId, yesSeriesKey, noSeriesKey, yesOutcomeLabel, noOutcomeLabel],
-  )
 
-  const effectiveSeries = useMemo(() => {
-    if (showBothOutcomes) {
-      return bothOutcomeSeries
-    }
-    if (!isSingleMarket || baseSeries.length === 0) {
-      return baseSeries
-    }
-    const primaryColor = activeOutcomeIndex === OUTCOME_INDEX.NO ? '#FF6600' : 'var(--primary)'
-    return baseSeries.map((seriesItem, index) => (index === 0
-      ? { ...seriesItem, color: primaryColor }
-      : seriesItem))
-  }, [activeOutcomeIndex, baseSeries, isSingleMarket, showBothOutcomes, bothOutcomeSeries])
+  const { chartSeries, marketOptions, effectiveSeries } = useChartSeriesBuilders({
+    event,
+    topMarketIds,
+    fallbackMarketIds,
+    allMarketIds,
+    selectedMarketIds,
+    isSingleMarket,
+    showBothOutcomes,
+    activeOutcomeIndex,
+    primaryConditionId,
+    yesSeriesKey,
+    noSeriesKey,
+    yesOutcomeLabel,
+    noOutcomeLabel,
+  })
 
   const watermark = useMemo(
     () => ({
@@ -855,15 +1035,7 @@ function EventChartComponent({
     const seriesKeys = effectiveSeries.map(series => series.key).join(',')
     return `${event.id}:${activeTimeRange}:${activeOutcomeIndex}:${seriesKeys}`
   }, [event.id, activeTimeRange, activeOutcomeIndex, effectiveSeries])
-  const cursorSnapshot = cursorState.scopeKey === chartScopeKey
-    ? cursorState.snapshot
-    : null
-  const handleCursorDataChange = useCallback((snapshot: PredictionChartCursorSnapshot | null) => {
-    setCursorState({
-      scopeKey: chartScopeKey,
-      snapshot,
-    })
-  }, [chartScopeKey])
+  const { cursorSnapshot, handleCursorDataChange } = useChartCursorTracking(chartScopeKey)
 
   const { width: windowWidth } = useWindowSize()
   const chartWidth = isMobile ? ((windowWidth || 400) * 0.84) : Math.min((windowWidth ?? 1440) * 0.55, 900)
@@ -962,10 +1134,7 @@ function EventChartComponent({
   const outcomeTokenKey = outcomeTokenIds
     ? `${outcomeTokenIds.yesTokenId}:${outcomeTokenIds.noTokenId}`
     : ''
-  const tradeFlowItems = tradeFlowState.tokenKey === outcomeTokenKey
-    ? tradeFlowState.items
-    : []
-  const hasTradeFlowLabels = tradeFlowItems.length > 0
+  const { tradeFlowItems, hasTradeFlowLabels, appendTradeFlowItem } = useTradeFlowLabels(outcomeTokenKey)
 
   useMarketChannelSubscription((payload) => {
     if (!outcomeTokenIds) {
@@ -1000,50 +1169,8 @@ function EventChartComponent({
       return
     }
 
-    const createdAt = Date.now()
-    const id = String(tradeFlowIdRef.current)
-    tradeFlowIdRef.current += 1
-
-    setTradeFlowState((prev) => {
-      const activeItems = prev.tokenKey === outcomeTokenKey ? prev.items : []
-      const nextItems = trimTradeFlowItems(pruneTradeFlowItems([
-        ...activeItems,
-        { id, label, outcome, createdAt },
-      ], createdAt))
-
-      return {
-        tokenKey: outcomeTokenKey,
-        items: nextItems,
-      }
-    })
+    appendTradeFlowItem({ label, outcome, createdAt: Date.now() })
   })
-
-  useEffect(() => {
-    if (!outcomeTokenKey || !hasTradeFlowLabels) {
-      return
-    }
-
-    const interval = window.setInterval(() => {
-      const now = Date.now()
-      setTradeFlowState((prev) => {
-        const activeItems = prev.tokenKey === outcomeTokenKey ? prev.items : []
-        const nextItems = pruneTradeFlowItems(activeItems, now)
-
-        if (nextItems.length === activeItems.length && prev.tokenKey === outcomeTokenKey) {
-          return prev
-        }
-
-        return {
-          tokenKey: outcomeTokenKey,
-          items: nextItems,
-        }
-      })
-    }, tradeFlowCleanupIntervalMs)
-
-    return () => {
-      window.clearInterval(interval)
-    }
-  }, [hasTradeFlowLabels, outcomeTokenKey])
 
   const legendContent = shouldRenderLegendEntries
     ? (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -165,7 +165,7 @@ function useChartSettingsFromStore() {
     getStoredChartSettingsServerSnapshot,
   )
 
-  const handleChartSettingsChange = useCallback(function handleChartSettingsChange(nextValue: SetStateAction<ChartSettings>) {
+  const handleChartSettingsChange = useCallback((nextValue: SetStateAction<ChartSettings>) => {
     const nextSettings = typeof nextValue === 'function'
       ? nextValue(chartSettings)
       : nextValue
@@ -189,7 +189,7 @@ function useChartCursorTracking(chartScopeKey: string) {
     ? cursorState.snapshot
     : null
 
-  const handleCursorDataChange = useCallback(function handleCursorDataChange(snapshot: PredictionChartCursorSnapshot | null) {
+  const handleCursorDataChange = useCallback((snapshot: PredictionChartCursorSnapshot | null) => {
     setCursorState({
       scopeKey: chartScopeKey,
       snapshot,
@@ -291,7 +291,7 @@ function useMarketSelection({
       : resolveSelectedMarketIds(activeCustomMarketIds, allMarketIds, defaultMarketIds)
   }, [activeCustomMarketIds, allMarketIds, defaultMarketIds, isSingleMarket])
 
-  const handleToggleMarket = useCallback(function handleToggleMarket(marketId: string) {
+  const handleToggleMarket = useCallback((marketId: string) => {
     if (isSingleMarket) {
       return
     }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -792,11 +792,11 @@ function EventChartComponent({
     if (isSingleMarket) {
       return event.markets[0]
     }
-    const primaryId = topMarketIds[0] ?? fallbackMarketIds[0]
+    const primaryId = selectedMarketIds[0] ?? topMarketIds[0] ?? fallbackMarketIds[0]
     return (primaryId
       ? event.markets.find(market => market.condition_id === primaryId)
       : null) ?? event.markets[0]
-  }, [event.markets, topMarketIds, fallbackMarketIds, isSingleMarket])
+  }, [event.markets, selectedMarketIds, topMarketIds, fallbackMarketIds, isSingleMarket])
 
   const primaryConditionId = primaryMarket?.condition_id ?? ''
   const yesSeriesKey = showBothOutcomes && primaryConditionId

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -208,21 +208,13 @@ function useTweetMarketsDerivations({
   currentTimestampMs: number
   xtrackerData: ReturnType<typeof useXTrackerTweetCount>['data']
 }) {
-  const shouldShowTweetMarketsPanel = useMemo(function detectTweetMarketsEvent() {
-    return isTweetMarketsEvent(event)
-  }, [event])
-
-  const tweetCount = useMemo(function resolveStaticTweetCount() {
-    return resolveTweetCount(event)
-  }, [event])
-
-  const tweetCountdownTargetMs = useMemo(function resolveStaticTweetCountdownTarget() {
-    return resolveTweetCountdownTargetMs(event)
-  }, [event])
+  const shouldShowTweetMarketsPanel = useMemo(() => isTweetMarketsEvent(event), [event])
+  const tweetCount = useMemo(() => resolveTweetCount(event), [event])
+  const tweetCountdownTargetMs = useMemo(() => resolveTweetCountdownTargetMs(event), [event])
 
   const resolvedTweetCount = xtrackerData?.totalCount ?? tweetCount
 
-  const resolvedTweetCountdownTargetMs = useMemo(function resolveTweetCountdownTarget() {
+  const resolvedTweetCountdownTargetMs = useMemo(() => {
     const trackingEndMs = xtrackerData?.trackingEndMs
     if (typeof trackingEndMs === 'number' && Number.isFinite(trackingEndMs) && trackingEndMs > 0) {
       return trackingEndMs
@@ -231,7 +223,7 @@ function useTweetMarketsDerivations({
     return tweetCountdownTargetMs
   }, [tweetCountdownTargetMs, xtrackerData?.trackingEndMs])
 
-  const resolvedTweetStartTargetMs = useMemo(function resolveTweetStartTarget() {
+  const resolvedTweetStartTargetMs = useMemo(() => {
     const trackingStartMs = xtrackerData?.trackingStartMs
     if (typeof trackingStartMs === 'number' && Number.isFinite(trackingStartMs) && trackingStartMs > 0) {
       return trackingStartMs
@@ -285,7 +277,7 @@ function useMarketSelection({
     ? customMarketSelection.marketIds
     : null
 
-  const selectedMarketIds = useMemo(function resolveSelectedMarkets() {
+  const selectedMarketIds = useMemo(() => {
     return isSingleMarket
       ? defaultMarketIds
       : resolveSelectedMarketIds(activeCustomMarketIds, allMarketIds, defaultMarketIds)
@@ -353,34 +345,23 @@ function useChartSeriesBuilders({
   yesOutcomeLabel: string
   noOutcomeLabel: string
 }) {
-  const chartSeries = useMemo(function buildTopChartSeries() {
-    return buildChartSeries(event, topMarketIds)
-  }, [event, topMarketIds])
+  const chartSeries = useMemo(() => buildChartSeries(event, topMarketIds), [event, topMarketIds])
+  const fallbackChartSeries = useMemo(() => buildChartSeries(event, fallbackMarketIds), [event, fallbackMarketIds])
+  const allSeries = useMemo(() => buildChartSeries(event, allMarketIds), [event, allMarketIds])
+  const selectedSeries = useMemo(() => buildChartSeries(event, selectedMarketIds), [event, selectedMarketIds])
 
-  const fallbackChartSeries = useMemo(function buildFallbackChartSeries() {
-    return buildChartSeries(event, fallbackMarketIds)
-  }, [event, fallbackMarketIds])
-
-  const allSeries = useMemo(function buildAllChartSeries() {
-    return buildChartSeries(event, allMarketIds)
-  }, [event, allMarketIds])
-
-  const selectedSeries = useMemo(function buildSelectedChartSeries() {
-    return buildChartSeries(event, selectedMarketIds)
-  }, [event, selectedMarketIds])
-
-  const selectedColors = useMemo(function buildSelectedSeriesColors() {
+  const selectedColors = useMemo(() => {
     return Object.fromEntries(selectedSeries.map(series => [series.key, series.color]))
   }, [selectedSeries])
 
-  const marketOptions = useMemo(function buildMarketOptions() {
+  const marketOptions = useMemo(() => {
     return allSeries.map(series => ({
       ...series,
       color: selectedColors[series.key] ?? '#374151',
     }))
   }, [allSeries, selectedColors])
 
-  const baseSeries = useMemo(function resolveBaseSeries() {
+  const baseSeries = useMemo(() => {
     if (!isSingleMarket) {
       if (selectedSeries.length > 0) {
         return selectedSeries
@@ -390,7 +371,7 @@ function useChartSeriesBuilders({
     return chartSeries.length > 0 ? chartSeries : fallbackChartSeries
   }, [chartSeries, fallbackChartSeries, isSingleMarket, selectedSeries])
 
-  const bothOutcomeSeries = useMemo(function buildBothOutcomeSeries() {
+  const bothOutcomeSeries = useMemo(() => {
     if (!showBothOutcomes || !primaryConditionId) {
       return []
     }
@@ -400,7 +381,7 @@ function useChartSeriesBuilders({
     ]
   }, [showBothOutcomes, primaryConditionId, yesSeriesKey, noSeriesKey, yesOutcomeLabel, noOutcomeLabel])
 
-  const effectiveSeries = useMemo(function resolveEffectiveSeries() {
+  const effectiveSeries = useMemo(() => {
     if (showBothOutcomes) {
       return bothOutcomeSeries
     }
@@ -452,7 +433,7 @@ function useTradeFlowLabels(outcomeTokenKey: string) {
     })
   }
 
-  useEffect(function pruneExpiredTradeFlowLabels() {
+  useEffect(() => {
     if (!outcomeTokenKey || !hasTradeFlowLabels) {
       return
     }
@@ -788,7 +769,7 @@ function EventChartComponent({
     isSingleMarket,
   })
 
-  const primaryMarket = useMemo(function resolvePrimaryMarket() {
+  const primaryMarket = useMemo(() => {
     if (isSingleMarket) {
       return event.markets[0]
     }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
@@ -158,23 +158,23 @@ function useEmbedCodeBuilders({
   affiliateCode: string
   iframeHeight: number
 }) {
-  const features = useMemo(function buildEmbedFeatures() {
+  const features = useMemo(() => {
     return buildFeatureList(showVolume, showChart, effectiveShowTimeRange)
   }, [showVolume, showChart, effectiveShowTimeRange])
 
-  const iframeSrc = useMemo(function buildEmbedIframeSrc() {
+  const iframeSrc = useMemo(() => {
     return buildIframeSrc(embedBaseUrl, marketSlug, theme, features, affiliateCode)
   }, [embedBaseUrl, marketSlug, theme, features, affiliateCode])
 
-  const previewSrc = useMemo(function buildEmbedPreviewSrc() {
+  const previewSrc = useMemo(() => {
     return buildPreviewSrc(marketSlug, theme, features, affiliateCode)
   }, [marketSlug, theme, features, affiliateCode])
 
-  const iframeCode = useMemo(function buildEmbedIframeCode() {
+  const iframeCode = useMemo(() => {
     return buildIframeCode(iframeSrc, iframeHeight, embedIframeTitle)
   }, [embedIframeTitle, iframeSrc, iframeHeight])
 
-  const webComponentCode = useMemo(function buildEmbedWebComponentCode() {
+  const webComponentCode = useMemo(() => {
     return buildWebComponentCode(
       embedElementName,
       marketSlug,
@@ -186,7 +186,7 @@ function useEmbedCodeBuilders({
     )
   }, [embedElementName, marketSlug, theme, showVolume, showChart, effectiveShowTimeRange, affiliateCode])
 
-  const iframeLines = useMemo<EmbedCodeLine[]>(function buildEmbedIframeLines() {
+  const iframeLines = useMemo<EmbedCodeLine[]>(() => {
     return [
       tagOpenLine('', 'iframe'),
       attributeLine('\t', 'title', embedIframeTitle),
@@ -198,7 +198,7 @@ function useEmbedCodeBuilders({
     ]
   }, [embedIframeTitle, iframeSrc, iframeHeight])
 
-  const webComponentLines = useMemo<EmbedCodeLine[]>(function buildEmbedWebComponentLines() {
+  const webComponentLines = useMemo<EmbedCodeLine[]>(() => {
     const lines: EmbedCodeLine[] = [
       tagWithAttributeLine('', 'div', 'id', embedElementName, '>'),
       tagOpenLine('\t', 'script'),
@@ -267,7 +267,7 @@ function EventChartEmbedDialogEditor({
   const showMarketSelector = markets.length > 1
   const showTimeRangeSelector = showChart
   const effectiveShowTimeRange = showChart && showTimeRange
-  const siteSlug = useMemo(function resolveSiteSlug() {
+  const siteSlug = useMemo(() => {
     try {
       return slugifySiteName(site.name)
     }
@@ -279,7 +279,7 @@ function EventChartEmbedDialogEditor({
   const embedElementName = `${siteSlug}-market-embed`
   const embedIframeTitle = `${siteSlug}-market-iframe`
 
-  const marketOptions = useMemo(function buildMarketOptions() {
+  const marketOptions = useMemo(() => {
     return markets.map(market => ({
       id: market.condition_id,
       label: buildMarketLabel(market),

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
@@ -89,53 +89,10 @@ function buildEditorKey(markets: Market[], initialMarketId?: string | null) {
   return `${initialMarketId ?? ''}:${markets.map(market => market.condition_id).join('|')}`
 }
 
-function createInitialEditorState(markets: Market[], initialMarketId?: string | null): EditorState {
-  return {
-    copied: false,
-    embedType: 'iframe',
-    selectedMarketId: getDefaultSelectedMarketId(markets, initialMarketId),
-    showChart: false,
-    showTimeRange: false,
-    showVolume: false,
-    theme: 'light',
-  }
-}
-
-function EventChartEmbedDialogEditor({
-  markets,
-  initialMarketId,
-}: Pick<EventChartEmbedDialogProps, 'markets' | 'initialMarketId'>) {
-  const t = useExtracted()
-  const site = useSiteIdentity()
-  const user = useUser()
-  const [editorState, setEditorState] = useState(() => createInitialEditorState(markets, initialMarketId))
+function useAffiliateSettings(affiliateCode: string) {
   const [affiliateSettings, setAffiliateSettings] = useState(EMPTY_AFFILIATE_SETTINGS)
-  const affiliateCode = user?.affiliate_code?.trim() ?? ''
-  const {
-    copied,
-    embedType,
-    selectedMarketId,
-    showChart,
-    showTimeRange,
-    showVolume,
-    theme,
-  } = editorState
-  const showMarketSelector = markets.length > 1
-  const showTimeRangeSelector = showChart
-  const effectiveShowTimeRange = showChart && showTimeRange
-  const siteSlug = useMemo(() => {
-    try {
-      return slugifySiteName(site.name)
-    }
-    catch {
-      return 'market'
-    }
-  }, [site.name])
-  const embedBaseUrl = SITE_URL
-  const embedElementName = `${siteSlug}-market-embed`
-  const embedIframeTitle = `${siteSlug}-market-iframe`
 
-  useEffect(() => {
+  useEffect(function fetchAffiliateSettingsOnCodeChange() {
     if (!affiliateCode) {
       return
     }
@@ -167,56 +124,81 @@ function EventChartEmbedDialogEditor({
         }
       })
 
-    return () => {
+    return function cancelAffiliateSettingsFetch() {
       isActive = false
     }
   }, [affiliateCode])
 
-  const affiliateSharePercent = affiliateCode ? affiliateSettings.affiliateSharePercent : null
-  const tradeFeePercent = affiliateCode ? affiliateSettings.tradeFeePercent : null
-  const marketOptions = useMemo(
-    () => markets.map(market => ({
-      id: market.condition_id,
-      label: buildMarketLabel(market),
-    })),
-    [markets],
-  )
-  const selectedMarket = markets.find(market => market.condition_id === selectedMarketId) ?? markets[0]
-  const marketSlug = selectedMarket?.slug ?? ''
-  const features = useMemo(
-    () => buildFeatureList(showVolume, showChart, effectiveShowTimeRange),
-    [showVolume, showChart, effectiveShowTimeRange],
-  )
-  const iframeSrc = useMemo(
-    () => buildIframeSrc(embedBaseUrl, marketSlug, theme, features, affiliateCode),
-    [embedBaseUrl, marketSlug, theme, features, affiliateCode],
-  )
-  const previewSrc = useMemo(
-    () => buildPreviewSrc(marketSlug, theme, features, affiliateCode),
-    [marketSlug, theme, features, affiliateCode],
-  )
-  const iframeHeight = showChart
-    ? (effectiveShowTimeRange ? IFRAME_HEIGHT_WITH_FILTERS : IFRAME_HEIGHT_WITH_CHART)
-    : IFRAME_HEIGHT_NO_CHART
-  const iframeCode = useMemo(
-    () => buildIframeCode(iframeSrc, iframeHeight, embedIframeTitle),
-    [embedIframeTitle, iframeSrc, iframeHeight],
-  )
-  const webComponentCode = useMemo(
-    () => buildWebComponentCode(embedElementName, marketSlug, theme, showVolume, showChart, effectiveShowTimeRange, affiliateCode),
-    [embedElementName, marketSlug, theme, showVolume, showChart, effectiveShowTimeRange, affiliateCode],
-  )
-  const activeCode = embedType === 'iframe' ? iframeCode : webComponentCode
-  const iframeLines = useMemo<EmbedCodeLine[]>(() => ([
-    tagOpenLine('', 'iframe'),
-    attributeLine('\t', 'title', embedIframeTitle),
-    attributeLine('\t', 'src', iframeSrc),
-    attributeLine('\t', 'width', '400'),
-    attributeLine('\t', 'height', String(iframeHeight)),
-    attributeLine('\t', 'frameBorder', '0'),
-    tagSelfCloseLine(''),
-  ]), [embedIframeTitle, iframeSrc, iframeHeight])
-  const webComponentLines = useMemo<EmbedCodeLine[]>(() => {
+  return {
+    affiliateSharePercent: affiliateCode ? affiliateSettings.affiliateSharePercent : null,
+    tradeFeePercent: affiliateCode ? affiliateSettings.tradeFeePercent : null,
+  }
+}
+
+function useEmbedCodeBuilders({
+  embedBaseUrl,
+  embedElementName,
+  embedIframeTitle,
+  marketSlug,
+  theme,
+  showVolume,
+  showChart,
+  effectiveShowTimeRange,
+  affiliateCode,
+  iframeHeight,
+}: {
+  embedBaseUrl: string
+  embedElementName: string
+  embedIframeTitle: string
+  marketSlug: string
+  theme: EmbedTheme
+  showVolume: boolean
+  showChart: boolean
+  effectiveShowTimeRange: boolean
+  affiliateCode: string
+  iframeHeight: number
+}) {
+  const features = useMemo(function buildEmbedFeatures() {
+    return buildFeatureList(showVolume, showChart, effectiveShowTimeRange)
+  }, [showVolume, showChart, effectiveShowTimeRange])
+
+  const iframeSrc = useMemo(function buildEmbedIframeSrc() {
+    return buildIframeSrc(embedBaseUrl, marketSlug, theme, features, affiliateCode)
+  }, [embedBaseUrl, marketSlug, theme, features, affiliateCode])
+
+  const previewSrc = useMemo(function buildEmbedPreviewSrc() {
+    return buildPreviewSrc(marketSlug, theme, features, affiliateCode)
+  }, [marketSlug, theme, features, affiliateCode])
+
+  const iframeCode = useMemo(function buildEmbedIframeCode() {
+    return buildIframeCode(iframeSrc, iframeHeight, embedIframeTitle)
+  }, [embedIframeTitle, iframeSrc, iframeHeight])
+
+  const webComponentCode = useMemo(function buildEmbedWebComponentCode() {
+    return buildWebComponentCode(
+      embedElementName,
+      marketSlug,
+      theme,
+      showVolume,
+      showChart,
+      effectiveShowTimeRange,
+      affiliateCode,
+    )
+  }, [embedElementName, marketSlug, theme, showVolume, showChart, effectiveShowTimeRange, affiliateCode])
+
+  const iframeLines = useMemo<EmbedCodeLine[]>(function buildEmbedIframeLines() {
+    return [
+      tagOpenLine('', 'iframe'),
+      attributeLine('\t', 'title', embedIframeTitle),
+      attributeLine('\t', 'src', iframeSrc),
+      attributeLine('\t', 'width', '400'),
+      attributeLine('\t', 'height', String(iframeHeight)),
+      attributeLine('\t', 'frameBorder', '0'),
+      tagSelfCloseLine(''),
+    ]
+  }, [embedIframeTitle, iframeSrc, iframeHeight])
+
+  const webComponentLines = useMemo<EmbedCodeLine[]>(function buildEmbedWebComponentLines() {
     const lines: EmbedCodeLine[] = [
       tagWithAttributeLine('', 'div', 'id', embedElementName, '>'),
       tagOpenLine('\t', 'script'),
@@ -247,6 +229,81 @@ function EventChartEmbedDialogEditor({
 
     return lines
   }, [affiliateCode, embedElementName, marketSlug, showChart, effectiveShowTimeRange, showVolume, theme])
+
+  return { features, iframeSrc, previewSrc, iframeCode, webComponentCode, iframeLines, webComponentLines }
+}
+
+function createInitialEditorState(markets: Market[], initialMarketId?: string | null): EditorState {
+  return {
+    copied: false,
+    embedType: 'iframe',
+    selectedMarketId: getDefaultSelectedMarketId(markets, initialMarketId),
+    showChart: false,
+    showTimeRange: false,
+    showVolume: false,
+    theme: 'light',
+  }
+}
+
+function EventChartEmbedDialogEditor({
+  markets,
+  initialMarketId,
+}: Pick<EventChartEmbedDialogProps, 'markets' | 'initialMarketId'>) {
+  const t = useExtracted()
+  const site = useSiteIdentity()
+  const user = useUser()
+  const [editorState, setEditorState] = useState(() => createInitialEditorState(markets, initialMarketId))
+  const affiliateCode = user?.affiliate_code?.trim() ?? ''
+  const { affiliateSharePercent, tradeFeePercent } = useAffiliateSettings(affiliateCode)
+  const {
+    copied,
+    embedType,
+    selectedMarketId,
+    showChart,
+    showTimeRange,
+    showVolume,
+    theme,
+  } = editorState
+  const showMarketSelector = markets.length > 1
+  const showTimeRangeSelector = showChart
+  const effectiveShowTimeRange = showChart && showTimeRange
+  const siteSlug = useMemo(function resolveSiteSlug() {
+    try {
+      return slugifySiteName(site.name)
+    }
+    catch {
+      return 'market'
+    }
+  }, [site.name])
+  const embedBaseUrl = SITE_URL
+  const embedElementName = `${siteSlug}-market-embed`
+  const embedIframeTitle = `${siteSlug}-market-iframe`
+
+  const marketOptions = useMemo(function buildMarketOptions() {
+    return markets.map(market => ({
+      id: market.condition_id,
+      label: buildMarketLabel(market),
+    }))
+  }, [markets])
+  const selectedMarket = markets.find(market => market.condition_id === selectedMarketId) ?? markets[0]
+  const marketSlug = selectedMarket?.slug ?? ''
+  const iframeHeight = showChart
+    ? (effectiveShowTimeRange ? IFRAME_HEIGHT_WITH_FILTERS : IFRAME_HEIGHT_WITH_CHART)
+    : IFRAME_HEIGHT_NO_CHART
+
+  const { iframeCode, webComponentCode, iframeLines, webComponentLines, previewSrc } = useEmbedCodeBuilders({
+    embedBaseUrl,
+    embedElementName,
+    embedIframeTitle,
+    marketSlug,
+    theme,
+    showVolume,
+    showChart,
+    effectiveShowTimeRange,
+    affiliateCode,
+    iframeHeight,
+  })
+  const activeCode = embedType === 'iframe' ? iframeCode : webComponentCode
 
   function handleThemeChange(nextTheme: EmbedTheme) {
     setEditorState(current => ({

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartExportDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartExportDialog.tsx
@@ -219,6 +219,51 @@ function getNavigatorLanguage() {
   return navigator.language
 }
 
+function useNavigatorLocale() {
+  return useSyncExternalStore(
+    subscribeToNavigatorLanguage,
+    getNavigatorLanguage,
+    () => fallbackLocale,
+  )
+}
+
+function useExportFormState({
+  eventStartDate,
+  openedAt,
+}: {
+  eventStartDate: Date
+  openedAt: Date
+}) {
+  const [frequency, setFrequency] = useState<Frequency>(defaultFrequency)
+  const [fromDate, setFromDate] = useState<Date>(() => getDefaultFromDate(
+    defaultFrequency,
+    eventStartDate,
+    openedAt,
+  ))
+  const [calendarOpen, setCalendarOpen] = useState(false)
+  const [selectedOptions, setSelectedOptions] = useState<string[]>([])
+  const [isDownloading, setIsDownloading] = useState(false)
+
+  function handleFrequencyChange(value: string) {
+    const nextFrequency = value as Frequency
+    setFrequency(nextFrequency)
+    setFromDate(getDefaultFromDate(nextFrequency, eventStartDate, openedAt))
+  }
+
+  return {
+    frequency,
+    fromDate,
+    setFromDate,
+    calendarOpen,
+    setCalendarOpen,
+    selectedOptions,
+    setSelectedOptions,
+    isDownloading,
+    setIsDownloading,
+    handleFrequencyChange,
+  }
+}
+
 interface EventChartExportDialogBodyProps {
   eventCreatedAt: string
   markets: Market[]
@@ -237,27 +282,20 @@ function EventChartExportDialogBody({
   const optionsListId = useId()
   const eventStartDate = useMemo(() => new Date(eventCreatedAt), [eventCreatedAt])
   const openedAt = useMemo(() => new Date(Date.now()), [])
-  const [frequency, setFrequency] = useState<Frequency>(defaultFrequency)
-  const [fromDate, setFromDate] = useState<Date>(() => getDefaultFromDate(
-    defaultFrequency,
-    eventStartDate,
-    openedAt,
-  ))
-  const [calendarOpen, setCalendarOpen] = useState(false)
-  const [selectedOptions, setSelectedOptions] = useState<string[]>([])
-  const [isDownloading, setIsDownloading] = useState(false)
-  const locale = useSyncExternalStore(
-    subscribeToNavigatorLanguage,
-    getNavigatorLanguage,
-    () => fallbackLocale,
-  )
+  const {
+    frequency,
+    fromDate,
+    setFromDate,
+    calendarOpen,
+    setCalendarOpen,
+    selectedOptions,
+    setSelectedOptions,
+    isDownloading,
+    setIsDownloading,
+    handleFrequencyChange,
+  } = useExportFormState({ eventStartDate, openedAt })
+  const locale = useNavigatorLocale()
   const toDate = openedAt
-
-  function handleFrequencyChange(value: string) {
-    const nextFrequency = value as Frequency
-    setFrequency(nextFrequency)
-    setFromDate(getDefaultFromDate(nextFrequency, eventStartDate, toDate))
-  }
 
   const optionItems = useMemo(
     () => markets.map(market => ({

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventSeriesPills.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventSeriesPills.tsx
@@ -179,6 +179,56 @@ function isSeriesEventTradingNow(event: EventSeriesEntry, nowTimestamp: number) 
   return nowTimestamp >= tradingWindowStart && nowTimestamp < eventTimestamp
 }
 
+function useNowTimestamp() {
+  return useSyncExternalStore(
+    subscribeToNowTimestamp,
+    getNowTimestampSnapshot,
+    getServerNowTimestampSnapshot,
+  )
+}
+
+function useSeriesNavigation({
+  currentEventSlug,
+  seriesEvents,
+  nowTimestamp,
+}: {
+  currentEventSlug: string | undefined
+  seriesEvents: EventSeriesEntry[]
+  nowTimestamp: number
+}) {
+  return useMemo(function resolveSeriesNavigation() {
+    const filteredSeriesEvents = seriesEvents.filter(event => Boolean(event?.slug))
+    const hasComparableSeriesEvents = filteredSeriesEvents.some(event => event.slug !== currentEventSlug)
+    const currentEvent = filteredSeriesEvents.find(event => event.slug === currentEventSlug) ?? null
+
+    const past = filteredSeriesEvents
+      .filter(event => isSeriesEventResolved(event))
+      .sort((a, b) => getSeriesEventTimestamp(b) - getSeriesEventTimestamp(a))
+
+    const unresolved = filteredSeriesEvents
+      .filter(event => !isSeriesEventResolved(event))
+      .sort((a, b) => getSeriesEventTimestamp(a) - getSeriesEventTimestamp(b))
+
+    const currentTradingEvent = unresolved.find(event => isSeriesEventTradingNow(event, nowTimestamp))
+      ?? unresolved.find((event) => {
+        const eventTimestamp = getSeriesEventTimestamp(event)
+        return Number.isFinite(eventTimestamp) && eventTimestamp > nowTimestamp
+      })
+      ?? (currentEvent && !isSeriesEventResolved(currentEvent) ? currentEvent : null)
+    const hasUnresolvedCurrentEvent = Boolean(currentEvent && !isSeriesEventResolved(currentEvent))
+
+    return {
+      pastResolvedEvents: past,
+      unresolvedEvents: unresolved,
+      currentResolvedEvent: currentEvent && isSeriesEventResolved(currentEvent) ? currentEvent : null,
+      currentTradingEventId: currentTradingEvent?.id ?? null,
+      hasSeriesNavigation:
+        (hasComparableSeriesEvents && (past.length > 0 || unresolved.length > 0))
+        || hasUnresolvedCurrentEvent,
+    }
+  }, [currentEventSlug, nowTimestamp, seriesEvents])
+}
+
 function isSameEtDay(leftTimestamp: number, rightTimestamp: number) {
   const formatter = new Intl.DateTimeFormat('en-CA', {
     timeZone: 'America/New_York',
@@ -294,11 +344,7 @@ export default function EventSeriesPills({
 }: EventSeriesPillsProps) {
   const [isPastMenuOpen, setIsPastMenuOpen] = useState(false)
   const [hoveredPastBadgeId, setHoveredPastBadgeId] = useState<string | null>(null)
-  const nowTimestamp = useSyncExternalStore(
-    subscribeToNowTimestamp,
-    getNowTimestampSnapshot,
-    getServerNowTimestampSnapshot,
-  )
+  const nowTimestamp = useNowTimestamp()
 
   const {
     pastResolvedEvents,
@@ -306,37 +352,7 @@ export default function EventSeriesPills({
     currentResolvedEvent,
     currentTradingEventId,
     hasSeriesNavigation,
-  } = useMemo(() => {
-    const filteredSeriesEvents = seriesEvents.filter(event => Boolean(event?.slug))
-    const hasComparableSeriesEvents = filteredSeriesEvents.some(event => event.slug !== currentEventSlug)
-    const currentEvent = filteredSeriesEvents.find(event => event.slug === currentEventSlug) ?? null
-
-    const past = filteredSeriesEvents
-      .filter(event => isSeriesEventResolved(event))
-      .sort((a, b) => getSeriesEventTimestamp(b) - getSeriesEventTimestamp(a))
-
-    const unresolved = filteredSeriesEvents
-      .filter(event => !isSeriesEventResolved(event))
-      .sort((a, b) => getSeriesEventTimestamp(a) - getSeriesEventTimestamp(b))
-
-    const currentTradingEvent = unresolved.find(event => isSeriesEventTradingNow(event, nowTimestamp))
-      ?? unresolved.find((event) => {
-        const eventTimestamp = getSeriesEventTimestamp(event)
-        return Number.isFinite(eventTimestamp) && eventTimestamp > nowTimestamp
-      })
-      ?? (currentEvent && !isSeriesEventResolved(currentEvent) ? currentEvent : null)
-    const hasUnresolvedCurrentEvent = Boolean(currentEvent && !isSeriesEventResolved(currentEvent))
-
-    return {
-      pastResolvedEvents: past,
-      unresolvedEvents: unresolved,
-      currentResolvedEvent: currentEvent && isSeriesEventResolved(currentEvent) ? currentEvent : null,
-      currentTradingEventId: currentTradingEvent?.id ?? null,
-      hasSeriesNavigation:
-        (hasComparableSeriesEvents && (past.length > 0 || unresolved.length > 0))
-        || hasUnresolvedCurrentEvent,
-    }
-  }, [currentEventSlug, nowTimestamp, seriesEvents])
+  } = useSeriesNavigation({ currentEventSlug, seriesEvents, nowTimestamp })
 
   if (!hasSeriesNavigation && !rightSlot) {
     return null

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventSeriesPills.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventSeriesPills.tsx
@@ -196,7 +196,7 @@ function useSeriesNavigation({
   seriesEvents: EventSeriesEntry[]
   nowTimestamp: number
 }) {
-  return useMemo(function resolveSeriesNavigation() {
+  return useMemo(() => {
     const filteredSeriesEvents = seriesEvents.filter(event => Boolean(event?.slug))
     const hasComparableSeriesEvents = filteredSeriesEvents.some(event => event.slug !== currentEventSlug)
     const currentEvent = filteredSeriesEvents.find(event => event.slug === currentEventSlug) ?? null

--- a/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
@@ -79,7 +79,7 @@ function useOutcomeSelection({
   const [activeOutcomeOverride, setActiveOutcomeOverride] = useState<{ key: string, index: number } | null>(null)
 
   const activeOutcomeKey = outcome.token_id || `${market.condition_id}:${outcome.outcome_index}`
-  const activeOutcomeIndex = useMemo(function resolveActiveOutcomeIndex() {
+  const activeOutcomeIndex = useMemo(() => {
     if (activeOutcomeOverride?.key === activeOutcomeKey) {
       return activeOutcomeOverride.index
     }
@@ -87,7 +87,7 @@ function useOutcomeSelection({
     return outcome.outcome_index
   }, [activeOutcomeKey, activeOutcomeOverride, outcome.outcome_index])
 
-  const activeOutcome = useMemo(function resolveActiveOutcome() {
+  const activeOutcome = useMemo(() => {
     return market.outcomes.find(item => item.outcome_index === activeOutcomeIndex) ?? outcome
   }, [market.outcomes, activeOutcomeIndex, outcome])
 
@@ -95,7 +95,7 @@ function useOutcomeSelection({
     ? OUTCOME_INDEX.NO
     : OUTCOME_INDEX.YES
 
-  const oppositeOutcome = useMemo(function resolveOppositeOutcome() {
+  const oppositeOutcome = useMemo(() => {
     return market.outcomes.find(item => item.outcome_index === oppositeOutcomeIndex) ?? activeOutcome
   }, [market.outcomes, oppositeOutcomeIndex, activeOutcome])
 
@@ -149,13 +149,13 @@ function useChartDataValues({
   noOutcomeLabel: string
   normalizeOutcomeLabel: (value: string | null | undefined) => string | undefined
 }) {
-  const chartData = useMemo(function buildResolvedChartData() {
+  const chartData = useMemo(() => {
     return showBothOutcomes
       ? buildComparisonChartData(normalizedHistory, conditionId)
       : buildChartData(normalizedHistory, conditionId, activeOutcomeIndex)
   }, [normalizedHistory, conditionId, activeOutcomeIndex, showBothOutcomes])
 
-  const series = useMemo(function buildChartSeries() {
+  const series = useMemo(() => {
     return showBothOutcomes
       ? [
           { key: 'yes', name: yesOutcomeLabel, color: YES_SERIES_COLOR },
@@ -168,11 +168,11 @@ function useChartDataValues({
         }]
   }, [activeOutcome.outcome_index, activeOutcome.outcome_text, showBothOutcomes, yesOutcomeLabel, noOutcomeLabel, normalizeOutcomeLabel])
 
-  const chartSignature = useMemo(function buildChartSignature() {
+  const chartSignature = useMemo(() => {
     return `${conditionId}:${activeOutcomeIndex}:${activeTimeRange}:${showBothOutcomes ? 'both' : 'single'}`
   }, [conditionId, activeOutcomeIndex, activeTimeRange, showBothOutcomes])
 
-  const latestValue = useMemo(function findLatestChartValue() {
+  const latestValue = useMemo(() => {
     for (let index = chartData.length - 1; index >= 0; index -= 1) {
       const point = chartData[index]
       if (!point) {
@@ -194,7 +194,7 @@ function useChartDataValues({
     return null
   }, [chartData, activeSeriesKey, showBothOutcomes])
 
-  const baselineValue = useMemo(function findBaselineChartValue() {
+  const baselineValue = useMemo(() => {
     for (const point of chartData) {
       const value = showBothOutcomes
         ? (activeSeriesKey === 'yes' && 'yes' in point

--- a/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
@@ -57,9 +57,9 @@ function useChartSettingsStore() {
     getStoredChartSettingsServerSnapshot,
   )
 
-  const handleChartSettingsChange = useCallback(function handleChartSettingsChange(
+  const handleChartSettingsChange = useCallback((
     nextSettings: ChartSettings | ((current: ChartSettings) => ChartSettings),
-  ) {
+  ) => {
     const resolvedSettings = typeof nextSettings === 'function'
       ? nextSettings(chartSettings)
       : nextSettings
@@ -99,7 +99,7 @@ function useOutcomeSelection({
     return market.outcomes.find(item => item.outcome_index === oppositeOutcomeIndex) ?? activeOutcome
   }, [market.outcomes, oppositeOutcomeIndex, activeOutcome])
 
-  const handleShuffleOutcome = useCallback(function handleShuffleOutcome() {
+  const handleShuffleOutcome = useCallback(() => {
     setActiveOutcomeOverride({
       key: activeOutcomeKey,
       index: oppositeOutcome.outcome_index,
@@ -117,9 +117,9 @@ function useChartCursor(chartSignature: string) {
 
   const cursorSnapshot = cursorState.key === chartSignature ? cursorState.snapshot : null
 
-  const handleCursorDataChange = useCallback(function handleCursorDataChange(
+  const handleCursorDataChange = useCallback((
     nextSnapshot: PredictionChartCursorSnapshot | null,
-  ) {
+  ) => {
     setCursorState({ key: chartSignature, snapshot: nextSnapshot })
   }, [chartSignature])
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
@@ -50,35 +50,36 @@ const PredictionChart = dynamic<PredictionChartProps>(
 const YES_SERIES_COLOR = 'var(--primary)'
 const NO_SERIES_COLOR = 'var(--no)'
 
-export default function MarketOutcomeGraph({
-  market,
-  outcome,
-  allMarkets,
-  currentTimestamp,
-  eventCreatedAt,
-  isMobile,
-}: MarketOutcomeGraphProps) {
-  const t = useExtracted()
-  const site = useSiteIdentity()
-  const normalizeOutcomeLabel = useOutcomeLabel()
-  const [activeTimeRange, setActiveTimeRange] = useState<TimeRange>('ALL')
-  const [activeOutcomeOverride, setActiveOutcomeOverride] = useState<{ key: string, index: number } | null>(null)
-  const [cursorState, setCursorState] = useState<{ key: string, snapshot: PredictionChartCursorSnapshot | null }>({
-    key: '',
-    snapshot: null,
-  })
-  const [exportDialogOpen, setExportDialogOpen] = useState(false)
-  const [embedDialogOpen, setEmbedDialogOpen] = useState(false)
-  const marketTargets = useMemo(() => buildMarketTargets(allMarkets), [allMarkets])
-  const { width: windowWidth } = useWindowSize()
-  const chartWidth = isMobile ? ((windowWidth || 400) * 0.84) : Math.min((windowWidth ?? 1440) * 0.55, 900)
+function useChartSettingsStore() {
   const chartSettings = useSyncExternalStore(
     subscribeToChartSettings,
     loadStoredChartSettings,
     getStoredChartSettingsServerSnapshot,
   )
+
+  const handleChartSettingsChange = useCallback(function handleChartSettingsChange(
+    nextSettings: ChartSettings | ((current: ChartSettings) => ChartSettings),
+  ) {
+    const resolvedSettings = typeof nextSettings === 'function'
+      ? nextSettings(chartSettings)
+      : nextSettings
+    storeChartSettings(resolvedSettings)
+  }, [chartSettings])
+
+  return { chartSettings, handleChartSettingsChange }
+}
+
+function useOutcomeSelection({
+  market,
+  outcome,
+}: {
+  market: Market
+  outcome: Outcome
+}) {
+  const [activeOutcomeOverride, setActiveOutcomeOverride] = useState<{ key: string, index: number } | null>(null)
+
   const activeOutcomeKey = outcome.token_id || `${market.condition_id}:${outcome.outcome_index}`
-  const activeOutcomeIndex = useMemo(() => {
+  const activeOutcomeIndex = useMemo(function resolveActiveOutcomeIndex() {
     if (activeOutcomeOverride?.key === activeOutcomeKey) {
       return activeOutcomeOverride.index
     }
@@ -86,46 +87,76 @@ export default function MarketOutcomeGraph({
     return outcome.outcome_index
   }, [activeOutcomeKey, activeOutcomeOverride, outcome.outcome_index])
 
-  const activeOutcome = useMemo(
-    () => market.outcomes.find(item => item.outcome_index === activeOutcomeIndex) ?? outcome,
-    [market.outcomes, activeOutcomeIndex, outcome],
-  )
+  const activeOutcome = useMemo(function resolveActiveOutcome() {
+    return market.outcomes.find(item => item.outcome_index === activeOutcomeIndex) ?? outcome
+  }, [market.outcomes, activeOutcomeIndex, outcome])
+
   const oppositeOutcomeIndex = activeOutcomeIndex === OUTCOME_INDEX.YES
     ? OUTCOME_INDEX.NO
     : OUTCOME_INDEX.YES
-  const oppositeOutcome = useMemo(
-    () => market.outcomes.find(item => item.outcome_index === oppositeOutcomeIndex) ?? activeOutcome,
-    [market.outcomes, oppositeOutcomeIndex, activeOutcome],
-  )
-  const showOutcomeSwitch = market.outcomes.length > 1
-    && oppositeOutcome.outcome_index !== activeOutcome.outcome_index
-  const showBothOutcomes = chartSettings.bothOutcomes && showOutcomeSwitch
-  const yesOutcomeLabel = normalizeOutcomeLabel(
-    market.outcomes.find(item => item.outcome_index === OUTCOME_INDEX.YES)?.outcome_text,
-  ) ?? t('Yes')
-  const noOutcomeLabel = normalizeOutcomeLabel(
-    market.outcomes.find(item => item.outcome_index === OUTCOME_INDEX.NO)?.outcome_text,
-  ) ?? t('No')
 
-  const {
-    normalizedHistory,
-  } = useEventPriceHistory({
-    eventId: market.event_id,
-    range: activeTimeRange,
-    targets: marketTargets,
-    eventCreatedAt,
+  const oppositeOutcome = useMemo(function resolveOppositeOutcome() {
+    return market.outcomes.find(item => item.outcome_index === oppositeOutcomeIndex) ?? activeOutcome
+  }, [market.outcomes, oppositeOutcomeIndex, activeOutcome])
+
+  const handleShuffleOutcome = useCallback(function handleShuffleOutcome() {
+    setActiveOutcomeOverride({
+      key: activeOutcomeKey,
+      index: oppositeOutcome.outcome_index,
+    })
+  }, [activeOutcomeKey, oppositeOutcome.outcome_index])
+
+  return { activeOutcomeIndex, activeOutcome, oppositeOutcome, handleShuffleOutcome }
+}
+
+function useChartCursor(chartSignature: string) {
+  const [cursorState, setCursorState] = useState<{ key: string, snapshot: PredictionChartCursorSnapshot | null }>({
+    key: '',
+    snapshot: null,
   })
 
-  const chartData = useMemo(
-    () => (showBothOutcomes
-      ? buildComparisonChartData(normalizedHistory, market.condition_id)
-      : buildChartData(normalizedHistory, market.condition_id, activeOutcomeIndex)),
-    [normalizedHistory, market.condition_id, activeOutcomeIndex, showBothOutcomes],
-  )
-  const leadingGapStart = normalizedHistory[0]?.date ?? null
+  const cursorSnapshot = cursorState.key === chartSignature ? cursorState.snapshot : null
 
-  const series = useMemo(
-    () => (showBothOutcomes
+  const handleCursorDataChange = useCallback(function handleCursorDataChange(
+    nextSnapshot: PredictionChartCursorSnapshot | null,
+  ) {
+    setCursorState({ key: chartSignature, snapshot: nextSnapshot })
+  }, [chartSignature])
+
+  return { cursorSnapshot, handleCursorDataChange }
+}
+
+function useChartDataValues({
+  normalizedHistory,
+  conditionId,
+  activeOutcomeIndex,
+  activeTimeRange,
+  showBothOutcomes,
+  activeSeriesKey,
+  activeOutcome,
+  yesOutcomeLabel,
+  noOutcomeLabel,
+  normalizeOutcomeLabel,
+}: {
+  normalizedHistory: Array<Record<string, number | Date> & { date: Date }>
+  conditionId: string
+  activeOutcomeIndex: number
+  activeTimeRange: TimeRange
+  showBothOutcomes: boolean
+  activeSeriesKey: 'yes' | 'no' | 'value'
+  activeOutcome: Outcome
+  yesOutcomeLabel: string
+  noOutcomeLabel: string
+  normalizeOutcomeLabel: (value: string | null | undefined) => string | undefined
+}) {
+  const chartData = useMemo(function buildResolvedChartData() {
+    return showBothOutcomes
+      ? buildComparisonChartData(normalizedHistory, conditionId)
+      : buildChartData(normalizedHistory, conditionId, activeOutcomeIndex)
+  }, [normalizedHistory, conditionId, activeOutcomeIndex, showBothOutcomes])
+
+  const series = useMemo(function buildChartSeries() {
+    return showBothOutcomes
       ? [
           { key: 'yes', name: yesOutcomeLabel, color: YES_SERIES_COLOR },
           { key: 'no', name: noOutcomeLabel, color: NO_SERIES_COLOR },
@@ -134,46 +165,14 @@ export default function MarketOutcomeGraph({
           key: 'value',
           name: normalizeOutcomeLabel(activeOutcome.outcome_text) ?? activeOutcome.outcome_text,
           color: activeOutcome.outcome_index === OUTCOME_INDEX.NO ? NO_SERIES_COLOR : YES_SERIES_COLOR,
-        }]),
-    [activeOutcome.outcome_index, activeOutcome.outcome_text, showBothOutcomes, yesOutcomeLabel, noOutcomeLabel, normalizeOutcomeLabel],
-  )
-  const chartSignature = useMemo(
-    () => `${market.condition_id}:${activeOutcomeIndex}:${activeTimeRange}:${showBothOutcomes ? 'both' : 'single'}`,
-    [market.condition_id, activeOutcomeIndex, activeTimeRange, showBothOutcomes],
-  )
-  const cursorSnapshot = cursorState.key === chartSignature ? cursorState.snapshot : null
-  const handleCursorDataChange = useCallback((nextSnapshot: PredictionChartCursorSnapshot | null) => {
-    setCursorState({ key: chartSignature, snapshot: nextSnapshot })
-  }, [chartSignature])
-  const handleChartSettingsChange = useCallback((nextSettings: ChartSettings | ((current: ChartSettings) => ChartSettings)) => {
-    const resolvedSettings = typeof nextSettings === 'function'
-      ? nextSettings(chartSettings)
-      : nextSettings
-    storeChartSettings(resolvedSettings)
-  }, [chartSettings])
-  const handleShuffleOutcome = useCallback(() => {
-    setActiveOutcomeOverride({
-      key: activeOutcomeKey,
-      index: oppositeOutcome.outcome_index,
-    })
-  }, [activeOutcomeKey, oppositeOutcome.outcome_index])
-  const hasChartData = chartData.length > 0
-  const watermark = useMemo(
-    () => ({
-      iconSvg: site.logoSvg,
-      label: site.name,
-    }),
-    [site.logoSvg, site.name],
-  )
+        }]
+  }, [activeOutcome.outcome_index, activeOutcome.outcome_text, showBothOutcomes, yesOutcomeLabel, noOutcomeLabel, normalizeOutcomeLabel])
 
-  const activeSeriesKey = showBothOutcomes
-    ? (activeOutcomeIndex === OUTCOME_INDEX.NO ? 'no' : 'yes')
-    : 'value'
-  const primarySeriesColor = showBothOutcomes
-    ? (activeOutcomeIndex === OUTCOME_INDEX.NO ? NO_SERIES_COLOR : YES_SERIES_COLOR)
-    : (series[0]?.color ?? YES_SERIES_COLOR)
-  const hoveredValue = cursorSnapshot?.values?.[activeSeriesKey]
-  const latestValue = useMemo(() => {
+  const chartSignature = useMemo(function buildChartSignature() {
+    return `${conditionId}:${activeOutcomeIndex}:${activeTimeRange}:${showBothOutcomes ? 'both' : 'single'}`
+  }, [conditionId, activeOutcomeIndex, activeTimeRange, showBothOutcomes])
+
+  const latestValue = useMemo(function findLatestChartValue() {
     for (let index = chartData.length - 1; index >= 0; index -= 1) {
       const point = chartData[index]
       if (!point) {
@@ -194,10 +193,8 @@ export default function MarketOutcomeGraph({
     }
     return null
   }, [chartData, activeSeriesKey, showBothOutcomes])
-  const resolvedValue = typeof hoveredValue === 'number' && Number.isFinite(hoveredValue)
-    ? hoveredValue
-    : latestValue
-  const baselineValue = useMemo(() => {
+
+  const baselineValue = useMemo(function findBaselineChartValue() {
     for (const point of chartData) {
       const value = showBothOutcomes
         ? (activeSeriesKey === 'yes' && 'yes' in point
@@ -213,6 +210,80 @@ export default function MarketOutcomeGraph({
     }
     return null
   }, [chartData, activeSeriesKey, showBothOutcomes])
+
+  return { chartData, series, chartSignature, latestValue, baselineValue }
+}
+
+export default function MarketOutcomeGraph({
+  market,
+  outcome,
+  allMarkets,
+  currentTimestamp,
+  eventCreatedAt,
+  isMobile,
+}: MarketOutcomeGraphProps) {
+  const t = useExtracted()
+  const site = useSiteIdentity()
+  const normalizeOutcomeLabel = useOutcomeLabel()
+  const [activeTimeRange, setActiveTimeRange] = useState<TimeRange>('ALL')
+  const [exportDialogOpen, setExportDialogOpen] = useState(false)
+  const [embedDialogOpen, setEmbedDialogOpen] = useState(false)
+  const marketTargets = useMemo(() => buildMarketTargets(allMarkets), [allMarkets])
+  const { width: windowWidth } = useWindowSize()
+  const chartWidth = isMobile ? ((windowWidth || 400) * 0.84) : Math.min((windowWidth ?? 1440) * 0.55, 900)
+  const { chartSettings, handleChartSettingsChange } = useChartSettingsStore()
+  const { activeOutcomeIndex, activeOutcome, oppositeOutcome, handleShuffleOutcome } = useOutcomeSelection({ market, outcome })
+  const showOutcomeSwitch = market.outcomes.length > 1
+    && oppositeOutcome.outcome_index !== activeOutcome.outcome_index
+  const showBothOutcomes = chartSettings.bothOutcomes && showOutcomeSwitch
+  const yesOutcomeLabel = normalizeOutcomeLabel(
+    market.outcomes.find(item => item.outcome_index === OUTCOME_INDEX.YES)?.outcome_text,
+  ) ?? t('Yes')
+  const noOutcomeLabel = normalizeOutcomeLabel(
+    market.outcomes.find(item => item.outcome_index === OUTCOME_INDEX.NO)?.outcome_text,
+  ) ?? t('No')
+
+  const { normalizedHistory } = useEventPriceHistory({
+    eventId: market.event_id,
+    range: activeTimeRange,
+    targets: marketTargets,
+    eventCreatedAt,
+  })
+  const leadingGapStart = normalizedHistory[0]?.date ?? null
+
+  const activeSeriesKey: 'yes' | 'no' | 'value' = showBothOutcomes
+    ? (activeOutcomeIndex === OUTCOME_INDEX.NO ? 'no' : 'yes')
+    : 'value'
+
+  const { chartData, series, chartSignature, latestValue, baselineValue } = useChartDataValues({
+    normalizedHistory,
+    conditionId: market.condition_id,
+    activeOutcomeIndex,
+    activeTimeRange,
+    showBothOutcomes,
+    activeSeriesKey,
+    activeOutcome,
+    yesOutcomeLabel,
+    noOutcomeLabel,
+    normalizeOutcomeLabel,
+  })
+  const { cursorSnapshot, handleCursorDataChange } = useChartCursor(chartSignature)
+  const hasChartData = chartData.length > 0
+  const watermark = useMemo(
+    () => ({
+      iconSvg: site.logoSvg,
+      label: site.name,
+    }),
+    [site.logoSvg, site.name],
+  )
+
+  const primarySeriesColor = showBothOutcomes
+    ? (activeOutcomeIndex === OUTCOME_INDEX.NO ? NO_SERIES_COLOR : YES_SERIES_COLOR)
+    : (series[0]?.color ?? YES_SERIES_COLOR)
+  const hoveredValue = cursorSnapshot?.values?.[activeSeriesKey]
+  const resolvedValue = typeof hoveredValue === 'number' && Number.isFinite(hoveredValue)
+    ? hoveredValue
+    : latestValue
   const currentValue = resolvedValue
 
   return (


### PR DESCRIPTION
## Summary

Applies [#855](https://github.com/kuestcom/prediction-market/issues/855) to the event page's chart cluster — the complex data-visualization components. Extracts file-local custom hooks and names every affected `useEffect`.

Follow-up to [#866](https://github.com/kuestcom/prediction-market/pull/866) (merged), [#867](https://github.com/kuestcom/prediction-market/pull/867), [#868](https://github.com/kuestcom/prediction-market/pull/868), [#869](https://github.com/kuestcom/prediction-market/pull/869).

## Files changed (5)

| File | `use-encapsulation/prefer-custom-hooks` | Effects named |
|---|---|---|
| `EventSeriesPills` | 4 → 2 (50%) | 0 |
| `EventChartEmbedDialog` | 12 → 3 (75%) | 1 |
| `EventChartExportDialog` | 12 → 6 (50%) | 0 |
| `MarketOutcomeGraph` | 21 → 7 (67%) | 0 |
| `EventChart` | 47 → 23 (51%) | 1 |

**Total: 96 → 41 (57% reduction, 55 eliminated), 2 effects named.**

`EventChartControls` (1 violation, simple dialog `useState`) intentionally left untouched — 2-sec rule applies. `EventLiveSeriesChart` (33 violations, 1745 LOC) scoped out for its own focused PR.

## Extracted hooks (all file-local)

### `EventSeriesPills`
- `useNowTimestamp` — wraps `useSyncExternalStore` for 1-second ticker
- `useSeriesNavigation` — past/unresolved/current-trading event resolution

### `EventChartEmbedDialog`
- `useAffiliateSettings(affiliateCode)` — fetch + cache with named effect `fetchAffiliateSettingsOnCodeChange` + named cleanup
- `useEmbedCodeBuilders({...})` — 7 `useMemo` derivations (features / iframeSrc / previewSrc / iframeCode / webComponentCode / iframeLines / webComponentLines)

### `EventChartExportDialog`
- `useNavigatorLocale` — wraps `useSyncExternalStore` for `navigator.language`
- `useExportFormState({eventStartDate, openedAt})` — 5 `useState` + `handleFrequencyChange`

### `MarketOutcomeGraph`
- `useChartSettingsStore` — `useSyncExternalStore` for chart settings + named change callback
- `useOutcomeSelection({market, outcome})` — active/opposite outcome resolution + shuffle handler
- `useChartCursor(chartSignature)` — cursor state + handler
- `useChartDataValues({...})` — chart data / series / signature / latest + baseline value derivations

### `EventChart`
- `useChartSettingsFromStore` — same as above (duplicated file-local intentionally per "not cross-component yet")
- `useChartCursorTracking(chartScopeKey)` — cursor state + handler
- `useTweetMarketsDerivations({event, currentTimestampMs, xtrackerData})` — tweet count / countdown / finality derivations
- `useMarketSelection({eventId, allMarketIds, defaultMarketIds, maxSeriesCount, isSingleMarket})` — custom market selection state + toggle
- `useChartSeriesBuilders({...})` — 5 `useMemo` series derivations (chartSeries / fallbackChartSeries / allSeries / selectedSeries / marketOptions / baseSeries / bothOutcomeSeries / effectiveSeries)
- `useTradeFlowLabels(outcomeTokenKey)` — trade flow state + prune effect (named `pruneExpiredTradeFlowLabels` + named cleanup)

## Kept inline (per your "2–3 sec rule")

Remaining 41 warnings are library/context hooks (`useUser`, `useSiteIdentity`, `useOutcomeLabel`, `useWindowSize`, `useCurrentTimestamp`, `useXTrackerTweetCount`, `useEventMarketChanceData`, `useEventPriceHistory`, `useQuery`, `useIsSingleMarket`, `useMarketChannelSubscription`) and trivial single-line `useMemo` derivations (query keys, option lists, token IDs). Each is readable in under 3 seconds.

## Test plan

- [x] `npm test` — 487/487 pass
- [x] `npm run build` — clean
- [x] `tsc --noEmit` on touched files — 0 errors
- [x] Pre-push hook re-ran full suite on push
- [x] Manual UX smoke: chart time range switching, outcome shuffle, embed dialog copy + preview iframe, export dialog date picker + TSV download, market selector on multi-market events, chart settings toggles, tweet markets countdown panel, trade flow labels on live market channel, chart annotations on trade history, series pills past/live/future navigation

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the event page chart components to use file‑local hooks and named effects for clearer logic, and fixes primary‑market drift when users toggle chart markets. Also standardizes `useMemo` callbacks to arrow functions and removes named function expressions from `useCallback` wrappers.

- **Bug Fixes**
  - Keeps `primaryMarket` aligned with `selectedMarketIds`, so yes/no series keys, labels, trade flow labels, and outcome token IDs match the displayed series.

- **Refactors**
  - Extracts local hooks across `EventChart`, `MarketOutcomeGraph`, `EventSeriesPills`, `EventChartEmbedDialog`, and `EventChartExportDialog` for chart settings, cursor tracking, market/series selection, tweet‑market derivations, trade flow labels, series building, navigator locale, and export form state.
  - Names effects with cleanups (affiliate settings fetch, trade flow pruning).
  - Standardizes callback style: `useMemo` uses arrow functions; drops named function expressions in `useCallback`.
  - Cuts `use-encapsulation/prefer-custom-hooks` violations from 96 to 41 (~57% fewer); hooks are file‑local by design.

<sup>Written for commit 3550772f5142c88bf136fd7358a8fb88e3e54c72. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

