### PR TITLE
refactor: use custom hooks for settings components

### DIFF
--- a/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
@@ -148,57 +148,66 @@ const IFRAME_HEIGHT_WITH_CHART = 400
 const IFRAME_HEIGHT_WITH_FILTERS = 440
 const IFRAME_HEIGHT_NO_CHART = 180
 
-export default function AffiliateWidgetDialog({
-  open,
-  onOpenChange,
-  categories,
-}: AffiliateWidgetDialogProps) {
-  const t = useExtracted()
-  const locale = useLocale()
-  const site = useSiteIdentity()
-  const user = useUser()
-  const affiliateCode = user?.affiliate_code?.trim() ?? ''
+function useEmbedOptions() {
   const [theme, setTheme] = useState<EmbedTheme>('light')
   const [embedType, setEmbedType] = useState<EmbedType>('iframe')
   const [showVolume, setShowVolume] = useState(false)
   const [showChart, setShowChart] = useState(false)
   const [showTimeRange, setShowTimeRange] = useState(false)
-  const [copied, setCopied] = useState(false)
+
+  function handleShowChartChange(nextValue: boolean) {
+    setShowChart(nextValue)
+    if (!nextValue) {
+      setShowTimeRange(false)
+    }
+  }
+
+  return {
+    theme,
+    setTheme,
+    embedType,
+    setEmbedType,
+    showVolume,
+    setShowVolume,
+    showChart,
+    showTimeRange,
+    setShowTimeRange,
+    handleShowChartChange,
+  }
+}
+
+function useEmbedCategorySelection(categories: AffiliateWidgetDialogProps['categories']) {
   const [selectedCategoryState, setSelectedCategoryState] = useState<string>(categories[0]?.slug ?? '')
-  const [affiliateSharePercent, setAffiliateSharePercent] = useState<number | null>(null)
-  const [tradeFeePercent, setTradeFeePercent] = useState<number | null>(null)
-
-  const siteSlug = useMemo(() => {
-    try {
-      return slugifySiteName(site.name)
-    }
-    catch {
-      return 'market'
-    }
-  }, [site.name])
-
   const selectedCategory = useMemo(
     () => categories.some(category => category.slug === selectedCategoryState)
       ? selectedCategoryState
       : (categories[0]?.slug ?? ''),
     [categories, selectedCategoryState],
   )
-  const {
-    data: currentMarkets = [],
-    isFetching: isFetchingCategory,
-    isError: categoryLoadFailed,
-  } = useQuery({
-    queryKey: ['affiliate-widget-category-markets', locale, selectedCategory],
-    enabled: open && Boolean(selectedCategory),
-    staleTime: 60_000,
-    gcTime: 300_000,
-    queryFn: ({ signal }) => fetchCategoryMarkets(selectedCategory, locale, signal),
-  })
-  const selectedMarket = currentMarkets[0]
-  const embedElementName = `${siteSlug}-market-embed`
-  const embedIframeTitle = `${siteSlug}-market-iframe`
+  return { selectedCategory, setSelectedCategoryState }
+}
 
-  useEffect(() => {
+function useCopyFlashState() {
+  const [copied, setCopied] = useState(false)
+  return { copied, setCopied }
+}
+
+function useSiteSlug(siteName: string) {
+  return useMemo(() => {
+    try {
+      return slugifySiteName(siteName)
+    }
+    catch {
+      return 'market'
+    }
+  }, [siteName])
+}
+
+function useAffiliateFeeSettings(affiliateCode: string) {
+  const [affiliateSharePercent, setAffiliateSharePercent] = useState<number | null>(null)
+  const [tradeFeePercent, setTradeFeePercent] = useState<number | null>(null)
+
+  useEffect(function loadAffiliateFeeSettings() {
     if (!affiliateCode) {
       setAffiliateSharePercent(null)
       setTradeFeePercent(null)
@@ -230,29 +239,55 @@ export default function AffiliateWidgetDialog({
         }
       })
 
-    return () => {
+    return function cleanupAffiliateFeeSettings() {
       isActive = false
     }
   }, [affiliateCode])
 
-  function handleShowChartChange(nextValue: boolean) {
-    setShowChart(nextValue)
-    if (!nextValue) {
-      setShowTimeRange(false)
-    }
-  }
+  return { affiliateSharePercent, tradeFeePercent }
+}
 
-  function handleSelectedCategoryChange(nextValue: string) {
-    setSelectedCategoryState(nextValue)
-  }
+function useCategoryMarkets({
+  enabled,
+  locale,
+  selectedCategory,
+}: {
+  enabled: boolean
+  locale: string
+  selectedCategory: string
+}) {
+  return useQuery({
+    queryKey: ['affiliate-widget-category-markets', locale, selectedCategory],
+    enabled: enabled && Boolean(selectedCategory),
+    staleTime: 60_000,
+    gcTime: 300_000,
+    queryFn: ({ signal }) => fetchCategoryMarkets(selectedCategory, locale, signal),
+  })
+}
 
-  function handleDialogOpenChange(nextOpen: boolean) {
-    if (!nextOpen) {
-      setCopied(false)
-    }
-    onOpenChange(nextOpen)
-  }
-
+function useEmbedCode({
+  selectedCategory,
+  locale,
+  theme,
+  showVolume,
+  showChart,
+  showTimeRange,
+  affiliateCode,
+  embedElementName,
+  embedIframeTitle,
+  selectedMarketSlug,
+}: {
+  selectedCategory: string
+  locale: string
+  theme: EmbedTheme
+  showVolume: boolean
+  showChart: boolean
+  showTimeRange: boolean
+  affiliateCode: string
+  embedElementName: string
+  embedIframeTitle: string
+  selectedMarketSlug: string
+}) {
   const features = useMemo(
     () => buildFeatureList(showVolume, showChart, showTimeRange),
     [showVolume, showChart, showTimeRange],
@@ -291,19 +326,15 @@ export default function AffiliateWidgetDialog({
     () =>
       buildWebComponentCode(
         embedElementName,
-        selectedMarket?.slug ?? '',
+        selectedMarketSlug,
         theme,
         showVolume,
         showChart,
         showTimeRange,
         affiliateCode,
       ),
-    [embedElementName, selectedMarket?.slug, theme, showVolume, showChart, showTimeRange, affiliateCode],
+    [embedElementName, selectedMarketSlug, theme, showVolume, showChart, showTimeRange, affiliateCode],
   )
-  const activeCode = embedType === 'iframe' ? iframeCode : webComponentCode
-  const canCopy = embedType === 'iframe'
-    ? Boolean(iframeSrc)
-    : Boolean(selectedMarket?.slug)
 
   const iframeLines = useMemo<EmbedCodeLine[]>(() => ([
     tagOpenLine('', 'iframe'),
@@ -324,7 +355,7 @@ export default function AffiliateWidgetDialog({
       tagEndLine('\t'),
       tagCloseLine('\t', 'script'),
       tagOpenLine('\t', embedElementName),
-      attributeLine('\t\t', 'market', selectedMarket?.slug ?? ''),
+      attributeLine('\t\t', 'market', selectedMarketSlug),
     ]
 
     if (showVolume) {
@@ -344,7 +375,89 @@ export default function AffiliateWidgetDialog({
     lines.push(tagSelfCloseLine('\t'))
     lines.push(tagCloseLine('', 'div'))
     return lines
-  }, [affiliateCode, embedElementName, selectedMarket?.slug, showVolume, showChart, showTimeRange, theme])
+  }, [affiliateCode, embedElementName, selectedMarketSlug, showVolume, showChart, showTimeRange, theme])
+
+  return {
+    iframeHeight,
+    iframeSrc,
+    previewSrc,
+    iframeCode,
+    webComponentCode,
+    iframeLines,
+    webComponentLines,
+  }
+}
+
+export default function AffiliateWidgetDialog({
+  open,
+  onOpenChange,
+  categories,
+}: AffiliateWidgetDialogProps) {
+  const t = useExtracted()
+  const locale = useLocale()
+  const site = useSiteIdentity()
+  const user = useUser()
+  const affiliateCode = user?.affiliate_code?.trim() ?? ''
+  const {
+    theme,
+    setTheme,
+    embedType,
+    setEmbedType,
+    showVolume,
+    setShowVolume,
+    showChart,
+    showTimeRange,
+    setShowTimeRange,
+    handleShowChartChange,
+  } = useEmbedOptions()
+  const { copied, setCopied } = useCopyFlashState()
+  const { selectedCategory, setSelectedCategoryState } = useEmbedCategorySelection(categories)
+  const siteSlug = useSiteSlug(site.name)
+  const { affiliateSharePercent, tradeFeePercent } = useAffiliateFeeSettings(affiliateCode)
+  const {
+    data: currentMarkets = [],
+    isFetching: isFetchingCategory,
+    isError: categoryLoadFailed,
+  } = useCategoryMarkets({ enabled: open, locale, selectedCategory })
+  const selectedMarket = currentMarkets[0]
+  const embedElementName = `${siteSlug}-market-embed`
+  const embedIframeTitle = `${siteSlug}-market-iframe`
+
+  function handleSelectedCategoryChange(nextValue: string) {
+    setSelectedCategoryState(nextValue)
+  }
+
+  function handleDialogOpenChange(nextOpen: boolean) {
+    if (!nextOpen) {
+      setCopied(false)
+    }
+    onOpenChange(nextOpen)
+  }
+
+  const {
+    iframeHeight,
+    iframeSrc,
+    previewSrc,
+    iframeCode,
+    webComponentCode,
+    iframeLines,
+    webComponentLines,
+  } = useEmbedCode({
+    selectedCategory,
+    locale,
+    theme,
+    showVolume,
+    showChart,
+    showTimeRange,
+    affiliateCode,
+    embedElementName,
+    embedIframeTitle,
+    selectedMarketSlug: selectedMarket?.slug ?? '',
+  })
+  const activeCode = embedType === 'iframe' ? iframeCode : webComponentCode
+  const canCopy = embedType === 'iframe'
+    ? Boolean(iframeSrc)
+    : Boolean(selectedMarket?.slug)
 
   async function handleCopy() {
     if (!canCopy) {

--- a/src/app/[locale]/(platform)/settings/_components/SettingsAffiliateContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsAffiliateContent.tsx
@@ -22,11 +22,16 @@ interface SettingsAffiliateContentProps {
   mainCategories: AffiliateMainCategory[]
 }
 
+function useWidgetDialogToggle() {
+  const [isWidgetDialogOpen, setIsWidgetDialogOpen] = useState(false)
+  return { isWidgetDialogOpen, setIsWidgetDialogOpen }
+}
+
 export default function SettingsAffiliateContent({ affiliateData, mainCategories }: SettingsAffiliateContentProps) {
   const t = useExtracted()
   const locale = useLocale()
   const { copied, copy } = useClipboard()
-  const [isWidgetDialogOpen, setIsWidgetDialogOpen] = useState(false)
+  const { isWidgetDialogOpen, setIsWidgetDialogOpen } = useWidgetDialogToggle()
 
   if (!affiliateData) {
     return (

--- a/src/app/[locale]/(platform)/settings/_components/SettingsNotificationsContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsNotificationsContent.tsx
@@ -17,10 +17,15 @@ interface NotificationSettings {
   inapp_resolutions: boolean
 }
 
-export default function SettingsNotificationsContent({ user }: { user: User }) {
-  const t = useExtracted()
+function useNotificationsFormState() {
   const [status, setStatus] = useState<{ error: string } | null>(null)
   const formRef = useRef<HTMLFormElement>(null)
+  return { status, setStatus, formRef }
+}
+
+export default function SettingsNotificationsContent({ user }: { user: User }) {
+  const t = useExtracted()
+  const { status, setStatus, formRef } = useNotificationsFormState()
   const initialSettings = user.settings?.notifications ?? {
     email_resolutions: false,
     inapp_order_fills: false,

--- a/src/app/[locale]/(platform)/settings/_components/SettingsProfileContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsProfileContent.tsx
@@ -23,31 +23,42 @@ import {
 import { buildPublicProfilePath } from '@/lib/platform-routing'
 import { useUser } from '@/stores/useUser'
 
+function useProfileFormState() {
+  const [errors, setErrors] = useState<Record<string, string | undefined>>({})
+  const [formError, setFormError] = useState<string | null>(null)
+  const [isPending, setIsPending] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
+  return { errors, setErrors, formError, setFormError, isPending, setIsPending, fileInputRef }
+}
+
+function useAvatarPreview() {
+  const [previewImage, setPreviewImage] = useState<string | null>(null)
+
+  useEffect(function revokePreviewUrlOnChange() {
+    return function cleanupRevokePreviewUrl() {
+      if (previewImage) {
+        URL.revokeObjectURL(previewImage)
+      }
+    }
+  }, [previewImage])
+
+  return { previewImage, setPreviewImage }
+}
+
 export default function SettingsProfileContent({ user }: { user: User }) {
   const t = useExtracted()
   const queryClient = useQueryClient()
   const { signMessageAsync } = useSignMessage()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
   const communityApiUrl = process.env.COMMUNITY_URL!
-  const [errors, setErrors] = useState<Record<string, string | undefined>>({})
-  const [formError, setFormError] = useState<string | null>(null)
-  const [isPending, setIsPending] = useState(false)
-  const fileInputRef = useRef<HTMLInputElement>(null)
-  const [previewImage, setPreviewImage] = useState<string | null>(null)
+  const { errors, setErrors, formError, setFormError, isPending, setIsPending, fileInputRef } = useProfileFormState()
+  const { previewImage, setPreviewImage } = useAvatarPreview()
   const avatarUrl = user.image?.trim() ?? ''
   const avatarSeed = user.proxy_wallet_address || user.address || user.username || 'user'
   const showPlaceholder = !previewImage && shouldUseAvatarPlaceholder(avatarUrl)
   const placeholderStyle = showPlaceholder
     ? getAvatarPlaceholderStyle(avatarSeed)
     : undefined
-
-  useEffect(() => {
-    return () => {
-      if (previewImage) {
-        URL.revokeObjectURL(previewImage)
-      }
-    }
-  }, [previewImage])
 
   function generatePreviewUrl(file: File): string {
     return URL.createObjectURL(file)

--- a/src/app/[locale]/(platform)/settings/_components/SettingsTradingContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsTradingContent.tsx
@@ -11,10 +11,15 @@ import { CLOB_ORDER_TYPE } from '@/lib/constants'
 import { cn } from '@/lib/utils'
 import { useUser } from '@/stores/useUser'
 
-export default function SettingsTradingContent({ user }: { user: User }) {
-  const t = useExtracted()
+function useTradingFormState() {
   const [error, setError] = useState<string | null>(null)
   const formRef = useRef<HTMLFormElement>(null)
+  return { error, setError, formRef }
+}
+
+export default function SettingsTradingContent({ user }: { user: User }) {
+  const t = useExtracted()
+  const { error, setError, formRef } = useTradingFormState()
   const initialOrderType = (user.settings?.trading?.market_order_type as MarketOrderType) ?? CLOB_ORDER_TYPE.FAK
   const orderTypeOptions = [
     {

--- a/src/app/[locale]/(platform)/settings/_components/SettingsTwoFactorAuthContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsTwoFactorAuthContent.tsx
@@ -37,9 +37,7 @@ const AUTHENTICATOR_APP_LINKS = {
   'Google Authenticator': 'https://support.google.com/accounts/answer/1066447',
 } as const
 
-export default function SettingsTwoFactorAuthContent({ user }: { user: User }) {
-  const t = useExtracted()
-  const { copied, copy } = useClipboard()
+function useTwoFactorState(user: User) {
   const [state, setState] = useState<ComponentState>({
     isLoading: false,
     setupData: null,
@@ -49,6 +47,13 @@ export default function SettingsTwoFactorAuthContent({ user }: { user: User }) {
     isVerifying: false,
     isDisabling: false,
   })
+  return { state, setState }
+}
+
+export default function SettingsTwoFactorAuthContent({ user }: { user: User }) {
+  const t = useExtracted()
+  const { copied, copy } = useClipboard()
+  const { state, setState } = useTwoFactorState(user)
 
   function extractTotpSecret() {
     try {


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855) to the settings area.

Follow-up to #866, #867, #868, #869, #870, #871, #872, #873, #874, #875, #876, #877, #878, #879.

## Files changed (6)

| File | Warnings |
|---|---|
| `AffiliateWidgetDialog` | 19 → 0 |
| `SettingsAffiliateContent` | 1 → 0 |
| `SettingsNotificationsContent` | 2 → 0 |
| `SettingsProfileContent` | 6 → 0 |
| `SettingsTradingContent` | 2 → 0 |
| `SettingsTwoFactorAuthContent` | 1 → 0 |

**Total: 31 → 0 (100% reduction).**

## Extracted hooks (all file-local)

### `AffiliateWidgetDialog`
- `useEmbedOptions` — theme / embedType / showVolume / showChart / showTimeRange state + `handleShowChartChange` (also clears time-range when chart is toggled off).
- `useEmbedCategorySelection(categories)` — category state + memoized `selectedCategory` with fallback when the stored slug is no longer valid.
- `useCopyFlashState` — copied flag for the copy-button icon.
- `useSiteSlug(siteName)` — memoized `slugifySiteName` with `'market'` fallback on error.
- `useAffiliateFeeSettings(affiliateCode)` — named effect `loadAffiliateFeeSettings` (+ cleanup `cleanupAffiliateFeeSettings`) fetching `affiliateSharePercent` / `tradeFeePercent`.
- `useCategoryMarkets({ enabled, locale, selectedCategory })` — wraps the `useQuery` for the selected category's markets.
- `useEmbedCode({...})` — bundles `features`, `iframeSrc`, `previewSrc`, `iframeCode`, `webComponentCode`, `iframeLines`, `webComponentLines` memos.

### `SettingsAffiliateContent`
- `useWidgetDialogToggle` — open state for the "Generate widget" dialog.

### `SettingsNotificationsContent`
- `useNotificationsFormState` — `status` state + `formRef`.

### `SettingsProfileContent`
- `useProfileFormState` — `errors` / `formError` / `isPending` state + `fileInputRef`.
- `useAvatarPreview` — `previewImage` state with named effect `revokePreviewUrlOnChange` (cleanup `cleanupRevokePreviewUrl`) that revokes the object URL on change/unmount.

### `SettingsTradingContent`
- `useTradingFormState` — `error` state + `formRef`.

### `SettingsTwoFactorAuthContent`
- `useTwoFactorState(user)` — bundled component state (loading / setupData / isEnabled / trustDevice / code / isVerifying / isDisabling).

## Shared-hook audit
Grepped all new hook names across `src/` — zero external references. Everything file-local per Bruno's rule.

## Remaining warnings
Zero `use-encapsulation/prefer-custom-hooks` across all 6 files. `AffiliateWidgetDialog` has a few unrelated warnings from other rule families (`react/set-state-in-effect`, `react-you-might-not-need-an-effect/no-adjust-state-on-prop-change`) that were pre-existing in the file — left as-is; they are out of scope for this refactor and mirror the trade-off accepted in the prior order-panel PRs.

## Test plan
- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: settings profile (avatar preview + form submit), notifications form, trading settings form, 2FA enable/disable + trust-device, affiliate widget dialog (theme / embed type / show-volume / show-chart + time-range / category markets / copy embed code / iframe + web-component previews)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored settings components to use file‑local custom hooks and named effects, removing all `use-encapsulation/prefer-custom-hooks` warnings (31 → 0). No user-facing changes.

- **Refactors**
  - `AffiliateWidgetDialog`: added hooks for embed options, category selection, fee settings, markets query, embed code, copy flash state, and site slug.
  - Settings pages: added small hooks for dialog/form state in notifications, profile (with safe avatar preview URL cleanup), trading, 2FA, and affiliate content.
  - All hooks are file‑local; no shared exports added.
  - Left pre‑existing warnings from other rule families in `AffiliateWidgetDialog` as-is.
  - `vitest` passes and `tsc --noEmit` is clean.

<sup>Written for commit 72e20dbea90c404d490562bd07119c61318307c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

