### PR TITLE
refactor: use custom hooks for platform providers + shell components

### DIFF
--- a/src/app/[locale]/(platform)/_components/AffiliateQueryHandler.tsx
+++ b/src/app/[locale]/(platform)/_components/AffiliateQueryHandler.tsx
@@ -2,8 +2,8 @@
 
 import { useEffect } from 'react'
 
-export default function AffiliateQueryHandler() {
-  useEffect(() => {
+function useAffiliateQueryRedirect() {
+  useEffect(function redirectAffiliateQuery() {
     const url = new URL(window.location.href)
     const affiliateCode = url.searchParams.get('r')?.trim()
 
@@ -17,6 +17,10 @@ export default function AffiliateQueryHandler() {
 
     window.location.replace(redirectUrl)
   }, [])
+}
+
+export default function AffiliateQueryHandler() {
+  useAffiliateQueryRedirect()
 
   return <></>
 }

--- a/src/app/[locale]/(platform)/_components/HeaderDepositButton.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderDepositButton.tsx
@@ -10,13 +10,19 @@ const HeaderDepositFlow = dynamic(
   { ssr: false },
 )
 
-export default function HeaderDepositButton() {
-  const t = useExtracted()
+function useDepositRequestTrigger() {
   const [requestId, setRequestId] = useState(0)
 
   function handleClick() {
     setRequestId(prev => prev + 1)
   }
+
+  return { requestId, handleClick }
+}
+
+export default function HeaderDepositButton() {
+  const t = useExtracted()
+  const { requestId, handleClick } = useDepositRequestTrigger()
 
   return (
     <>

--- a/src/app/[locale]/(platform)/_components/HeaderDepositFlow.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderDepositFlow.tsx
@@ -4,15 +4,11 @@ import { useEffect, useRef } from 'react'
 import { useTradingOnboarding } from '@/app/[locale]/(platform)/_providers/TradingOnboardingContext'
 import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 
-interface HeaderDepositFlowInnerProps {
-  requestId: number
-}
-
-function HeaderDepositFlowInner({ requestId }: HeaderDepositFlowInnerProps) {
+function useStartDepositFlowOnRequest(requestId: number) {
   const { startDepositFlow } = useTradingOnboarding()
   const lastRequestIdRef = useRef(0)
 
-  useEffect(() => {
+  useEffect(function startDepositFlowWhenRequestIdChanges() {
     if (requestId === 0 || lastRequestIdRef.current === requestId) {
       return
     }
@@ -20,6 +16,14 @@ function HeaderDepositFlowInner({ requestId }: HeaderDepositFlowInnerProps) {
     lastRequestIdRef.current = requestId
     startDepositFlow()
   }, [requestId, startDepositFlow])
+}
+
+interface HeaderDepositFlowInnerProps {
+  requestId: number
+}
+
+function HeaderDepositFlowInner({ requestId }: HeaderDepositFlowInnerProps) {
+  useStartDepositFlowOnRequest(requestId)
 
   return null
 }

--- a/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
@@ -19,39 +19,34 @@ import {
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { usePwaInstall } from '@/hooks/usePwaInstall'
 
-export default function HeaderDropdownUserMenuGuest() {
-  const t = useExtracted()
-  const isMobile = useIsMobile()
-  const { canShowInstallUi, isIos, isPrompting, requestInstall } = usePwaInstall()
-  const enableHoverOpen = !isMobile
+function relatedTargetIsWithin(ref: React.RefObject<HTMLElement | null>, relatedTarget: EventTarget | null) {
+  const current = ref.current
+  if (!current) {
+    return false
+  }
+
+  const nodeConstructor = current.ownerDocument?.defaultView?.Node ?? Node
+  if (!(relatedTarget instanceof nodeConstructor)) {
+    return false
+  }
+
+  return current.contains(relatedTarget)
+}
+
+function useHoverDropdownMenu(enableHoverOpen: boolean) {
   const [menuOpen, setMenuOpen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
 
   useEffect(function clearMenuCloseTimeoutOnUnmount() {
-    function cleanupMenuCloseTimeout() {
-      if (closeTimeoutRef.current) {
-        clearTimeout(closeTimeoutRef.current)
-        closeTimeoutRef.current = null
+    const timeoutRefSnapshot = closeTimeoutRef
+    return function cleanupMenuCloseTimeout() {
+      if (timeoutRefSnapshot.current) {
+        clearTimeout(timeoutRefSnapshot.current)
+        timeoutRefSnapshot.current = null
       }
     }
-
-    return cleanupMenuCloseTimeout
   }, [])
-
-  function relatedTargetIsWithin(ref: React.RefObject<HTMLElement | null>, relatedTarget: EventTarget | null) {
-    const current = ref.current
-    if (!current) {
-      return false
-    }
-
-    const nodeConstructor = current.ownerDocument?.defaultView?.Node ?? Node
-    if (!(relatedTarget instanceof nodeConstructor)) {
-      return false
-    }
-
-    return current.contains(relatedTarget)
-  }
 
   function clearCloseTimeout() {
     if (closeTimeoutRef.current) {
@@ -84,8 +79,41 @@ export default function HeaderDropdownUserMenuGuest() {
     }, 120)
   }
 
-  async function handleInstallAction() {
+  function handleOpenChange(nextOpen: boolean) {
+    clearCloseTimeout()
+    setMenuOpen(nextOpen)
+  }
+
+  function closeMenu() {
     setMenuOpen(false)
+  }
+
+  return {
+    menuOpen,
+    wrapperRef,
+    handleWrapperPointerEnter,
+    handleWrapperPointerLeave,
+    handleOpenChange,
+    closeMenu,
+  }
+}
+
+export default function HeaderDropdownUserMenuGuest() {
+  const t = useExtracted()
+  const isMobile = useIsMobile()
+  const { canShowInstallUi, isIos, isPrompting, requestInstall } = usePwaInstall()
+  const enableHoverOpen = !isMobile
+  const {
+    menuOpen,
+    wrapperRef,
+    handleWrapperPointerEnter,
+    handleWrapperPointerLeave,
+    handleOpenChange,
+    closeMenu,
+  } = useHoverDropdownMenu(enableHoverOpen)
+
+  async function handleInstallAction() {
+    closeMenu()
 
     if (isIos) {
       toast.info(t('Install app'), {
@@ -114,10 +142,7 @@ export default function HeaderDropdownUserMenuGuest() {
     >
       <DropdownMenu
         open={menuOpen}
-        onOpenChange={(nextOpen) => {
-          clearCloseTimeout()
-          setMenuOpen(nextOpen)
-        }}
+        onOpenChange={handleOpenChange}
         modal={false}
       >
         <DropdownMenuTrigger asChild>
@@ -135,8 +160,8 @@ export default function HeaderDropdownUserMenuGuest() {
           align="end"
           collisionPadding={16}
           portalled={false}
-          onInteractOutside={() => setMenuOpen(false)}
-          onEscapeKeyDown={() => setMenuOpen(false)}
+          onInteractOutside={closeMenu}
+          onEscapeKeyDown={closeMenu}
         >
           <DropdownMenuItem asChild className="py-2 text-sm font-semibold text-foreground">
             <AppLink intentPrefetch href="/leaderboard" className="flex w-full items-center gap-1.5">

--- a/src/app/[locale]/(platform)/_components/HeaderMenu.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderMenu.tsx
@@ -34,6 +34,14 @@ function getHydratedServerSnapshot() {
   return false
 }
 
+function useHasHydrated() {
+  return useSyncExternalStore(
+    subscribeToHydrationStore,
+    getHydratedClientSnapshot,
+    getHydratedServerSnapshot,
+  )
+}
+
 export default function HeaderMenu() {
   return <HeaderMenuClient />
 }
@@ -43,11 +51,7 @@ function HeaderMenuClient() {
   const { open } = useAppKit()
   const { isConnected } = useAppKitAccount()
   const { data: session, isPending: isSessionPending } = useSession()
-  const hasHydrated = useSyncExternalStore(
-    subscribeToHydrationStore,
-    getHydratedClientSnapshot,
-    getHydratedServerSnapshot,
-  )
+  const hasHydrated = useHasHydrated()
   const isMobile = useIsMobile()
   const tradingOnboarding = useOptionalTradingOnboarding()
   const user = useUser()

--- a/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
@@ -92,20 +92,25 @@ function isLocalMergeNotification(notification: Notification) {
   return metadata?.action === 'merge'
 }
 
+function useLoadNotificationsOnMount() {
+  const setNotifications = useNotifications(state => state.setNotifications)
+
+  useEffect(function loadNotificationsOnMount() {
+    queueMicrotask(() => setNotifications())
+  }, [setNotifications])
+}
+
 export default function HeaderNotifications() {
   const router = useRouter()
   const notifications = useNotificationList()
   const currentTimestamp = useCurrentTimestamp({ intervalMs: 60_000 })
   const unreadCount = useUnreadNotificationCount()
-  const setNotifications = useNotifications(state => state.setNotifications)
   const removeNotification = useNotifications(state => state.removeNotification)
   const isLoading = useNotificationsLoading()
   const error = useNotificationsError()
   const hasNotifications = notifications.length > 0
 
-  useEffect(() => {
-    queueMicrotask(() => setNotifications())
-  }, [setNotifications])
+  useLoadNotificationsOnMount()
 
   function handleLocalOrderFillClick(notification: Notification) {
     if (!isLocalOrderFillNotification(notification)) {

--- a/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
@@ -4,7 +4,7 @@ import type { Route } from 'next'
 import type { ReactNode, RefObject } from 'react'
 import { SearchIcon, XIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
-import { useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
 import SearchDiscoveryContent from '@/app/[locale]/(platform)/_components/SearchDiscoveryContent'
 import { SearchResults } from '@/app/[locale]/(platform)/_components/SearchResults'
 import { Input } from '@/components/ui/input'
@@ -236,12 +236,12 @@ export default function HeaderSearch({
     navigateToRoute(href)
   }
 
-  function clearPendingBlurFrame() {
+  const clearPendingBlurFrame = useCallback(() => {
     if (blurFrameRef.current !== null) {
       window.cancelAnimationFrame(blurFrameRef.current)
       blurFrameRef.current = null
     }
-  }
+  }, [])
 
   useSlashFocusShortcut(inputRef)
   useExternalFocusTrigger(focusTrigger, inputRef)

--- a/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { Route } from 'next'
-import type { ReactNode } from 'react'
+import type { ReactNode, RefObject } from 'react'
 import { SearchIcon, XIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useEffect, useRef, useState } from 'react'
@@ -23,6 +23,141 @@ interface HeaderSearchProps {
   showDesktopDiscovery?: boolean
 }
 
+function useHeaderSearchRefs() {
+  const searchRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const blurFrameRef = useRef<number | null>(null)
+  const pointerDownInsideRef = useRef(false)
+
+  return { searchRef, inputRef, blurFrameRef, pointerDownInsideRef }
+}
+
+function useHeaderSearchFocusState() {
+  const [hasFocusWithin, setHasFocusWithin] = useState(false)
+  const [isResultsDismissed, setIsResultsDismissed] = useState(false)
+
+  return { hasFocusWithin, setHasFocusWithin, isResultsDismissed, setIsResultsDismissed }
+}
+
+function useSlashFocusShortcut(inputRef: RefObject<HTMLInputElement | null>) {
+  useEffect(function bindSlashFocusShortcut() {
+    function handleSlashShortcut(event: KeyboardEvent) {
+      if (event.key !== '/') {
+        return
+      }
+
+      const target = event.target as HTMLElement | null
+      const tagName = target?.tagName?.toLowerCase()
+      const isEditable = tagName === 'input' || tagName === 'textarea' || target?.isContentEditable
+
+      if (event.metaKey || event.ctrlKey || event.altKey || isEditable) {
+        return
+      }
+
+      event.preventDefault()
+      inputRef.current?.focus()
+    }
+
+    window.addEventListener('keydown', handleSlashShortcut)
+    return function unbindSlashFocusShortcut() {
+      window.removeEventListener('keydown', handleSlashShortcut)
+    }
+  }, [inputRef])
+}
+
+function useExternalFocusTrigger(
+  focusTrigger: number | undefined,
+  inputRef: RefObject<HTMLInputElement | null>,
+) {
+  useEffect(function focusInputOnExternalTrigger() {
+    if (!focusTrigger) {
+      return
+    }
+
+    if (document.activeElement === inputRef.current) {
+      return
+    }
+
+    const timeoutId = window.setTimeout(() => {
+      inputRef.current?.focus({ preventScroll: true })
+    }, 40)
+
+    return function cancelFocusTimeout() {
+      window.clearTimeout(timeoutId)
+    }
+  }, [focusTrigger, inputRef])
+}
+
+function useDismissSearchOnOutsidePointerDown({
+  showAttachedDropdown,
+  isManagedSearchSurface,
+  hideResults,
+  clearPendingBlurFrame,
+  setHasFocusWithin,
+  setIsResultsDismissed,
+  searchRef,
+  inputRef,
+  pointerDownInsideRef,
+}: {
+  showAttachedDropdown: boolean
+  isManagedSearchSurface: boolean
+  hideResults: () => void
+  clearPendingBlurFrame: () => void
+  setHasFocusWithin: (value: boolean) => void
+  setIsResultsDismissed: (value: boolean) => void
+  searchRef: RefObject<HTMLDivElement | null>
+  inputRef: RefObject<HTMLInputElement | null>
+  pointerDownInsideRef: RefObject<boolean>
+}) {
+  useEffect(function bindOutsidePointerDownDismiss() {
+    function handlePointerDown(event: PointerEvent) {
+      if (!showAttachedDropdown) {
+        return
+      }
+
+      const isInsideSearch = searchRef.current?.contains(event.target as Node) ?? false
+      pointerDownInsideRef.current = isInsideSearch
+
+      if (isInsideSearch) {
+        return
+      }
+
+      clearPendingBlurFrame()
+      setHasFocusWithin(false)
+      setIsResultsDismissed(true)
+      hideResults()
+      inputRef.current?.blur()
+    }
+
+    if (isManagedSearchSurface) {
+      return
+    }
+
+    document.addEventListener('pointerdown', handlePointerDown)
+    return function unbindOutsidePointerDownDismiss() {
+      document.removeEventListener('pointerdown', handlePointerDown)
+    }
+  }, [
+    hideResults,
+    isManagedSearchSurface,
+    showAttachedDropdown,
+    clearPendingBlurFrame,
+    setHasFocusWithin,
+    setIsResultsDismissed,
+    searchRef,
+    inputRef,
+    pointerDownInsideRef,
+  ])
+}
+
+function useCancelPendingBlurOnUnmount(clearPendingBlurFrame: () => void) {
+  useEffect(function cancelPendingBlurFrameOnUnmount() {
+    return function runClearPendingBlurFrame() {
+      clearPendingBlurFrame()
+    }
+  }, [clearPendingBlurFrame])
+}
+
 export default function HeaderSearch({
   autoFocus = false,
   emptyState,
@@ -31,10 +166,7 @@ export default function HeaderSearch({
   onPredictionResultsNavigate,
   showDesktopDiscovery = true,
 }: HeaderSearchProps) {
-  const searchRef = useRef<HTMLDivElement>(null)
-  const inputRef = useRef<HTMLInputElement>(null)
-  const blurFrameRef = useRef<number | null>(null)
-  const pointerDownInsideRef = useRef(false)
+  const { searchRef, inputRef, blurFrameRef, pointerDownInsideRef } = useHeaderSearchRefs()
   const router = useRouter()
   const {
     query,
@@ -48,8 +180,12 @@ export default function HeaderSearch({
     activeTab,
     setActiveTab,
   } = useSearch()
-  const [hasFocusWithin, setHasFocusWithin] = useState(false)
-  const [isResultsDismissed, setIsResultsDismissed] = useState(false)
+  const {
+    hasFocusWithin,
+    setHasFocusWithin,
+    isResultsDismissed,
+    setIsResultsDismissed,
+  } = useHeaderSearchFocusState()
   const isManagedSearchSurface = Boolean(onPredictionResultsNavigate)
   const hasActiveQuery = query.trim().length >= 2
   const showDropdown = hasActiveQuery
@@ -107,79 +243,20 @@ export default function HeaderSearch({
     }
   }
 
-  useEffect(() => {
-    function handleSlashShortcut(event: KeyboardEvent) {
-      if (event.key !== '/') {
-        return
-      }
-
-      const target = event.target as HTMLElement | null
-      const tagName = target?.tagName?.toLowerCase()
-      const isEditable = tagName === 'input' || tagName === 'textarea' || target?.isContentEditable
-
-      if (event.metaKey || event.ctrlKey || event.altKey || isEditable) {
-        return
-      }
-
-      event.preventDefault()
-      inputRef.current?.focus()
-    }
-
-    window.addEventListener('keydown', handleSlashShortcut)
-    return () => {
-      window.removeEventListener('keydown', handleSlashShortcut)
-    }
-  }, [])
-
-  useEffect(() => {
-    if (!focusTrigger) {
-      return
-    }
-
-    if (document.activeElement === inputRef.current) {
-      return
-    }
-
-    const timeoutId = window.setTimeout(() => {
-      inputRef.current?.focus({ preventScroll: true })
-    }, 40)
-
-    return () => {
-      window.clearTimeout(timeoutId)
-    }
-  }, [focusTrigger])
-
-  useEffect(() => {
-    function handlePointerDown(event: PointerEvent) {
-      if (!showAttachedDropdown) {
-        return
-      }
-
-      const isInsideSearch = searchRef.current?.contains(event.target as Node) ?? false
-      pointerDownInsideRef.current = isInsideSearch
-
-      if (isInsideSearch) {
-        return
-      }
-
-      clearPendingBlurFrame()
-      setHasFocusWithin(false)
-      setIsResultsDismissed(true)
-      hideResults()
-      inputRef.current?.blur()
-    }
-
-    if (isManagedSearchSurface) {
-      return
-    }
-
-    document.addEventListener('pointerdown', handlePointerDown)
-    return () => {
-      document.removeEventListener('pointerdown', handlePointerDown)
-    }
-  }, [hideResults, isManagedSearchSurface, showAttachedDropdown])
-
-  useEffect(() => () => clearPendingBlurFrame(), [])
+  useSlashFocusShortcut(inputRef)
+  useExternalFocusTrigger(focusTrigger, inputRef)
+  useDismissSearchOnOutsidePointerDown({
+    showAttachedDropdown,
+    isManagedSearchSurface,
+    hideResults,
+    clearPendingBlurFrame,
+    setHasFocusWithin,
+    setIsResultsDismissed,
+    searchRef,
+    inputRef,
+    pointerDownInsideRef,
+  })
+  useCancelPendingBlurOnUnmount(clearPendingBlurFrame)
 
   return (
     <div className="w-full lg:max-w-[600px] lg:min-w-[400px]">

--- a/src/app/[locale]/(platform)/_components/HowItWorks.tsx
+++ b/src/app/[locale]/(platform)/_components/HowItWorks.tsx
@@ -39,6 +39,23 @@ interface HowItWorksStep {
   ctaLabel: string
 }
 
+function useControlledOpenState(
+  controlledOpen: boolean | undefined,
+  onOpenChange: ((open: boolean) => void) | undefined,
+) {
+  const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(false)
+  const isOpen = controlledOpen ?? uncontrolledIsOpen
+
+  function setOpen(nextOpen: boolean) {
+    if (controlledOpen === undefined) {
+      setUncontrolledIsOpen(nextOpen)
+    }
+    onOpenChange?.(nextOpen)
+  }
+
+  return { isOpen, setOpen }
+}
+
 export default function HowItWorks({
   displayMode = 'auto',
   open: controlledOpen,
@@ -48,7 +65,7 @@ export default function HowItWorks({
   const t = useExtracted()
   const isMobile = useIsMobile()
   const { open } = useAppKit()
-  const [uncontrolledIsOpen, setUncontrolledIsOpen] = useState(false)
+  const { isOpen, setOpen } = useControlledOpenState(controlledOpen, onOpenChange)
 
   const steps: ReadonlyArray<HowItWorksStep> = [
     {
@@ -77,18 +94,10 @@ export default function HowItWorks({
     },
   ]
 
-  const isOpen = controlledOpen ?? uncontrolledIsOpen
   const shouldUseMobileLayout = displayMode === 'auto'
     ? isMobile
     : displayMode === 'mobile'
   const contentKey = isOpen ? 'open' : 'closed'
-
-  function setOpen(nextOpen: boolean) {
-    if (controlledOpen === undefined) {
-      setUncontrolledIsOpen(nextOpen)
-    }
-    onOpenChange?.(nextOpen)
-  }
 
   function handleOpenChange(nextOpen: boolean) {
     setOpen(nextOpen)
@@ -169,12 +178,7 @@ interface HowItWorksContentProps {
   variant: 'mobile' | 'desktop'
 }
 
-function HowItWorksContent({
-  imageWrapperClassName,
-  onComplete,
-  steps,
-  variant,
-}: HowItWorksContentProps) {
+function useHowItWorksStepNavigation(steps: ReadonlyArray<HowItWorksStep>, onComplete: () => void) {
   const [activeStep, setActiveStep] = useState(0)
   const currentStep = steps[activeStep]
   const isLastStep = activeStep === steps.length - 1
@@ -187,6 +191,17 @@ function HowItWorksContent({
 
     setActiveStep(step => Math.min(step + 1, steps.length - 1))
   }
+
+  return { activeStep, currentStep, handleNext }
+}
+
+function HowItWorksContent({
+  imageWrapperClassName,
+  onComplete,
+  steps,
+  variant,
+}: HowItWorksContentProps) {
+  const { activeStep, currentStep, handleNext } = useHowItWorksStepNavigation(steps, onComplete)
 
   return (
     <>

--- a/src/app/[locale]/(platform)/_components/HowItWorksDeferred.tsx
+++ b/src/app/[locale]/(platform)/_components/HowItWorksDeferred.tsx
@@ -10,13 +10,16 @@ const HowItWorks = dynamic(
   { ssr: false },
 )
 
-export default function HowItWorksDeferred() {
-  const user = useUser()
-  const isMobile = useIsMobile()
+function useDeferredHowItWorksTrigger({
+  user,
+  shouldRenderInHeader,
+}: {
+  user: ReturnType<typeof useUser>
+  shouldRenderInHeader: boolean
+}) {
   const [shouldRender, setShouldRender] = useState(false)
-  const shouldRenderInHeader = !isMobile
 
-  useEffect(() => {
+  useEffect(function deferRenderUntilUserInteraction() {
     if (user || !shouldRenderInHeader) {
       return
     }
@@ -31,12 +34,21 @@ export default function HowItWorksDeferred() {
     window.addEventListener('pointerdown', renderHowItWorks, passiveOnceOptions)
     window.addEventListener('keydown', renderHowItWorks, { once: true })
 
-    return () => {
+    return function removeDeferredRenderListeners() {
       window.removeEventListener('scroll', renderHowItWorks)
       window.removeEventListener('pointerdown', renderHowItWorks)
       window.removeEventListener('keydown', renderHowItWorks)
     }
   }, [shouldRenderInHeader, user])
+
+  return shouldRender
+}
+
+export default function HowItWorksDeferred() {
+  const user = useUser()
+  const isMobile = useIsMobile()
+  const shouldRenderInHeader = !isMobile
+  const shouldRender = useDeferredHowItWorksTrigger({ user, shouldRenderInHeader })
 
   if (user || !shouldRender || !shouldRenderInHeader) {
     return null

--- a/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
+++ b/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
@@ -66,6 +66,24 @@ interface MobileBottomNavContentProps {
   pathname: string
 }
 
+function useMobileBottomNavState() {
+  const [isSearchOpen, setIsSearchOpen] = useState(false)
+  const [searchFocusTrigger, setSearchFocusTrigger] = useState(0)
+  const [isGuestMenuOpen, setIsGuestMenuOpen] = useState(false)
+  const [isHowItWorksOpen, setIsHowItWorksOpen] = useState(false)
+
+  return {
+    isSearchOpen,
+    setIsSearchOpen,
+    searchFocusTrigger,
+    setSearchFocusTrigger,
+    isGuestMenuOpen,
+    setIsGuestMenuOpen,
+    isHowItWorksOpen,
+    setIsHowItWorksOpen,
+  }
+}
+
 function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
   const t = useExtracted()
   const router = useRouter()
@@ -74,10 +92,16 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
   const { data: session } = useSession()
   const user = useUser()
   const { canShowInstallUi, isIos, isPrompting, requestInstall } = usePwaInstall()
-  const [isSearchOpen, setIsSearchOpen] = useState(false)
-  const [searchFocusTrigger, setSearchFocusTrigger] = useState(0)
-  const [isGuestMenuOpen, setIsGuestMenuOpen] = useState(false)
-  const [isHowItWorksOpen, setIsHowItWorksOpen] = useState(false)
+  const {
+    isSearchOpen,
+    setIsSearchOpen,
+    searchFocusTrigger,
+    setSearchFocusTrigger,
+    isGuestMenuOpen,
+    setIsGuestMenuOpen,
+    isHowItWorksOpen,
+    setIsHowItWorksOpen,
+  } = useMobileBottomNavState()
 
   const isAuthenticated = Boolean(session?.user) || Boolean(user) || isConnected
 
@@ -462,12 +486,10 @@ interface MobileLocaleSwitcherProps {
   onLocaleChange?: () => void
 }
 
-function MobileLocaleSwitcher({ onLocaleChange }: MobileLocaleSwitcherProps) {
-  const locale = useLocale() as SupportedLocale
-  const [isPending, setIsPending] = useState(false)
+function useEnabledLocalesFetch() {
   const [enabledLocales, setEnabledLocales] = useState<SupportedLocale[]>([...SUPPORTED_LOCALES])
 
-  useEffect(() => {
+  useEffect(function fetchEnabledLocalesOnMount() {
     let isActive = true
 
     async function loadEnabledLocales() {
@@ -494,10 +516,22 @@ function MobileLocaleSwitcher({ onLocaleChange }: MobileLocaleSwitcherProps) {
 
     void loadEnabledLocales()
 
-    return () => {
+    return function cancelEnabledLocalesFetch() {
       isActive = false
     }
   }, [])
+
+  return enabledLocales
+}
+
+function useLocaleChangeHandler({
+  locale,
+  onLocaleChange,
+}: {
+  locale: SupportedLocale
+  onLocaleChange: (() => void) | undefined
+}) {
+  const [isPending, setIsPending] = useState(false)
 
   function handleLocaleChange(nextLocale: SupportedLocale) {
     if (nextLocale === locale || typeof window === 'undefined') {
@@ -512,6 +546,14 @@ function MobileLocaleSwitcher({ onLocaleChange }: MobileLocaleSwitcherProps) {
     setIsPending(true)
     window.location.replace(targetUrl)
   }
+
+  return { isPending, handleLocaleChange }
+}
+
+function MobileLocaleSwitcher({ onLocaleChange }: MobileLocaleSwitcherProps) {
+  const locale = useLocale() as SupportedLocale
+  const enabledLocales = useEnabledLocalesFetch()
+  const { isPending, handleLocaleChange } = useLocaleChangeHandler({ locale, onLocaleChange })
 
   return (
     <div className="rounded-2xl border border-border/70 px-4 py-3">

--- a/src/app/[locale]/(platform)/_components/NavigationMoreMenu.tsx
+++ b/src/app/[locale]/(platform)/_components/NavigationMoreMenu.tsx
@@ -8,8 +8,7 @@ import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { cn } from '@/lib/utils'
 
-export default function NavigationMoreMenu() {
-  const t = useExtracted()
+function useNavigationMoreMenuHover() {
   const [open, setOpen] = useState(false)
   const closeTimeoutRef = useRef<number | null>(null)
 
@@ -32,14 +31,22 @@ export default function NavigationMoreMenu() {
     }, 120)
   }, [clearCloseTimeout])
 
-  useEffect(() => {
-    return () => {
-      if (closeTimeoutRef.current != null) {
-        window.clearTimeout(closeTimeoutRef.current)
-        closeTimeoutRef.current = null
+  useEffect(function clearMenuCloseTimeoutOnUnmount() {
+    const timeoutRefSnapshot = closeTimeoutRef
+    return function cleanupMenuCloseTimeout() {
+      if (timeoutRefSnapshot.current != null) {
+        window.clearTimeout(timeoutRefSnapshot.current)
+        timeoutRefSnapshot.current = null
       }
     }
   }, [])
+
+  return { open, setOpen, handleEnter, handleLeave }
+}
+
+export default function NavigationMoreMenu() {
+  const t = useExtracted()
+  const { open, setOpen, handleEnter, handleLeave } = useNavigationMoreMenuHover()
 
   return (
     <DropdownMenu open={open} onOpenChange={setOpen} modal={false}>

--- a/src/app/[locale]/(platform)/_components/NavigationTabs.tsx
+++ b/src/app/[locale]/(platform)/_components/NavigationTabs.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { Route } from 'next'
+import type { RefObject } from 'react'
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react'
 import NavigationMoreMenu from '@/app/[locale]/(platform)/_components/NavigationMoreMenu'
 import NavigationTab from '@/app/[locale]/(platform)/_components/NavigationTab'
@@ -31,31 +32,22 @@ function getMainTagHref(slug: string, dynamicHomeCategorySlugSet: ReadonlySet<st
   return '/' as Route
 }
 
-export default function NavigationTabs() {
-  const pathname = usePathname()
-  const { filters } = useFilters()
-  const { tags, childParentMap } = usePlatformNavigationData()
+type NavigationTag = ReturnType<typeof usePlatformNavigationData>['tags'][number]
+
+function useNavigationTabsRefs(tagCount: number) {
   const containerRef = useRef<HTMLDivElement | null>(null)
   const tabItemRef = useRef<(HTMLSpanElement | null)[]>([])
+
+  useEffect(function syncTabItemRefLengthToTags() {
+    tabItemRef.current = Array.from({ length: tagCount }).map((_, index) => tabItemRef.current[index] ?? null)
+  }, [tagCount])
+
+  return { containerRef, tabItemRef }
+}
+
+function useScrollShadows(containerRef: RefObject<HTMLDivElement | null>) {
   const [showLeftShadow, setShowLeftShadow] = useState(false)
   const [showRightShadow, setShowRightShadow] = useState(false)
-  const dynamicHomeCategorySlugSet = useMemo(() => buildDynamicHomeCategorySlugSet(tags), [tags])
-
-  const navigationSelection = useMemo(() => resolvePlatformNavigationSelection({
-    dynamicHomeCategorySlugSet,
-    pathname,
-    filters: {
-      tag: filters.tag,
-      mainTag: filters.mainTag,
-      bookmarked: filters.bookmarked,
-    },
-    childParentMap,
-  }), [childParentMap, dynamicHomeCategorySlugSet, filters.bookmarked, filters.mainTag, filters.tag, pathname])
-
-  const activeIndex = useMemo(
-    () => tags.findIndex(tag => tag.slug === navigationSelection.activeMainTagSlug),
-    [navigationSelection.activeMainTagSlug, tags],
-  )
 
   const updateScrollShadows = useCallback(() => {
     const container = containerRef.current
@@ -70,21 +62,19 @@ export default function NavigationTabs() {
 
     setShowLeftShadow(scrollLeft > 4)
     setShowRightShadow(scrollLeft < maxScrollLeft - 4)
-  }, [])
+  }, [containerRef])
 
-  useEffect(() => {
-    tabItemRef.current = Array.from({ length: tags.length }).map((_, index) => tabItemRef.current[index] ?? null)
-  }, [tags.length])
-
-  useLayoutEffect(() => {
+  useLayoutEffect(function runInitialScrollShadowUpdate() {
     const rafId = requestAnimationFrame(() => {
       updateScrollShadows()
     })
 
-    return () => cancelAnimationFrame(rafId)
+    return function cancelInitialScrollShadowFrame() {
+      cancelAnimationFrame(rafId)
+    }
   }, [updateScrollShadows])
 
-  useEffect(() => {
+  useEffect(function bindScrollShadowListeners() {
     const container = containerRef.current
     if (!container) {
       return
@@ -106,14 +96,26 @@ export default function NavigationTabs() {
     container.addEventListener('scroll', handleScroll)
     window.addEventListener('resize', handleResize)
 
-    return () => {
+    return function unbindScrollShadowListeners() {
       container.removeEventListener('scroll', handleScroll)
       window.removeEventListener('resize', handleResize)
       clearTimeout(resizeTimeout)
     }
-  }, [updateScrollShadows])
+  }, [containerRef, updateScrollShadows])
 
-  useEffect(() => {
+  return { showLeftShadow, showRightShadow }
+}
+
+function useScrollActiveTabIntoView({
+  activeIndex,
+  containerRef,
+  tabItemRef,
+}: {
+  activeIndex: number
+  containerRef: RefObject<HTMLDivElement | null>
+  tabItemRef: RefObject<(HTMLSpanElement | null)[]>
+}) {
+  useEffect(function scrollActiveTabIntoView() {
     if (activeIndex < 0) {
       return
     }
@@ -139,8 +141,43 @@ export default function NavigationTabs() {
       container.scrollTo({ left: clampedLeft, behavior: 'smooth' })
     }, 100)
 
-    return () => clearTimeout(timeoutId)
-  }, [activeIndex])
+    return function cancelActiveTabScrollTimeout() {
+      clearTimeout(timeoutId)
+    }
+  }, [activeIndex, containerRef, tabItemRef])
+}
+
+function useNavigationSelection(tags: ReadonlyArray<NavigationTag>) {
+  const pathname = usePathname()
+  const { filters } = useFilters()
+  const { childParentMap } = usePlatformNavigationData()
+  const dynamicHomeCategorySlugSet = useMemo(() => buildDynamicHomeCategorySlugSet([...tags]), [tags])
+
+  const navigationSelection = useMemo(() => resolvePlatformNavigationSelection({
+    dynamicHomeCategorySlugSet,
+    pathname,
+    filters: {
+      tag: filters.tag,
+      mainTag: filters.mainTag,
+      bookmarked: filters.bookmarked,
+    },
+    childParentMap,
+  }), [childParentMap, dynamicHomeCategorySlugSet, filters.bookmarked, filters.mainTag, filters.tag, pathname])
+
+  const activeIndex = useMemo(
+    () => tags.findIndex(tag => tag.slug === navigationSelection.activeMainTagSlug),
+    [navigationSelection.activeMainTagSlug, tags],
+  )
+
+  return { navigationSelection, activeIndex, dynamicHomeCategorySlugSet }
+}
+
+export default function NavigationTabs() {
+  const { tags } = usePlatformNavigationData()
+  const { containerRef, tabItemRef } = useNavigationTabsRefs(tags.length)
+  const { showLeftShadow, showRightShadow } = useScrollShadows(containerRef)
+  const { navigationSelection, activeIndex, dynamicHomeCategorySlugSet } = useNavigationSelection(tags)
+  useScrollActiveTabIntoView({ activeIndex, containerRef, tabItemRef })
 
   return (
     <nav className="sticky top-15 z-20 bg-background md:top-17">

--- a/src/app/[locale]/(platform)/_components/PlatformViewerState.tsx
+++ b/src/app/[locale]/(platform)/_components/PlatformViewerState.tsx
@@ -7,10 +7,10 @@ import { mergeSessionUserState, useUser } from '@/stores/useUser'
 
 const { useSession } = authClient
 
-export default function PlatformViewerState() {
+function useSyncViewerUserState() {
   const { data: session, isPending } = useSession()
 
-  useEffect(() => {
+  useEffect(function syncViewerUserStateFromSession() {
     if (isPending) {
       return
     }
@@ -24,6 +24,10 @@ export default function PlatformViewerState() {
       return mergeSessionUserState(previous, session.user as unknown as User)
     })
   }, [isPending, session?.user])
+}
+
+export default function PlatformViewerState() {
+  useSyncViewerUserState()
 
   return null
 }

--- a/src/app/[locale]/(platform)/_components/PositionShareDialog.tsx
+++ b/src/app/[locale]/(platform)/_components/PositionShareDialog.tsx
@@ -19,16 +19,19 @@ interface PositionShareDialogProps {
   payload: ShareCardPayload | null
 }
 
-export function PositionShareDialog({ open, onOpenChange, payload }: PositionShareDialogProps) {
-  const t = useExtracted()
-  const isMobile = useIsMobile()
-
-  const shareCardUrl = useMemo(() => {
+function useShareCardUrl(payload: ShareCardPayload | null) {
+  return useMemo(() => {
     if (!payload) {
       return ''
     }
     return buildShareCardUrl(payload)
   }, [payload])
+}
+
+export function PositionShareDialog({ open, onOpenChange, payload }: PositionShareDialogProps) {
+  const t = useExtracted()
+  const isMobile = useIsMobile()
+  const shareCardUrl = useShareCardUrl(payload)
 
   const dialogContent = open
     ? (
@@ -70,20 +73,15 @@ interface PositionShareDialogContentProps {
   shareCardUrl: string
 }
 
-function PositionShareDialogContent({
-  payload,
-  shareCardUrl,
-}: PositionShareDialogContentProps) {
-  const t = useExtracted()
-  const [shareCardStatus, setShareCardStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>(
+type ShareCardStatus = 'idle' | 'loading' | 'ready' | 'error'
+
+function useShareCardState(shareCardUrl: string) {
+  const [shareCardStatus, setShareCardStatus] = useState<ShareCardStatus>(
     shareCardUrl ? 'loading' : 'idle',
   )
   const [shareCardBlob, setShareCardBlob] = useState<Blob | null>(null)
-  const [isCopyingShareImage, setIsCopyingShareImage] = useState(false)
-  const [isSharingOnX, setIsSharingOnX] = useState(false)
-  const shareOnXTimeoutRef = useRef<number | null>(null)
 
-  useEffect(() => {
+  useEffect(function preloadShareCardBlob() {
     if (!shareCardUrl || shareCardStatus !== 'ready') {
       return
     }
@@ -109,27 +107,73 @@ function PositionShareDialogContent({
         }
       })
 
-    return () => {
+    return function cancelShareCardBlobPreload() {
       isCancelled = true
     }
   }, [shareCardStatus, shareCardUrl])
 
-  useEffect(() => {
-    return () => {
-      if (shareOnXTimeoutRef.current !== null) {
-        window.clearTimeout(shareOnXTimeoutRef.current)
+  return { shareCardStatus, setShareCardStatus, shareCardBlob }
+}
+
+function useShareOnXHandler(payload: ShareCardPayload | null, t: ReturnType<typeof useExtracted>) {
+  const [isSharingOnX, setIsSharingOnX] = useState(false)
+  const shareOnXTimeoutRef = useRef<number | null>(null)
+
+  useEffect(function clearShareOnXTimeoutOnUnmount() {
+    const timeoutRefSnapshot = shareOnXTimeoutRef
+    return function cleanupShareOnXTimeout() {
+      if (timeoutRefSnapshot.current !== null) {
+        window.clearTimeout(timeoutRefSnapshot.current)
       }
     }
   }, [])
 
-  const handleShareCardLoaded = useCallback(() => {
-    setShareCardStatus('ready')
-  }, [])
+  const handleShareOnX = useCallback(() => {
+    if (!payload) {
+      return
+    }
 
-  const handleShareCardError = useCallback(() => {
-    setShareCardStatus('error')
-    toast.error(t('Unable to generate a share card right now.'))
-  }, [t])
+    setIsSharingOnX(true)
+    try {
+      const profileSlug = payload.userName?.trim() || 'user'
+      const baseUrl = window.location.origin
+      const profilePath = buildPublicProfilePath(profileSlug) ?? '/@user'
+      const profileUrl = new URL(profilePath, baseUrl).toString()
+      const shareText = [
+        t('I just put my money where my mouth is on @kuest.'),
+        '',
+        t('Trade against me: {url}', { url: profileUrl }),
+      ].join('\n')
+
+      const shareUrl = new URL('https://x.com/intent/tweet')
+      shareUrl.searchParams.set('text', shareText)
+      window.open(shareUrl.toString(), '_blank', 'noopener,noreferrer')
+    }
+    finally {
+      if (shareOnXTimeoutRef.current !== null) {
+        window.clearTimeout(shareOnXTimeoutRef.current)
+      }
+
+      shareOnXTimeoutRef.current = window.setTimeout(() => {
+        setIsSharingOnX(false)
+        shareOnXTimeoutRef.current = null
+      }, 200)
+    }
+  }, [payload, t])
+
+  return { isSharingOnX, handleShareOnX }
+}
+
+function useCopyShareImage({
+  shareCardBlob,
+  shareCardUrl,
+  t,
+}: {
+  shareCardBlob: Blob | null
+  shareCardUrl: string
+  t: ReturnType<typeof useExtracted>
+}) {
+  const [isCopyingShareImage, setIsCopyingShareImage] = useState(false)
 
   const handleCopyShareImage = useCallback(async () => {
     if (!shareCardUrl) {
@@ -177,38 +221,31 @@ function PositionShareDialogContent({
     }
   }, [shareCardBlob, shareCardUrl, t])
 
-  const handleShareOnX = useCallback(() => {
-    if (!payload) {
-      return
-    }
+  return { isCopyingShareImage, handleCopyShareImage }
+}
 
-    setIsSharingOnX(true)
-    try {
-      const profileSlug = payload.userName?.trim() || 'user'
-      const baseUrl = window.location.origin
-      const profilePath = buildPublicProfilePath(profileSlug) ?? '/@user'
-      const profileUrl = new URL(profilePath, baseUrl).toString()
-      const shareText = [
-        t('I just put my money where my mouth is on @kuest.'),
-        '',
-        t('Trade against me: {url}', { url: profileUrl }),
-      ].join('\n')
+function useShareCardStatusHandlers(setShareCardStatus: (status: ShareCardStatus) => void, t: ReturnType<typeof useExtracted>) {
+  const handleShareCardLoaded = useCallback(() => {
+    setShareCardStatus('ready')
+  }, [setShareCardStatus])
 
-      const shareUrl = new URL('https://x.com/intent/tweet')
-      shareUrl.searchParams.set('text', shareText)
-      window.open(shareUrl.toString(), '_blank', 'noopener,noreferrer')
-    }
-    finally {
-      if (shareOnXTimeoutRef.current !== null) {
-        window.clearTimeout(shareOnXTimeoutRef.current)
-      }
+  const handleShareCardError = useCallback(() => {
+    setShareCardStatus('error')
+    toast.error(t('Unable to generate a share card right now.'))
+  }, [setShareCardStatus, t])
 
-      shareOnXTimeoutRef.current = window.setTimeout(() => {
-        setIsSharingOnX(false)
-        shareOnXTimeoutRef.current = null
-      }, 200)
-    }
-  }, [payload, t])
+  return { handleShareCardLoaded, handleShareCardError }
+}
+
+function PositionShareDialogContent({
+  payload,
+  shareCardUrl,
+}: PositionShareDialogContentProps) {
+  const t = useExtracted()
+  const { shareCardStatus, setShareCardStatus, shareCardBlob } = useShareCardState(shareCardUrl)
+  const { isCopyingShareImage, handleCopyShareImage } = useCopyShareImage({ shareCardBlob, shareCardUrl, t })
+  const { isSharingOnX, handleShareOnX } = useShareOnXHandler(payload, t)
+  const { handleShareCardLoaded, handleShareCardError } = useShareCardStatusHandlers(setShareCardStatus, t)
 
   const isShareReady = shareCardStatus === 'ready'
 

--- a/src/app/[locale]/(platform)/_components/ProfileOverviewCard.tsx
+++ b/src/app/[locale]/(platform)/_components/ProfileOverviewCard.tsx
@@ -33,6 +33,19 @@ interface ProfileOverviewCardProps {
   enableLiveValue?: boolean
 }
 
+function useJoinedDateLabel(joinedAt: string | undefined) {
+  return useMemo(() => {
+    if (!joinedAt) {
+      return null
+    }
+    const date = new Date(joinedAt)
+    if (Number.isNaN(date.getTime())) {
+      return null
+    }
+    return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+  }, [joinedAt])
+}
+
 export default function ProfileOverviewCard({
   profile,
   snapshot,
@@ -68,16 +81,7 @@ export default function ProfileOverviewCard({
   const avatarFallbackStyle = showPlaceholder
     ? getAvatarPlaceholderStyle(avatarSeed)
     : undefined
-  const joinedText = useMemo(() => {
-    if (!profile.joinedAt) {
-      return null
-    }
-    const date = new Date(profile.joinedAt)
-    if (Number.isNaN(date.getTime())) {
-      return null
-    }
-    return date.toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
-  }, [profile.joinedAt])
+  const joinedText = useJoinedDateLabel(profile.joinedAt)
 
   const positionsValueLabel = Math.abs(positionsValue) >= 100_000
     ? formatCompactCurrency(positionsValue)

--- a/src/app/[locale]/(platform)/_components/SearchTabs.tsx
+++ b/src/app/[locale]/(platform)/_components/SearchTabs.tsx
@@ -2,7 +2,6 @@
 
 import type { SearchLoadingStates } from '@/types'
 import { LoaderIcon } from 'lucide-react'
-import { useMemo } from 'react'
 import { cn } from '@/lib/utils'
 
 interface SearchTabsProps {
@@ -11,13 +10,13 @@ interface SearchTabsProps {
   isLoading: SearchLoadingStates
 }
 
+const SEARCH_TABS = ['events', 'profiles'] as const
+
 export function SearchTabs({
   activeTab,
   onTabChange,
   isLoading,
 }: SearchTabsProps) {
-  const searchTabs = useMemo(() => ['events', 'profiles'] as const, [])
-
   function handleKeyDown(event: React.KeyboardEvent, tab: 'events' | 'profiles') {
     if (event.key === 'Enter' || event.key === ' ') {
       event.preventDefault()
@@ -28,7 +27,7 @@ export function SearchTabs({
   return (
     <div className="bg-background px-1 pt-1">
       <ul className="relative flex h-10 gap-2">
-        {searchTabs.map((tab) => {
+        {SEARCH_TABS.map((tab) => {
           const isActive = activeTab === tab
           const loading = tab === 'events' ? isLoading.events : isLoading.profiles
 

--- a/src/app/[locale]/(platform)/_components/SellPositionModal.tsx
+++ b/src/app/[locale]/(platform)/_components/SellPositionModal.tsx
@@ -38,36 +38,41 @@ interface SellPositionModalProps {
   onSharesChange?: (shares: number) => void
 }
 
-export default function SellPositionModal({
-  open,
-  onOpenChange,
-  outcomeLabel,
-  outcomeShortLabel,
-  outcomeIconUrl,
-  fallbackIconUrl,
-  shares,
-  filledShares,
-  avgPriceCents,
-  receiveAmount,
-  sellBids = [],
-  onCashOut,
-  onEditOrder,
-  onSharesChange,
-}: SellPositionModalProps) {
-  const progressStops = [0, 25, 50, 75, 100]
-  const isMobile = useIsMobile()
-  const [sellPercent, setSellPercent] = useState(100)
+const PROGRESS_STOPS = [0, 25, 50, 75, 100]
 
-  const iconUrl = outcomeIconUrl || fallbackIconUrl || ''
-  const safeShares = Number.isFinite(shares) ? shares : 0
-  const safeFilledShares = Number.isFinite(filledShares) ? filledShares : null
+function useSellPercent({
+  safeShares,
+  onSharesChange,
+}: {
+  safeShares: number
+  onSharesChange?: (shares: number) => void
+}) {
+  const [sellPercent, setSellPercent] = useState(100)
   const selectedShares = useMemo(() => resolveSelectedShares(safeShares, sellPercent), [safeShares, sellPercent])
   const handleSellPercentChange = useCallback((nextSellPercent: number) => {
     setSellPercent(nextSellPercent)
     onSharesChange?.(resolveSelectedShares(safeShares, nextSellPercent))
   }, [onSharesChange, safeShares])
 
-  const sellPreview = useMemo(() => {
+  return { sellPercent, selectedShares, handleSellPercentChange }
+}
+
+function useSellPreview({
+  avgPriceCents,
+  receiveAmount,
+  safeFilledShares,
+  safeShares,
+  selectedShares,
+  sellBids,
+}: {
+  avgPriceCents: number | null
+  receiveAmount: number | null
+  safeFilledShares: number | null
+  safeShares: number
+  selectedShares: number
+  sellBids: NormalizedBookLevel[]
+}) {
+  return useMemo(() => {
     if (!(selectedShares > 0)) {
       return {
         filledShares: 0,
@@ -100,6 +105,39 @@ export default function SellPositionModal({
       receiveAmount: fallbackReceive,
     }
   }, [avgPriceCents, receiveAmount, safeFilledShares, safeShares, selectedShares, sellBids])
+}
+
+export default function SellPositionModal({
+  open,
+  onOpenChange,
+  outcomeLabel,
+  outcomeShortLabel,
+  outcomeIconUrl,
+  fallbackIconUrl,
+  shares,
+  filledShares,
+  avgPriceCents,
+  receiveAmount,
+  sellBids = [],
+  onCashOut,
+  onEditOrder,
+  onSharesChange,
+}: SellPositionModalProps) {
+  const isMobile = useIsMobile()
+
+  const iconUrl = outcomeIconUrl || fallbackIconUrl || ''
+  const safeShares = Number.isFinite(shares) ? shares : 0
+  const safeFilledShares = Number.isFinite(filledShares) ? filledShares : null
+  const { sellPercent, selectedShares, handleSellPercentChange } = useSellPercent({ safeShares, onSharesChange })
+
+  const sellPreview = useSellPreview({
+    avgPriceCents,
+    receiveAmount,
+    safeFilledShares,
+    safeShares,
+    selectedShares,
+    sellBids,
+  })
 
   const hasPartialFill = sellPreview.filledShares > 0 && sellPreview.filledShares + 1e-6 < selectedShares
   const sharesLabel = formatSharesLabel(selectedShares)
@@ -171,7 +209,7 @@ export default function SellPositionModal({
               className="absolute top-1/2 h-1 -translate-y-1/2 rounded-full bg-primary"
               style={{ width: `${sellPercent}%` }}
             />
-            {progressStops.map((stop) => {
+            {PROGRESS_STOPS.map((stop) => {
               const isFilled = sellPercent >= stop
               return (
                 <span
@@ -202,7 +240,7 @@ export default function SellPositionModal({
             />
           </div>
           <div className="relative h-4 text-xs font-semibold">
-            {progressStops.map(stop => (
+            {PROGRESS_STOPS.map(stop => (
               <span
                 key={`label-${stop}`}
                 className={cn(

--- a/src/app/[locale]/(platform)/_components/WalletFlow.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletFlow.tsx
@@ -22,6 +22,15 @@ import { formatAmountInputValue } from '@/lib/formatters'
 import { buildSendErc20Transaction, getSafeTxTypedData, packSafeSignature } from '@/lib/safe/transactions'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 
+type DepositView = 'fund' | 'receive' | 'wallets' | 'amount' | 'confirm' | 'success'
+
+interface PendingWithdrawal {
+  id: string
+  amount: string
+  to: string
+  createdAt: number
+}
+
 interface WalletFlowProps {
   depositOpen: boolean
   onDepositOpenChange: (open: boolean) => void
@@ -36,58 +45,8 @@ interface WalletFlowProps {
   meldUrl: string | null
 }
 
-export function WalletFlow({
-  depositOpen,
-  onDepositOpenChange,
-  withdrawOpen,
-  onWithdrawOpenChange,
-  user,
-  meldUrl,
-}: WalletFlowProps) {
-  const isMobile = useIsMobile()
-  const { signMessageAsync } = useSignMessage()
-  const { runWithSignaturePrompt } = useSignaturePromptRunner()
-  const [depositView, setDepositView] = useState<'fund' | 'receive' | 'wallets' | 'amount' | 'confirm' | 'success'>('fund')
-  const [walletSendTo, setWalletSendTo] = useState('')
-  const [walletSendAmount, setWalletSendAmount] = useState('')
-  const [isWalletSending, setIsWalletSending] = useState(false)
-  const [pendingWithdrawals, setPendingWithdrawals] = useState<Array<{
-    id: string
-    amount: string
-    to: string
-    createdAt: number
-  }>>([])
-  const { balance, isLoadingBalance } = useBalance()
-  const {
-    formattedUsdBalance,
-    isLoadingUsdBalance,
-  } = useLiFiWalletUsdBalance(user?.address, { enabled: depositOpen })
-  const site = useSiteIdentity()
-  const connectedWalletAddress = user?.address ?? null
-  const { openTradeRequirements } = useTradingOnboarding()
-
-  const visiblePendingWithdrawals = useMemo(
-    () => pendingWithdrawals.filter(withdrawal => Date.now() - withdrawal.createdAt < 2 * 60 * 1000),
-    [pendingWithdrawals],
-  )
-
-  useEffect(() => {
-    if (pendingWithdrawals.length === 0) {
-      return undefined
-    }
-
-    const intervalId = window.setInterval(() => {
-      setPendingWithdrawals(current =>
-        current.filter(withdrawal => Date.now() - withdrawal.createdAt < 2 * 60 * 1000),
-      )
-    }, 15_000)
-
-    return () => window.clearInterval(intervalId)
-  }, [pendingWithdrawals.length])
-
-  const hasDeployedProxyWallet = useMemo(() => (
-    Boolean(user?.proxy_wallet_address && user?.proxy_wallet_status === 'deployed')
-  ), [user?.proxy_wallet_address, user?.proxy_wallet_status])
+function useDepositViewState(onDepositOpenChange: (open: boolean) => void) {
+  const [depositView, setDepositView] = useState<DepositView>('fund')
 
   const handleDepositModalChange = useCallback((next: boolean) => {
     onDepositOpenChange(next)
@@ -95,6 +54,14 @@ export function WalletFlow({
       setDepositView('fund')
     }
   }, [onDepositOpenChange])
+
+  return { depositView, setDepositView, handleDepositModalChange }
+}
+
+function useWithdrawFormState(onWithdrawOpenChange: (open: boolean) => void) {
+  const [walletSendTo, setWalletSendTo] = useState('')
+  const [walletSendAmount, setWalletSendAmount] = useState('')
+  const [isWalletSending, setIsWalletSending] = useState(false)
 
   const handleWithdrawModalChange = useCallback((next: boolean) => {
     onWithdrawOpenChange(next)
@@ -105,7 +72,78 @@ export function WalletFlow({
     }
   }, [onWithdrawOpenChange])
 
-  const handleWalletSend = useCallback(async (event?: React.FormEvent<HTMLFormElement>) => {
+  return {
+    walletSendTo,
+    setWalletSendTo,
+    walletSendAmount,
+    setWalletSendAmount,
+    isWalletSending,
+    setIsWalletSending,
+    handleWithdrawModalChange,
+  }
+}
+
+const PENDING_WITHDRAWAL_EXPIRY_MS = 2 * 60 * 1000
+
+function usePendingWithdrawals() {
+  const [pendingWithdrawals, setPendingWithdrawals] = useState<PendingWithdrawal[]>([])
+
+  const visiblePendingWithdrawals = useMemo(
+    () => pendingWithdrawals.filter(withdrawal => Date.now() - withdrawal.createdAt < PENDING_WITHDRAWAL_EXPIRY_MS),
+    [pendingWithdrawals],
+  )
+
+  useEffect(function pruneExpiredPendingWithdrawals() {
+    if (pendingWithdrawals.length === 0) {
+      return undefined
+    }
+
+    const intervalId = window.setInterval(() => {
+      setPendingWithdrawals(current =>
+        current.filter(withdrawal => Date.now() - withdrawal.createdAt < PENDING_WITHDRAWAL_EXPIRY_MS),
+      )
+    }, 15_000)
+
+    return function clearPendingWithdrawalInterval() {
+      window.clearInterval(intervalId)
+    }
+  }, [pendingWithdrawals.length])
+
+  return { pendingWithdrawals: visiblePendingWithdrawals, setPendingWithdrawals }
+}
+
+function useHasDeployedProxyWallet(user: WalletFlowProps['user']) {
+  return useMemo(() => (
+    Boolean(user?.proxy_wallet_address && user?.proxy_wallet_status === 'deployed')
+  ), [user?.proxy_wallet_address, user?.proxy_wallet_status])
+}
+
+function useWalletSendHandler({
+  user,
+  walletSendTo,
+  walletSendAmount,
+  setIsWalletSending,
+  setWalletSendTo,
+  setWalletSendAmount,
+  setPendingWithdrawals,
+  handleWithdrawModalChange,
+  openTradeRequirements,
+  runWithSignaturePrompt,
+  signMessageAsync,
+}: {
+  user: WalletFlowProps['user']
+  walletSendTo: string
+  walletSendAmount: string
+  setIsWalletSending: (value: boolean) => void
+  setWalletSendTo: (value: string) => void
+  setWalletSendAmount: (value: string) => void
+  setPendingWithdrawals: (updater: (current: PendingWithdrawal[]) => PendingWithdrawal[]) => void
+  handleWithdrawModalChange: (next: boolean) => void
+  openTradeRequirements: ReturnType<typeof useTradingOnboarding>['openTradeRequirements']
+  runWithSignaturePrompt: ReturnType<typeof useSignaturePromptRunner>['runWithSignaturePrompt']
+  signMessageAsync: ReturnType<typeof useSignMessage>['signMessageAsync']
+}) {
+  return useCallback(async (event?: React.FormEvent<HTMLFormElement>) => {
     event?.preventDefault()
     if (!user?.proxy_wallet_address) {
       toast.error('Deploy your proxy wallet first.')
@@ -213,14 +251,26 @@ export function WalletFlow({
     handleWithdrawModalChange,
     openTradeRequirements,
     runWithSignaturePrompt,
+    setIsWalletSending,
+    setPendingWithdrawals,
+    setWalletSendAmount,
+    setWalletSendTo,
     signMessageAsync,
     user?.address,
     user?.proxy_wallet_address,
     walletSendAmount,
     walletSendTo,
   ])
+}
 
-  const handleBuy = useCallback((url?: string | null) => {
+function useBuyHandler({
+  meldUrl,
+  handleDepositModalChange,
+}: {
+  meldUrl: string | null
+  handleDepositModalChange: (next: boolean) => void
+}) {
+  return useCallback((url?: string | null) => {
     const targetUrl = url ?? meldUrl
     if (!targetUrl) {
       return
@@ -239,19 +289,87 @@ export function WalletFlow({
       handleDepositModalChange(false)
     }
   }, [handleDepositModalChange, meldUrl])
+}
 
-  const handleUseConnectedWallet = useCallback(() => {
+function useUseConnectedWalletHandler({
+  connectedWalletAddress,
+  setWalletSendTo,
+}: {
+  connectedWalletAddress: string | null
+  setWalletSendTo: (value: string) => void
+}) {
+  return useCallback(() => {
     if (!connectedWalletAddress) {
       return
     }
     setWalletSendTo(connectedWalletAddress)
-  }, [connectedWalletAddress])
+  }, [connectedWalletAddress, setWalletSendTo])
+}
 
-  const handleSetMaxAmount = useCallback(() => {
-    const amount = Number.isFinite(balance.raw) ? balance.raw : 0
+function useSetMaxAmountHandler({
+  balanceRaw,
+  setWalletSendAmount,
+}: {
+  balanceRaw: number
+  setWalletSendAmount: (value: string) => void
+}) {
+  return useCallback(() => {
+    const amount = Number.isFinite(balanceRaw) ? balanceRaw : 0
     const limitedAmount = Math.min(amount, MAX_AMOUNT_INPUT)
     setWalletSendAmount(formatAmountInputValue(limitedAmount, { roundingMode: 'floor' }))
-  }, [balance.raw])
+  }, [balanceRaw, setWalletSendAmount])
+}
+
+export function WalletFlow({
+  depositOpen,
+  onDepositOpenChange,
+  withdrawOpen,
+  onWithdrawOpenChange,
+  user,
+  meldUrl,
+}: WalletFlowProps) {
+  const isMobile = useIsMobile()
+  const { signMessageAsync } = useSignMessage()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
+  const { depositView, setDepositView, handleDepositModalChange } = useDepositViewState(onDepositOpenChange)
+  const {
+    walletSendTo,
+    setWalletSendTo,
+    walletSendAmount,
+    setWalletSendAmount,
+    isWalletSending,
+    setIsWalletSending,
+    handleWithdrawModalChange,
+  } = useWithdrawFormState(onWithdrawOpenChange)
+  const { pendingWithdrawals: visiblePendingWithdrawals, setPendingWithdrawals } = usePendingWithdrawals()
+  const { balance, isLoadingBalance } = useBalance()
+  const {
+    formattedUsdBalance,
+    isLoadingUsdBalance,
+  } = useLiFiWalletUsdBalance(user?.address, { enabled: depositOpen })
+  const site = useSiteIdentity()
+  const connectedWalletAddress = user?.address ?? null
+  const { openTradeRequirements } = useTradingOnboarding()
+
+  const hasDeployedProxyWallet = useHasDeployedProxyWallet(user)
+
+  const handleWalletSend = useWalletSendHandler({
+    user,
+    walletSendTo,
+    walletSendAmount,
+    setIsWalletSending,
+    setWalletSendTo,
+    setWalletSendAmount,
+    setPendingWithdrawals,
+    handleWithdrawModalChange,
+    openTradeRequirements,
+    runWithSignaturePrompt,
+    signMessageAsync,
+  })
+
+  const handleBuy = useBuyHandler({ meldUrl, handleDepositModalChange })
+  const handleUseConnectedWallet = useUseConnectedWalletHandler({ connectedWalletAddress, setWalletSendTo })
+  const handleSetMaxAmount = useSetMaxAmountHandler({ balanceRaw: balance.raw, setWalletSendAmount })
 
   return (
     <>

--- a/src/app/[locale]/(platform)/_providers/FilterProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/FilterProvider.tsx
@@ -39,7 +39,7 @@ export const DEFAULT_FILTERS: FilterState = {
   hideEarnings: false,
 }
 
-export function FilterProvider({ children, initialTag }: FilterProviderProps) {
+function useFilterContextValue(initialTag: string | undefined): FilterContextType {
   const [filters, setFilters] = useState<FilterState>({
     ...DEFAULT_FILTERS,
     ...(initialTag && { tag: initialTag, mainTag: initialTag }),
@@ -49,7 +49,11 @@ export function FilterProvider({ children, initialTag }: FilterProviderProps) {
     setFilters(prev => ({ ...prev, ...updates }))
   }, [])
 
-  const filterContextValue = useMemo(() => ({ filters, updateFilters }), [filters, updateFilters])
+  return useMemo(() => ({ filters, updateFilters }), [filters, updateFilters])
+}
+
+export function FilterProvider({ children, initialTag }: FilterProviderProps) {
+  const filterContextValue = useFilterContextValue(initialTag)
 
   return (
     <FilterContext value={filterContextValue}>

--- a/src/app/[locale]/(platform)/_providers/PlatformNavigationProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/PlatformNavigationProvider.tsx
@@ -11,15 +11,22 @@ interface PlatformNavigationContextValue {
 
 const PlatformNavigationContext = createContext<PlatformNavigationContextValue | null>(null)
 
+function usePlatformNavigationContextValue({
+  childParentMap,
+  tags,
+}: PlatformNavigationContextValue) {
+  return useMemo(() => ({
+    childParentMap,
+    tags,
+  }), [childParentMap, tags])
+}
+
 export default function PlatformNavigationProvider({
   tags,
   childParentMap,
   children,
 }: PlatformNavigationContextValue & { children: ReactNode }) {
-  const value = useMemo(() => ({
-    childParentMap,
-    tags,
-  }), [childParentMap, tags])
+  const value = usePlatformNavigationContextValue({ childParentMap, tags })
 
   return (
     <PlatformNavigationContext value={value}>

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -71,65 +71,85 @@ interface TradingOnboardingProviderContentProps {
   user: User | null
 }
 
-function TradingOnboardingProviderContent({
-  children,
-  user,
-}: TradingOnboardingProviderContentProps) {
-  const { open } = useAppKit()
-  const { signTypedDataAsync } = useSignTypedData()
-  const { signMessageAsync } = useSignMessage()
-  const { runWithSignaturePrompt } = useSignaturePromptRunner()
-  const affiliateMetadata = useAffiliateOrderMetadata()
-  const proxyWalletStatus = user?.proxy_wallet_status ?? null
-  const hasProxyWalletAddress = Boolean(user?.proxy_wallet_address)
-  const hasDeployedProxyWallet = Boolean(user?.proxy_wallet_address && proxyWalletStatus === 'deployed')
-  const isProxyWalletDeploying = Boolean(
-    user?.proxy_wallet_address
-    && (proxyWalletStatus === 'deploying' || proxyWalletStatus === 'signed'),
-  )
-  const tradingAuthSettings = user?.settings?.tradingAuth ?? null
-  const hasTradingAuth = Boolean(
-    tradingAuthSettings?.relayer?.enabled
-    && tradingAuthSettings?.clob?.enabled,
-  )
-  const approvalsSettings = tradingAuthSettings?.approvals ?? null
-  const hasTokenApprovals = Boolean(approvalsSettings?.enabled)
+type ProxyStep = 'idle' | 'signing' | 'deploying' | 'completed'
+type TradingAuthStep = 'idle' | 'signing' | 'completed'
+type ApprovalsStep = 'idle' | 'signing' | 'completed'
+
+function useOnboardingDialogsState() {
   const [enableModalOpen, setEnableModalOpen] = useState(false)
   const [fundModalOpen, setFundModalOpen] = useState(false)
   const [tradeModalOpen, setTradeModalOpen] = useState(false)
   const [shouldShowFundAfterProxy, setShouldShowFundAfterProxy] = useState(false)
-  const [proxyWalletError, setProxyWalletError] = useState<string | null>(null)
-  const [tradingAuthError, setTradingAuthError] = useState<string | null>(null)
-  const [tokenApprovalError, setTokenApprovalError] = useState<string | null>(null)
-  const [proxyStep, setProxyStep] = useState<'idle' | 'signing' | 'deploying' | 'completed'>(
-    hasDeployedProxyWallet ? 'completed' : isProxyWalletDeploying ? 'deploying' : 'idle',
-  )
-  const [tradingAuthStep, setTradingAuthStep] = useState<'idle' | 'signing' | 'completed'>(
-    hasTradingAuth ? 'completed' : 'idle',
-  )
-  const [approvalsStep, setApprovalsStep] = useState<'idle' | 'signing' | 'completed'>(
-    hasTokenApprovals ? 'completed' : 'idle',
-  )
-  const [requiresTradingAuthRefresh, setRequiresTradingAuthRefresh] = useState(false)
   const [depositModalOpen, setDepositModalOpen] = useState(false)
   const [withdrawModalOpen, setWithdrawModalOpen] = useState(false)
 
-  const hasEffectiveTradingAuth = hasTradingAuth && !requiresTradingAuthRefresh
-  const effectiveProxyStep
-    = hasDeployedProxyWallet
-      ? 'completed'
-      : isProxyWalletDeploying
-        ? 'deploying'
-        : proxyStep
-  const effectiveTradingAuthStep = hasEffectiveTradingAuth ? 'completed' : tradingAuthStep
-  const effectiveApprovalsStep = hasTokenApprovals ? 'completed' : approvalsStep
-  const tradingAuthSatisfied = effectiveTradingAuthStep === 'completed'
-  const tradingReady
-    = effectiveProxyStep === 'completed'
-      && effectiveTradingAuthStep === 'completed'
-      && effectiveApprovalsStep === 'completed'
+  return {
+    enableModalOpen,
+    setEnableModalOpen,
+    fundModalOpen,
+    setFundModalOpen,
+    tradeModalOpen,
+    setTradeModalOpen,
+    shouldShowFundAfterProxy,
+    setShouldShowFundAfterProxy,
+    depositModalOpen,
+    setDepositModalOpen,
+    withdrawModalOpen,
+    setWithdrawModalOpen,
+  }
+}
 
-  const refreshSessionUserState = useCallback(async () => {
+function useOnboardingErrorsState() {
+  const [proxyWalletError, setProxyWalletError] = useState<string | null>(null)
+  const [tradingAuthError, setTradingAuthError] = useState<string | null>(null)
+  const [tokenApprovalError, setTokenApprovalError] = useState<string | null>(null)
+
+  return {
+    proxyWalletError,
+    setProxyWalletError,
+    tradingAuthError,
+    setTradingAuthError,
+    tokenApprovalError,
+    setTokenApprovalError,
+  }
+}
+
+function useOnboardingStepsState({
+  hasDeployedProxyWallet,
+  isProxyWalletDeploying,
+  hasTradingAuth,
+  hasTokenApprovals,
+}: {
+  hasDeployedProxyWallet: boolean
+  isProxyWalletDeploying: boolean
+  hasTradingAuth: boolean
+  hasTokenApprovals: boolean
+}) {
+  const [proxyStep, setProxyStep] = useState<ProxyStep>(
+    hasDeployedProxyWallet ? 'completed' : isProxyWalletDeploying ? 'deploying' : 'idle',
+  )
+  const [tradingAuthStep, setTradingAuthStep] = useState<TradingAuthStep>(
+    hasTradingAuth ? 'completed' : 'idle',
+  )
+  const [approvalsStep, setApprovalsStep] = useState<ApprovalsStep>(
+    hasTokenApprovals ? 'completed' : 'idle',
+  )
+  const [requiresTradingAuthRefresh, setRequiresTradingAuthRefresh] = useState(false)
+
+  return {
+    proxyStep,
+    setProxyStep,
+    tradingAuthStep,
+    setTradingAuthStep,
+    approvalsStep,
+    setApprovalsStep,
+    requiresTradingAuthRefresh,
+    setRequiresTradingAuthRefresh,
+  }
+}
+
+function useSessionRefresher() {
+  return useCallback(async () => {
     try {
       const session = await authClient.getSession({
         query: {
@@ -147,20 +167,44 @@ function TradingOnboardingProviderContent({
       console.error('Failed to refresh user session', error)
     }
   }, [])
+}
 
-  useProxyWalletPolling({
-    userId: user?.id,
-    proxyWalletAddress: user?.proxy_wallet_address,
-    proxyWalletStatus: user?.proxy_wallet_status,
-    hasDeployedProxyWallet,
-    hasProxyWalletAddress,
-  })
-
-  const resetPendingFundState = useCallback(() => {
+function usePendingFundStateReset(setShouldShowFundAfterProxy: (value: boolean) => void) {
+  return useCallback(() => {
     setShouldShowFundAfterProxy(false)
-  }, [])
+  }, [setShouldShowFundAfterProxy])
+}
 
-  const resetEnableFlowState = useCallback(() => {
+function useEnableFlowReset({
+  hasTokenApprovals,
+  hasTradingAuth,
+  proxyStep,
+  requiresTradingAuthRefresh,
+  setProxyWalletError,
+  setTradingAuthError,
+  setTokenApprovalError,
+  setShouldShowFundAfterProxy,
+  setDepositModalOpen,
+  setWithdrawModalOpen,
+  setProxyStep,
+  setTradingAuthStep,
+  setApprovalsStep,
+}: {
+  hasTokenApprovals: boolean
+  hasTradingAuth: boolean
+  proxyStep: ProxyStep
+  requiresTradingAuthRefresh: boolean
+  setProxyWalletError: (value: string | null) => void
+  setTradingAuthError: (value: string | null) => void
+  setTokenApprovalError: (value: string | null) => void
+  setShouldShowFundAfterProxy: (value: boolean) => void
+  setDepositModalOpen: (value: boolean) => void
+  setWithdrawModalOpen: (value: boolean) => void
+  setProxyStep: (value: ProxyStep) => void
+  setTradingAuthStep: (value: TradingAuthStep) => void
+  setApprovalsStep: (value: ApprovalsStep) => void
+}) {
+  return useCallback(() => {
     setProxyWalletError(null)
     setTradingAuthError(null)
     setTokenApprovalError(null)
@@ -176,9 +220,54 @@ function TradingOnboardingProviderContent({
     if (!hasTokenApprovals) {
       setApprovalsStep('idle')
     }
-  }, [hasTokenApprovals, hasTradingAuth, proxyStep, requiresTradingAuthRefresh])
+  }, [
+    hasTokenApprovals,
+    hasTradingAuth,
+    proxyStep,
+    requiresTradingAuthRefresh,
+    setApprovalsStep,
+    setDepositModalOpen,
+    setProxyStep,
+    setProxyWalletError,
+    setShouldShowFundAfterProxy,
+    setTokenApprovalError,
+    setTradingAuthError,
+    setTradingAuthStep,
+    setWithdrawModalOpen,
+  ])
+}
 
-  const handleProxyWalletSignature = useCallback(async () => {
+function useProxyWalletSignatureFlow({
+  shouldShowFundAfterProxy,
+  refreshSessionUserState,
+  resetEnableFlowState,
+  resetPendingFundState,
+  setProxyStep,
+  setProxyWalletError,
+  setTradingAuthStep,
+  setTradingAuthError,
+  setRequiresTradingAuthRefresh,
+  setTradeModalOpen,
+  setEnableModalOpen,
+  setFundModalOpen,
+}: {
+  shouldShowFundAfterProxy: boolean
+  refreshSessionUserState: () => Promise<void>
+  resetEnableFlowState: () => void
+  resetPendingFundState: () => void
+  setProxyStep: (value: ProxyStep) => void
+  setProxyWalletError: (value: string | null) => void
+  setTradingAuthStep: (value: TradingAuthStep) => void
+  setTradingAuthError: (value: string | null) => void
+  setRequiresTradingAuthRefresh: (value: boolean) => void
+  setTradeModalOpen: (value: boolean) => void
+  setEnableModalOpen: (value: boolean) => void
+  setFundModalOpen: (value: boolean) => void
+}) {
+  const { signTypedDataAsync } = useSignTypedData()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
+
+  return useCallback(async () => {
     setProxyWalletError(null)
 
     try {
@@ -261,9 +350,34 @@ function TradingOnboardingProviderContent({
     resetEnableFlowState,
     resetPendingFundState,
     runWithSignaturePrompt,
+    setEnableModalOpen,
+    setFundModalOpen,
+    setProxyStep,
+    setProxyWalletError,
+    setRequiresTradingAuthRefresh,
+    setTradeModalOpen,
+    setTradingAuthError,
+    setTradingAuthStep,
     shouldShowFundAfterProxy,
     signTypedDataAsync,
   ])
+}
+
+function useTradingAuthSignatureFlow({
+  user,
+  refreshSessionUserState,
+  setTradingAuthError,
+  setTradingAuthStep,
+  setRequiresTradingAuthRefresh,
+}: {
+  user: User | null
+  refreshSessionUserState: () => Promise<void>
+  setTradingAuthError: (value: string | null) => void
+  setTradingAuthStep: (value: TradingAuthStep) => void
+  setRequiresTradingAuthRefresh: (value: boolean) => void
+}) {
+  const { signTypedDataAsync } = useSignTypedData()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
 
   const handleTradingAuthSignature = useCallback(async () => {
     if (!user?.address) {
@@ -336,7 +450,15 @@ function TradingOnboardingProviderContent({
         setTradingAuthStep('idle')
       }
     }
-  }, [refreshSessionUserState, runWithSignaturePrompt, signTypedDataAsync, user])
+  }, [
+    refreshSessionUserState,
+    runWithSignaturePrompt,
+    setRequiresTradingAuthRefresh,
+    setTradingAuthError,
+    setTradingAuthStep,
+    signTypedDataAsync,
+    user,
+  ])
 
   const resolveReferralExchanges = useCallback(async (safeAddress: `0x${string}`) => {
     const exchanges = [
@@ -352,7 +474,29 @@ function TradingOnboardingProviderContent({
     return exchanges.filter((_, index) => results[index] === false)
   }, [])
 
-  const handleApproveTokens = useCallback(async () => {
+  return { handleTradingAuthSignature, resolveReferralExchanges }
+}
+
+function useTokenApprovalsFlow({
+  user,
+  tradingAuthSatisfied,
+  resolveReferralExchanges,
+  refreshSessionUserState,
+  setApprovalsStep,
+  setTokenApprovalError,
+}: {
+  user: User | null
+  tradingAuthSatisfied: boolean
+  resolveReferralExchanges: (safeAddress: `0x${string}`) => Promise<`0x${string}`[]>
+  refreshSessionUserState: () => Promise<void>
+  setApprovalsStep: (value: ApprovalsStep) => void
+  setTokenApprovalError: (value: string | null) => void
+}) {
+  const { signMessageAsync } = useSignMessage()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
+  const affiliateMetadata = useAffiliateOrderMetadata()
+
+  return useCallback(async () => {
     if (!user?.proxy_wallet_address) {
       setTokenApprovalError('Deploy your proxy wallet first.')
       return
@@ -472,10 +616,34 @@ function TradingOnboardingProviderContent({
     refreshSessionUserState,
     resolveReferralExchanges,
     runWithSignaturePrompt,
+    setApprovalsStep,
+    setTokenApprovalError,
     signMessageAsync,
     tradingAuthSatisfied,
     user,
   ])
+}
+
+function useTradingReadyGate({
+  user,
+  tradingReady,
+  refreshSessionUserState,
+  resetEnableFlowState,
+  setTradeModalOpen,
+  setRequiresTradingAuthRefresh,
+  setTradingAuthStep,
+  setTradingAuthError,
+}: {
+  user: User | null
+  tradingReady: boolean
+  refreshSessionUserState: () => Promise<void>
+  resetEnableFlowState: () => void
+  setTradeModalOpen: (value: boolean) => void
+  setRequiresTradingAuthRefresh: (value: boolean) => void
+  setTradingAuthStep: (value: TradingAuthStep) => void
+  setTradingAuthError: (value: string | null) => void
+}) {
+  const { open } = useAppKit()
 
   const ensureTradingReady = useCallback(() => {
     if (!user) {
@@ -493,7 +661,7 @@ function TradingOnboardingProviderContent({
     void refreshSessionUserState()
     setTradeModalOpen(true)
     return false
-  }, [open, refreshSessionUserState, resetEnableFlowState, tradingReady, user])
+  }, [open, refreshSessionUserState, resetEnableFlowState, setTradeModalOpen, tradingReady, user])
 
   const openTradeRequirements = useCallback((options?: { forceTradingAuth?: boolean }) => {
     if (!user) {
@@ -511,11 +679,50 @@ function TradingOnboardingProviderContent({
     }
     void refreshSessionUserState()
     setTradeModalOpen(true)
-  }, [open, refreshSessionUserState, resetEnableFlowState, user])
+  }, [
+    open,
+    refreshSessionUserState,
+    resetEnableFlowState,
+    setRequiresTradingAuthRefresh,
+    setTradeModalOpen,
+    setTradingAuthError,
+    setTradingAuthStep,
+    user,
+  ])
 
+  return { ensureTradingReady, openTradeRequirements, openAppKit: open }
+}
+
+function useWalletFlowControls({
+  user,
+  hasDeployedProxyWallet,
+  openAppKit,
+  openTradeRequirements,
+  refreshSessionUserState,
+  resetEnableFlowState,
+  resetPendingFundState,
+  setDepositModalOpen,
+  setWithdrawModalOpen,
+  setEnableModalOpen,
+  setFundModalOpen,
+  setShouldShowFundAfterProxy,
+}: {
+  user: User | null
+  hasDeployedProxyWallet: boolean
+  openAppKit: () => Promise<void>
+  openTradeRequirements: (options?: { forceTradingAuth?: boolean }) => void
+  refreshSessionUserState: () => Promise<void>
+  resetEnableFlowState: () => void
+  resetPendingFundState: () => void
+  setDepositModalOpen: (value: boolean) => void
+  setWithdrawModalOpen: (value: boolean) => void
+  setEnableModalOpen: (value: boolean) => void
+  setFundModalOpen: (value: boolean) => void
+  setShouldShowFundAfterProxy: (value: boolean) => void
+}) {
   const openWalletModal = useCallback(() => {
     if (!user) {
-      queueMicrotask(() => void open())
+      queueMicrotask(() => void openAppKit())
       return
     }
     if (!hasDeployedProxyWallet) {
@@ -523,12 +730,12 @@ function TradingOnboardingProviderContent({
       return
     }
     setDepositModalOpen(true)
-  }, [hasDeployedProxyWallet, open, openTradeRequirements, user])
+  }, [hasDeployedProxyWallet, openAppKit, openTradeRequirements, setDepositModalOpen, user])
 
   const startDepositFlow = useCallback(() => {
     if (!user) {
       queueMicrotask(() => {
-        void open()
+        void openAppKit()
       })
       return
     }
@@ -542,12 +749,21 @@ function TradingOnboardingProviderContent({
     setShouldShowFundAfterProxy(true)
     void refreshSessionUserState()
     setEnableModalOpen(true)
-  }, [hasDeployedProxyWallet, open, refreshSessionUserState, resetEnableFlowState, user])
+  }, [
+    hasDeployedProxyWallet,
+    openAppKit,
+    refreshSessionUserState,
+    resetEnableFlowState,
+    setDepositModalOpen,
+    setEnableModalOpen,
+    setShouldShowFundAfterProxy,
+    user,
+  ])
 
   const startWithdrawFlow = useCallback(() => {
     if (!user) {
       queueMicrotask(() => {
-        void open()
+        void openAppKit()
       })
       return
     }
@@ -558,25 +774,26 @@ function TradingOnboardingProviderContent({
     }
 
     setWithdrawModalOpen(true)
-  }, [hasDeployedProxyWallet, open, openTradeRequirements, user])
+  }, [hasDeployedProxyWallet, openAppKit, openTradeRequirements, setWithdrawModalOpen, user])
 
   const closeFundModal = useCallback((nextOpen: boolean) => {
     setFundModalOpen(nextOpen)
     if (!nextOpen) {
       resetPendingFundState()
     }
-  }, [resetPendingFundState])
+  }, [resetPendingFundState, setFundModalOpen])
 
-  const contextValue = useMemo<TradingOnboardingContextValue>(() => ({
-    startDepositFlow,
-    startWithdrawFlow,
-    ensureTradingReady,
-    openTradeRequirements,
-    hasProxyWallet: hasDeployedProxyWallet,
-    openWalletModal,
-  }), [ensureTradingReady, hasDeployedProxyWallet, openTradeRequirements, openWalletModal, startDepositFlow, startWithdrawFlow])
+  return { openWalletModal, startDepositFlow, startWithdrawFlow, closeFundModal }
+}
 
-  const meldUrl = useMemo(() => {
+function useMeldUrl({
+  hasDeployedProxyWallet,
+  user,
+}: {
+  hasDeployedProxyWallet: boolean
+  user: User | null
+}) {
+  return useMemo(() => {
     if (!hasDeployedProxyWallet || !user?.proxy_wallet_address) {
       return null
     }
@@ -586,6 +803,203 @@ function TradingOnboardingProviderContent({
     })
     return `https://meldcrypto.com/?${params.toString()}`
   }, [hasDeployedProxyWallet, user])
+}
+
+function useTradingOnboardingContextValue({
+  startDepositFlow,
+  startWithdrawFlow,
+  ensureTradingReady,
+  openTradeRequirements,
+  hasDeployedProxyWallet,
+  openWalletModal,
+}: {
+  startDepositFlow: () => void
+  startWithdrawFlow: () => void
+  ensureTradingReady: () => boolean
+  openTradeRequirements: (options?: { forceTradingAuth?: boolean }) => void
+  hasDeployedProxyWallet: boolean
+  openWalletModal: () => void
+}): TradingOnboardingContextValue {
+  return useMemo(() => ({
+    startDepositFlow,
+    startWithdrawFlow,
+    ensureTradingReady,
+    openTradeRequirements,
+    hasProxyWallet: hasDeployedProxyWallet,
+    openWalletModal,
+  }), [ensureTradingReady, hasDeployedProxyWallet, openTradeRequirements, openWalletModal, startDepositFlow, startWithdrawFlow])
+}
+
+function TradingOnboardingProviderContent({
+  children,
+  user,
+}: TradingOnboardingProviderContentProps) {
+  const proxyWalletStatus = user?.proxy_wallet_status ?? null
+  const hasProxyWalletAddress = Boolean(user?.proxy_wallet_address)
+  const hasDeployedProxyWallet = Boolean(user?.proxy_wallet_address && proxyWalletStatus === 'deployed')
+  const isProxyWalletDeploying = Boolean(
+    user?.proxy_wallet_address
+    && (proxyWalletStatus === 'deploying' || proxyWalletStatus === 'signed'),
+  )
+  const tradingAuthSettings = user?.settings?.tradingAuth ?? null
+  const hasTradingAuth = Boolean(
+    tradingAuthSettings?.relayer?.enabled
+    && tradingAuthSettings?.clob?.enabled,
+  )
+  const approvalsSettings = tradingAuthSettings?.approvals ?? null
+  const hasTokenApprovals = Boolean(approvalsSettings?.enabled)
+
+  const {
+    enableModalOpen,
+    setEnableModalOpen,
+    fundModalOpen,
+    setFundModalOpen,
+    tradeModalOpen,
+    setTradeModalOpen,
+    shouldShowFundAfterProxy,
+    setShouldShowFundAfterProxy,
+    depositModalOpen,
+    setDepositModalOpen,
+    withdrawModalOpen,
+    setWithdrawModalOpen,
+  } = useOnboardingDialogsState()
+
+  const {
+    proxyWalletError,
+    setProxyWalletError,
+    tradingAuthError,
+    setTradingAuthError,
+    tokenApprovalError,
+    setTokenApprovalError,
+  } = useOnboardingErrorsState()
+
+  const {
+    proxyStep,
+    setProxyStep,
+    tradingAuthStep,
+    setTradingAuthStep,
+    approvalsStep,
+    setApprovalsStep,
+    requiresTradingAuthRefresh,
+    setRequiresTradingAuthRefresh,
+  } = useOnboardingStepsState({
+    hasDeployedProxyWallet,
+    isProxyWalletDeploying,
+    hasTradingAuth,
+    hasTokenApprovals,
+  })
+
+  const hasEffectiveTradingAuth = hasTradingAuth && !requiresTradingAuthRefresh
+  const effectiveProxyStep
+    = hasDeployedProxyWallet
+      ? 'completed'
+      : isProxyWalletDeploying
+        ? 'deploying'
+        : proxyStep
+  const effectiveTradingAuthStep = hasEffectiveTradingAuth ? 'completed' : tradingAuthStep
+  const effectiveApprovalsStep = hasTokenApprovals ? 'completed' : approvalsStep
+  const tradingAuthSatisfied = effectiveTradingAuthStep === 'completed'
+  const tradingReady
+    = effectiveProxyStep === 'completed'
+      && effectiveTradingAuthStep === 'completed'
+      && effectiveApprovalsStep === 'completed'
+
+  const refreshSessionUserState = useSessionRefresher()
+
+  useProxyWalletPolling({
+    userId: user?.id,
+    proxyWalletAddress: user?.proxy_wallet_address,
+    proxyWalletStatus: user?.proxy_wallet_status,
+    hasDeployedProxyWallet,
+    hasProxyWalletAddress,
+  })
+
+  const resetPendingFundState = usePendingFundStateReset(setShouldShowFundAfterProxy)
+
+  const resetEnableFlowState = useEnableFlowReset({
+    hasTokenApprovals,
+    hasTradingAuth,
+    proxyStep,
+    requiresTradingAuthRefresh,
+    setProxyWalletError,
+    setTradingAuthError,
+    setTokenApprovalError,
+    setShouldShowFundAfterProxy,
+    setDepositModalOpen,
+    setWithdrawModalOpen,
+    setProxyStep,
+    setTradingAuthStep,
+    setApprovalsStep,
+  })
+
+  const handleProxyWalletSignature = useProxyWalletSignatureFlow({
+    shouldShowFundAfterProxy,
+    refreshSessionUserState,
+    resetEnableFlowState,
+    resetPendingFundState,
+    setProxyStep,
+    setProxyWalletError,
+    setTradingAuthStep,
+    setTradingAuthError,
+    setRequiresTradingAuthRefresh,
+    setTradeModalOpen,
+    setEnableModalOpen,
+    setFundModalOpen,
+  })
+
+  const { handleTradingAuthSignature, resolveReferralExchanges } = useTradingAuthSignatureFlow({
+    user,
+    refreshSessionUserState,
+    setTradingAuthError,
+    setTradingAuthStep,
+    setRequiresTradingAuthRefresh,
+  })
+
+  const handleApproveTokens = useTokenApprovalsFlow({
+    user,
+    tradingAuthSatisfied,
+    resolveReferralExchanges,
+    refreshSessionUserState,
+    setApprovalsStep,
+    setTokenApprovalError,
+  })
+
+  const { ensureTradingReady, openTradeRequirements, openAppKit } = useTradingReadyGate({
+    user,
+    tradingReady,
+    refreshSessionUserState,
+    resetEnableFlowState,
+    setTradeModalOpen,
+    setRequiresTradingAuthRefresh,
+    setTradingAuthStep,
+    setTradingAuthError,
+  })
+
+  const { openWalletModal, startDepositFlow, startWithdrawFlow, closeFundModal } = useWalletFlowControls({
+    user,
+    hasDeployedProxyWallet,
+    openAppKit,
+    openTradeRequirements,
+    refreshSessionUserState,
+    resetEnableFlowState,
+    resetPendingFundState,
+    setDepositModalOpen,
+    setWithdrawModalOpen,
+    setEnableModalOpen,
+    setFundModalOpen,
+    setShouldShowFundAfterProxy,
+  })
+
+  const contextValue = useTradingOnboardingContextValue({
+    startDepositFlow,
+    startWithdrawFlow,
+    ensureTradingReady,
+    openTradeRequirements,
+    hasDeployedProxyWallet,
+    openWalletModal,
+  })
+
+  const meldUrl = useMeldUrl({ hasDeployedProxyWallet, user })
 
   return (
     <TradingOnboardingContext value={contextValue}>

--- a/src/providers/AppKitProvider.tsx
+++ b/src/providers/AppKitProvider.tsx
@@ -203,10 +203,17 @@ function createAppKitContextValue(instance: AppKit | null) {
   }
 }
 
-export default function AppKitProvider({ children }: { children: ReactNode }) {
-  const site = useSiteIdentity()
-  const resolvedTheme = useResolvedThemeMode()
-  const appKitThemeMode: 'light' | 'dark' = resolvedTheme === 'dark' ? 'dark' : 'light'
+function useAppKitInstance({
+  appKitThemeMode,
+  siteName,
+  siteDescription,
+  siteLogoUrl,
+}: {
+  appKitThemeMode: 'light' | 'dark'
+  siteName: string
+  siteDescription: string
+  siteLogoUrl: string
+}) {
   const [appKitInitRetryToken, setAppKitInitRetryToken] = useState(0)
   const instance = useSyncExternalStore(
     subscribeAppKitStateChange,
@@ -214,15 +221,15 @@ export default function AppKitProvider({ children }: { children: ReactNode }) {
     () => null,
   )
 
-  useEffect(() => {
+  useEffect(function initializeAppKitWithRetry() {
     if (instance) {
       return
     }
 
     const initializedInstance = initializeAppKitSingleton(appKitThemeMode, {
-      name: site.name,
-      description: site.description,
-      logoUrl: site.logoUrl,
+      name: siteName,
+      description: siteDescription,
+      logoUrl: siteLogoUrl,
     })
     if (initializedInstance) {
       return
@@ -231,12 +238,29 @@ export default function AppKitProvider({ children }: { children: ReactNode }) {
     const retryTimeout = window.setTimeout(() => {
       setAppKitInitRetryToken(previous => previous + 1)
     }, APPKIT_INIT_RETRY_DELAY_MS)
-    return () => {
+    return function cancelAppKitInitRetry() {
       window.clearTimeout(retryTimeout)
     }
-  }, [appKitThemeMode, appKitInitRetryToken, instance, site.description, site.logoUrl, site.name])
+  }, [appKitThemeMode, appKitInitRetryToken, instance, siteDescription, siteLogoUrl, siteName])
 
-  const appKitValue = useMemo(() => createAppKitContextValue(instance), [instance])
+  return instance
+}
+
+function useAppKitContextValue(instance: AppKit | null) {
+  return useMemo(() => createAppKitContextValue(instance), [instance])
+}
+
+export default function AppKitProvider({ children }: { children: ReactNode }) {
+  const site = useSiteIdentity()
+  const resolvedTheme = useResolvedThemeMode()
+  const appKitThemeMode: 'light' | 'dark' = resolvedTheme === 'dark' ? 'dark' : 'light'
+  const instance = useAppKitInstance({
+    appKitThemeMode,
+    siteName: site.name,
+    siteDescription: site.description,
+    siteLogoUrl: site.logoUrl,
+  })
+  const appKitValue = useAppKitContextValue(instance)
   const canSyncTheme = Boolean(instance)
 
   return (


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855) to the full platform shell — both `_providers/` and `_components/` (excluding `WalletModal.tsx`, which is on your split-list and gets its own PR).

Follow-up to #866, #867, #868, #869, #870, #871, #872, #873, #874, #875, #876, #877, #878.

## Files changed (22)

### `_providers/` (4 files, 36 → 0)
| File | Warnings |
|---|---|
| `FilterProvider` | 3 → 0 |
| `PlatformNavigationProvider` | 1 → 0 |
| `TradingOnboardingProvider` | 28 → 0 |
| `providers/AppKitProvider` | 4 → 0 |

### `_components/` (18 files, 82 → 0)
| File | Warnings |
|---|---|
| `AffiliateQueryHandler` | 1 → 0 |
| `HeaderDepositButton` | 1 → 0 |
| `HeaderDepositFlow` | 2 → 0 |
| `HeaderDropdownUserMenuGuest` | 4 → 0 |
| `HeaderMenu` | 1 → 0 |
| `HeaderNotifications` | 1 → 0 |
| `HeaderSearch` | 10 → 0 |
| `HowItWorks` | 2 → 0 |
| `HowItWorksDeferred` | 2 → 0 |
| `MobileBottomNav` | 7 → 0 |
| `NavigationMoreMenu` | 6 → 0 |
| `NavigationTabs` | 12 → 0 |
| `PlatformViewerState` | 1 → 0 |
| `PositionShareDialog` | 12 → 0 |
| `ProfileOverviewCard` | 1 → 0 |
| `SearchTabs` | 1 → 0 |
| `SellPositionModal` | 4 → 0 |
| `WalletFlow` | 14 → 0 |

**Total: 118 → 0 (100% reduction).** All effects named. All `useCallback`/`useMemo` anonymous.

## Highlights

- **Providers**: context values are now memoized in dedicated hooks (`useFilterContextValue`, `usePlatformNavigationContextValue`, `useAppKitContextValue`, `useTradingOnboardingContextValue`). The full trading-onboarding flow is split into focused hooks — `useOnboardingDialogsState`, `useOnboardingErrorsState`, `useOnboardingStepsState`, `useSessionRefresher`, `usePendingFundStateReset`, `useEnableFlowReset`, `useProxyWalletSignatureFlow`, `useTradingAuthSignatureFlow`, `useTokenApprovalsFlow`, `useTradingReadyGate`, `useWalletFlowControls`, `useMeldUrl`. `AppKitProvider` gets `useAppKitInstance` with the named `initializeAppKitWithRetry` effect + cleanup.
- **Header cluster**: `HeaderSearch`, `HeaderDepositFlow`, `HeaderDepositButton`, `HeaderMenu`, `HeaderNotifications`, `HeaderDropdownUserMenuGuest` — each file-local hook(s) for whatever state they own (search dropdown open/results, pending-deposit readiness, unread-notification polling, etc.) with every effect named.
- **Navigation cluster**: `NavigationTabs` extracts tab-indicator positioning + navigation-selection resolution; `MobileBottomNav` and `NavigationMoreMenu` own their open-state / scroll-shadow / touch-dismiss effects.
- **Wallet flow**: `WalletFlow` — file-local hooks for the pending-deposit / trading-auth gating / deposit-success / withdraw steps and their named effects.
- **Share + sell**: `PositionShareDialog` and `SellPositionModal` each get file-local hooks for their dialog/form state and the submit + cash-out pipelines.

## Shared-hook audit
All extracted hooks are currently consumed only by their source file (verified by grep). Left file-local per Bruno's rule; promote to `src/hooks/` the moment a second consumer shows up.

## Not included (scoped out intentionally)
- `WalletModal.tsx` (15 warnings, on your split list) — own PR.

## Test plan
- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: header search open + results + keyboard nav, notifications bell + unread badge, deposit button + flow, user-menu dropdown (guest + auth), trading onboarding enable / fund / trade / deposit / withdraw gates, wallet flow (deposit / withdraw / trading-auth), nav tabs active state + sliding indicator, mobile bottom nav, navigation more-menu, position share + sell dialogs