### PR TITLE
refactor: use custom hooks for sports page components

### DIFF
--- a/src/app/[locale]/(platform)/sports/_components/SportsClient.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsClient.tsx
@@ -19,6 +19,28 @@ interface SportsClientProps {
   sportsSection?: SportsSection | null
 }
 
+function useInitialTagFilterSync({
+  initialTag,
+  effectiveMainTag,
+  updateFilters,
+}: {
+  initialTag: string | undefined
+  effectiveMainTag: string
+  updateFilters: ReturnType<typeof useFilters>['updateFilters']
+}) {
+  const lastAppliedInitialTagRef = useRef<string | null>(null)
+
+  useEffect(function syncInitialTagToFilters() {
+    const targetTag = initialTag ?? 'sports'
+    if (lastAppliedInitialTagRef.current === targetTag) {
+      return
+    }
+
+    lastAppliedInitialTagRef.current = targetTag
+    updateFilters({ tag: targetTag, mainTag: effectiveMainTag })
+  }, [effectiveMainTag, initialTag, updateFilters])
+}
+
 export default function SportsClient({
   initialEvents,
   initialTag,
@@ -29,18 +51,9 @@ export default function SportsClient({
   sportsSection = null,
 }: SportsClientProps) {
   const { filters, updateFilters } = useFilters()
-  const lastAppliedInitialTagRef = useRef<string | null>(null)
   const effectiveMainTag = mainTag?.trim() || initialTag?.trim() || 'sports'
 
-  useEffect(() => {
-    const targetTag = initialTag ?? 'sports'
-    if (lastAppliedInitialTagRef.current === targetTag) {
-      return
-    }
-
-    lastAppliedInitialTagRef.current = targetTag
-    updateFilters({ tag: targetTag, mainTag: effectiveMainTag })
-  }, [effectiveMainTag, initialTag, updateFilters])
+  useInitialTagFilterSync({ initialTag, effectiveMainTag, updateFilters })
 
   return (
     <SportsEventsGrid

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventAboutPanel.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventAboutPanel.tsx
@@ -27,15 +27,17 @@ interface SportsEventAboutPanelProps {
   mode?: 'inline' | 'page'
 }
 
-export default function SportsEventAboutPanel({
+function useAboutPanelDerivations({
   event,
   rulesEvent,
   market,
-  marketContextEnabled = false,
-  mode = 'inline',
-}: SportsEventAboutPanelProps) {
-  const t = useExtracted()
-  const siteIdentity = useSiteIdentity()
+  siteIdentityName,
+}: {
+  event: SportsGamesCard['event']
+  rulesEvent?: SportsGamesCard['event'] | null
+  market: Market | null
+  siteIdentityName: string
+}) {
   const aboutRulesEvent = useMemo(() => {
     const sourceEvent = rulesEvent ?? event
     if (!market) {
@@ -60,16 +62,37 @@ export default function SportsEventAboutPanel({
       ],
     }
   }, [event, market, rulesEvent])
+
   const shouldShowResolution = useMemo(
     () => Boolean(market && shouldDisplayResolutionTimeline(market)),
     [market],
   )
+
   const resolutionDetailsUrl = useMemo(
     () => market
-      ? (buildUmaSettledUrl(market.condition, siteIdentity.name) ?? buildUmaProposeUrl(market.condition, siteIdentity.name))
+      ? (buildUmaSettledUrl(market.condition, siteIdentityName) ?? buildUmaProposeUrl(market.condition, siteIdentityName))
       : null,
-    [market, siteIdentity.name],
+    [market, siteIdentityName],
   )
+
+  return { aboutRulesEvent, shouldShowResolution, resolutionDetailsUrl }
+}
+
+export default function SportsEventAboutPanel({
+  event,
+  rulesEvent,
+  market,
+  marketContextEnabled = false,
+  mode = 'inline',
+}: SportsEventAboutPanelProps) {
+  const t = useExtracted()
+  const siteIdentity = useSiteIdentity()
+  const { aboutRulesEvent, shouldShowResolution, resolutionDetailsUrl } = useAboutPanelDerivations({
+    event,
+    rulesEvent,
+    market,
+    siteIdentityName: siteIdentity.name,
+  })
   const isInline = mode === 'inline'
 
   if (!isInline) {

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventsGrid.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventsGrid.tsx
@@ -128,24 +128,28 @@ async function fetchEvents({
   })
 }
 
-export default function SportsEventsGrid({
+function useSportsQueryScopeKey({
   eventTag,
   filters,
-  initialEvents = EMPTY_EVENTS,
-  initialMode = 'all',
+  locale,
   mainTag,
-  sportsVertical = null,
-  sportsSportSlug = null,
-  sportsSection = null,
-}: SportsEventsGridProps) {
-  const locale = useLocale()
-  const parentRef = useRef<HTMLDivElement | null>(null)
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
-  const user = useUser()
-  const userCacheKey = user?.id ?? 'guest'
-  const sportsMode: SportsSidebarMode = initialMode
-  const normalizedSportsSportSlug = sportsSportSlug?.trim().toLowerCase() || null
-  const queryScopeKey = useMemo(
+  sportsVertical,
+  normalizedSportsSportSlug,
+  sportsSection,
+  sportsMode,
+  userCacheKey,
+}: {
+  eventTag: string
+  filters: FilterState
+  locale: string
+  mainTag: string
+  sportsVertical: SportsVertical | null
+  normalizedSportsSportSlug: string | null
+  sportsSection: 'games' | 'props' | null
+  sportsMode: SportsSidebarMode
+  userCacheKey: string
+}) {
+  return useMemo(
     () => [
       filters.bookmarked,
       filters.frequency,
@@ -181,6 +185,192 @@ export default function SportsEventsGrid({
       userCacheKey,
     ],
   )
+}
+
+function useRefetchEventsOnUserChange({
+  userCacheKey,
+  refetch,
+}: {
+  userCacheKey: string
+  refetch: () => Promise<unknown>
+}) {
+  const previousUserKeyRef = useRef(userCacheKey)
+
+  useEffect(function refetchSportsEventsOnUserChange() {
+    if (previousUserKeyRef.current === userCacheKey) {
+      return
+    }
+
+    previousUserKeyRef.current = userCacheKey
+    void refetch()
+  }, [refetch, userCacheKey])
+}
+
+function useSportsVisibleEvents({
+  data,
+  filters,
+  currentTimestamp,
+  sportsMode,
+}: {
+  data: { pages: Event[][] } | undefined
+  filters: FilterState
+  currentTimestamp: number | null
+  sportsMode: SportsSidebarMode
+}) {
+  const allEvents = useMemo(() => (data ? data.pages.flat() : []), [data])
+
+  const filteredEvents = useMemo(() => {
+    if (!allEvents || allEvents.length === 0) {
+      return EMPTY_EVENTS
+    }
+
+    return filterHomeEvents(allEvents, {
+      currentTimestamp,
+      hideSports: filters.hideSports,
+      hideCrypto: filters.hideCrypto,
+      hideEarnings: filters.hideEarnings,
+      status: filters.status,
+    })
+  }, [allEvents, currentTimestamp, filters.hideSports, filters.hideCrypto, filters.hideEarnings, filters.status])
+
+  const visibleEvents = useMemo(() => {
+    if (sportsMode === 'all') {
+      return filteredEvents
+    }
+
+    if (currentTimestamp == null) {
+      return filteredEvents
+    }
+
+    if (sportsMode === 'live') {
+      return filteredEvents.filter(event => isEventLiveNow(event, currentTimestamp))
+    }
+
+    return filteredEvents.filter(event => isEventFuture(event, currentTimestamp))
+  }, [currentTimestamp, filteredEvents, sportsMode])
+
+  return { allEvents, visibleEvents }
+}
+
+function useSportsLivePriceOverrides(visibleEvents: Event[]) {
+  const marketTargets = useMemo(
+    () => visibleEvents.flatMap(event => buildMarketTargets(resolveSportsCardMarkets(event))),
+    [visibleEvents],
+  )
+  const marketQuotesByMarket = useEventMarketQuotes(marketTargets)
+  const lastTradesByMarket = useEventLastTrades(marketTargets)
+
+  const priceOverridesByMarket = useMemo(() => {
+    const strictPriceByMarket: Record<string, number> = {}
+    Object.keys({ ...marketQuotesByMarket, ...lastTradesByMarket }).forEach((conditionId) => {
+      const quote = marketQuotesByMarket[conditionId]
+      const lastTrade = lastTradesByMarket[conditionId]
+      const displayPrice = resolveDisplayPrice({
+        bid: quote?.bid ?? null,
+        ask: quote?.ask ?? null,
+        midpoint: quote?.mid ?? null,
+        lastTrade,
+        strictFallbacks: true,
+      })
+
+      if (displayPrice != null) {
+        strictPriceByMarket[conditionId] = displayPrice
+      }
+    })
+
+    const nextOverrides: Record<string, number> = {}
+    visibleEvents.forEach((event) => {
+      const displayMarkets = resolveSportsCardMarkets(event)
+      if (displayMarkets.length === 0) {
+        return
+      }
+
+      displayMarkets.forEach((market) => {
+        const displayPrice = strictPriceByMarket[market.condition_id]
+        if (displayPrice != null) {
+          nextOverrides[market.condition_id] = displayPrice
+        }
+      })
+    })
+
+    return nextOverrides
+  }, [lastTradesByMarket, marketQuotesByMarket, visibleEvents])
+
+  const priceOverrideSignature = useMemo(
+    () => Object.entries(priceOverridesByMarket)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([marketId, price]) => `${marketId}:${price}`)
+      .join('|'),
+    [priceOverridesByMarket],
+  )
+
+  const [stablePriceOverrideState, setStablePriceOverrideState] = useState<{
+    signature: string
+    overrides: Record<string, number>
+  }>({
+    signature: '',
+    overrides: EMPTY_PRICE_OVERRIDES,
+  })
+  const pendingPriceOverrideSignatureRef = useRef<string>('')
+  const priceOverrideCommitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(function commitStableSportsPriceOverrides() {
+    if (priceOverrideCommitTimeoutRef.current) {
+      clearTimeout(priceOverrideCommitTimeoutRef.current)
+      priceOverrideCommitTimeoutRef.current = null
+    }
+
+    if (!priceOverrideSignature) {
+      pendingPriceOverrideSignatureRef.current = ''
+      return
+    }
+
+    pendingPriceOverrideSignatureRef.current = priceOverrideSignature
+    const nextOverrides = priceOverridesByMarket
+    priceOverrideCommitTimeoutRef.current = setTimeout(() => {
+      if (pendingPriceOverrideSignatureRef.current !== priceOverrideSignature) {
+        return
+      }
+
+      setStablePriceOverrideState((current) => {
+        if (current.signature === priceOverrideSignature) {
+          return current
+        }
+
+        return {
+          signature: priceOverrideSignature,
+          overrides: nextOverrides,
+        }
+      })
+    }, SPORTS_LIVE_OVERRIDE_SETTLE_DELAY_MS)
+
+    return function cancelStablePriceOverridesCommit() {
+      if (priceOverrideCommitTimeoutRef.current) {
+        clearTimeout(priceOverrideCommitTimeoutRef.current)
+        priceOverrideCommitTimeoutRef.current = null
+      }
+    }
+  }, [priceOverrideSignature, priceOverridesByMarket])
+
+  const stablePriceOverridesByMarket = stablePriceOverrideState.signature === priceOverrideSignature
+    ? stablePriceOverrideState.overrides
+    : EMPTY_PRICE_OVERRIDES
+
+  return { stablePriceOverridesByMarket }
+}
+
+function useSportsInfiniteScrollSentinel({
+  queryScopeKey,
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+}: {
+  queryScopeKey: string
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  fetchNextPage: () => Promise<unknown>
+}) {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const [infiniteScrollErrorState, setInfiniteScrollErrorState] = useState<{ key: string, error: string | null }>({
     key: queryScopeKey,
     error: null,
@@ -193,6 +383,82 @@ export default function SportsEventsGrid({
     ? infiniteScrollErrorState.error
     : null
   const canRetryLoadMore = canRetryState.key === queryScopeKey ? canRetryState.canRetry : true
+
+  useEffect(function observeSportsLoadMoreSentinel() {
+    if (!loadMoreRef.current || !hasNextPage) {
+      return
+    }
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (!entry) {
+        return
+      }
+
+      if (!entry.isIntersecting) {
+        setCanRetryState({ key: queryScopeKey, canRetry: true })
+        return
+      }
+
+      if (isFetchingNextPage) {
+        return
+      }
+
+      if (infiniteScrollError) {
+        if (!canRetryLoadMore) {
+          return
+        }
+
+        setInfiniteScrollErrorState({ key: queryScopeKey, error: null })
+      }
+
+      fetchNextPage().catch((error: any) => {
+        if (error?.name === 'CanceledError' || error?.name === 'AbortError') {
+          return
+        }
+
+        setCanRetryState({ key: queryScopeKey, canRetry: false })
+        setInfiniteScrollErrorState({
+          key: queryScopeKey,
+          error: error?.message || 'Failed to load more events.',
+        })
+      })
+    }, { rootMargin: '200px 0px' })
+
+    observer.observe(loadMoreRef.current)
+    return function disconnectSportsLoadMoreObserver() {
+      observer.disconnect()
+    }
+  }, [canRetryLoadMore, fetchNextPage, hasNextPage, infiniteScrollError, isFetchingNextPage, queryScopeKey])
+
+  return { loadMoreRef, infiniteScrollError }
+}
+
+export default function SportsEventsGrid({
+  eventTag,
+  filters,
+  initialEvents = EMPTY_EVENTS,
+  initialMode = 'all',
+  mainTag,
+  sportsVertical = null,
+  sportsSportSlug = null,
+  sportsSection = null,
+}: SportsEventsGridProps) {
+  const locale = useLocale()
+  const user = useUser()
+  const userCacheKey = user?.id ?? 'guest'
+  const sportsMode: SportsSidebarMode = initialMode
+  const normalizedSportsSportSlug = sportsSportSlug?.trim().toLowerCase() || null
+  const queryScopeKey = useSportsQueryScopeKey({
+    eventTag,
+    filters,
+    locale,
+    mainTag,
+    sportsVertical,
+    normalizedSportsSportSlug,
+    sportsSection,
+    sportsMode,
+    userCacheKey,
+  })
   const currentTimestamp = useCurrentTimestamp({ intervalMs: 60_000 })
   const PAGE_SIZE = HOME_EVENTS_PAGE_SIZE
   const isDefaultState = filters.search === ''
@@ -251,112 +517,23 @@ export default function SportsEventsGrid({
     placeholderData: previousData => previousData,
   })
 
-  const previousUserKeyRef = useRef(userCacheKey)
-  const [stablePriceOverrideState, setStablePriceOverrideState] = useState<{
-    signature: string
-    overrides: Record<string, number>
-  }>({
-    signature: '',
-    overrides: EMPTY_PRICE_OVERRIDES,
+  useRefetchEventsOnUserChange({ userCacheKey, refetch })
+
+  const { allEvents, visibleEvents } = useSportsVisibleEvents({
+    data,
+    filters,
+    currentTimestamp,
+    sportsMode,
   })
-  const pendingPriceOverrideSignatureRef = useRef<string>('')
-  const priceOverrideCommitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
-  useEffect(() => {
-    if (previousUserKeyRef.current === userCacheKey) {
-      return
-    }
+  const { stablePriceOverridesByMarket } = useSportsLivePriceOverrides(visibleEvents)
 
-    previousUserKeyRef.current = userCacheKey
-    void refetch()
-  }, [refetch, userCacheKey])
-
-  const allEvents = useMemo(() => (data ? data.pages.flat() : []), [data])
-
-  const filteredEvents = useMemo(() => {
-    if (!allEvents || allEvents.length === 0) {
-      return EMPTY_EVENTS
-    }
-
-    return filterHomeEvents(allEvents, {
-      currentTimestamp,
-      hideSports: filters.hideSports,
-      hideCrypto: filters.hideCrypto,
-      hideEarnings: filters.hideEarnings,
-      status: filters.status,
-    })
-  }, [allEvents, currentTimestamp, filters.hideSports, filters.hideCrypto, filters.hideEarnings, filters.status])
-
-  const sportsBaseEvents = useMemo(() => {
-    return filteredEvents
-  }, [filteredEvents])
-  const sportsModeEvents = useMemo(() => {
-    if (sportsMode === 'all') {
-      return sportsBaseEvents
-    }
-
-    if (currentTimestamp == null) {
-      return sportsBaseEvents
-    }
-
-    if (sportsMode === 'live') {
-      return sportsBaseEvents.filter(event => isEventLiveNow(event, currentTimestamp))
-    }
-
-    return sportsBaseEvents.filter(event => isEventFuture(event, currentTimestamp))
-  }, [currentTimestamp, sportsBaseEvents, sportsMode])
-  const visibleEvents = sportsModeEvents
-  const marketTargets = useMemo(
-    () => visibleEvents.flatMap(event => buildMarketTargets(resolveSportsCardMarkets(event))),
-    [visibleEvents],
-  )
-  const marketQuotesByMarket = useEventMarketQuotes(marketTargets)
-  const lastTradesByMarket = useEventLastTrades(marketTargets)
-  const priceOverridesByMarket = useMemo(() => {
-    const strictPriceByMarket: Record<string, number> = {}
-    Object.keys({ ...marketQuotesByMarket, ...lastTradesByMarket }).forEach((conditionId) => {
-      const quote = marketQuotesByMarket[conditionId]
-      const lastTrade = lastTradesByMarket[conditionId]
-      const displayPrice = resolveDisplayPrice({
-        bid: quote?.bid ?? null,
-        ask: quote?.ask ?? null,
-        midpoint: quote?.mid ?? null,
-        lastTrade,
-        strictFallbacks: true,
-      })
-
-      if (displayPrice != null) {
-        strictPriceByMarket[conditionId] = displayPrice
-      }
-    })
-
-    const nextOverrides: Record<string, number> = {}
-    visibleEvents.forEach((event) => {
-      const displayMarkets = resolveSportsCardMarkets(event)
-      if (displayMarkets.length === 0) {
-        return
-      }
-
-      displayMarkets.forEach((market) => {
-        const displayPrice = strictPriceByMarket[market.condition_id]
-        if (displayPrice != null) {
-          nextOverrides[market.condition_id] = displayPrice
-        }
-      })
-    })
-
-    return nextOverrides
-  }, [lastTradesByMarket, marketQuotesByMarket, visibleEvents])
-  const priceOverrideSignature = useMemo(
-    () => Object.entries(priceOverridesByMarket)
-      .sort(([left], [right]) => left.localeCompare(right))
-      .map(([marketId, price]) => `${marketId}:${price}`)
-      .join('|'),
-    [priceOverridesByMarket],
-  )
-  const stablePriceOverridesByMarket = stablePriceOverrideState.signature === priceOverrideSignature
-    ? stablePriceOverrideState.overrides
-    : EMPTY_PRICE_OVERRIDES
+  const { loadMoreRef, infiniteScrollError } = useSportsInfiniteScrollSentinel({
+    queryScopeKey,
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  })
 
   const columns = useColumns()
   const activeColumns = columns >= 3 ? columns - 1 : columns
@@ -364,91 +541,9 @@ export default function SportsEventsGrid({
 
   const isLoadingNewData = isPending || (isFetching && !isFetchingNextPage && (!data || data.pages.length === 0))
 
-  useEffect(() => {
-    if (priceOverrideCommitTimeoutRef.current) {
-      clearTimeout(priceOverrideCommitTimeoutRef.current)
-      priceOverrideCommitTimeoutRef.current = null
-    }
-
-    if (!priceOverrideSignature) {
-      pendingPriceOverrideSignatureRef.current = ''
-      return
-    }
-
-    pendingPriceOverrideSignatureRef.current = priceOverrideSignature
-    const nextOverrides = priceOverridesByMarket
-    priceOverrideCommitTimeoutRef.current = setTimeout(() => {
-      if (pendingPriceOverrideSignatureRef.current !== priceOverrideSignature) {
-        return
-      }
-
-      setStablePriceOverrideState((current) => {
-        if (current.signature === priceOverrideSignature) {
-          return current
-        }
-
-        return {
-          signature: priceOverrideSignature,
-          overrides: nextOverrides,
-        }
-      })
-    }, SPORTS_LIVE_OVERRIDE_SETTLE_DELAY_MS)
-
-    return () => {
-      if (priceOverrideCommitTimeoutRef.current) {
-        clearTimeout(priceOverrideCommitTimeoutRef.current)
-        priceOverrideCommitTimeoutRef.current = null
-      }
-    }
-  }, [priceOverrideSignature, priceOverridesByMarket])
-
-  useEffect(() => {
-    if (!loadMoreRef.current || !hasNextPage) {
-      return
-    }
-
-    const observer = new IntersectionObserver(([entry]) => {
-      if (!entry) {
-        return
-      }
-
-      if (!entry.isIntersecting) {
-        setCanRetryState({ key: queryScopeKey, canRetry: true })
-        return
-      }
-
-      if (isFetchingNextPage) {
-        return
-      }
-
-      if (infiniteScrollError) {
-        if (!canRetryLoadMore) {
-          return
-        }
-
-        setInfiniteScrollErrorState({ key: queryScopeKey, error: null })
-      }
-
-      fetchNextPage().catch((error: any) => {
-        if (error?.name === 'CanceledError' || error?.name === 'AbortError') {
-          return
-        }
-
-        setCanRetryState({ key: queryScopeKey, canRetry: false })
-        setInfiniteScrollErrorState({
-          key: queryScopeKey,
-          error: error?.message || 'Failed to load more events.',
-        })
-      })
-    }, { rootMargin: '200px 0px' })
-
-    observer.observe(loadMoreRef.current)
-    return () => observer.disconnect()
-  }, [canRetryLoadMore, fetchNextPage, hasNextPage, infiniteScrollError, isFetchingNextPage, queryScopeKey])
-
   if (isLoadingNewData) {
     return (
-      <div ref={parentRef}>
+      <div>
         <EventsGridSkeleton />
       </div>
     )
@@ -464,17 +559,14 @@ export default function SportsEventsGrid({
 
   if (!visibleEvents || visibleEvents.length === 0) {
     return (
-      <div
-        ref={parentRef}
-        className="flex min-h-50 min-w-0 items-center justify-center text-sm text-muted-foreground"
-      >
+      <div className="flex min-h-50 min-w-0 items-center justify-center text-sm text-muted-foreground">
         No events match your filters.
       </div>
     )
   }
 
   return (
-    <div ref={parentRef} className="min-w-0 flex-1 space-y-3">
+    <div className="min-w-0 flex-1 space-y-3">
       <div
         className={cn('grid gap-3', { 'opacity-80': isFetching })}
         style={{

--- a/src/app/[locale]/(platform)/sports/_components/SportsLayoutShell.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsLayoutShell.tsx
@@ -166,19 +166,20 @@ function getSportsPathContext(params: {
   }
 }
 
-export default function SportsLayoutShell({
-  children,
-  vertical = 'sports',
-  sportsCountsBySlug = {},
+function useSportsPathContext({
+  vertical,
+  pathname,
   sportsMenuEntries,
   canonicalSlugByAliasKey,
   h1TitleBySlug,
-  sectionsBySlug,
-}: SportsLayoutShellProps) {
-  const pathname = usePathname()
-  const router = useRouter()
-  const verticalConfig = getSportsVerticalConfig(vertical)
-  const context = useMemo(
+}: {
+  vertical: SportsVertical
+  pathname: string
+  sportsMenuEntries: SportsMenuEntry[]
+  canonicalSlugByAliasKey: Record<string, string>
+  h1TitleBySlug: Record<string, string>
+}) {
+  return useMemo(
     () => getSportsPathContext({
       vertical,
       pathname,
@@ -188,33 +189,10 @@ export default function SportsLayoutShell({
     }),
     [vertical, pathname, sportsMenuEntries, canonicalSlugByAliasKey, h1TitleBySlug],
   )
+}
 
-  const sectionConfig = context.sportSlug ? sectionsBySlug[context.sportSlug] : null
-  const showSportSectionPills = context.mode === 'all'
-    && Boolean(context.sportSlug)
-    && !context.isEventRoute
-    && Boolean(sectionConfig?.gamesEnabled && sectionConfig?.propsEnabled)
-  const useIndependentColumns = context.mode === 'live'
-    || context.mode === 'soon'
-    || (
-      context.mode === 'all'
-      && (context.section === 'games' || context.isEventRoute)
-    )
-  const headerInsideGamesCenter = !context.isEventRoute
-    && (
-      context.mode === 'live'
-      || context.mode === 'soon'
-      || (context.mode === 'all' && context.section === 'games')
-    )
-  const showShellHeader = !headerInsideGamesCenter
-  const showTitle = Boolean(context.title) && !context.isEventRoute
-  const activeSection = context.section ?? 'games'
-  const shouldConstrainHeaderToCenterColumn = activeSection === 'games'
-  const centerColumnHeaderClass = shouldConstrainHeaderToCenterColumn
-    ? 'min-[1200px]:max-w-[calc(100%-22.75rem)]'
-    : ''
-
-  useEffect(() => {
+function useCenterPaneWheelRouting(useIndependentColumns: boolean) {
+  useEffect(function routeWheelToSportsCenterPane() {
     if (typeof window === 'undefined' || !useIndependentColumns) {
       return
     }
@@ -261,10 +239,58 @@ export default function SportsLayoutShell({
 
     window.addEventListener('wheel', handleWindowWheel, { passive: false })
 
-    return () => {
+    return function removeWheelRoutingListener() {
       window.removeEventListener('wheel', handleWindowWheel)
     }
   }, [useIndependentColumns])
+}
+
+export default function SportsLayoutShell({
+  children,
+  vertical = 'sports',
+  sportsCountsBySlug = {},
+  sportsMenuEntries,
+  canonicalSlugByAliasKey,
+  h1TitleBySlug,
+  sectionsBySlug,
+}: SportsLayoutShellProps) {
+  const pathname = usePathname()
+  const router = useRouter()
+  const verticalConfig = getSportsVerticalConfig(vertical)
+  const context = useSportsPathContext({
+    vertical,
+    pathname,
+    sportsMenuEntries,
+    canonicalSlugByAliasKey,
+    h1TitleBySlug,
+  })
+
+  const sectionConfig = context.sportSlug ? sectionsBySlug[context.sportSlug] : null
+  const showSportSectionPills = context.mode === 'all'
+    && Boolean(context.sportSlug)
+    && !context.isEventRoute
+    && Boolean(sectionConfig?.gamesEnabled && sectionConfig?.propsEnabled)
+  const useIndependentColumns = context.mode === 'live'
+    || context.mode === 'soon'
+    || (
+      context.mode === 'all'
+      && (context.section === 'games' || context.isEventRoute)
+    )
+  const headerInsideGamesCenter = !context.isEventRoute
+    && (
+      context.mode === 'live'
+      || context.mode === 'soon'
+      || (context.mode === 'all' && context.section === 'games')
+    )
+  const showShellHeader = !headerInsideGamesCenter
+  const showTitle = Boolean(context.title) && !context.isEventRoute
+  const activeSection = context.section ?? 'games'
+  const shouldConstrainHeaderToCenterColumn = activeSection === 'games'
+  const centerColumnHeaderClass = shouldConstrainHeaderToCenterColumn
+    ? 'min-[1200px]:max-w-[calc(100%-22.75rem)]'
+    : ''
+
+  useCenterPaneWheelRouting(useIndependentColumns)
 
   return (
     <main

--- a/src/app/[locale]/(platform)/sports/_components/SportsLivestreamFloatingPlayer.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsLivestreamFloatingPlayer.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { MutableRefObject } from 'react'
 import { ExternalLinkIcon, GripVerticalIcon, RadioIcon, XIcon } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { resolveLivestreamEmbedTarget } from '@/lib/livestream-embed'
@@ -33,10 +34,13 @@ function getViewportWidthServerSnapshot() {
   return 0
 }
 
-export default function SportsLivestreamFloatingPlayer() {
-  const streamUrl = useSportsLivestream(state => state.streamUrl)
-  const streamTitle = useSportsLivestream(state => state.streamTitle)
-  const closeStream = useSportsLivestream(state => state.closeStream)
+function useResizablePlayerWidth(): {
+  effectiveWidth: number
+  minWidth: number
+  maxWidth: number
+  setRequestedWidth: (value: number) => void
+  dragCleanupRef: MutableRefObject<(() => void) | null>
+} {
   const viewportWidth = useSyncExternalStore(
     subscribeToViewportWidth,
     getViewportWidthSnapshot,
@@ -67,20 +71,32 @@ export default function SportsLivestreamFloatingPlayer() {
 
   const effectiveWidth = useMemo(() => clamp(requestedWidth, minWidth, maxWidth), [maxWidth, minWidth, requestedWidth])
 
-  useEffect(() => {
-    function cleanupDragListenersOnUnmount() {
-      dragCleanupRef.current?.()
+  useEffect(function cleanupDragListenersOnUnmount() {
+    const cleanupRef = dragCleanupRef
+    return function runDragCleanupOnUnmount() {
+      cleanupRef.current?.()
     }
-    return cleanupDragListenersOnUnmount
   }, [])
 
-  const embedTarget = useMemo(() => {
+  return { effectiveWidth, minWidth, maxWidth, setRequestedWidth, dragCleanupRef }
+}
+
+function useLivestreamEmbedTarget(streamUrl: string | null) {
+  return useMemo(() => {
     if (!streamUrl) {
       return null
     }
     const parentDomain = typeof window !== 'undefined' ? window.location.hostname : null
     return resolveLivestreamEmbedTarget(streamUrl, { parentDomain })
   }, [streamUrl])
+}
+
+export default function SportsLivestreamFloatingPlayer() {
+  const streamUrl = useSportsLivestream(state => state.streamUrl)
+  const streamTitle = useSportsLivestream(state => state.streamTitle)
+  const closeStream = useSportsLivestream(state => state.closeStream)
+  const { effectiveWidth, minWidth, maxWidth, setRequestedWidth, dragCleanupRef } = useResizablePlayerWidth()
+  const embedTarget = useLivestreamEmbedTarget(streamUrl)
 
   if (!streamUrl || !embedTarget) {
     return null

--- a/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
@@ -137,24 +137,17 @@ function markConditionsAsClaimedInPositions<T extends {
   return hasChanges ? next : positions
 }
 
-export default function SportsRedeemModal({
-  open,
-  onOpenChange,
-  title,
-  subtitle,
+function useRedeemSelectionState({
   sections,
-  defaultSelectedSectionKey = null,
-  defaultSelectedConditionId = null,
-  onClaimSuccess,
-}: SportsRedeemModalProps) {
-  const isMobile = useIsMobile()
-  const user = useUser()
-  const queryClient = useQueryClient()
-  const { signMessageAsync } = useSignMessage()
-  const { runWithSignaturePrompt } = useSignaturePromptRunner()
-  const { ensureTradingReady, openTradeRequirements } = useTradingOnboarding()
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
+  defaultSelectedConditionId,
+  defaultSelectedSectionKey,
+  open,
+}: {
+  sections: SportsRedeemModalSection[]
+  defaultSelectedConditionId: string | null
+  defaultSelectedSectionKey: string | null
+  open: boolean
+}) {
   const normalizedSections = useMemo(() => {
     return sections
       .map(section => ({
@@ -220,11 +213,6 @@ export default function SportsRedeemModal({
     return selectedGroups.reduce((sum, group) => sum + resolveGroupAmount(group), 0)
   }, [selectedGroups])
 
-  const submitLabel = useMemo(
-    () => `Cash out ${formatCurrency(selectedAmount, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`,
-    [selectedAmount],
-  )
-
   function toggleConditionSelection(conditionId: string) {
     setSelectionState((current) => {
       const baseSelected = current.key === selectionStateKey
@@ -267,7 +255,35 @@ export default function SportsRedeemModal({
     })
   }
 
-  async function handleSubmit() {
+  return {
+    normalizedSections,
+    normalizedGroups,
+    selectedConditionIds,
+    expandedConditionIds,
+    selectedGroups,
+    selectedAmount,
+    toggleConditionSelection,
+    toggleConditionExpansion,
+  }
+}
+
+function useRedeemClaimSubmission({
+  selectedGroups,
+  onClaimSuccess,
+  onOpenChange,
+}: {
+  selectedGroups: SportsRedeemModalGroup[]
+  onClaimSuccess?: (conditionIds: string[]) => void
+  onOpenChange: (open: boolean) => void
+}) {
+  const user = useUser()
+  const queryClient = useQueryClient()
+  const { signMessageAsync } = useSignMessage()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
+  const { ensureTradingReady, openTradeRequirements } = useTradingOnboarding()
+  const [isSubmitting, setIsSubmitting] = useState(false)
+
+  async function submitClaim() {
     if (isSubmitting) {
       return
     }
@@ -398,6 +414,41 @@ export default function SportsRedeemModal({
     }
   }
 
+  return { isSubmitting, submitClaim }
+}
+
+export default function SportsRedeemModal({
+  open,
+  onOpenChange,
+  title,
+  subtitle,
+  sections,
+  defaultSelectedSectionKey = null,
+  defaultSelectedConditionId = null,
+  onClaimSuccess,
+}: SportsRedeemModalProps) {
+  const isMobile = useIsMobile()
+  const {
+    normalizedSections,
+    selectedConditionIds,
+    expandedConditionIds,
+    selectedGroups,
+    selectedAmount,
+    toggleConditionSelection,
+    toggleConditionExpansion,
+  } = useRedeemSelectionState({
+    sections,
+    defaultSelectedConditionId,
+    defaultSelectedSectionKey,
+    open,
+  })
+  const { isSubmitting, submitClaim } = useRedeemClaimSubmission({
+    selectedGroups,
+    onClaimSuccess,
+    onOpenChange,
+  })
+  const submitLabel = `Cash out ${formatCurrency(selectedAmount, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`
+
   const content = (
     <div className="grid gap-4">
       <header className="grid gap-1 text-left">
@@ -508,7 +559,7 @@ export default function SportsRedeemModal({
       <Button
         type="button"
         className="h-10 w-full"
-        onClick={() => void handleSubmit()}
+        onClick={() => void submitClaim()}
         disabled={isSubmitting || selectedAmount <= 0 || selectedGroups.length === 0}
       >
         {isSubmitting ? 'Submitting...' : submitLabel}


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855), moving from the home page (#872) to the sports page — focused on the small/medium files. The three huge sports files (`SportsEventCenter`, `SportsGamesCenter`, `SportsSidebarMenu`) and the admin, portfolio, profile, settings areas will come in their own PRs.

Follow-up to #866, #867, #868, #869, #870, #871, #872.

## Files changed (6)

| File | `use-encapsulation/prefer-custom-hooks` | Effects named |
|---|---|---|
| `SportsClient` | 2 → 0 | 1 (`syncInitialTagToFilters`) |
| `SportsEventAboutPanel` | 3 → 0 | — |
| `SportsLayoutShell` | 2 → 0 | 1 (`routeWheelToSportsCenterPane` + cleanup `removeWheelRoutingListener`) |
| `SportsLivestreamFloatingPlayer` | 8 → 0 | 1 (`cleanupDragListenersOnUnmount` + cleanup `runDragCleanupOnUnmount`) |
| `SportsRedeemModal` | 9 → 0 | — |
| `SportsEventsGrid` | 19 → 0 | 3 (`refetchSportsEventsOnUserChange`, `commitStableSportsPriceOverrides` + cleanup `cancelStablePriceOverridesCommit`, `observeSportsLoadMoreSentinel` + cleanup `disconnectSportsLoadMoreObserver`) |

**Total: 43 → 0 (100% reduction), 5 effects named (zero unnamed).**

## Extracted hooks (all file-local)

### `SportsClient`
- `useInitialTagFilterSync({ initialTag, effectiveMainTag, updateFilters })` — owns `lastAppliedInitialTagRef` + the named effect that writes the resolved tag to the filter store on mount / `initialTag` change.

### `SportsEventAboutPanel`
- `useAboutPanelDerivations({ event, rulesEvent, market, siteIdentityName })` — returns `{ aboutRulesEvent, shouldShowResolution, resolutionDetailsUrl }`.

### `SportsLayoutShell`
- `useSportsPathContext({ vertical, pathname, sportsMenuEntries, canonicalSlugByAliasKey, h1TitleBySlug })` — wraps the `getSportsPathContext` memo.
- `useCenterPaneWheelRouting(useIndependentColumns)` — owns the wheel-routing effect and its named cleanup.

### `SportsLivestreamFloatingPlayer`
- `useResizablePlayerWidth()` — owns `viewportWidth` (via `useSyncExternalStore`), `requestedWidth`, `dragCleanupRef`, and the `maxWidth` / `minWidth` / `effectiveWidth` memos plus the unmount cleanup effect.
- `useLivestreamEmbedTarget(streamUrl)` — wraps the embed target memo.

### `SportsRedeemModal`
- `useRedeemSelectionState({ sections, defaultSelectedConditionId, defaultSelectedSectionKey, open })` — owns all selection + expansion state, `normalizedSections` / `normalizedGroups` / `selectionStateKey` / `initialSelectedConditionIds`, plus `selectedGroups` / `selectedAmount` and the two toggle handlers.
- `useRedeemClaimSubmission({ selectedGroups, onClaimSuccess, onOpenChange })` — owns `isSubmitting` plus the full `submitClaim` pipeline (safe nonce → transactions → signature → optimistic cache writes → invalidations).

### `SportsEventsGrid`
- `useSportsQueryScopeKey({...})` — the combined query-scope key memo.
- `useRefetchEventsOnUserChange({ userCacheKey, refetch })` — named effect `refetchSportsEventsOnUserChange`.
- `useSportsVisibleEvents({ data, filters, currentTimestamp, sportsMode })` — returns `{ allEvents, visibleEvents }` after applying home-filter + sports mode (all/live/futures) pass.
- `useSportsLivePriceOverrides(visibleEvents)` — builds market targets, runs quotes + last-trade queries, computes the raw overrides map + signature, and owns the 2s settle-delay `commitStableSportsPriceOverrides` effect that debounces commits into `stablePriceOverridesByMarket`.
- `useSportsInfiniteScrollSentinel({ queryScopeKey, hasNextPage, isFetchingNextPage, fetchNextPage })` — owns `loadMoreRef`, the scoped `infiniteScrollErrorState` + `canRetryState` pair, and the named `observeSportsLoadMoreSentinel` effect.

Also removed a dead `parentRef` that was attached to JSX but never read.

## Kept inline (per the \"2–3 sec rule\")

- `SportsContent.tsx` — server component (`'use cache'`), 0 warnings, not touched.
- `SportsRedeemModal` submit label (single-line template string with `formatCurrency`).
- `SportsEventsGrid` column/page-size derivations, `isDefaultState`, `shouldUseInitialData`, `shouldAutoRefreshEvents` — direct boolean derivations from props/filters.
- All library/context hooks (`useUser`, `useLocale`, `useInfiniteQuery`, `useColumns`, `useCurrentTimestamp`, `useIsMobile`, `useSignMessage`, `useQueryClient`, `useFilters`, etc.).

## Not included (scoped out intentionally)

- `SportsEventCenter.tsx` (110 warnings, 162 KB) — own PR.
- `SportsGamesCenter.tsx` (119 warnings, 193 KB) — own PR.
- `SportsSidebarMenu.tsx` (11 warnings, 30 KB) — own PR.

These three are on your split-components follow-up list and each deserves focused extraction boundaries.

## Test plan

- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: sports vertical landing (all / live / futures), sports sport slug + games/props sections, initial-tag filter sync, resizable floating livestream player (drag + unmount), sports redeem modal (select + expand + submit), sports grid infinite scroll + live price overrides settle-delay, center-pane wheel routing on desktop

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored sports page components to extract stateful logic into custom hooks and name effects. This eliminates all `use-encapsulation/prefer-custom-hooks` warnings for small/medium files with no behavior changes.

- **Refactors**
  - Components covered: SportsClient, SportsEventAboutPanel, SportsLayoutShell, SportsLivestreamFloatingPlayer, SportsRedeemModal, SportsEventsGrid.
  - SportsEventsGrid: hooks for query scope key, refetch on user change, visible event filtering, debounced live price overrides with cleanup, and infinite-scroll sentinel with observer cleanup.
  - Layout/Client: hooks for sports path context, center-pane wheel routing, and initial tag-to-filter sync.
  - Livestream/Redeem: hooks for resizable player width and embed target; selection state and claim submission pipeline.
  - Effects: 5 effects named with explicit cleanups for wheel routing, drag listeners, price override debounce, and intersection observer.
  - Lint/cleanup: `use-encapsulation/prefer-custom-hooks` warnings 43 → 0; removed an unused parentRef.

<sup>Written for commit f5b6462f50997d8e547b99d2e42358274e1fb2c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

