### PR TITLE
refactor: use custom hooks for home page components

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeSecondaryNavigation.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeSecondaryNavigation.tsx
@@ -14,23 +14,20 @@ interface HomeSecondaryNavigationProps {
   tag: Pick<PlatformNavigationTag, 'childs' | 'name' | 'sidebarItems' | 'slug'>
 }
 
-export default function HomeSecondaryNavigation({
-  tag,
-  activeSubtagSlug,
-  onSelectTag,
-  showCategoryTitle = false,
-  hideOnDesktop = false,
-}: HomeSecondaryNavigationProps) {
-  const t = useExtracted()
-  const [showLeftShadow, setShowLeftShadow] = useState(false)
-  const [showRightShadow, setShowRightShadow] = useState(false)
-  const scrollContainerRef = useRef<HTMLDivElement>(null)
-  const buttonRef = useRef<(HTMLButtonElement | null)[]>([])
-  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 })
-  const [indicatorReady, setIndicatorReady] = useState(false)
-  const indicatorRetryRef = useRef<number | null>(null)
+interface TagItem {
+  href: string | undefined
+  slug: string
+  label: string
+}
 
-  const tagItems = useMemo(() => {
+interface UseResolvedTagItemsParams {
+  tag: Pick<PlatformNavigationTag, 'childs' | 'sidebarItems' | 'slug'>
+  activeSubtagSlug: string
+  t: ReturnType<typeof useExtracted>
+}
+
+function useResolvedTagItems({ tag, activeSubtagSlug, t }: UseResolvedTagItemsParams) {
+  const tagItems = useMemo<TagItem[]>(() => {
     if (tag.sidebarItems) {
       return tag.sidebarItems
         .filter(item => item.type === 'link')
@@ -51,6 +48,23 @@ export default function HomeSecondaryNavigation({
     () => (tagItems.some(item => item.slug === activeSubtagSlug) ? activeSubtagSlug : tag.slug),
     [activeSubtagSlug, tag.slug, tagItems],
   )
+
+  return { tagItems, resolvedActiveSubtagSlug }
+}
+
+interface UseTagNavigationParams {
+  tagItems: TagItem[]
+  resolvedActiveSubtagSlug: string
+}
+
+function useTagNavigation({ tagItems, resolvedActiveSubtagSlug }: UseTagNavigationParams) {
+  const scrollContainerRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<(HTMLButtonElement | null)[]>([])
+  const indicatorRetryRef = useRef<number | null>(null)
+  const [showLeftShadow, setShowLeftShadow] = useState(false)
+  const [showRightShadow, setShowRightShadow] = useState(false)
+  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 })
+  const [indicatorReady, setIndicatorReady] = useState(false)
 
   const cancelIndicatorRetry = useCallback(() => {
     if (indicatorRetryRef.current !== null) {
@@ -101,25 +115,27 @@ export default function HomeSecondaryNavigation({
     applyIndicatorPosition()
   }, [cancelIndicatorRetry, resolvedActiveSubtagSlug, tagItems])
 
-  useEffect(() => {
+  useEffect(function syncButtonRefArrayLength() {
     buttonRef.current = Array.from({ length: tagItems.length }).map((_, index) => buttonRef.current[index] ?? null)
   }, [tagItems.length])
 
-  useLayoutEffect(() => {
+  useLayoutEffect(function repaintNavigationOnLayout() {
     const rafId = requestAnimationFrame(() => {
       updateScrollShadows()
       updateIndicator()
     })
 
-    return () => {
+    return function cleanupNavigationLayoutPaint() {
       cancelAnimationFrame(rafId)
       cancelIndicatorRetry()
     }
   }, [cancelIndicatorRetry, updateIndicator, updateScrollShadows])
 
-  useEffect(() => cancelIndicatorRetry, [cancelIndicatorRetry])
+  useEffect(function cancelPendingIndicatorRetryOnUnmount() {
+    return cancelIndicatorRetry
+  }, [cancelIndicatorRetry])
 
-  useEffect(() => {
+  useEffect(function reactNavigationToScrollAndResize() {
     const container = scrollContainerRef.current
     if (!container) {
       return
@@ -142,14 +158,14 @@ export default function HomeSecondaryNavigation({
     container.addEventListener('scroll', handleScroll)
     window.addEventListener('resize', handleResize)
 
-    return () => {
+    return function detachNavigationScrollResizeListeners() {
       container.removeEventListener('scroll', handleScroll)
       window.removeEventListener('resize', handleResize)
       clearTimeout(resizeTimeout)
     }
   }, [updateIndicator, updateScrollShadows])
 
-  useEffect(() => {
+  useEffect(function scrollActiveTagIntoView() {
     const activeIndex = tagItems.findIndex(item => item.slug === resolvedActiveSubtagSlug)
     if (activeIndex < 0) {
       return
@@ -176,8 +192,38 @@ export default function HomeSecondaryNavigation({
       container.scrollTo({ left: clampedLeft, behavior: 'smooth' })
     }, 100)
 
-    return () => clearTimeout(timeoutId)
+    return function cancelScrollActiveTagIntoView() {
+      clearTimeout(timeoutId)
+    }
   }, [resolvedActiveSubtagSlug, tagItems])
+
+  return {
+    scrollContainerRef,
+    buttonRef,
+    showLeftShadow,
+    showRightShadow,
+    indicatorStyle,
+    indicatorReady,
+  }
+}
+
+export default function HomeSecondaryNavigation({
+  tag,
+  activeSubtagSlug,
+  onSelectTag,
+  showCategoryTitle = false,
+  hideOnDesktop = false,
+}: HomeSecondaryNavigationProps) {
+  const t = useExtracted()
+  const { tagItems, resolvedActiveSubtagSlug } = useResolvedTagItems({ tag, activeSubtagSlug, t })
+  const {
+    scrollContainerRef,
+    buttonRef,
+    showLeftShadow,
+    showRightShadow,
+    indicatorStyle,
+    indicatorReady,
+  } = useTagNavigation({ tagItems, resolvedActiveSubtagSlug })
 
   return (
     <div className="flex w-full max-w-full min-w-0 items-center gap-2">

--- a/src/app/[locale]/(platform)/(home)/_components/HydratedEventsGrid.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HydratedEventsGrid.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { InfiniteData } from '@tanstack/react-query'
 import type { FilterState } from '@/app/[locale]/(platform)/_providers/FilterProvider'
 import type { Event } from '@/types'
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query'
@@ -129,89 +130,33 @@ async function fetchEvents({
   })
 }
 
-export default function HydratedEventsGrid({
-  filters,
-  initialEvents = EMPTY_EVENTS,
-  initialCurrentTimestamp,
-  maxColumns,
-  onClearFilters,
-  routeMainTag,
-  routeTag,
-}: HydratedEventsGridProps) {
-  const locale = useLocale()
-  const parentRef = useRef<HTMLDivElement | null>(null)
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
-  const canRetryLoadMoreAfterErrorRef = useRef(true)
-  const user = useUser()
-  const queryUserScope = user?.id ?? 'guest'
-  const currentTimestamp = useCurrentTimestamp({
-    initialTimestamp: initialCurrentTimestamp,
-    intervalMs: HOME_FEED_REFRESH_INTERVAL_MS,
-  })
-  const hasHydrated = useSyncExternalStore(
+function useHasHydrated() {
+  return useSyncExternalStore(
     subscribeToHydrationStore,
     getHydratedClientSnapshot,
     getHydratedServerSnapshot,
   )
-  const snapshotKey = [
-    locale,
-    routeMainTag,
-    routeTag,
-    filters.tag,
-    filters.mainTag,
-    filters.search,
-    filters.bookmarked ? 'bookmarked' : 'all-events',
-    queryUserScope,
-    filters.frequency,
-    filters.status,
-    filters.hideSports ? 'hide-sports' : 'show-sports',
-    filters.hideCrypto ? 'hide-crypto' : 'show-crypto',
-    filters.hideEarnings ? 'hide-earnings' : 'show-earnings',
-  ].join(':')
-  const isRouteInitialState = filters.tag === routeTag
-    && filters.mainTag === routeMainTag
-    && filters.search === ''
-    && !filters.bookmarked
-    && filters.frequency === 'all'
-    && filters.status === 'active'
-    && !filters.hideSports
-    && !filters.hideCrypto
-    && !filters.hideEarnings
-  const initialSnapshotEvents = isRouteInitialState ? initialEvents : EMPTY_EVENTS
-  const PAGE_SIZE = HOME_EVENTS_PAGE_SIZE
-  const shouldUseInitialData = isRouteInitialState
-    && initialEvents.length > 0
-    && queryUserScope === 'guest'
-  const shouldAutoRefreshEvents = filters.status === 'active'
-  const resolvedCurrentTimestamp = currentTimestamp ?? initialCurrentTimestamp
-  const queryRunKey = [
-    locale,
-    routeMainTag,
-    routeTag,
-    filters.tag,
-    filters.mainTag,
-    filters.search,
-    filters.bookmarked ? 'bookmarked' : 'all-events',
-    queryUserScope,
-    filters.frequency,
-    filters.status,
-    filters.hideSports ? 'hide-sports' : 'show-sports',
-    filters.hideCrypto ? 'hide-crypto' : 'show-crypto',
-    filters.hideEarnings ? 'hide-earnings' : 'show-earnings',
-  ].join(':')
-  const loadMoreStateKey = [
-    filters.tag,
-    filters.mainTag,
-    filters.search,
-    filters.bookmarked ? 'bookmarked' : 'all-events',
-    filters.frequency,
-    filters.status,
-    filters.hideSports ? 'hide-sports' : 'show-sports',
-    filters.hideCrypto ? 'hide-crypto' : 'show-crypto',
-    filters.hideEarnings ? 'hide-earnings' : 'show-earnings',
-    locale,
-    queryUserScope,
-  ].join(':')
+}
+
+interface UseEventsRefetchOnTimestampParams {
+  queryRunKey: string
+  resolvedCurrentTimestamp: number | null
+  status: string
+  isFetching: boolean
+  isFetchingNextPage: boolean
+  refetch: () => Promise<unknown>
+  shouldAutoRefreshEvents: boolean
+}
+
+function useEventsRefetchOnTimestamp({
+  queryRunKey,
+  resolvedCurrentTimestamp,
+  status,
+  isFetching,
+  isFetchingNextPage,
+  refetch,
+  shouldAutoRefreshEvents,
+}: UseEventsRefetchOnTimestampParams) {
   const queryTimestampRef = useRef<{
     key: string
     timestamp: number | null
@@ -219,62 +164,6 @@ export default function HydratedEventsGrid({
     key: queryRunKey,
     timestamp: resolvedCurrentTimestamp,
   })
-  const previousLoadMoreStateKeyRef = useRef(loadMoreStateKey)
-  const [infiniteScrollErrorState, setInfiniteScrollErrorState] = useState<{
-    key: string
-    value: string | null
-  }>({
-    key: loadMoreStateKey,
-    value: null,
-  })
-  const infiniteScrollError = infiniteScrollErrorState.key === loadMoreStateKey
-    ? infiniteScrollErrorState.value
-    : null
-
-  const eventsQueryKey = [
-    'events',
-    filters.tag,
-    filters.mainTag,
-    filters.search,
-    filters.bookmarked,
-    filters.frequency,
-    filters.status,
-    filters.hideSports,
-    filters.hideCrypto,
-    filters.hideEarnings,
-    locale,
-    queryUserScope,
-  ]
-
-  const {
-    status,
-    data,
-    dataUpdatedAt,
-    isFetching,
-    isFetchingNextPage,
-    fetchNextPage,
-    hasNextPage,
-    isPending,
-    refetch,
-  } = useInfiniteQuery({
-    queryKey: eventsQueryKey,
-    queryFn: ({ pageParam }) => fetchEvents({
-      pageParam,
-      currentTimestamp: resolvedCurrentTimestamp,
-      filters,
-      locale,
-    }),
-    getNextPageParam: (lastPage, allPages) => lastPage.length === PAGE_SIZE ? allPages.length * PAGE_SIZE : undefined,
-    initialPageParam: 0,
-    initialData: shouldUseInitialData ? { pages: [initialEvents], pageParams: [0] } : undefined,
-    refetchOnMount: false,
-    refetchOnWindowFocus: false,
-    staleTime: 'static',
-    initialDataUpdatedAt: 0,
-    placeholderData: keepPreviousData,
-  })
-
-  const [livePriceEventIds, setLivePriceEventIds] = useState<string[]>([])
 
   useEffect(function syncQueryTimestampForCurrentQueryKey() {
     if (queryTimestampRef.current.key === queryRunKey) {
@@ -287,16 +176,7 @@ export default function HydratedEventsGrid({
     }
   }, [queryRunKey, resolvedCurrentTimestamp])
 
-  useEffect(function resetLoadMoreRetryStateOnQueryScopeChange() {
-    if (previousLoadMoreStateKeyRef.current === loadMoreStateKey) {
-      return
-    }
-
-    previousLoadMoreStateKeyRef.current = loadMoreStateKey
-    canRetryLoadMoreAfterErrorRef.current = true
-  }, [loadMoreStateKey])
-
-  useEffect(() => {
+  useEffect(function refetchEventsWhenTimestampWindowElapses() {
     if (!shouldAutoRefreshEvents || status !== 'success') {
       return
     }
@@ -345,10 +225,22 @@ export default function HydratedEventsGrid({
     shouldAutoRefreshEvents,
     status,
   ])
+}
 
+interface UseHydratedEventsListParams {
+  data: InfiniteData<Event[], unknown> | undefined
+  snapshotKey: string
+  status: string
+  initialSnapshotEvents: Event[]
+}
+
+function useHydratedEventsList({
+  data,
+  snapshotKey,
+  status,
+  initialSnapshotEvents,
+}: UseHydratedEventsListParams) {
   const allEvents = useMemo(() => (data ? data.pages.flat() : []), [data])
-  const hasFreshQueryData = !shouldUseInitialData || dataUpdatedAt > 0
-
   const visibleEvents = useMemo(
     () => (allEvents.length === 0 ? EMPTY_EVENTS : allEvents),
     [allEvents],
@@ -358,7 +250,7 @@ export default function HydratedEventsGrid({
     [initialSnapshotEvents, snapshotKey],
   )
 
-  useEffect(() => {
+  useEffect(function persistVisibleEventsSnapshot() {
     if (visibleEvents.length === 0) {
       return
     }
@@ -366,7 +258,7 @@ export default function HydratedEventsGrid({
     setHydratedEventsSnapshot(snapshotKey, visibleEvents)
   }, [snapshotKey, visibleEvents])
 
-  useEffect(() => {
+  useEffect(function clearStaleEventsSnapshotOnEmptySuccess() {
     if (status !== 'success' || visibleEvents.length > 0) {
       return
     }
@@ -374,15 +266,71 @@ export default function HydratedEventsGrid({
     hydratedEventsSnapshotCache.delete(snapshotKey)
   }, [snapshotKey, status, visibleEvents.length])
 
-  const columns = useColumns(maxColumns)
-  const loadingMoreColumns = Math.max(1, columns)
-  const shouldShowSnapshotFallback = visibleEvents.length === 0
-    && cachedSnapshotEvents.length > 0
-    && status !== 'success'
-  const eventsToRender = shouldShowSnapshotFallback ? cachedSnapshotEvents : visibleEvents
-  const hydrationSafeEventsToRender = !hasHydrated && isRouteInitialState
-    ? initialEvents
-    : eventsToRender
+  return { allEvents, visibleEvents, cachedSnapshotEvents }
+}
+
+function useHomeLivePriceVisibility(hydrationSafeEventsToRender: Event[]) {
+  const parentRef = useRef<HTMLDivElement | null>(null)
+  const [livePriceEventIds, setLivePriceEventIds] = useState<string[]>([])
+
+  useEffect(function observeVisibleHomeEventCards() {
+    if (!parentRef.current || hydrationSafeEventsToRender.length === 0) {
+      return
+    }
+
+    const observedIds = new Set<string>()
+    const cardElements = Array.from(parentRef.current.querySelectorAll<HTMLElement>('[data-home-event-id]'))
+
+    if (cardElements.length === 0) {
+      return
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      let hasChanges = false
+
+      entries.forEach((entry) => {
+        const eventId = entry.target.getAttribute('data-home-event-id')
+        if (!eventId) {
+          return
+        }
+
+        if (entry.isIntersecting) {
+          if (!observedIds.has(eventId)) {
+            observedIds.add(eventId)
+            hasChanges = true
+          }
+          return
+        }
+
+        if (observedIds.delete(eventId)) {
+          hasChanges = true
+        }
+      })
+
+      if (hasChanges) {
+        setLivePriceEventIds(Array.from(observedIds))
+      }
+    }, { rootMargin: HOME_LIVE_PRICE_OBSERVER_ROOT_MARGIN })
+
+    cardElements.forEach(element => observer.observe(element))
+
+    return function disconnectHomeEventCardObserver() {
+      observer.disconnect()
+    }
+  }, [hydrationSafeEventsToRender])
+
+  return { parentRef, livePriceEventIds }
+}
+
+interface UseHomeLivePriceOverridesParams {
+  hydrationSafeEventsToRender: Event[]
+  livePriceEventIds: string[]
+}
+
+function useHomeLivePriceOverrides({
+  hydrationSafeEventsToRender,
+  livePriceEventIds,
+}: UseHomeLivePriceOverridesParams) {
   const livePriceEvents = useMemo(
     () => hydrationSafeEventsToRender.filter(event => livePriceEventIds.includes(String(event.id))),
     [hydrationSafeEventsToRender, livePriceEventIds],
@@ -443,54 +391,49 @@ export default function HydratedEventsGrid({
   const stablePriceOverridesByMarket = priceOverrideSignature
     ? debouncedPriceOverridesByMarket
     : EMPTY_PRICE_OVERRIDES
-  const isLoadingNewData = eventsToRender.length === 0
-    && (isPending || (isFetching && !isFetchingNextPage && (!data || data.pages.length === 0)))
 
-  useEffect(() => {
-    if (!parentRef.current || hydrationSafeEventsToRender.length === 0) {
+  return { stablePriceOverridesByMarket }
+}
+
+interface UseInfiniteScrollLoadMoreParams {
+  hasNextPage: boolean
+  fetchNextPage: () => Promise<unknown>
+  isFetching: boolean
+  isFetchingNextPage: boolean
+  loadMoreStateKey: string
+}
+
+function useInfiniteScrollLoadMore({
+  hasNextPage,
+  fetchNextPage,
+  isFetching,
+  isFetchingNextPage,
+  loadMoreStateKey,
+}: UseInfiniteScrollLoadMoreParams) {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+  const canRetryLoadMoreAfterErrorRef = useRef(true)
+  const previousLoadMoreStateKeyRef = useRef(loadMoreStateKey)
+  const [infiniteScrollErrorState, setInfiniteScrollErrorState] = useState<{
+    key: string
+    value: string | null
+  }>({
+    key: loadMoreStateKey,
+    value: null,
+  })
+  const infiniteScrollError = infiniteScrollErrorState.key === loadMoreStateKey
+    ? infiniteScrollErrorState.value
+    : null
+
+  useEffect(function resetLoadMoreRetryStateOnQueryScopeChange() {
+    if (previousLoadMoreStateKeyRef.current === loadMoreStateKey) {
       return
     }
 
-    const observedIds = new Set<string>()
-    const cardElements = Array.from(parentRef.current.querySelectorAll<HTMLElement>('[data-home-event-id]'))
+    previousLoadMoreStateKeyRef.current = loadMoreStateKey
+    canRetryLoadMoreAfterErrorRef.current = true
+  }, [loadMoreStateKey])
 
-    if (cardElements.length === 0) {
-      return
-    }
-
-    const observer = new IntersectionObserver((entries) => {
-      let hasChanges = false
-
-      entries.forEach((entry) => {
-        const eventId = entry.target.getAttribute('data-home-event-id')
-        if (!eventId) {
-          return
-        }
-
-        if (entry.isIntersecting) {
-          if (!observedIds.has(eventId)) {
-            observedIds.add(eventId)
-            hasChanges = true
-          }
-          return
-        }
-
-        if (observedIds.delete(eventId)) {
-          hasChanges = true
-        }
-      })
-
-      if (hasChanges) {
-        setLivePriceEventIds(Array.from(observedIds))
-      }
-    }, { rootMargin: HOME_LIVE_PRICE_OBSERVER_ROOT_MARGIN })
-
-    cardElements.forEach(element => observer.observe(element))
-
-    return () => observer.disconnect()
-  }, [hydrationSafeEventsToRender])
-
-  useEffect(() => {
+  useEffect(function observeLoadMoreSentinelForFetch() {
     if (!loadMoreRef.current || !hasNextPage) {
       return
     }
@@ -531,8 +474,178 @@ export default function HydratedEventsGrid({
     }, { rootMargin: '200px 0px' })
 
     observer.observe(loadMoreRef.current)
-    return () => observer.disconnect()
+    return function disconnectLoadMoreObserver() {
+      observer.disconnect()
+    }
   }, [fetchNextPage, hasNextPage, infiniteScrollError, isFetching, isFetchingNextPage, loadMoreStateKey])
+
+  return { loadMoreRef, infiniteScrollError }
+}
+
+export default function HydratedEventsGrid({
+  filters,
+  initialEvents = EMPTY_EVENTS,
+  initialCurrentTimestamp,
+  maxColumns,
+  onClearFilters,
+  routeMainTag,
+  routeTag,
+}: HydratedEventsGridProps) {
+  const locale = useLocale()
+  const user = useUser()
+  const queryUserScope = user?.id ?? 'guest'
+  const currentTimestamp = useCurrentTimestamp({
+    initialTimestamp: initialCurrentTimestamp,
+    intervalMs: HOME_FEED_REFRESH_INTERVAL_MS,
+  })
+  const hasHydrated = useHasHydrated()
+  const snapshotKey = [
+    locale,
+    routeMainTag,
+    routeTag,
+    filters.tag,
+    filters.mainTag,
+    filters.search,
+    filters.bookmarked ? 'bookmarked' : 'all-events',
+    queryUserScope,
+    filters.frequency,
+    filters.status,
+    filters.hideSports ? 'hide-sports' : 'show-sports',
+    filters.hideCrypto ? 'hide-crypto' : 'show-crypto',
+    filters.hideEarnings ? 'hide-earnings' : 'show-earnings',
+  ].join(':')
+  const isRouteInitialState = filters.tag === routeTag
+    && filters.mainTag === routeMainTag
+    && filters.search === ''
+    && !filters.bookmarked
+    && filters.frequency === 'all'
+    && filters.status === 'active'
+    && !filters.hideSports
+    && !filters.hideCrypto
+    && !filters.hideEarnings
+  const initialSnapshotEvents = isRouteInitialState ? initialEvents : EMPTY_EVENTS
+  const PAGE_SIZE = HOME_EVENTS_PAGE_SIZE
+  const shouldUseInitialData = isRouteInitialState
+    && initialEvents.length > 0
+    && queryUserScope === 'guest'
+  const shouldAutoRefreshEvents = filters.status === 'active'
+  const resolvedCurrentTimestamp = currentTimestamp ?? initialCurrentTimestamp
+  const queryRunKey = [
+    locale,
+    routeMainTag,
+    routeTag,
+    filters.tag,
+    filters.mainTag,
+    filters.search,
+    filters.bookmarked ? 'bookmarked' : 'all-events',
+    queryUserScope,
+    filters.frequency,
+    filters.status,
+    filters.hideSports ? 'hide-sports' : 'show-sports',
+    filters.hideCrypto ? 'hide-crypto' : 'show-crypto',
+    filters.hideEarnings ? 'hide-earnings' : 'show-earnings',
+  ].join(':')
+  const loadMoreStateKey = [
+    filters.tag,
+    filters.mainTag,
+    filters.search,
+    filters.bookmarked ? 'bookmarked' : 'all-events',
+    filters.frequency,
+    filters.status,
+    filters.hideSports ? 'hide-sports' : 'show-sports',
+    filters.hideCrypto ? 'hide-crypto' : 'show-crypto',
+    filters.hideEarnings ? 'hide-earnings' : 'show-earnings',
+    locale,
+    queryUserScope,
+  ].join(':')
+
+  const eventsQueryKey = [
+    'events',
+    filters.tag,
+    filters.mainTag,
+    filters.search,
+    filters.bookmarked,
+    filters.frequency,
+    filters.status,
+    filters.hideSports,
+    filters.hideCrypto,
+    filters.hideEarnings,
+    locale,
+    queryUserScope,
+  ]
+
+  const {
+    status,
+    data,
+    dataUpdatedAt,
+    isFetching,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+    isPending,
+    refetch,
+  } = useInfiniteQuery({
+    queryKey: eventsQueryKey,
+    queryFn: ({ pageParam }) => fetchEvents({
+      pageParam,
+      currentTimestamp: resolvedCurrentTimestamp,
+      filters,
+      locale,
+    }),
+    getNextPageParam: (lastPage, allPages) => lastPage.length === PAGE_SIZE ? allPages.length * PAGE_SIZE : undefined,
+    initialPageParam: 0,
+    initialData: shouldUseInitialData ? { pages: [initialEvents], pageParams: [0] } : undefined,
+    refetchOnMount: false,
+    refetchOnWindowFocus: false,
+    staleTime: 'static',
+    initialDataUpdatedAt: 0,
+    placeholderData: keepPreviousData,
+  })
+
+  useEventsRefetchOnTimestamp({
+    queryRunKey,
+    resolvedCurrentTimestamp,
+    status,
+    isFetching,
+    isFetchingNextPage,
+    refetch,
+    shouldAutoRefreshEvents,
+  })
+
+  const { allEvents, visibleEvents, cachedSnapshotEvents } = useHydratedEventsList({
+    data,
+    snapshotKey,
+    status,
+    initialSnapshotEvents,
+  })
+
+  const columns = useColumns(maxColumns)
+  const loadingMoreColumns = Math.max(1, columns)
+  const hasFreshQueryData = !shouldUseInitialData || dataUpdatedAt > 0
+  const shouldShowSnapshotFallback = visibleEvents.length === 0
+    && cachedSnapshotEvents.length > 0
+    && status !== 'success'
+  const eventsToRender = shouldShowSnapshotFallback ? cachedSnapshotEvents : visibleEvents
+  const hydrationSafeEventsToRender = !hasHydrated && isRouteInitialState
+    ? initialEvents
+    : eventsToRender
+
+  const { parentRef, livePriceEventIds } = useHomeLivePriceVisibility(hydrationSafeEventsToRender)
+  const { stablePriceOverridesByMarket } = useHomeLivePriceOverrides({
+    hydrationSafeEventsToRender,
+    livePriceEventIds,
+  })
+
+  const isLoadingNewData = eventsToRender.length === 0
+    && (isPending || (isFetching && !isFetchingNextPage && (!data || data.pages.length === 0)))
+
+  const { loadMoreRef, infiniteScrollError } = useInfiniteScrollLoadMore({
+    hasNextPage,
+    fetchNextPage,
+    isFetching,
+    isFetchingNextPage,
+    loadMoreStateKey,
+  })
 
   if (isLoadingNewData) {
     return (

--- a/src/app/[locale]/(platform)/(home)/_components/HydratedEventsGrid.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HydratedEventsGrid.tsx
@@ -5,7 +5,7 @@ import type { FilterState } from '@/app/[locale]/(platform)/_providers/FilterPro
 import type { Event } from '@/types'
 import { keepPreviousData, useInfiniteQuery } from '@tanstack/react-query'
 import { useLocale } from 'next-intl'
-import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import EventCardSkeleton from '@/app/[locale]/(platform)/(home)/_components/EventCardSkeleton'
 import EventsGridSkeleton from '@/app/[locale]/(platform)/(home)/_components/EventsGridSkeleton'
 import EventsStaticGrid from '@/app/[locale]/(platform)/(home)/_components/EventsStaticGrid'
@@ -16,6 +16,7 @@ import { buildMarketTargets } from '@/app/[locale]/(platform)/event/[slug]/_hook
 import { useColumns } from '@/hooks/useColumns'
 import { useCurrentTimestamp } from '@/hooks/useCurrentTimestamp'
 import { useDebounce } from '@/hooks/useDebounce'
+import { useHasHydrated } from '@/hooks/useHasHydrated'
 import { fetchEventsApi } from '@/lib/events-api'
 import { HOME_EVENTS_PAGE_SIZE, isHomeEventResolvedLike } from '@/lib/home-events'
 import { resolveDisplayPrice } from '@/lib/market-chance'
@@ -90,18 +91,6 @@ function setHydratedEventsSnapshot(key: string, events: Event[]) {
   }
 }
 
-function subscribeToHydrationStore() {
-  return function unsubscribeFromHydrationStore() {}
-}
-
-function getHydratedClientSnapshot() {
-  return true
-}
-
-function getHydratedServerSnapshot() {
-  return false
-}
-
 async function fetchEvents({
   pageParam = 0,
   currentTimestamp,
@@ -128,14 +117,6 @@ async function fetchEvents({
     hideCrypto: filters.hideCrypto,
     hideEarnings: filters.hideEarnings,
   })
-}
-
-function useHasHydrated() {
-  return useSyncExternalStore(
-    subscribeToHydrationStore,
-    getHydratedClientSnapshot,
-    getHydratedServerSnapshot,
-  )
 }
 
 interface UseEventsRefetchOnTimestampParams {

--- a/src/hooks/useHasHydrated.ts
+++ b/src/hooks/useHasHydrated.ts
@@ -1,0 +1,21 @@
+import { useSyncExternalStore } from 'react'
+
+function subscribeToHydrationStore() {
+  return function unsubscribeFromHydrationStore() {}
+}
+
+function getHydratedClientSnapshot() {
+  return true
+}
+
+function getHydratedServerSnapshot() {
+  return false
+}
+
+export function useHasHydrated() {
+  return useSyncExternalStore(
+    subscribeToHydrationStore,
+    getHydratedClientSnapshot,
+    getHydratedServerSnapshot,
+  )
+}


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855), moving from the event page (#866, #867, #868, #869, #870, #871) to the home page.

## Summary

### `HomeSecondaryNavigation`
- `useResolvedTagItems({ tag, activeSubtagSlug, t })` — the two `useMemo`s for `tagItems` and `resolvedActiveSubtagSlug`.
- `useTagNavigation({ tagItems, resolvedActiveSubtagSlug })` — owns the three refs (`scrollContainerRef`, `buttonRef`, `indicatorRetryRef`), the four pieces of UI state (`showLeftShadow`, `showRightShadow`, `indicatorStyle`, `indicatorReady`), the three callbacks, and the five layout/scroll/resize/active-tag effects.
- All five effects are named: `syncButtonRefArrayLength`, `repaintNavigationOnLayout`, `cancelPendingIndicatorRetryOnUnmount`, `reactNavigationToScrollAndResize`, `scrollActiveTagIntoView`. Cleanups are named too.

### `HydratedEventsGrid`
- `useHasHydrated` — wraps the `useSyncExternalStore` hydration probe.
- `useEventsRefetchOnTimestamp({ ... })` — owns `queryTimestampRef` and the two effects that keep the per-key timestamp ref in sync and trigger refetch when the active-feed window elapses (`syncQueryTimestampForCurrentQueryKey`, `refetchEventsWhenTimestampWindowElapses`).
- `useHydratedEventsList({ data, snapshotKey, status, initialSnapshotEvents })` — owns `allEvents` / `visibleEvents` / `cachedSnapshotEvents` and the snapshot persist/clear effects (`persistVisibleEventsSnapshot`, `clearStaleEventsSnapshotOnEmptySuccess`).
- `useHomeLivePriceVisibility(events)` — owns `parentRef`, `livePriceEventIds`, and the `IntersectionObserver` effect (`observeVisibleHomeEventCards`).
- `useHomeLivePriceOverrides({ ... })` — owns the four price-derivation `useMemo`s plus the `useEventMarketQuotes` / `useEventLastTrades` / `useDebounce` calls and exposes the stable overrides map.
- `useInfiniteScrollLoadMore({ ... })` — owns `loadMoreRef`, `canRetryLoadMoreAfterErrorRef`, `previousLoadMoreStateKeyRef`, the error state, and the two effects (`resetLoadMoreRetryStateOnQueryScopeChange`, `observeLoadMoreSentinelForFetch`).
- All effect cleanups are named (`disconnectHomeEventCardObserver`, `disconnectLoadMoreObserver`, etc.).

### Lint impact
- `HomeSecondaryNavigation`: 17 warnings → 0
- `HydratedEventsGrid`: 22 warnings → 0
- Combined: 39 warnings → 0

## Test plan

- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors the Home page navigation and events grid into focused hooks and extracts a shared `useHasHydrated` hook. This cleans up the components and removes 39 lint warnings.

- **Refactors**
  - `HomeSecondaryNavigation`: extracted `useResolvedTagItems` and `useTagNavigation`; named effect cleanups for scroll, resize, and indicator updates.
  - `HydratedEventsGrid`: extracted `useEventsRefetchOnTimestamp`, `useHydratedEventsList`, `useHomeLivePriceVisibility`, `useHomeLivePriceOverrides`, and `useInfiniteScrollLoadMore`; now imports shared `useHasHydrated` from `src/hooks/useHasHydrated`.
  - No behavior changes; improves readability, testability, and effect cleanup reliability.
  - Lint: `HomeSecondaryNavigation` (17→0), `HydratedEventsGrid` (22→0); combined 39→0.

<sup>Written for commit 2211d9fc340bdcc6780d47aab6a89732a13245a1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

