### PR TITLE
refactor: use custom hooks for portfolio components

### DIFF
--- a/src/app/[locale]/(platform)/portfolio/_components/PendingDepositBanner.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PendingDepositBanner.tsx
@@ -2,7 +2,7 @@
 
 import type { SafeOperationType } from '@/lib/safe/transactions'
 import { ArrowDownToLineIcon, CheckIcon, Loader2Icon } from 'lucide-react'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 import { hashTypedData } from 'viem'
 import { useSignMessage } from 'wagmi'
@@ -27,23 +27,10 @@ const CONFIRMATION_DELAY_MS = 900
 
 type PendingDepositStep = 'prompt' | 'signing' | 'success'
 
-export default function PendingDepositBanner() {
-  const { pendingBalance, hasPendingDeposit, refetchPendingDeposit } = usePendingUsdcDeposit()
-  const { signMessageAsync } = useSignMessage()
-  const { runWithSignaturePrompt } = useSignaturePromptRunner()
-  const router = useRouter()
-  const user = useUser()
-  const userAddress = user?.address ?? null
-  const userProxyWalletAddress = user?.proxy_wallet_address ?? null
-  const { openTradeRequirements } = useTradingOnboarding()
+function usePendingDepositDialogState() {
   const [open, setOpen] = useState(false)
   const [step, setStep] = useState<PendingDepositStep>('prompt')
   const [statusMessage, setStatusMessage] = useState<string | null>(null)
-
-  const formattedAmount = useMemo(() => formatCurrency(pendingBalance.raw, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }), [pendingBalance.raw])
 
   const resetDialogState = useCallback(() => {
     setStep('prompt')
@@ -69,6 +56,43 @@ export default function PendingDepositBanner() {
     closeDialog()
   }, [openDialog, closeDialog])
 
+  return {
+    open,
+    step,
+    setStep,
+    statusMessage,
+    setStatusMessage,
+    openDialog,
+    closeDialog,
+    handleOpenChange,
+  }
+}
+
+function usePendingDepositSwap({
+  step,
+  setStep,
+  setStatusMessage,
+  closeDialog,
+  userAddress,
+  userProxyWalletAddress,
+  pendingBalanceRawBase,
+  refetchPendingDeposit,
+  openTradeRequirements,
+  runWithSignaturePrompt,
+  signMessageAsync,
+}: {
+  step: PendingDepositStep
+  setStep: (step: PendingDepositStep) => void
+  setStatusMessage: (message: string | null) => void
+  closeDialog: () => void
+  userAddress: string | null
+  userProxyWalletAddress: string | null
+  pendingBalanceRawBase: string | null
+  refetchPendingDeposit: () => void
+  openTradeRequirements: ReturnType<typeof useTradingOnboarding>['openTradeRequirements']
+  runWithSignaturePrompt: ReturnType<typeof useSignaturePromptRunner>['runWithSignaturePrompt']
+  signMessageAsync: ReturnType<typeof useSignMessage>['signMessageAsync']
+}) {
   const handleConfirm = useCallback(async () => {
     if (step === 'signing') {
       return
@@ -84,7 +108,7 @@ export default function PendingDepositBanner() {
       return
     }
 
-    if (!pendingBalance.rawBase || pendingBalance.rawBase === '0') {
+    if (!pendingBalanceRawBase || pendingBalanceRawBase === '0') {
       toast.error('No pending deposit found.')
       return
     }
@@ -94,7 +118,7 @@ export default function PendingDepositBanner() {
 
     try {
       const buildResult = await buildPendingUsdcSwapAction({
-        amount: pendingBalance.rawBase,
+        amount: pendingBalanceRawBase,
       })
 
       if (buildResult.error || !buildResult.payload) {
@@ -169,21 +193,59 @@ export default function PendingDepositBanner() {
       setStep('prompt')
     }
   }, [
-    openTradeRequirements,
     closeDialog,
-    pendingBalance.rawBase,
+    openTradeRequirements,
+    pendingBalanceRawBase,
     refetchPendingDeposit,
     runWithSignaturePrompt,
+    setStatusMessage,
+    setStep,
     signMessageAsync,
     step,
     userAddress,
     userProxyWalletAddress,
   ])
 
-  const handleStartTrading = useCallback(() => {
-    closeDialog()
-    router.push('/')
-  }, [closeDialog, router])
+  return { handleConfirm }
+}
+
+export default function PendingDepositBanner() {
+  const { pendingBalance, hasPendingDeposit, refetchPendingDeposit } = usePendingUsdcDeposit()
+  const { signMessageAsync } = useSignMessage()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
+  const router = useRouter()
+  const user = useUser()
+  const userAddress = user?.address ?? null
+  const userProxyWalletAddress = user?.proxy_wallet_address ?? null
+  const { openTradeRequirements } = useTradingOnboarding()
+  const {
+    open,
+    step,
+    setStep,
+    statusMessage,
+    setStatusMessage,
+    openDialog,
+    closeDialog,
+    handleOpenChange,
+  } = usePendingDepositDialogState()
+  const { handleConfirm } = usePendingDepositSwap({
+    step,
+    setStep,
+    setStatusMessage,
+    closeDialog,
+    userAddress,
+    userProxyWalletAddress,
+    pendingBalanceRawBase: pendingBalance.rawBase,
+    refetchPendingDeposit,
+    openTradeRequirements,
+    runWithSignaturePrompt,
+    signMessageAsync,
+  })
+
+  const formattedAmount = formatCurrency(pendingBalance.raw, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
 
   if (!hasPendingDeposit) {
     return null
@@ -242,7 +304,13 @@ export default function PendingDepositBanner() {
           )}
 
           {step === 'success' && (
-            <Button className="mt-6 h-11 w-full text-base" onClick={handleStartTrading}>
+            <Button
+              className="mt-6 h-11 w-full text-base"
+              onClick={() => {
+                closeDialog()
+                router.push('/')
+              }}
+            >
               Start Trading
             </Button>
           )}

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
@@ -80,24 +80,9 @@ function formatSignedPercent(value: number, digits: number) {
   return `${sign}${formatted}`
 }
 
-export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarketsWonCardClientProps) {
-  const { summary, markets } = data
-  const [isDialogOpen, setIsDialogOpen] = useState(false)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-  const [isSharingOnX, setIsSharingOnX] = useState(false)
-  const [hiddenClaimSignature, setHiddenClaimSignature] = useState<string | null>(null)
-  const { ensureTradingReady, openTradeRequirements } = useTradingOnboarding()
-  const { signMessageAsync } = useSignMessage()
-  const { runWithSignaturePrompt } = useSignaturePromptRunner()
-  const queryClient = useQueryClient()
-  const user = useUser()
-  const router = useRouter()
-  const site = useSiteIdentity()
-
-  const siteName = site.name
+function useMarketsWonClaimSignature(markets: PortfolioClaimMarket[]) {
   const previewMarkets = useMemo(() => markets.slice(0, 3), [markets])
   const previewExtraCount = Math.max(0, markets.length - 3)
-
   const claimableSignature = useMemo(() => {
     const claimableMarkets = markets
       .filter(market => market.indexSets.length > 0)
@@ -111,12 +96,40 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
   }, [markets])
   const hasClaimableMarkets = claimableSignature.length > 0
 
+  return { previewMarkets, previewExtraCount, claimableSignature, hasClaimableMarkets }
+}
+
+function useMarketsWonDialogState() {
+  const [isDialogOpen, setIsDialogOpen] = useState(false)
+
   const handleDialogOpenChange = useCallback((nextOpen: boolean) => {
     setIsDialogOpen(nextOpen)
     if (nextOpen) {
       triggerConfetti('yes')
     }
   }, [])
+
+  return { isDialogOpen, setIsDialogOpen, handleDialogOpenChange }
+}
+
+function useMarketsWonClaimState() {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [hiddenClaimSignature, setHiddenClaimSignature] = useState<string | null>(null)
+  return { isSubmitting, setIsSubmitting, hiddenClaimSignature, setHiddenClaimSignature }
+}
+
+function useMarketsWonShareOnX({
+  siteName,
+  totalProceeds,
+  userUsername,
+  userProxyWalletAddress,
+}: {
+  siteName: string
+  totalProceeds: number
+  userUsername: string | null | undefined
+  userProxyWalletAddress: string | null | undefined
+}) {
+  const [isSharingOnX, setIsSharingOnX] = useState(false)
 
   const handleShareOnX = useCallback(() => {
     if (typeof window === 'undefined') {
@@ -125,12 +138,12 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
 
     setIsSharingOnX(true)
     try {
-      const profileSlug = user?.username?.trim() || user?.proxy_wallet_address?.trim() || ''
+      const profileSlug = userUsername?.trim() || userProxyWalletAddress?.trim() || ''
       const shareTargetUrl = profileSlug
         ? new URL(buildPublicProfilePath(profileSlug) ?? '/', window.location.origin).toString()
         : window.location.origin
       const shareText = [
-        `I just won ${formatCurrency(summary.totalProceeds)} on ${siteName}!`,
+        `I just won ${formatCurrency(totalProceeds)} on ${siteName}!`,
         '',
         'Join me and put your money where your mouth is:',
       ].join('\n')
@@ -144,7 +157,31 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
     finally {
       window.setTimeout(setIsSharingOnX, 200, false)
     }
-  }, [siteName, summary.totalProceeds, user?.proxy_wallet_address, user?.username])
+  }, [siteName, totalProceeds, userProxyWalletAddress, userUsername])
+
+  return { isSharingOnX, handleShareOnX }
+}
+
+export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarketsWonCardClientProps) {
+  const { summary, markets } = data
+  const { isSubmitting, setIsSubmitting, hiddenClaimSignature, setHiddenClaimSignature } = useMarketsWonClaimState()
+  const { ensureTradingReady, openTradeRequirements } = useTradingOnboarding()
+  const { signMessageAsync } = useSignMessage()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
+  const queryClient = useQueryClient()
+  const user = useUser()
+  const router = useRouter()
+  const site = useSiteIdentity()
+
+  const siteName = site.name
+  const { previewMarkets, previewExtraCount, claimableSignature, hasClaimableMarkets } = useMarketsWonClaimSignature(markets)
+  const { isDialogOpen, setIsDialogOpen, handleDialogOpenChange } = useMarketsWonDialogState()
+  const { isSharingOnX, handleShareOnX } = useMarketsWonShareOnX({
+    siteName,
+    totalProceeds: summary.totalProceeds,
+    userUsername: user?.username,
+    userProxyWalletAddress: user?.proxy_wallet_address,
+  })
 
   async function handleClaimAll() {
     if (isSubmitting) {

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import type { InfiniteData } from '@tanstack/react-query'
+import type { InfiniteData, QueryClient } from '@tanstack/react-query'
+import type { RefObject } from 'react'
 import type { PortfolioOpenOrdersSort, PortfolioUserOpenOrder } from '@/app/[locale]/(platform)/portfolio/_types/PortfolioOpenOrdersTypes'
 import type { UserOpenOrder } from '@/types'
 import { useQueryClient } from '@tanstack/react-query'
@@ -22,15 +23,10 @@ interface PortfolioOpenOrdersListProps {
   userAddress: string
 }
 
-export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOrdersListProps) {
-  const user = useUser()
-  const queryClient = useQueryClient()
-  const { openTradeRequirements } = useTradingOnboarding()
+function useOpenOrdersFilterState(userAddress: string) {
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebounce(searchQuery, 300)
   const [sortBy, setSortBy] = useState<PortfolioOpenOrdersSort>('market')
-  const [isCancellingAll, setIsCancellingAll] = useState(false)
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
   const apiSearchFilters = useMemo(
     () => resolveOpenOrdersSearchParams(debouncedSearchQuery),
     [debouncedSearchQuery],
@@ -43,28 +39,49 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
     [apiSearchKey, userAddress],
   )
 
-  const {
-    status,
-    data,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-  } = usePortfolioOpenOrdersQuery({
-    userAddress,
-    apiSearchKey,
+  return {
+    searchQuery,
+    setSearchQuery,
+    sortBy,
+    setSortBy,
     apiSearchFilters,
-  })
+    apiSearchKey,
+    openOrdersQueryKey,
+  }
+}
 
+function useVisibleOpenOrders({
+  data,
+  searchQuery,
+  sortBy,
+}: {
+  data: InfiniteData<{ data: PortfolioUserOpenOrder[], next_cursor: string }> | undefined
+  searchQuery: string
+  sortBy: PortfolioOpenOrdersSort
+}) {
   const orders = useMemo(() => data?.pages.flatMap(page => page.data) ?? [], [data?.pages])
   const visibleOrders = useMemo(() => {
     const filtered = orders.filter(order => matchesOpenOrdersSearchQuery(order, searchQuery))
     return sortOpenOrders(filtered, sortBy)
   }, [orders, searchQuery, sortBy])
-  const canCancelAll = Boolean(
-    user?.proxy_wallet_address
-    && userAddress
-    && user.proxy_wallet_address.toLowerCase() === userAddress.toLowerCase(),
-  )
+
+  return { orders, visibleOrders }
+}
+
+function useCancelAllOpenOrders({
+  userAddress,
+  orders,
+  queryClient,
+  openOrdersQueryKey,
+  openTradeRequirements,
+}: {
+  userAddress: string
+  orders: PortfolioUserOpenOrder[]
+  queryClient: QueryClient
+  openOrdersQueryKey: (string | undefined)[]
+  openTradeRequirements: ReturnType<typeof useTradingOnboarding>['openTradeRequirements']
+}) {
+  const [isCancellingAll, setIsCancellingAll] = useState(false)
 
   const removeOrdersFromCache = useCallback((orderIds: string[]) => {
     if (!orderIds.length) {
@@ -125,7 +142,21 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
     }
   }, [isCancellingAll, openTradeRequirements, orders.length, queryClient, removeOrdersFromCache, userAddress])
 
-  useEffect(() => {
+  return { isCancellingAll, handleCancelAll }
+}
+
+function useInfiniteScrollSentinel({
+  hasNextPage,
+  isFetchingNextPage,
+  fetchNextPage,
+}: {
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  fetchNextPage: () => Promise<unknown>
+}): { loadMoreRef: RefObject<HTMLDivElement | null> } {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(function observeLoadMoreSentinel() {
     if (!hasNextPage || !loadMoreRef.current) {
       return undefined
     }
@@ -138,8 +169,61 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
     }, { rootMargin: '200px' })
 
     observer.observe(loadMoreRef.current)
-    return () => observer.disconnect()
+    return function disconnectLoadMoreObserver() {
+      observer.disconnect()
+    }
   }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+
+  return { loadMoreRef }
+}
+
+export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOrdersListProps) {
+  const user = useUser()
+  const queryClient = useQueryClient()
+  const { openTradeRequirements } = useTradingOnboarding()
+  const {
+    searchQuery,
+    setSearchQuery,
+    sortBy,
+    setSortBy,
+    apiSearchFilters,
+    apiSearchKey,
+    openOrdersQueryKey,
+  } = useOpenOrdersFilterState(userAddress)
+
+  const {
+    status,
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+  } = usePortfolioOpenOrdersQuery({
+    userAddress,
+    apiSearchKey,
+    apiSearchFilters,
+  })
+
+  const { orders, visibleOrders } = useVisibleOpenOrders({ data, searchQuery, sortBy })
+
+  const canCancelAll = Boolean(
+    user?.proxy_wallet_address
+    && userAddress
+    && user.proxy_wallet_address.toLowerCase() === userAddress.toLowerCase(),
+  )
+
+  const { isCancellingAll, handleCancelAll } = useCancelAllOpenOrders({
+    userAddress,
+    orders,
+    queryClient,
+    openOrdersQueryKey,
+    openTradeRequirements,
+  })
+
+  const { loadMoreRef } = useInfiniteScrollSentinel({
+    hasNextPage,
+    isFetchingNextPage,
+    fetchNextPage,
+  })
 
   const emptyText = userAddress
     ? (searchQuery.trim() ? 'No open orders match your search.' : 'No open orders found.')

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioTabs.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioTabs.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { Route } from 'next'
+import type { ReadonlyURLSearchParams } from 'next/navigation'
 import { usePathname, useRouter, useSearchParams } from 'next/navigation'
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import PortfolioOpenOrdersList from '@/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList'
@@ -44,40 +45,38 @@ const baseTabs = [
   { id: 'history' as const, label: 'History' },
 ]
 
+type PortfolioTab = (typeof baseTabs)[number]
+
 interface PortfolioTabsProps {
   userAddress: string
 }
 
-export default function PortfolioTabs({ userAddress }: PortfolioTabsProps) {
-  const router = useRouter()
-  const pathname = usePathname()
-  const searchParams = useSearchParams()
+function useActiveTabWithQuerySync(searchParams: ReadonlyURLSearchParams) {
   const activeTabFromQuery = useMemo(
     () => resolveTabFromQueryValue(searchParams.get(TAB_QUERY_PARAM)),
     [searchParams],
   )
   const [activeTab, setActiveTab] = useState<TabType>(activeTabFromQuery)
-  const tabRef = useRef<(HTMLButtonElement | null)[]>([])
-  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 })
-  const [isInitialized, setIsInitialized] = useState(false)
-  const tabs = useMemo(() => baseTabs, [])
 
-  useEffect(() => {
+  useEffect(function syncActiveTabFromQuery() {
     setActiveTab(activeTabFromQuery)
   }, [activeTabFromQuery])
 
-  function handleTabChange(nextTab: TabType) {
-    setActiveTab(nextTab)
+  return { activeTab, setActiveTab }
+}
 
-    const nextParams = new URLSearchParams(searchParams.toString())
-    nextParams.set(TAB_QUERY_PARAM, tabQueryValueByTab[nextTab])
-    const nextQuery = nextParams.toString()
-    const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname
+function useTabIndicatorPosition({
+  tabs,
+  activeTab,
+}: {
+  tabs: PortfolioTab[]
+  activeTab: TabType
+}) {
+  const tabRef = useRef<(HTMLButtonElement | null)[]>([])
+  const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 })
+  const [isInitialized, setIsInitialized] = useState(false)
 
-    router.replace(nextUrl as Route, { scroll: false })
-  }
-
-  useLayoutEffect(() => {
+  useLayoutEffect(function positionActiveTabIndicator() {
     const activeTabIndex = tabs.findIndex(tab => tab.id === activeTab)
     const activeTabElement = tabRef.current[activeTabIndex]
 
@@ -95,6 +94,28 @@ export default function PortfolioTabs({ userAddress }: PortfolioTabsProps) {
       })
     }
   }, [activeTab, tabs])
+
+  return { tabRef, indicatorStyle, isInitialized }
+}
+
+export default function PortfolioTabs({ userAddress }: PortfolioTabsProps) {
+  const router = useRouter()
+  const pathname = usePathname()
+  const searchParams = useSearchParams()
+  const tabs = baseTabs
+  const { activeTab, setActiveTab } = useActiveTabWithQuerySync(searchParams)
+  const { tabRef, indicatorStyle, isInitialized } = useTabIndicatorPosition({ tabs, activeTab })
+
+  function handleTabChange(nextTab: TabType) {
+    setActiveTab(nextTab)
+
+    const nextParams = new URLSearchParams(searchParams.toString())
+    nextParams.set(TAB_QUERY_PARAM, tabQueryValueByTab[nextTab])
+    const nextQuery = nextParams.toString()
+    const nextUrl = nextQuery ? `${pathname}?${nextQuery}` : pathname
+
+    router.replace(nextUrl as Route, { scroll: false })
+  }
 
   return (
     <div className="overflow-hidden rounded-lg border">


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855) to the portfolio area.

Follow-up to #866, #867, #868, #869, #870, #871, #872, #873, #874, #875, #876.

## Files changed (4)

| File | `use-encapsulation/prefer-custom-hooks` | Effects named |
|---|---|---|
| `PortfolioTabs` | 8 → 0 | 2 (`syncActiveTabFromQuery`, `positionActiveTabIndicator` as layout effect) |
| `PendingDepositBanner` | 10 → 0 | — |
| `PortfolioOpenOrdersList` | 12 → 0 | 1 (`observeLoadMoreSentinel` + cleanup `disconnectLoadMoreObserver`) |
| `PortfolioMarketsWonCardClient` | 8 → 0 | — |

**Total: 38 → 0 (100% reduction), 3 effects all named.**

## Extracted hooks (all file-local)

### `PortfolioTabs`
- `useActiveTabWithQuerySync(searchParams)` — resolves the active tab from the URL query and owns the named effect that syncs state to URL updates.
- `useTabIndicatorPosition({ tabs, activeTab })` — owns `tabRef`, `indicatorStyle`, `isInitialized` and the named layout effect that positions the underline indicator.

Removed the trivial `useMemo(() => baseTabs, [])` — `baseTabs` is already a stable module-level constant; used directly.

### `PendingDepositBanner`
- `usePendingDepositDialogState()` — owns `open`, `step`, `statusMessage` and the `resetDialogState` / `openDialog` / `closeDialog` / `handleOpenChange` callbacks.
- `usePendingDepositSwap({...})` — owns the full safe-nonce → swap → signature → submit pipeline plus its status transitions.

Inlined the trivial `formattedAmount` currency derivation (`formatCurrency` is cheap), and inlined the one-liner `handleStartTrading` onto the success-state button's `onClick`.

### `PortfolioOpenOrdersList`
- `useOpenOrdersFilterState(userAddress)` — owns `searchQuery`/`sortBy` state, `useDebounce`, `apiSearchFilters`/`apiSearchKey` memos, and the derived `openOrdersQueryKey`.
- `useVisibleOpenOrders({ data, searchQuery, sortBy })` — returns `orders` and `visibleOrders`.
- `useCancelAllOpenOrders({...})` — owns `isCancellingAll` + `removeOrdersFromCache` + `handleCancelAll` with its cache pruning and invalidation logic.
- `useInfiniteScrollSentinel({ hasNextPage, isFetchingNextPage, fetchNextPage })` — owns `loadMoreRef` and the named `observeLoadMoreSentinel` effect + named cleanup.

### `PortfolioMarketsWonCardClient`
- `useMarketsWonClaimSignature(markets)` — `previewMarkets`, `previewExtraCount`, `claimableSignature`, `hasClaimableMarkets`.
- `useMarketsWonDialogState()` — `isDialogOpen`, `setIsDialogOpen`, `handleDialogOpenChange` (triggers confetti on open).
- `useMarketsWonShareOnX({ siteName, totalProceeds, userUsername, userProxyWalletAddress })` — `isSharingOnX` + `handleShareOnX`.
- `useMarketsWonClaimState()` — holds `isSubmitting` + `hiddenClaimSignature` (still consumed by the inline `handleClaimAll` submit pipeline).

No shared-hook candidates — none of the extracted patterns are currently duplicated in another file.

## Kept inline (per the \"2–3 sec rule\")

- `canCancelAll`, `emptyText`, `loading`, `shouldHideClaimCard`, `siteName` — single-line boolean / string derivations.

## Not included (scoped out intentionally)

- `PortfolioWalletActions`, `PortfolioOpenOrdersFilters`, `PortfolioOpenOrdersRow`, `PortfolioOpenOrdersTable`, `PortfolioMarketsWonCard` — already 0 warnings, no changes needed.

## Test plan

- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: portfolio tabs positions / open orders / history switching via URL query, pending deposit dialog prompt / signing / success, swap transaction flow, portfolio open orders search + sort + infinite scroll + cancel-all flow, markets-won claim dialog + share-on-X + claim-all flow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored portfolio components to use small, file-local hooks and named effects, removing all remaining `use-encapsulation/prefer-custom-hooks` warnings. No UI or API changes.

- **Refactors**
  - Eliminated 38 → 0 `use-encapsulation/prefer-custom-hooks` warnings; named 3 effects for clarity.
  - Extracted hooks per component to own state/effects:
    - Tabs: active tab sync from query; underline indicator positioning.
    - Pending deposit: dialog state; swap/sign/submit flow.
    - Open orders: filter/sort state; visible list; cancel-all logic; infinite-scroll sentinel.
    - Markets won: claim signature; dialog state; share on X; claim state.
  - Minor cleanups: removed unnecessary memos; inlined trivial derivations and handlers.

<sup>Written for commit 528f10920a6471ff996bb87b862d1e16837791d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

