### PR TITLE
refactor: use custom hooks for public profile components

### DIFF
--- a/src/app/[locale]/(platform)/profile/_components/PublicActivityList.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicActivityList.tsx
@@ -218,6 +218,13 @@ export default function PublicActivityList({ userAddress }: PublicActivityListPr
       isLoadingMore: true,
     })
     fetchNextPage()
+      .then(() => {
+        setLoadMoreState({
+          key: loadMoreScopeKey,
+          infiniteScrollError: null,
+          isLoadingMore: false,
+        })
+      })
       .catch((error) => {
         if (error.name !== 'AbortError') {
           setLoadMoreState({
@@ -225,9 +232,8 @@ export default function PublicActivityList({ userAddress }: PublicActivityListPr
             infiniteScrollError: error.message || 'Failed to load more activity.',
             isLoadingMore: false,
           })
+          return
         }
-      })
-      .finally(() => {
         setLoadMoreState({
           key: loadMoreScopeKey,
           infiniteScrollError: null,

--- a/src/app/[locale]/(platform)/profile/_components/PublicActivityList.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicActivityList.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { RefObject } from 'react'
 import type { ActivitySort, ActivityTypeFilter } from '@/app/[locale]/(platform)/profile/_types/PublicActivityTypes'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { usePublicActivityQuery } from '@/app/[locale]/(platform)/profile/_hooks/usePublicActivityQuery'
@@ -12,42 +13,37 @@ interface PublicActivityListProps {
   userAddress: string
 }
 
-export default function PublicActivityList({ userAddress }: PublicActivityListProps) {
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+type PublicActivityItem = ReturnType<typeof usePublicActivityQuery>['data'] extends infer T
+  ? T extends { pages: (infer P)[] }
+    ? P extends (infer Item)[] ? Item : never
+    : never
+  : never
+
+interface LoadMoreState {
+  key: string
+  infiniteScrollError: string | null
+  isLoadingMore: boolean
+}
+
+function usePublicActivityFilters() {
   const [searchQuery, setSearchQuery] = useState('')
   const [typeFilter, setTypeFilter] = useState<ActivityTypeFilter>('all')
   const [sortFilter, setSortFilter] = useState<ActivitySort>('newest')
-  const loadMoreScopeKey = `${userAddress}:${searchQuery}:${typeFilter}:${sortFilter}`
-  const [loadMoreState, setLoadMoreState] = useState<{
-    key: string
-    infiniteScrollError: string | null
-    isLoadingMore: boolean
-  }>({
-    key: loadMoreScopeKey,
-    infiniteScrollError: null,
-    isLoadingMore: false,
-  })
-  const scopedLoadMoreState = loadMoreState.key === loadMoreScopeKey
-    ? loadMoreState
-    : {
-        key: loadMoreScopeKey,
-        infiniteScrollError: null,
-        isLoadingMore: false,
-      }
-  const infiniteScrollError = scopedLoadMoreState.infiniteScrollError
-  const isLoadingMore = scopedLoadMoreState.isLoadingMore
-  const site = useSiteIdentity()
 
-  const {
-    status,
-    data,
-    fetchNextPage,
-    hasNextPage,
-    isFetchingNextPage,
-    refetch,
-  } = usePublicActivityQuery({ userAddress, typeFilter, sortFilter })
+  return { searchQuery, setSearchQuery, typeFilter, setTypeFilter, sortFilter, setSortFilter }
+}
 
-  const hasUserAddress = Boolean(userAddress)
+function useVisibleActivities({
+  data,
+  searchQuery,
+  typeFilter,
+  sortFilter,
+}: {
+  data: ReturnType<typeof usePublicActivityQuery>['data']
+  searchQuery: string
+  typeFilter: ActivityTypeFilter
+  sortFilter: ActivitySort
+}) {
   const activities = useMemo(
     () => data?.pages.flat() ?? [],
     [data?.pages],
@@ -74,27 +70,50 @@ export default function PublicActivityList({ userAddress }: PublicActivityListPr
     return sorted
   }, [activities, searchQuery, sortFilter, typeFilter])
 
-  const isLoading = hasUserAddress && status === 'pending'
-  const hasError = hasUserAddress && status === 'error'
-  function handleExportCsv() {
-    if (visibleActivities.length === 0) {
-      return
-    }
+  return { activities, visibleActivities }
+}
 
-    const siteName = site.name
-    const { csvContent, filename } = buildActivityCsv(visibleActivities, siteName)
-    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
-    const url = URL.createObjectURL(blob)
-    const link = document.createElement('a')
-    link.href = url
-    link.download = filename
-    document.body.appendChild(link)
-    link.click()
-    link.remove()
-    URL.revokeObjectURL(url)
+function useLoadMoreScopedState(loadMoreScopeKey: string) {
+  const [loadMoreState, setLoadMoreState] = useState<LoadMoreState>({
+    key: loadMoreScopeKey,
+    infiniteScrollError: null,
+    isLoadingMore: false,
+  })
+  const scopedLoadMoreState = loadMoreState.key === loadMoreScopeKey
+    ? loadMoreState
+    : {
+        key: loadMoreScopeKey,
+        infiniteScrollError: null,
+        isLoadingMore: false,
+      }
+
+  return {
+    infiniteScrollError: scopedLoadMoreState.infiniteScrollError,
+    isLoadingMore: scopedLoadMoreState.isLoadingMore,
+    setLoadMoreState,
   }
+}
 
-  useEffect(() => {
+function useActivityInfiniteScrollSentinel({
+  hasNextPage,
+  isFetchingNextPage,
+  isLoadingMore,
+  infiniteScrollError,
+  fetchNextPage,
+  loadMoreScopeKey,
+  setLoadMoreState,
+}: {
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  isLoadingMore: boolean
+  infiniteScrollError: string | null
+  fetchNextPage: () => Promise<unknown>
+  loadMoreScopeKey: string
+  setLoadMoreState: (state: LoadMoreState) => void
+}): { loadMoreRef: RefObject<HTMLDivElement | null> } {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(function observeActivityLoadMoreSentinel() {
     if (!hasNextPage || !loadMoreRef.current) {
       return undefined
     }
@@ -135,8 +154,87 @@ export default function PublicActivityList({ userAddress }: PublicActivityListPr
 
     observer.observe(loadMoreRef.current)
 
-    return () => observer.disconnect()
-  }, [fetchNextPage, hasNextPage, infiniteScrollError, isFetchingNextPage, isLoadingMore, loadMoreScopeKey])
+    return function disconnectActivityLoadMoreObserver() {
+      observer.disconnect()
+    }
+  }, [fetchNextPage, hasNextPage, infiniteScrollError, isFetchingNextPage, isLoadingMore, loadMoreScopeKey, setLoadMoreState])
+
+  return { loadMoreRef }
+}
+
+export default function PublicActivityList({ userAddress }: PublicActivityListProps) {
+  const { searchQuery, setSearchQuery, typeFilter, setTypeFilter, sortFilter, setSortFilter } = usePublicActivityFilters()
+  const loadMoreScopeKey = `${userAddress}:${searchQuery}:${typeFilter}:${sortFilter}`
+  const { infiniteScrollError, isLoadingMore, setLoadMoreState } = useLoadMoreScopedState(loadMoreScopeKey)
+  const site = useSiteIdentity()
+
+  const {
+    status,
+    data,
+    fetchNextPage,
+    hasNextPage,
+    isFetchingNextPage,
+    refetch,
+  } = usePublicActivityQuery({ userAddress, typeFilter, sortFilter })
+
+  const hasUserAddress = Boolean(userAddress)
+  const { visibleActivities } = useVisibleActivities({ data, searchQuery, typeFilter, sortFilter })
+
+  const { loadMoreRef } = useActivityInfiniteScrollSentinel({
+    hasNextPage,
+    isFetchingNextPage,
+    isLoadingMore,
+    infiniteScrollError,
+    fetchNextPage,
+    loadMoreScopeKey,
+    setLoadMoreState,
+  })
+
+  const isLoading = hasUserAddress && status === 'pending'
+  const hasError = hasUserAddress && status === 'error'
+
+  function handleExportCsv() {
+    if (visibleActivities.length === 0) {
+      return
+    }
+
+    const siteName = site.name
+    const { csvContent, filename } = buildActivityCsv(visibleActivities as PublicActivityItem[], siteName)
+    const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' })
+    const url = URL.createObjectURL(blob)
+    const link = document.createElement('a')
+    link.href = url
+    link.download = filename
+    document.body.appendChild(link)
+    link.click()
+    link.remove()
+    URL.revokeObjectURL(url)
+  }
+
+  function handleRetryLoadMore() {
+    setLoadMoreState({
+      key: loadMoreScopeKey,
+      infiniteScrollError: null,
+      isLoadingMore: true,
+    })
+    fetchNextPage()
+      .catch((error) => {
+        if (error.name !== 'AbortError') {
+          setLoadMoreState({
+            key: loadMoreScopeKey,
+            infiniteScrollError: error.message || 'Failed to load more activity.',
+            isLoadingMore: false,
+          })
+        }
+      })
+      .finally(() => {
+        setLoadMoreState({
+          key: loadMoreScopeKey,
+          infiniteScrollError: null,
+          isLoadingMore: false,
+        })
+      })
+  }
 
   return (
     <div className="space-y-3 pb-0">
@@ -159,30 +257,7 @@ export default function PublicActivityList({ userAddress }: PublicActivityListPr
         isFetchingNextPage={isFetchingNextPage}
         isLoadingMore={isLoadingMore}
         infiniteScrollError={infiniteScrollError}
-        onRetryLoadMore={() => {
-          setLoadMoreState({
-            key: loadMoreScopeKey,
-            infiniteScrollError: null,
-            isLoadingMore: true,
-          })
-          fetchNextPage()
-            .catch((error) => {
-              if (error.name !== 'AbortError') {
-                setLoadMoreState({
-                  key: loadMoreScopeKey,
-                  infiniteScrollError: error.message || 'Failed to load more activity.',
-                  isLoadingMore: false,
-                })
-              }
-            })
-            .finally(() => {
-              setLoadMoreState(previous => ({
-                key: loadMoreScopeKey,
-                infiniteScrollError: previous.key === loadMoreScopeKey ? previous.infiniteScrollError : null,
-                isLoadingMore: false,
-              }))
-            })
-        }}
+        onRetryLoadMore={handleRetryLoadMore}
         loadMoreRef={loadMoreRef}
       />
     </div>

--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
@@ -1,10 +1,12 @@
 'use client'
 
-import type { InfiniteData } from '@tanstack/react-query'
+import type { InfiniteData, QueryClient } from '@tanstack/react-query'
+import type { RefObject } from 'react'
 import type { MergeableMarket } from './MergePositionsDialog'
 import type { PublicPosition } from './PublicPositionItem'
 import type { SortDirection, SortOption } from '@/app/[locale]/(platform)/profile/_types/PublicPositionsTypes'
 import type { NormalizedBookLevel } from '@/lib/order-panel-utils'
+import type { User } from '@/types'
 import { useAppKitAccount } from '@reown/appkit/react'
 import { useQueryClient } from '@tanstack/react-query'
 import { useRouter } from 'next/navigation'
@@ -48,29 +50,46 @@ interface PublicPositionsListProps {
   userAddress: string
 }
 
-export default function PublicPositionsList({ userAddress }: PublicPositionsListProps) {
-  const queryClient = useQueryClient()
-  const router = useRouter()
-  const { open } = useAppKit()
-  const { isConnected } = useAppKitAccount()
-  const { signTypedDataAsync } = useSignTypedData()
-  const { runWithSignaturePrompt } = useSignaturePromptRunner()
-  const { ensureTradingReady, openTradeRequirements } = useTradingOnboarding()
-  const affiliateMetadata = useAffiliateOrderMetadata()
+interface SellModalPayload {
+  position: PublicPosition
+  shares: number
+  filledShares: number | null
+  avgPriceCents: number | null
+  receiveAmount: number | null
+  sellBids: NormalizedBookLevel[]
+  tokenId: string | null
+  isNegRisk: boolean
+}
+
+interface LoadMoreStateValue {
+  key: string
+  infiniteScrollError: string | null
+  isLoadingMore: boolean
+}
+
+function useUserTradingContext(userAddress: string) {
   const user = useUser()
-  const { signMessageAsync } = useSignMessage()
   const hasDeployedProxyWallet = Boolean(user?.proxy_wallet_address && user?.proxy_wallet_status === 'deployed')
   const proxyWalletAddress = hasDeployedProxyWallet ? normalizeAddress(user?.proxy_wallet_address) : null
   const userAddressNormalized = normalizeAddress(user?.address)
   const makerAddress = proxyWalletAddress ?? null
-  const signatureType = proxyWalletAddress ? 2 : 0
+  const signatureType: 0 | 2 = proxyWalletAddress ? 2 : 0
   const canSell = Boolean(
     hasDeployedProxyWallet
     && user?.proxy_wallet_address
     && user.proxy_wallet_address.toLowerCase() === userAddress.toLowerCase(),
   )
 
-  const marketStatusFilter: 'active' | 'closed' = 'active'
+  return {
+    user,
+    userAddressNormalized,
+    makerAddress,
+    signatureType,
+    canSell,
+  }
+}
+
+function useSearchAndSortState(userAddress: string) {
   const [searchQueryState, setSearchQueryState] = useState<{ key: string, value: string }>({
     key: userAddress,
     value: '',
@@ -79,70 +98,6 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
   const debouncedSearchQuery = useDebounce(searchQuery, 300)
   const [sortBy, setSortBy] = useState<SortOption>('currentValue')
   const [sortDirection, setSortDirection] = useState<SortDirection>(() => getDefaultSortDirection('currentValue'))
-  const minAmountFilter = 'All'
-  const loadMoreScopeKey = `${userAddress}:${debouncedSearchQuery}:${minAmountFilter}:${marketStatusFilter}:${sortBy}:${sortDirection}`
-  const [loadMoreState, setLoadMoreState] = useState<{
-    key: string
-    infiniteScrollError: string | null
-    isLoadingMore: boolean
-  }>({
-    key: loadMoreScopeKey,
-    infiniteScrollError: null,
-    isLoadingMore: false,
-  })
-  const scopedLoadMoreState = loadMoreState.key === loadMoreScopeKey
-    ? loadMoreState
-    : {
-        key: loadMoreScopeKey,
-        infiniteScrollError: null,
-        isLoadingMore: false,
-      }
-  const infiniteScrollError = scopedLoadMoreState.infiniteScrollError
-  const isLoadingMore = scopedLoadMoreState.isLoadingMore
-  const [retryCountState, setRetryCountState] = useState<{ key: string, value: number }>({
-    key: userAddress,
-    value: 0,
-  })
-  const retryCount = retryCountState.key === userAddress ? retryCountState.value : 0
-  const [isMergeDialogOpen, setIsMergeDialogOpen] = useState(false)
-  const [mergeSuccess, setMergeSuccess] = useState(false)
-  const [hideMergeButtonState, setHideMergeButtonState] = useState<{ key: string, value: boolean }>({
-    key: userAddress,
-    value: false,
-  })
-  const hideMergeButton = hideMergeButtonState.key === userAddress ? hideMergeButtonState.value : false
-  const [isShareDialogOpen, setIsShareDialogOpen] = useState(false)
-  const [sharePosition, setSharePosition] = useState<PublicPosition | null>(null)
-  const [availableMergeableMarketsState, setAvailableMergeableMarketsState] = useState<{
-    key: string
-    markets: MergeableMarket[]
-  }>({
-    key: 'inactive',
-    markets: [],
-  })
-  const [sellModalPayload, setSellModalPayload] = useState<{
-    position: PublicPosition
-    shares: number
-    filledShares: number | null
-    avgPriceCents: number | null
-    receiveAmount: number | null
-    sellBids: NormalizedBookLevel[]
-    tokenId: string | null
-    isNegRisk: boolean
-  } | null>(null)
-  const [isCashOutSubmitting, setIsCashOutSubmitting] = useState(false)
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
-  const sellRequestIdRef = useRef(0)
-
-  const handleSearchChange = useCallback((query: string) => {
-    setLoadMoreState({
-      key: loadMoreScopeKey,
-      infiniteScrollError: null,
-      isLoadingMore: false,
-    })
-    setRetryCountState({ key: userAddress, value: 0 })
-    setSearchQueryState({ key: userAddress, value: query })
-  }, [loadMoreScopeKey, userAddress])
 
   const handleSortChange = useCallback((value: SortOption) => {
     setSortBy(value)
@@ -161,22 +116,165 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
     })
   }, [])
 
-  const {
-    status,
-    data,
-    isFetchingNextPage,
-    fetchNextPage,
-    hasNextPage,
-    refetch,
-  } = usePublicPositionsQuery({
-    userAddress,
-    status: marketStatusFilter,
-    minAmountFilter,
+  return {
+    searchQuery,
+    debouncedSearchQuery,
     sortBy,
     sortDirection,
-    searchQuery: debouncedSearchQuery,
-  })
+    setSearchQueryState,
+    handleSortChange,
+    handleHeaderSortToggle,
+  }
+}
 
+function useLoadMoreState(loadMoreScopeKey: string) {
+  const [loadMoreState, setLoadMoreState] = useState<LoadMoreStateValue>({
+    key: loadMoreScopeKey,
+    infiniteScrollError: null,
+    isLoadingMore: false,
+  })
+  const scopedLoadMoreState = loadMoreState.key === loadMoreScopeKey
+    ? loadMoreState
+    : {
+        key: loadMoreScopeKey,
+        infiniteScrollError: null,
+        isLoadingMore: false,
+      }
+
+  return {
+    infiniteScrollError: scopedLoadMoreState.infiniteScrollError,
+    isLoadingMore: scopedLoadMoreState.isLoadingMore,
+    setLoadMoreState,
+  }
+}
+
+function useRetryCountState(userAddress: string) {
+  const [retryCountState, setRetryCountState] = useState<{ key: string, value: number }>({
+    key: userAddress,
+    value: 0,
+  })
+  const retryCount = retryCountState.key === userAddress ? retryCountState.value : 0
+
+  return { retryCount, setRetryCountState }
+}
+
+function useSearchChangeHandler({
+  userAddress,
+  loadMoreScopeKey,
+  setLoadMoreState,
+  setRetryCountState,
+  setSearchQueryState,
+}: {
+  userAddress: string
+  loadMoreScopeKey: string
+  setLoadMoreState: (value: LoadMoreStateValue) => void
+  setRetryCountState: (value: { key: string, value: number }) => void
+  setSearchQueryState: (value: { key: string, value: string }) => void
+}) {
+  return useCallback((query: string) => {
+    setLoadMoreState({
+      key: loadMoreScopeKey,
+      infiniteScrollError: null,
+      isLoadingMore: false,
+    })
+    setRetryCountState({ key: userAddress, value: 0 })
+    setSearchQueryState({ key: userAddress, value: query })
+  }, [loadMoreScopeKey, setLoadMoreState, setRetryCountState, setSearchQueryState, userAddress])
+}
+
+function useMergeButtonVisibility(userAddress: string) {
+  const [hideMergeButtonState, setHideMergeButtonState] = useState<{ key: string, value: boolean }>({
+    key: userAddress,
+    value: false,
+  })
+  const hideMergeButton = hideMergeButtonState.key === userAddress ? hideMergeButtonState.value : false
+
+  return { hideMergeButton, setHideMergeButtonState }
+}
+
+function useShareDialog() {
+  const [isShareDialogOpen, setIsShareDialogOpen] = useState(false)
+  const [sharePosition, setSharePosition] = useState<PublicPosition | null>(null)
+
+  const handleShareOpenChange = useCallback((open: boolean) => {
+    setIsShareDialogOpen(open)
+    if (!open) {
+      setSharePosition(null)
+    }
+  }, [])
+
+  const handleShareClick = useCallback((position: PublicPosition) => {
+    setSharePosition(position)
+    setIsShareDialogOpen(true)
+  }, [])
+
+  return {
+    isShareDialogOpen,
+    sharePosition,
+    handleShareOpenChange,
+    handleShareClick,
+  }
+}
+
+function useShareCardPayload({
+  sharePosition,
+  user,
+}: {
+  sharePosition: PublicPosition | null
+  user: User | null
+}) {
+  return useMemo(() => {
+    if (!sharePosition) {
+      return null
+    }
+
+    return buildShareCardPayload(sharePosition, {
+      userName: user?.username || undefined,
+      userImage: user?.image || undefined,
+    })
+  }, [sharePosition, user?.image, user?.username])
+}
+
+function useMergeDialog({
+  userAddress,
+  setHideMergeButtonState,
+}: {
+  userAddress: string
+  setHideMergeButtonState: (value: { key: string, value: boolean }) => void
+}) {
+  const [isMergeDialogOpen, setIsMergeDialogOpen] = useState(false)
+  const [mergeSuccess, setMergeSuccess] = useState(false)
+
+  const handleMergeDialogChange = useCallback((open: boolean) => {
+    setIsMergeDialogOpen(open)
+    if (!open) {
+      if (mergeSuccess) {
+        setHideMergeButtonState({ key: userAddress, value: true })
+      }
+      setMergeSuccess(false)
+    }
+  }, [mergeSuccess, setHideMergeButtonState, userAddress])
+
+  return {
+    isMergeDialogOpen,
+    setIsMergeDialogOpen,
+    mergeSuccess,
+    setMergeSuccess,
+    handleMergeDialogChange,
+  }
+}
+
+function usePositionsDerivations({
+  data,
+  debouncedSearchQuery,
+  sortBy,
+  sortDirection,
+}: {
+  data: InfiniteData<PublicPosition[]> | undefined
+  debouncedSearchQuery: string
+  sortBy: SortOption
+  sortDirection: SortDirection
+}) {
   const positions = useMemo(
     () =>
       (data?.pages.flat() ?? []).filter(
@@ -229,15 +327,31 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
     [sortBy, sortDirection, visiblePositions],
   )
 
-  const hasUserAddress = Boolean(userAddress)
-  const loading = hasUserAddress && status === 'pending'
-  const hasInitialError = hasUserAddress && status === 'error'
+  const totals = useMemo(
+    () => calculatePositionsTotals(visiblePositions),
+    [visiblePositions],
+  )
 
-  const isSearchActive = debouncedSearchQuery.trim().length > 0
+  return {
+    positionsWithIcons,
+    visiblePositions,
+    sortedPositions,
+    totals,
+  }
+}
+
+function useMergeableMarketsAvailability({
+  canSell,
+  positionsWithIcons,
+}: {
+  canSell: boolean
+  positionsWithIcons: PublicPosition[]
+}) {
   const mergeableMarkets = useMemo(
     () => buildMergeableMarkets(positionsWithIcons),
     [positionsWithIcons],
   )
+
   const positionsByCondition = useMemo(() => {
     const map: Record<string, Record<string, number>> = {}
 
@@ -262,6 +376,7 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
 
     return map
   }, [positionsWithIcons])
+
   const mergeableScopeKey = useMemo(() => {
     if (!canSell || mergeableMarkets.length === 0) {
       return 'inactive'
@@ -278,15 +393,23 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
 
     return `${marketsKey}::${lockedSharesKey}`
   }, [canSell, mergeableMarkets, positionsByCondition])
+
+  const [availableMergeableMarketsState, setAvailableMergeableMarketsState] = useState<{
+    key: string
+    markets: MergeableMarket[]
+  }>({
+    key: 'inactive',
+    markets: [],
+  })
   const availableMergeableMarkets = availableMergeableMarketsState.key === mergeableScopeKey
     ? availableMergeableMarketsState.markets
     : []
 
-  useEffect(() => {
+  useEffect(function resolveAvailableMergeableMarkets() {
     let cancelled = false
 
     if (!canSell || mergeableMarkets.length === 0) {
-      return () => {
+      return function cancelAvailabilityLookup() {
         cancelled = true
       }
     }
@@ -350,59 +473,144 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
         })
       })
 
-    return () => {
+    return function cancelAvailabilityLookup() {
       cancelled = true
     }
   }, [canSell, mergeableMarkets, positionsByCondition, mergeableScopeKey])
 
-  const hasMergeableMarkets = availableMergeableMarkets.length > 0
-
-  const { isMergeProcessing, mergeBatchCount, handleMergeAll } = useMergePositionsAction({
-    mergeableMarkets: availableMergeableMarkets,
+  return {
     positionsByCondition,
-    hasMergeableMarkets,
-    user,
-    ensureTradingReady,
-    openTradeRequirements,
-    queryClient,
-    signMessageAsync,
-    onSuccess: () => setMergeSuccess(true),
-  })
+    availableMergeableMarkets,
+  }
+}
 
-  const handleMergeDialogChange = useCallback((open: boolean) => {
-    setIsMergeDialogOpen(open)
-    if (!open) {
-      if (mergeSuccess) {
-        setHideMergeButtonState({ key: userAddress, value: true })
+function useScrollToTopOnFilterChange({
+  debouncedSearchQuery,
+  minAmountFilter,
+  marketStatusFilter,
+  sortBy,
+  sortDirection,
+}: {
+  debouncedSearchQuery: string
+  minAmountFilter: string
+  marketStatusFilter: string
+  sortBy: SortOption
+  sortDirection: SortDirection
+}) {
+  useEffect(function scrollToTopOnFilterChange() {
+    if (typeof window !== 'undefined') {
+      window.scrollTo({ top: 0, behavior: 'smooth' })
+    }
+  }, [debouncedSearchQuery, minAmountFilter, marketStatusFilter, sortBy, sortDirection])
+}
+
+function useInfiniteScrollSentinel({
+  hasNextPage,
+  isFetchingNextPage,
+  isLoadingMore,
+  infiniteScrollError,
+  fetchNextPage,
+  loadMoreScopeKey,
+  userAddress,
+  setLoadMoreState,
+  setRetryCountState,
+}: {
+  hasNextPage: boolean
+  isFetchingNextPage: boolean
+  isLoadingMore: boolean
+  infiniteScrollError: string | null
+  fetchNextPage: () => Promise<unknown>
+  loadMoreScopeKey: string
+  userAddress: string
+  setLoadMoreState: (value: LoadMoreStateValue) => void
+  setRetryCountState: (value: { key: string, value: number }) => void
+}): { loadMoreRef: RefObject<HTMLDivElement | null> } {
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(function observeLoadMoreSentinel() {
+    if (!hasNextPage || !loadMoreRef.current) {
+      return undefined
+    }
+
+    const observer = new IntersectionObserver((entries) => {
+      const [entry] = entries
+      if (entry?.isIntersecting && !isFetchingNextPage && !isLoadingMore && !infiniteScrollError) {
+        setLoadMoreState({
+          key: loadMoreScopeKey,
+          infiniteScrollError: null,
+          isLoadingMore: true,
+        })
+        fetchNextPage()
+          .then(() => {
+            setLoadMoreState({
+              key: loadMoreScopeKey,
+              infiniteScrollError: null,
+              isLoadingMore: false,
+            })
+            setRetryCountState({ key: userAddress, value: 0 })
+          })
+          .catch((error) => {
+            if (error.name !== 'AbortError') {
+              setLoadMoreState({
+                key: loadMoreScopeKey,
+                infiniteScrollError: error.message || 'Failed to load more positions',
+                isLoadingMore: false,
+              })
+              return
+            }
+            setLoadMoreState({
+              key: loadMoreScopeKey,
+              infiniteScrollError: null,
+              isLoadingMore: false,
+            })
+          })
       }
-      setMergeSuccess(false)
-    }
-  }, [mergeSuccess, userAddress])
+    }, { rootMargin: '200px' })
 
-  const shareCardPayload = useMemo(() => {
-    if (!sharePosition) {
-      return null
-    }
+    observer.observe(loadMoreRef.current)
 
-    return buildShareCardPayload(sharePosition, {
-      userName: user?.username || undefined,
-      userImage: user?.image || undefined,
+    return function disconnectLoadMoreObserver() {
+      observer.disconnect()
+    }
+  }, [fetchNextPage, hasNextPage, infiniteScrollError, isFetchingNextPage, isLoadingMore, loadMoreScopeKey, setLoadMoreState, setRetryCountState, userAddress])
+
+  return { loadMoreRef }
+}
+
+function useRetryInitialLoad({
+  userAddress,
+  loadMoreScopeKey,
+  retryCount,
+  refetch,
+  setRetryCountState,
+  setLoadMoreState,
+}: {
+  userAddress: string
+  loadMoreScopeKey: string
+  retryCount: number
+  refetch: () => Promise<unknown>
+  setRetryCountState: (value: { key: string, value: number }) => void
+  setLoadMoreState: (value: LoadMoreStateValue) => void
+}) {
+  return useCallback(() => {
+    const currentRetryCount = retryCount + 1
+    setRetryCountState({ key: userAddress, value: currentRetryCount })
+    setLoadMoreState({
+      key: loadMoreScopeKey,
+      infiniteScrollError: null,
+      isLoadingMore: false,
     })
-  }, [sharePosition, user?.image, user?.username])
 
-  const handleShareOpenChange = useCallback((open: boolean) => {
-    setIsShareDialogOpen(open)
-    if (!open) {
-      setSharePosition(null)
-    }
-  }, [])
+    const delay = Math.min(1000 * 2 ** (currentRetryCount - 1), 8000)
 
-  const handleShareClick = useCallback((position: PublicPosition) => {
-    setSharePosition(position)
-    setIsShareDialogOpen(true)
-  }, [])
+    setTimeout(() => {
+      void refetch()
+    }, delay)
+  }, [loadMoreScopeKey, refetch, retryCount, setLoadMoreState, setRetryCountState, userAddress])
+}
 
-  const resolveOutcomeIndex = useCallback((position: PublicPosition) => {
+function useResolveOutcomeIndex() {
+  return useCallback((position: PublicPosition) => {
     if (typeof position.outcomeIndex === 'number') {
       return position.outcomeIndex
     }
@@ -411,6 +619,44 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
       ? OUTCOME_INDEX.NO
       : OUTCOME_INDEX.YES
   }, [])
+}
+
+function useSellPositionFlow({
+  userAddress,
+  userAddressNormalized,
+  makerAddress,
+  signatureType,
+  user,
+  isConnected,
+  openWalletModal,
+  queryClient,
+  router,
+  affiliateMetadata,
+  ensureTradingReady,
+  openTradeRequirements,
+  runWithSignaturePrompt,
+  signTypedDataAsync,
+  resolveOutcomeIndex,
+}: {
+  userAddress: string
+  userAddressNormalized: `0x${string}` | null
+  makerAddress: `0x${string}` | null
+  signatureType: 0 | 2
+  user: User | null
+  isConnected: boolean
+  openWalletModal: ReturnType<typeof useAppKit>['open']
+  queryClient: QueryClient
+  router: ReturnType<typeof useRouter>
+  affiliateMetadata: ReturnType<typeof useAffiliateOrderMetadata>
+  ensureTradingReady: () => boolean
+  openTradeRequirements: (options?: { forceTradingAuth?: boolean }) => void
+  runWithSignaturePrompt: ReturnType<typeof useSignaturePromptRunner>['runWithSignaturePrompt']
+  signTypedDataAsync: ReturnType<typeof useSignTypedData>['signTypedDataAsync']
+  resolveOutcomeIndex: (position: PublicPosition) => number
+}) {
+  const [sellModalPayload, setSellModalPayload] = useState<SellModalPayload | null>(null)
+  const [isCashOutSubmitting, setIsCashOutSubmitting] = useState(false)
+  const sellRequestIdRef = useRef(0)
 
   const handleSellClick = useCallback(async (position: PublicPosition) => {
     const shares = typeof position.size === 'number' ? position.size : 0
@@ -574,12 +820,12 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
     }
 
     if (!isConnected) {
-      handleValidationError('NOT_CONNECTED', { openWalletModal: open })
+      handleValidationError('NOT_CONNECTED', { openWalletModal })
       return
     }
 
     if (!user) {
-      handleValidationError('MISSING_USER', { openWalletModal: open })
+      handleValidationError('MISSING_USER', { openWalletModal })
       return
     }
 
@@ -731,7 +977,7 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
     isCashOutSubmitting,
     isConnected,
     makerAddress,
-    open,
+    openWalletModal,
     queryClient,
     resolveOutcomeIndex,
     runWithSignaturePrompt,
@@ -743,77 +989,183 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
     userAddressNormalized,
   ])
 
-  useEffect(() => {
-    if (typeof window !== 'undefined') {
-      window.scrollTo({ top: 0, behavior: 'smooth' })
-    }
-  }, [debouncedSearchQuery, minAmountFilter, marketStatusFilter, sortBy, sortDirection])
+  return {
+    sellModalPayload,
+    handleSellClick,
+    handleSellModalChange,
+    handleEditOrder,
+    handleCashOut,
+  }
+}
 
-  useEffect(() => {
-    if (!hasNextPage || !loadMoreRef.current) {
-      return undefined
-    }
+export default function PublicPositionsList({ userAddress }: PublicPositionsListProps) {
+  const queryClient = useQueryClient()
+  const router = useRouter()
+  const { open } = useAppKit()
+  const { isConnected } = useAppKitAccount()
+  const { signTypedDataAsync } = useSignTypedData()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
+  const { ensureTradingReady, openTradeRequirements } = useTradingOnboarding()
+  const affiliateMetadata = useAffiliateOrderMetadata()
+  const { signMessageAsync } = useSignMessage()
+  const {
+    user,
+    userAddressNormalized,
+    makerAddress,
+    signatureType,
+    canSell,
+  } = useUserTradingContext(userAddress)
 
-    const observer = new IntersectionObserver((entries) => {
-      const [entry] = entries
-      if (entry?.isIntersecting && !isFetchingNextPage && !isLoadingMore && !infiniteScrollError) {
-        setLoadMoreState({
-          key: loadMoreScopeKey,
-          infiniteScrollError: null,
-          isLoadingMore: true,
-        })
-        fetchNextPage()
-          .then(() => {
-            setLoadMoreState({
-              key: loadMoreScopeKey,
-              infiniteScrollError: null,
-              isLoadingMore: false,
-            })
-            setRetryCountState({ key: userAddress, value: 0 })
-          })
-          .catch((error) => {
-            if (error.name !== 'AbortError') {
-              setLoadMoreState({
-                key: loadMoreScopeKey,
-                infiniteScrollError: error.message || 'Failed to load more positions',
-                isLoadingMore: false,
-              })
-              return
-            }
-            setLoadMoreState({
-              key: loadMoreScopeKey,
-              infiniteScrollError: null,
-              isLoadingMore: false,
-            })
-          })
-      }
-    }, { rootMargin: '200px' })
+  const marketStatusFilter: 'active' | 'closed' = 'active'
+  const minAmountFilter = 'All'
 
-    observer.observe(loadMoreRef.current)
+  const {
+    searchQuery,
+    debouncedSearchQuery,
+    sortBy,
+    sortDirection,
+    setSearchQueryState,
+    handleSortChange,
+    handleHeaderSortToggle,
+  } = useSearchAndSortState(userAddress)
 
-    return () => observer.disconnect()
-  }, [fetchNextPage, hasNextPage, infiniteScrollError, isFetchingNextPage, isLoadingMore, loadMoreScopeKey, userAddress])
+  const loadMoreScopeKey = `${userAddress}:${debouncedSearchQuery}:${minAmountFilter}:${marketStatusFilter}:${sortBy}:${sortDirection}`
 
-  const retryInitialLoad = useCallback(() => {
-    const currentRetryCount = retryCount + 1
-    setRetryCountState({ key: userAddress, value: currentRetryCount })
-    setLoadMoreState({
-      key: loadMoreScopeKey,
-      infiniteScrollError: null,
-      isLoadingMore: false,
-    })
+  const { infiniteScrollError, isLoadingMore, setLoadMoreState } = useLoadMoreState(loadMoreScopeKey)
+  const { retryCount, setRetryCountState } = useRetryCountState(userAddress)
 
-    const delay = Math.min(1000 * 2 ** (currentRetryCount - 1), 8000)
+  const handleSearchChange = useSearchChangeHandler({
+    userAddress,
+    loadMoreScopeKey,
+    setLoadMoreState,
+    setRetryCountState,
+    setSearchQueryState,
+  })
 
-    setTimeout(() => {
-      void refetch()
-    }, delay)
-  }, [loadMoreScopeKey, refetch, retryCount, userAddress])
+  const { hideMergeButton, setHideMergeButtonState } = useMergeButtonVisibility(userAddress)
 
-  const totals = useMemo(
-    () => calculatePositionsTotals(visiblePositions),
-    [visiblePositions],
-  )
+  const {
+    isShareDialogOpen,
+    sharePosition,
+    handleShareOpenChange,
+    handleShareClick,
+  } = useShareDialog()
+
+  const {
+    isMergeDialogOpen,
+    setIsMergeDialogOpen,
+    mergeSuccess,
+    setMergeSuccess,
+    handleMergeDialogChange,
+  } = useMergeDialog({ userAddress, setHideMergeButtonState })
+
+  const {
+    status,
+    data,
+    isFetchingNextPage,
+    fetchNextPage,
+    hasNextPage,
+    refetch,
+  } = usePublicPositionsQuery({
+    userAddress,
+    status: marketStatusFilter,
+    minAmountFilter,
+    sortBy,
+    sortDirection,
+    searchQuery: debouncedSearchQuery,
+  })
+
+  const {
+    positionsWithIcons,
+    sortedPositions,
+    totals,
+  } = usePositionsDerivations({
+    data,
+    debouncedSearchQuery,
+    sortBy,
+    sortDirection,
+  })
+
+  const {
+    positionsByCondition,
+    availableMergeableMarkets,
+  } = useMergeableMarketsAvailability({ canSell, positionsWithIcons })
+
+  const hasMergeableMarkets = availableMergeableMarkets.length > 0
+
+  const { isMergeProcessing, mergeBatchCount, handleMergeAll } = useMergePositionsAction({
+    mergeableMarkets: availableMergeableMarkets,
+    positionsByCondition,
+    hasMergeableMarkets,
+    user,
+    ensureTradingReady,
+    openTradeRequirements,
+    queryClient,
+    signMessageAsync,
+    onSuccess: () => setMergeSuccess(true),
+  })
+
+  const shareCardPayload = useShareCardPayload({ sharePosition, user })
+
+  const resolveOutcomeIndex = useResolveOutcomeIndex()
+
+  const {
+    sellModalPayload,
+    handleSellClick,
+    handleSellModalChange,
+    handleEditOrder,
+    handleCashOut,
+  } = useSellPositionFlow({
+    userAddress,
+    userAddressNormalized,
+    makerAddress,
+    signatureType,
+    user,
+    isConnected,
+    openWalletModal: open,
+    queryClient,
+    router,
+    affiliateMetadata,
+    ensureTradingReady,
+    openTradeRequirements,
+    runWithSignaturePrompt,
+    signTypedDataAsync,
+    resolveOutcomeIndex,
+  })
+
+  useScrollToTopOnFilterChange({
+    debouncedSearchQuery,
+    minAmountFilter,
+    marketStatusFilter,
+    sortBy,
+    sortDirection,
+  })
+
+  const { loadMoreRef } = useInfiniteScrollSentinel({
+    hasNextPage,
+    isFetchingNextPage,
+    isLoadingMore,
+    infiniteScrollError,
+    fetchNextPage,
+    loadMoreScopeKey,
+    userAddress,
+    setLoadMoreState,
+    setRetryCountState,
+  })
+
+  const retryInitialLoad = useRetryInitialLoad({
+    userAddress,
+    loadMoreScopeKey,
+    retryCount,
+    refetch,
+    setRetryCountState,
+    setLoadMoreState,
+  })
+
+  const hasUserAddress = Boolean(userAddress)
+  const loading = hasUserAddress && status === 'pending'
+  const hasInitialError = hasUserAddress && status === 'error'
+  const isSearchActive = debouncedSearchQuery.trim().length > 0
 
   return (
     <div className="space-y-3 pb-0">

--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsLoadingState.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsLoadingState.tsx
@@ -25,6 +25,14 @@ function getViewportWidthServerSnapshot() {
   return 1024
 }
 
+function useViewportWidth() {
+  return useSyncExternalStore(
+    subscribeToWindowResize,
+    getViewportWidthSnapshot,
+    getViewportWidthServerSnapshot,
+  )
+}
+
 export default function PublicPositionsLoadingState({
   skeletonCount,
   isSearchActive = false,
@@ -32,11 +40,7 @@ export default function PublicPositionsLoadingState({
   marketStatusFilter = 'active',
   retryCount = 0,
 }: PositionsLoadingStateProps) {
-  const viewportWidth = useSyncExternalStore(
-    subscribeToWindowResize,
-    getViewportWidthSnapshot,
-    getViewportWidthServerSnapshot,
-  )
+  const viewportWidth = useViewportWidth()
   const resolvedCount = skeletonCount ?? (viewportWidth < 768 ? 6 : 8)
 
   return (

--- a/src/app/[locale]/(platform)/profile/_components/PublicProfileHeroCards.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicProfileHeroCards.tsx
@@ -34,40 +34,23 @@ interface PublicProfileHeroCardsProps {
   fallbackChartEndDate?: string
 }
 
-function ProfitLossCard({
-  snapshot: _snapshot,
-  portfolioAddress,
-  fallbackChartEndDate,
+function usePnlSeries({
+  pnlAddress,
+  pnlBaseUrl,
+  activeTimeframe,
+  pnlSeriesKey,
 }: {
-  snapshot: PortfolioSnapshot
-  portfolioAddress?: string | null
-  fallbackChartEndDate?: string
+  pnlAddress: string | null | undefined
+  pnlBaseUrl: string
+  activeTimeframe: (typeof PNL_TIMEFRAMES)[number]
+  pnlSeriesKey: string
 }) {
-  const site = useSiteIdentity()
-  const platformName = site.name ?? ''
-  const [activeTimeframe, setActiveTimeframe] = useState<(typeof PNL_TIMEFRAMES)[number]>('ALL')
-  const [cursorX, setCursorX] = useState<number | null>(null)
-  const timeRangeContainerRef = useRef<HTMLDivElement | null>(null)
-  const timeRangeRef = useRef<(HTMLButtonElement | null)[]>([])
-  const [timeRangeIndicator, setTimeRangeIndicator] = useState({ width: 0, left: 0 })
-  const [timeRangeIndicatorReady, setTimeRangeIndicatorReady] = useState(false)
-  const chartId = useId().replace(/:/g, '')
-  const lineGradientId = `${chartId}-line`
-  const areaGradientId = `${chartId}-area`
-  const areaFadeId = `${chartId}-fade`
-  const areaMaskId = `${chartId}-mask`
-  const logoSvg = site.logoSvg
-    .replace(/fill="url\([^"]+\)"/gi, 'fill="currentColor"')
-  const pnlAddress = portfolioAddress
-  const pnlBaseUrl = process.env.USER_PNL_URL!
-  const pnlSeriesKey = `${pnlAddress ?? ''}:${pnlBaseUrl}:${activeTimeframe}`
   const [pnlSeriesState, setPnlSeriesState] = useState<{ key: string, series: PnlPoint[] }>({
     key: pnlSeriesKey,
     series: [],
   })
-  const pnlSeries = pnlSeriesState.key === pnlSeriesKey ? pnlSeriesState.series : []
 
-  useEffect(() => {
+  useEffect(function fetchPnlSeriesEffect() {
     if (!pnlAddress || !pnlBaseUrl) {
       return
     }
@@ -124,8 +107,20 @@ function ProfitLossCard({
         }
       })
 
-    return () => controller.abort()
+    return function abortPnlFetch() {
+      controller.abort()
+    }
   }, [activeTimeframe, pnlAddress, pnlBaseUrl, pnlSeriesKey])
+
+  const pnlSeries = pnlSeriesState.key === pnlSeriesKey ? pnlSeriesState.series : []
+  return { pnlSeries }
+}
+
+function usePnlTimeframeIndicator(activeTimeframe: (typeof PNL_TIMEFRAMES)[number]) {
+  const timeRangeContainerRef = useRef<HTMLDivElement | null>(null)
+  const timeRangeRef = useRef<(HTMLButtonElement | null)[]>([])
+  const [timeRangeIndicator, setTimeRangeIndicator] = useState({ width: 0, left: 0 })
+  const [timeRangeIndicatorReady, setTimeRangeIndicatorReady] = useState(false)
 
   const updateIndicator = useCallback(() => {
     const activeIndex = PNL_TIMEFRAMES.findIndex(range => range === activeTimeframe)
@@ -142,16 +137,33 @@ function ProfitLossCard({
     })
   }, [activeTimeframe])
 
-  useLayoutEffect(() => {
+  useLayoutEffect(function runIndicatorLayoutSync() {
     updateIndicator()
   }, [updateIndicator])
 
-  useEffect(() => {
+  useEffect(function bindIndicatorResizeListener() {
     updateIndicator()
     window.addEventListener('resize', updateIndicator)
-    return () => window.removeEventListener('resize', updateIndicator)
+    return function unbindIndicatorResizeListener() {
+      window.removeEventListener('resize', updateIndicator)
+    }
   }, [updateIndicator])
 
+  return {
+    timeRangeContainerRef,
+    timeRangeRef,
+    timeRangeIndicator,
+    timeRangeIndicatorReady,
+  }
+}
+
+function usePnlChartFallbackData({
+  fallbackChartEndDate,
+  activeTimeframe,
+}: {
+  fallbackChartEndDate: string | undefined
+  activeTimeframe: (typeof PNL_TIMEFRAMES)[number]
+}) {
   const fallbackRange = useMemo(() => ({ startValue: 0, endValue: 0 }), [])
   const fallbackDurationMs = useMemo(() => {
     const ranges = {
@@ -181,24 +193,13 @@ function ProfitLossCard({
     })
   }, [fallbackEndDate, fallbackRange, fallbackStartDate])
 
-  const hasPnlSeries = pnlSeries.length > 0
-  const chartData = hasPnlSeries ? pnlSeries : fallbackData
-  const startDate = chartData[0]?.date ?? fallbackStartDate
-  const endDate = chartData.at(-1)?.date ?? fallbackEndDate
-  const startValue = chartData[0]?.value ?? fallbackRange.startValue
-  const endValue = chartData.at(-1)?.value ?? fallbackRange.endValue
+  return { fallbackRange, fallbackEndDate, fallbackStartDate, fallbackData }
+}
 
-  const chartWidth = 360
-  const chartHeight = 80
-  const margin = { top: 0, right: 0, bottom: 0, left: 0 }
-  const innerWidth = chartWidth - margin.left - margin.right
-  const innerHeight = chartHeight - margin.top - margin.bottom
-  const linePadding = Math.round(innerHeight * 0.22)
-  const lineTop = linePadding
-  const lineBottom = innerHeight - linePadding
-  const [minValue, maxValue] = useMemo(() => {
+function usePnlChartDomain(chartData: PnlPoint[]) {
+  return useMemo(() => {
     if (!chartData.length) {
-      return [0, 0]
+      return [0, 0] as const
     }
     let min = chartData[0].value
     let max = chartData[0].value
@@ -210,12 +211,27 @@ function ProfitLossCard({
         max = point.value
       }
     }
-    return [min, max]
+    return [min, max] as const
   }, [chartData])
-  const domainPadding = minValue === maxValue ? Math.max(1, Math.abs(minValue || 1)) : 0
-  const paddedMin = minValue - domainPadding
-  const paddedMax = maxValue + domainPadding
+}
 
+function usePnlChartScales({
+  startDate,
+  endDate,
+  paddedMin,
+  paddedMax,
+  innerWidth,
+  lineBottom,
+  lineTop,
+}: {
+  startDate: Date
+  endDate: Date
+  paddedMin: number
+  paddedMax: number
+  innerWidth: number
+  lineBottom: number
+  lineTop: number
+}) {
   const xScale = useMemo(
     () => scaleTime<number>({
       range: [0, innerWidth],
@@ -231,6 +247,39 @@ function ProfitLossCard({
     }),
     [lineBottom, lineTop, paddedMax, paddedMin],
   )
+  return { xScale, yScale }
+}
+
+function usePnlCursorInteraction({
+  innerWidth,
+  innerHeight,
+  chartData,
+  endDate,
+  endValue,
+  xScale,
+  yScale,
+}: {
+  innerWidth: number
+  innerHeight: number
+  chartData: PnlPoint[]
+  endDate: Date
+  endValue: number
+  xScale: ReturnType<typeof scaleTime<number>>
+  yScale: ReturnType<typeof scaleLinear<number>>
+}) {
+  const [cursorX, setCursorX] = useState<number | null>(null)
+
+  const handlePointerMove = useCallback((event: ReactTouchEvent<SVGRectElement> | ReactMouseEvent<SVGRectElement>) => {
+    const point = localPoint(event)
+    if (!point) {
+      return
+    }
+    setCursorX(point.x)
+  }, [])
+
+  const handlePointerLeave = useCallback(() => {
+    setCursorX(null)
+  }, [])
 
   const clampedCursorX = cursorX == null ? null : Math.max(0, Math.min(cursorX, innerWidth))
   const cursorDate = useMemo(
@@ -284,15 +333,31 @@ function ProfitLossCard({
       top: `${(cursorY / innerHeight) * 100}%`,
     }
   }, [clampedCursorX, cursorY, innerHeight, innerWidth])
-  const displayAbsoluteValue = clampedCursorX == null ? endValue : cursorValue
-  const displayBaselineValue = activeTimeframe === 'ALL' ? 0 : startValue
-  const displayNetValue = displayAbsoluteValue - displayBaselineValue
-  const isDeltaPositive = displayNetValue > 0
-  const isDeltaNegative = displayNetValue < 0
-  const areValuesHidden = usePortfolioValueVisibility(state => state.isHidden)
-  const [gainTotal, lossTotal] = useMemo(() => {
+
+  return {
+    handlePointerMove,
+    handlePointerLeave,
+    clampedCursorX,
+    cursorDate,
+    cursorValue,
+    cursorDotPosition,
+  }
+}
+
+function usePnlGainLoss({
+  chartData,
+  cursorDate,
+  endDate,
+  activeTimeframe,
+}: {
+  chartData: PnlPoint[]
+  cursorDate: Date | null
+  endDate: Date
+  activeTimeframe: (typeof PNL_TIMEFRAMES)[number]
+}) {
+  return useMemo(() => {
     if (!chartData.length) {
-      return [0, 0]
+      return [0, 0] as const
     }
 
     const targetTime = (cursorDate ?? endDate).getTime()
@@ -301,7 +366,7 @@ function ProfitLossCard({
     const baseline = activeTimeframe === 'ALL' ? 0 : firstPoint.value
 
     if (targetTime < firstTime) {
-      return [0, 0]
+      return [0, 0] as const
     }
 
     let gain = 0
@@ -349,8 +414,111 @@ function ProfitLossCard({
       break
     }
 
-    return [gain, loss]
+    return [gain, loss] as const
   }, [activeTimeframe, chartData, cursorDate, endDate])
+}
+
+function usePnlChartIds() {
+  const chartId = useId().replace(/:/g, '')
+  return {
+    lineGradientId: `${chartId}-line`,
+    areaGradientId: `${chartId}-area`,
+    areaFadeId: `${chartId}-fade`,
+    areaMaskId: `${chartId}-mask`,
+  }
+}
+
+function usePnlActiveTimeframe() {
+  const [activeTimeframe, setActiveTimeframe] = useState<(typeof PNL_TIMEFRAMES)[number]>('ALL')
+  return { activeTimeframe, setActiveTimeframe }
+}
+
+function ProfitLossCard({
+  snapshot: _snapshot,
+  portfolioAddress,
+  fallbackChartEndDate,
+}: {
+  snapshot: PortfolioSnapshot
+  portfolioAddress?: string | null
+  fallbackChartEndDate?: string
+}) {
+  const site = useSiteIdentity()
+  const platformName = site.name ?? ''
+  const { activeTimeframe, setActiveTimeframe } = usePnlActiveTimeframe()
+  const { lineGradientId, areaGradientId, areaFadeId, areaMaskId } = usePnlChartIds()
+  const logoSvg = site.logoSvg
+    .replace(/fill="url\([^"]+\)"/gi, 'fill="currentColor"')
+  const pnlAddress = portfolioAddress
+  const pnlBaseUrl = process.env.USER_PNL_URL!
+  const pnlSeriesKey = `${pnlAddress ?? ''}:${pnlBaseUrl}:${activeTimeframe}`
+  const { pnlSeries } = usePnlSeries({ pnlAddress, pnlBaseUrl, activeTimeframe, pnlSeriesKey })
+
+  const {
+    timeRangeContainerRef,
+    timeRangeRef,
+    timeRangeIndicator,
+    timeRangeIndicatorReady,
+  } = usePnlTimeframeIndicator(activeTimeframe)
+
+  const { fallbackRange, fallbackEndDate, fallbackStartDate, fallbackData } = usePnlChartFallbackData({
+    fallbackChartEndDate,
+    activeTimeframe,
+  })
+
+  const hasPnlSeries = pnlSeries.length > 0
+  const chartData = hasPnlSeries ? pnlSeries : fallbackData
+  const startDate = chartData[0]?.date ?? fallbackStartDate
+  const endDate = chartData.at(-1)?.date ?? fallbackEndDate
+  const startValue = chartData[0]?.value ?? fallbackRange.startValue
+  const endValue = chartData.at(-1)?.value ?? fallbackRange.endValue
+
+  const chartWidth = 360
+  const chartHeight = 80
+  const margin = { top: 0, right: 0, bottom: 0, left: 0 }
+  const innerWidth = chartWidth - margin.left - margin.right
+  const innerHeight = chartHeight - margin.top - margin.bottom
+  const linePadding = Math.round(innerHeight * 0.22)
+  const lineTop = linePadding
+  const lineBottom = innerHeight - linePadding
+  const [minValue, maxValue] = usePnlChartDomain(chartData)
+  const domainPadding = minValue === maxValue ? Math.max(1, Math.abs(minValue || 1)) : 0
+  const paddedMin = minValue - domainPadding
+  const paddedMax = maxValue + domainPadding
+
+  const { xScale, yScale } = usePnlChartScales({
+    startDate,
+    endDate,
+    paddedMin,
+    paddedMax,
+    innerWidth,
+    lineBottom,
+    lineTop,
+  })
+
+  const {
+    handlePointerMove,
+    handlePointerLeave,
+    clampedCursorX,
+    cursorDate,
+    cursorValue,
+    cursorDotPosition,
+  } = usePnlCursorInteraction({
+    innerWidth,
+    innerHeight,
+    chartData,
+    endDate,
+    endValue,
+    xScale,
+    yScale,
+  })
+
+  const displayAbsoluteValue = clampedCursorX == null ? endValue : cursorValue
+  const displayBaselineValue = activeTimeframe === 'ALL' ? 0 : startValue
+  const displayNetValue = displayAbsoluteValue - displayBaselineValue
+  const isDeltaPositive = displayNetValue > 0
+  const isDeltaNegative = displayNetValue < 0
+  const areValuesHidden = usePortfolioValueVisibility(state => state.isHidden)
+  const [gainTotal, lossTotal] = usePnlGainLoss({ chartData, cursorDate, endDate, activeTimeframe })
   const timeframeLabel = ({
     'ALL': 'All-Time',
     '1D': 'Past Day',
@@ -362,18 +530,6 @@ function ProfitLossCard({
       cursorDate.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' })
     }`
     : null
-
-  const handlePointerMove = useCallback((event: ReactTouchEvent<SVGRectElement> | ReactMouseEvent<SVGRectElement>) => {
-    const point = localPoint(event)
-    if (!point) {
-      return
-    }
-    setCursorX(point.x)
-  }, [])
-
-  const handlePointerLeave = useCallback(() => {
-    setCursorX(null)
-  }, [])
 
   return (
     <Card className="relative h-full overflow-hidden rounded-lg bg-background">

--- a/src/app/[locale]/(platform)/profile/_components/PublicProfileTabs.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicProfileTabs.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useLayoutEffect, useMemo, useRef, useState } from 'react'
+import { useLayoutEffect, useRef, useState } from 'react'
 import PublicActivityList from '@/app/[locale]/(platform)/profile/_components/PublicActivityList'
 import PublicPositionsList from '@/app/[locale]/(platform)/profile/_components/PublicPositionsList'
 import { cn } from '@/lib/utils'
@@ -12,18 +12,28 @@ const baseTabs = [
   { id: 'activity' as const, label: 'Activity' },
 ]
 
+type PublicProfileTab = (typeof baseTabs)[number]
+
 interface PublicProfileTabsProps {
   userAddress: string
 }
 
-export default function PublicProfileTabs({ userAddress }: PublicProfileTabsProps) {
-  const [activeTab, setActiveTab] = useState<TabType>('positions')
+function useActiveProfileTab() {
+  return useState<TabType>('positions')
+}
+
+function useTabIndicatorPosition({
+  tabs,
+  activeTab,
+}: {
+  tabs: PublicProfileTab[]
+  activeTab: TabType
+}) {
   const tabRef = useRef<(HTMLButtonElement | null)[]>([])
   const [indicatorStyle, setIndicatorStyle] = useState({ left: 0, width: 0 })
   const [isInitialized, setIsInitialized] = useState(false)
-  const tabs = useMemo(() => baseTabs, [])
 
-  useLayoutEffect(() => {
+  useLayoutEffect(function positionActiveTabIndicator() {
     const activeTabIndex = tabs.findIndex(tab => tab.id === activeTab)
     const activeTabElement = tabRef.current[activeTabIndex]
 
@@ -41,6 +51,14 @@ export default function PublicProfileTabs({ userAddress }: PublicProfileTabsProp
       })
     }
   }, [activeTab, tabs])
+
+  return { tabRef, indicatorStyle, isInitialized }
+}
+
+export default function PublicProfileTabs({ userAddress }: PublicProfileTabsProps) {
+  const [activeTab, setActiveTab] = useActiveProfileTab()
+  const tabs = baseTabs
+  const { tabRef, indicatorStyle, isInitialized } = useTabIndicatorPosition({ tabs, activeTab })
 
   return (
     <div className="overflow-hidden rounded-2xl border">


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855) to the public profile area.

Follow-up to #866, #867, #868, #869, #870, #871, #872, #873, #874, #875, #876, #877.

## Files changed (5)

| File | `use-encapsulation/prefer-custom-hooks` | Effects named |
|---|---|---|
| `PublicPositionsLoadingState` | 1 → 0 | — |
| `PublicProfileTabs` | 6 → 0 | 1 (`positionActiveTabIndicator` layout effect) |
| `PublicActivityList` | 8 → 0 | 1 (`observeActivityLoadMoreSentinel` + cleanup `disconnectActivityLoadMoreObserver`) |
| `PublicProfileHeroCards` | 26 → 0 | 3 (`fetchPnlSeriesEffect` + cleanup `abortPnlFetch`, `runIndicatorLayoutSync`, `bindIndicatorResizeListener` + cleanup `unbindIndicatorResizeListener`) |
| `PublicPositionsList` | 39 → 0 | 3 (`resolveAvailableMergeableMarkets` + cleanup `cancelAvailabilityLookup`, `scrollToTopOnFilterChange`, `observeLoadMoreSentinel` + cleanup `disconnectLoadMoreObserver`) |

**Total: 80 → 0 (100% reduction), 8 effects named.**

## Extracted hooks (all file-local)

### `PublicPositionsLoadingState`
- `useViewportWidth()` — wraps the `useSyncExternalStore` read for `window.innerWidth`.

### `PublicProfileTabs`
- `useActiveProfileTab()` — wraps `useState<TabType>('positions')`.
- `useTabIndicatorPosition({ tabs, activeTab })` — owns `tabRef`, `indicatorStyle`, `isInitialized` + named layout effect positioning the underline.

### `PublicActivityList`
- `usePublicActivityFilters()` — `searchQuery` / `typeFilter` / `sortFilter` state.
- `useVisibleActivities({ data, searchQuery, typeFilter, sortFilter })` — `activities` + filtered/sorted `visibleActivities`.
- `useLoadMoreScopedState(loadMoreScopeKey)` — scoped `infiniteScrollError` + `isLoadingMore` + setter.
- `useActivityInfiniteScrollSentinel({...})` — owns `loadMoreRef` + named observer effect + named cleanup.

### `PublicProfileHeroCards` (all in the internal `ProfitLossCard`)
- `usePnlActiveTimeframe()` — `activeTimeframe` state + setter.
- `usePnlSeries({ pnlAddress, pnlBaseUrl, activeTimeframe, pnlSeriesKey })` — owns `pnlSeriesState` + the abort-aware PNL fetch effect, returns `pnlSeries`.
- `usePnlTimeframeIndicator(activeTimeframe)` — owns indicator refs/state, `updateIndicator` callback, and the two layout + resize-listener effects.
- `usePnlChartFallbackData({ fallbackChartEndDate, activeTimeframe })` — `fallbackRange` / `fallbackDurationMs` / `fallbackEndDate` / `fallbackStartDate` / `fallbackData` memos.
- `usePnlChartDomain(chartData)` — `[minValue, maxValue]` memo.
- `usePnlChartScales({...})` — `xScale` + `yScale` memos.
- `usePnlCursorInteraction({...})` — `cursorX` state, pointer callbacks, and derived `clampedCursorX` / `cursorDate` / `cursorValue` / `cursorDotPosition`.
- `usePnlGainLoss({...})` — `[gainTotal, lossTotal]` memo.
- `usePnlChartIds()` — wraps `useId` and returns the four gradient / fade / mask IDs.

### `PublicPositionsList`
- `useUserTradingContext` — derives `user`, `makerAddress`, `proxyAddress`, `signatureType`, `canSell` from `useUser()`.
- `useSearchAndSortState` — address-scoped search query (+ debounce) + sort state + sort handlers.
- `useLoadMoreState` — scoped `infiniteScrollError` + `isLoadingMore` + setter.
- `useRetryCountState` — address-scoped retry counter.
- `useSearchChangeHandler` — `handleSearchChange` callback that resets load-more + retry-count on input change.
- `useMergeButtonVisibility` — `hideMergeButton` scoped state after successful merge.
- `useShareDialog` — share dialog open state, selected position, open / click handlers.
- `useShareCardPayload` — memoized share-card payload derived from `sharePosition` + user.
- `useMergeDialog` — merge dialog open state, `mergeSuccess` flag, open-change handler.
- `usePositionsDerivations` — flatten pages; `positionsWithIcons` / `visiblePositions` / `sortedPositions` / totals.
- `useMergeableMarketsAvailability` — mergeable markets + `positionsByCondition` + `mergeableScopeKey` + the `resolveAvailableMergeableMarkets` effect.
- `useScrollToTopOnFilterChange` — scrolls window to top on filter change (named effect).
- `useInfiniteScrollSentinel` — `loadMoreRef` + `observeLoadMoreSentinel` effect + named cleanup.
- `useRetryInitialLoad` — retry callback with exponential backoff.
- `useResolveOutcomeIndex` — stable callback resolving a position's outcome index (YES/NO fallback).
- `useSellPositionFlow` — owns `sellModalPayload` / `isCashOutSubmitting` / `sellRequestIdRef` + `handleSellClick` / `handleSellModalChange` / `handleEditOrder` / `handleCashOut`.

## Kept inline (per the \"2–3 sec rule\")
- `loadMoreScopeKey` (template string), `hasUserAddress`, `loading`, `hasInitialError`, `isSearchActive`, `hasMergeableMarkets`, and small JSX-inline arrows (`onMergeClick`, `onRefreshPage`) — single-line derivations a reader reads instantly.

## Shared-hook note
`useTabIndicatorPosition` is now a file-local pattern in both `PortfolioTabs` (#877) and `PublicProfileTabs`. Kept file-local for independence between these PRs; once both merge, happy to extract to `src/hooks/useTabIndicatorPosition.ts` in a follow-up (it would take a generic `T extends { id: string }` for the tab type).

`useInfiniteScrollSentinel` is also file-local in `EventMarketOpenOrders` / `PortfolioOpenOrdersList` / `PublicActivityList` / `PublicPositionsList` — each has subtly different error/retry semantics. Same follow-up candidate for consolidation once the surface stabilizes.

## Test plan

- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: public profile positions / activity tab switching, positions search + sort + retry + infinite scroll + scroll-to-top on filter change, merge-shares dialog availability lookup, sell / cash-out flow, share-position dialog, portfolio variant hero profit/loss chart (timeframe toggle 1D / 1W / 1M / ALL, hover cursor, gain/loss tooltip)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors public profile components to use file-local custom hooks and named effects for clearer code and encapsulation. Includes a small UX fix to keep activity load-more errors visible when a retry fails.

- **Refactors**
  - PublicPositionsList: encapsulated trading context, search/sort + debounce, scoped load-more + retry, mergeable markets availability, infinite scroll sentinel, share/merge dialogs, sell/cash-out flow, and totals.
  - PublicActivityList: added filter/visibility hooks, scoped load-more state, and an intersection observer with named cleanup.
  - PublicProfileHeroCards: extracted PnL fetch (abortable), timeframe indicator (layout + resize effects), chart helpers (domain/scales/cursor/gain-loss), ID generation, and timeframe state.
  - PublicProfileTabs: new hooks for active tab and indicator positioning (named layout effect).
  - PublicPositionsLoadingState: introduced `useViewportWidth()` via `useSyncExternalStore`.
  - Named 8 effects and removed 80 inline usages to align with `use-encapsulation/prefer-custom-hooks`.

- **Bug Fixes**
  - Preserve activity load-more error state on retry failure in PublicActivityList to avoid clearing the message prematurely.

<sup>Written for commit db611274f542e646f7c6f7238d197478a70ba5ec. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

