### PR TITLE
refactor: use custom hooks for SportsSidebarMenu

### DIFF
--- a/src/app/[locale]/(platform)/sports/_components/SportsSidebarMenu.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsSidebarMenu.tsx
@@ -621,15 +621,13 @@ function SportsMenuLink({
   )
 }
 
-export default function SportsSidebarMenu({
+function useSidebarEntryDerivations({
   entries,
   vertical,
-  mode,
-  activeTagSlug,
-  countByTagSlug,
-  independentScroll = false,
-}: SportsSidebarMenuProps) {
-  const verticalConfig = getSportsVerticalConfig(vertical)
+}: {
+  entries: SportsMenuEntry[]
+  vertical: SportsVertical
+}) {
   const visibleEntries = useMemo(
     () => entries.filter((entry) => {
       return !(
@@ -639,23 +637,6 @@ export default function SportsSidebarMenu({
       )
     }),
     [entries, vertical],
-  )
-  const mobileQuickMenuContainerRef = useRef<HTMLDivElement | null>(null)
-  const [isMobileMoreMenuOpen, setIsMobileMoreMenuOpen] = useState(false)
-  const [mobileVisiblePrimaryLinkCount, setMobileVisiblePrimaryLinkCount] = useState(() => {
-    if (typeof window === 'undefined') {
-      return MOBILE_MENU_DEFAULT_VISIBLE_LINKS
-    }
-    return resolveMobileVisiblePrimaryLinkCount(window.innerWidth)
-  })
-  const [groupExpansionOverride, setGroupExpansionOverride] = useState<GroupExpansionOverride>(null)
-  const activeGroupId = useMemo(
-    () => findActiveGroupId(visibleEntries, activeTagSlug),
-    [activeTagSlug, visibleEntries],
-  )
-  const expandedGroupId = useMemo(
-    () => resolveExpandedGroupId(groupExpansionOverride, activeGroupId, visibleEntries),
-    [activeGroupId, groupExpansionOverride, visibleEntries],
   )
   const primaryTopLevelLinks = useMemo(
     () => visibleEntries.filter(isLinkEntry),
@@ -675,27 +656,54 @@ export default function SportsSidebarMenu({
     }),
     [visibleEntries],
   )
-  const mobileVisiblePrimaryLinks = useMemo(
-    () => primaryTopLevelLinks.slice(0, mobileVisiblePrimaryLinkCount),
-    [primaryTopLevelLinks, mobileVisiblePrimaryLinkCount],
+  return { visibleEntries, primaryTopLevelLinks, allMenuEntries }
+}
+
+function useSidebarGroupExpansion({
+  visibleEntries,
+  activeTagSlug,
+}: {
+  visibleEntries: SportsMenuEntry[]
+  activeTagSlug: string | null
+}) {
+  const [groupExpansionOverride, setGroupExpansionOverride] = useState<GroupExpansionOverride>(null)
+  const activeGroupId = useMemo(
+    () => findActiveGroupId(visibleEntries, activeTagSlug),
+    [activeTagSlug, visibleEntries],
   )
-  const mobileQuickNavColumnCount = Math.max(1, mobileVisiblePrimaryLinks.length + 1)
-  const hasVisibleActiveMobilePrimaryLink = mobileVisiblePrimaryLinks.some(entry => isMenuLinkActive({
-    entry,
-    vertical,
-    mode,
-    activeTagSlug,
-  }))
-  const isMobileMoreButtonActive = !hasVisibleActiveMobilePrimaryLink && allMenuEntries.some(entry =>
-    isMenuEntryActive({
-      entry,
-      vertical,
-      mode,
-      activeTagSlug,
-    }),
+  const expandedGroupId = useMemo(
+    () => resolveExpandedGroupId(groupExpansionOverride, activeGroupId, visibleEntries),
+    [activeGroupId, groupExpansionOverride, visibleEntries],
   )
 
-  useEffect(() => {
+  function toggleExpandedGroup(groupId: string) {
+    setGroupExpansionOverride((current) => {
+      const currentExpandedGroupId = resolveExpandedGroupId(current, activeGroupId, visibleEntries)
+      if (currentExpandedGroupId === groupId) {
+        return { type: 'none' }
+      }
+      return { type: 'group', groupId }
+    })
+  }
+
+  return { expandedGroupId, toggleExpandedGroup, setGroupExpansionOverride }
+}
+
+function useMobileQuickMenuSizing({
+  primaryTopLevelLinks,
+}: {
+  primaryTopLevelLinks: SportsMenuLinkEntry[]
+}) {
+  const mobileQuickMenuContainerRef = useRef<HTMLDivElement | null>(null)
+  const [isMobileMoreMenuOpen, setIsMobileMoreMenuOpen] = useState(false)
+  const [mobileVisiblePrimaryLinkCount, setMobileVisiblePrimaryLinkCount] = useState(() => {
+    if (typeof window === 'undefined') {
+      return MOBILE_MENU_DEFAULT_VISIBLE_LINKS
+    }
+    return resolveMobileVisiblePrimaryLinkCount(window.innerWidth)
+  })
+
+  useEffect(function observeMobileQuickMenuContainerWidth() {
     const container = mobileQuickMenuContainerRef.current
     if (!container) {
       return
@@ -718,7 +726,7 @@ export default function SportsSidebarMenu({
 
     if (typeof ResizeObserver === 'undefined') {
       window.addEventListener('resize', updateVisibleLinkCount)
-      return () => {
+      return function removeMobileQuickMenuResizeListener() {
         window.removeEventListener('resize', updateVisibleLinkCount)
       }
     }
@@ -726,20 +734,62 @@ export default function SportsSidebarMenu({
     const resizeObserver = new ResizeObserver(updateVisibleLinkCount)
     resizeObserver.observe(container)
 
-    return () => {
+    return function disconnectMobileQuickMenuResizeObserver() {
       resizeObserver.disconnect()
     }
   }, [])
 
-  function toggleExpandedGroup(groupId: string) {
-    setGroupExpansionOverride((current) => {
-      const currentExpandedGroupId = resolveExpandedGroupId(current, activeGroupId, visibleEntries)
-      if (currentExpandedGroupId === groupId) {
-        return { type: 'none' }
-      }
-      return { type: 'group', groupId }
-    })
+  const mobileVisiblePrimaryLinks = useMemo(
+    () => primaryTopLevelLinks.slice(0, mobileVisiblePrimaryLinkCount),
+    [primaryTopLevelLinks, mobileVisiblePrimaryLinkCount],
+  )
+
+  return {
+    mobileQuickMenuContainerRef,
+    mobileVisiblePrimaryLinks,
+    isMobileMoreMenuOpen,
+    setIsMobileMoreMenuOpen,
   }
+}
+
+export default function SportsSidebarMenu({
+  entries,
+  vertical,
+  mode,
+  activeTagSlug,
+  countByTagSlug,
+  independentScroll = false,
+}: SportsSidebarMenuProps) {
+  const verticalConfig = getSportsVerticalConfig(vertical)
+  const { visibleEntries, primaryTopLevelLinks, allMenuEntries } = useSidebarEntryDerivations({
+    entries,
+    vertical,
+  })
+  const { expandedGroupId, toggleExpandedGroup, setGroupExpansionOverride } = useSidebarGroupExpansion({
+    visibleEntries,
+    activeTagSlug,
+  })
+  const {
+    mobileQuickMenuContainerRef,
+    mobileVisiblePrimaryLinks,
+    isMobileMoreMenuOpen,
+    setIsMobileMoreMenuOpen,
+  } = useMobileQuickMenuSizing({ primaryTopLevelLinks })
+  const mobileQuickNavColumnCount = Math.max(1, mobileVisiblePrimaryLinks.length + 1)
+  const hasVisibleActiveMobilePrimaryLink = mobileVisiblePrimaryLinks.some(entry => isMenuLinkActive({
+    entry,
+    vertical,
+    mode,
+    activeTagSlug,
+  }))
+  const isMobileMoreButtonActive = !hasVisibleActiveMobilePrimaryLink && allMenuEntries.some(entry =>
+    isMenuEntryActive({
+      entry,
+      vertical,
+      mode,
+      activeTagSlug,
+    }),
+  )
 
   function renderDesktopMenuEntries(onActionComplete?: () => void) {
     return visibleEntries.map((entry) => {


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855) to `SportsSidebarMenu.tsx` — the last of the three large sports files on your split-components follow-up list. With this one merged, the whole sports area is clean.

Follow-up to #866, #867, #868, #869, #870, #871, #872, #873, #874, #875.

## Scope

Single file: `src/app/[locale]/(platform)/sports/_components/SportsSidebarMenu.tsx` (~1050 LOC).

**Lint impact:** `use-encapsulation/prefer-custom-hooks` on this file: **11 → 0 (100% reduction)**.

## Extracted hooks (all file-local)

- `useSidebarEntryDerivations({ entries, vertical })` — `visibleEntries` (future-route filter), `primaryTopLevelLinks`, `allMenuEntries`.
- `useSidebarGroupExpansion({ visibleEntries, activeTagSlug })` — owns `groupExpansionOverride`, returns `expandedGroupId`, `toggleExpandedGroup`, and the raw `setGroupExpansionOverride` setter (still needed for one inline onClick handler).
- `useMobileQuickMenuSizing({ primaryTopLevelLinks })` — owns `mobileQuickMenuContainerRef`, `mobileVisiblePrimaryLinkCount` state, `isMobileMoreMenuOpen` state, and the `ResizeObserver` effect (named `observeMobileQuickMenuContainerWidth` + named cleanups `removeMobileQuickMenuResizeListener` / `disconnectMobileQuickMenuResizeObserver`). Returns the ref, the sliced `mobileVisiblePrimaryLinks`, plus the mobile-more-menu open state.

No shared-hook candidates — the menu-entry filtering + mobile resize observer patterns are used only here.

## Kept inline (per the \"2–3 sec rule\")

- `mobileQuickNavColumnCount`, `hasVisibleActiveMobilePrimaryLink`, `isMobileMoreButtonActive` — direct single-line derivations from hook outputs a reader reads instantly.

## Test plan

- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: desktop + mobile sidebar navigation, active tag highlighting, group expand / collapse, mobile quick-menu slot count on resize (keyboard, small, medium, wide), more-menu drawer open / close, menu link counts per tag

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `SportsSidebarMenu` to use file-local custom hooks and named effects, simplifying state/effect logic and satisfying `use-encapsulation/prefer-custom-hooks`. Completes the rollout for the sports area with no behavior changes.

- **Refactors**
  - Extracted `useSidebarEntryDerivations` for `visibleEntries`, `primaryTopLevelLinks`, and `allMenuEntries`.
  - Added `useSidebarGroupExpansion` for `expandedGroupId` and `toggleExpandedGroup` (setter exposed for one inline handler).
  - Added `useMobileQuickMenuSizing` for the mobile quick menu ref, visible links, and open state, with a named `ResizeObserver` effect and cleanups.
  - Kept simple inline derivations: `mobileQuickNavColumnCount`, `hasVisibleActiveMobilePrimaryLink`, `isMobileMoreButtonActive`.
  - Scope: single file (`SportsSidebarMenu.tsx`); `use-encapsulation/prefer-custom-hooks` warnings reduced from 11 to 0.

<sup>Written for commit c26e9690e38b340a1eef2bebc74f98999914c11f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

