### PR TITLE
refactor: use custom hooks for LeaderboardClient

### DIFF
--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
@@ -2,6 +2,7 @@
 
 import type { Route } from 'next'
 import type { LeaderboardFilters } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardFilters'
+import type { User } from '@/types'
 import { ChevronLeftIcon, ChevronRightIcon, MoveRightIcon, SearchIcon } from 'lucide-react'
 import Image from 'next/image'
 import { useEffect, useMemo, useState } from 'react'
@@ -302,37 +303,67 @@ function sortEntriesForDisplay(
   }))
 }
 
-export default function LeaderboardClient({ initialFilters }: { initialFilters: LeaderboardFilters }) {
+function useLeaderboardFilters(initialFilters: LeaderboardFilters) {
   const router = useRouter()
-  const user = useUser()
   const initialFiltersKey = buildFiltersKey(initialFilters)
   const [filtersState, setFiltersState] = useState<{ key: string, value: LeaderboardFilters }>(() => ({
     key: initialFiltersKey,
     value: initialFilters,
   }))
-  const [entries, setEntries] = useState<LeaderboardEntry[]>([])
-  const [loadedLeaderboardKey, setLoadedLeaderboardKey] = useState<string | null>(null)
+  const filters = filtersState.key === initialFiltersKey ? filtersState.value : initialFilters
+
+  function updateFilters(next: LeaderboardFilters) {
+    setFiltersState({
+      key: initialFiltersKey,
+      value: next,
+    })
+    const nextPath = buildLeaderboardPath(next) as Route
+    router.push(nextPath)
+  }
+
+  return { filters, updateFilters }
+}
+
+function useDebouncedLeaderboardSearch() {
   const [searchInput, setSearchInput] = useState('')
   const [searchQuery, setSearchQuery] = useState('')
-  const filters = filtersState.key === initialFiltersKey ? filtersState.value : initialFilters
-  const leaderboardScopeKey = buildLeaderboardScopeKey(filters, searchQuery)
+
+  useEffect(function syncDebouncedSearchQuery() {
+    const timeoutId = window.setTimeout(() => {
+      setSearchQuery(searchInput.trim())
+    }, 300)
+
+    return function cancelDebouncedSearchTimeout() {
+      window.clearTimeout(timeoutId)
+    }
+  }, [searchInput])
+
+  return { searchInput, setSearchInput, searchQuery }
+}
+
+function useLeaderboardPagination(scopeKey: string) {
   const [pageState, setPageState] = useState<{ key: string, value: number }>({
-    key: leaderboardScopeKey,
+    key: scopeKey,
     value: 1,
   })
-  const page = pageState.key === leaderboardScopeKey ? pageState.value : 1
-  const leaderboardRequestKey = `${leaderboardScopeKey}:${page}`
-  const isLoading = loadedLeaderboardKey !== leaderboardRequestKey
-  const [userEntry, setUserEntry] = useState<LeaderboardEntry | null>(null)
-  const initialBiggestWinsKey = `${resolveCategoryApiValue(initialFilters.category)}:${resolvePeriodApiValue(initialFilters.period)}`
-  const initialBiggestWins = BIGGEST_WINS_CACHE.get(initialBiggestWinsKey) ?? []
-  const [biggestWins, setBiggestWins] = useState<BiggestWinEntry[]>(initialBiggestWins)
-  const [isBiggestWinsLoading, setIsBiggestWinsLoading] = useState(!BIGGEST_WINS_CACHE.has(initialBiggestWinsKey))
-  const userAddress = useMemo(
-    () => (user?.proxy_wallet_address ?? user?.address ?? '').trim(),
-    [user?.address, user?.proxy_wallet_address],
-  )
-  const currentFilters = useMemo<LeaderboardFilters>(
+  const page = pageState.key === scopeKey ? pageState.value : 1
+
+  function setPageValue(nextPage: number | ((currentPage: number) => number)) {
+    setPageState((currentState) => {
+      const currentPage = currentState.key === scopeKey ? currentState.value : 1
+      const resolvedPage = typeof nextPage === 'function' ? nextPage(currentPage) : nextPage
+      return {
+        key: scopeKey,
+        value: Math.max(1, resolvedPage),
+      }
+    })
+  }
+
+  return { page, setPageValue }
+}
+
+function useCurrentLeaderboardFilters(filters: LeaderboardFilters) {
+  return useMemo<LeaderboardFilters>(
     () => ({
       category: filters.category,
       period: filters.period,
@@ -340,16 +371,35 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
     }),
     [filters.category, filters.period, filters.order],
   )
+}
 
-  useEffect(() => {
-    const timeoutId = window.setTimeout(() => {
-      setSearchQuery(searchInput.trim())
-    }, 300)
+function useLeaderboardUserAddress() {
+  const user = useUser()
+  const userAddress = useMemo(
+    () => (user?.proxy_wallet_address ?? user?.address ?? '').trim(),
+    [user?.address, user?.proxy_wallet_address],
+  )
+  return { user, userAddress }
+}
 
-    return () => window.clearTimeout(timeoutId)
-  }, [searchInput])
+function useLeaderboardEntries({
+  filters,
+  currentFilters,
+  searchQuery,
+  page,
+  leaderboardRequestKey,
+}: {
+  filters: LeaderboardFilters
+  currentFilters: LeaderboardFilters
+  searchQuery: string
+  page: number
+  leaderboardRequestKey: string
+}) {
+  const [entries, setEntries] = useState<LeaderboardEntry[]>([])
+  const [loadedLeaderboardKey, setLoadedLeaderboardKey] = useState<string | null>(null)
+  const isLoading = loadedLeaderboardKey !== leaderboardRequestKey
 
-  useEffect(() => {
+  useEffect(function loadLeaderboardEntries() {
     const controller = new AbortController()
 
     const params = new URLSearchParams({
@@ -391,10 +441,26 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
         }
       })
 
-    return () => controller.abort()
+    return function abortLeaderboardEntriesRequest() {
+      controller.abort()
+    }
   }, [filters.category, filters.period, filters.order, searchQuery, page, leaderboardRequestKey, currentFilters])
 
-  useEffect(() => {
+  return { entries, isLoading }
+}
+
+function useLeaderboardUserEntry({
+  filters,
+  currentFilters,
+  userAddress,
+}: {
+  filters: LeaderboardFilters
+  currentFilters: LeaderboardFilters
+  userAddress: string
+}) {
+  const [userEntry, setUserEntry] = useState<LeaderboardEntry | null>(null)
+
+  useEffect(function loadLeaderboardUserEntry() {
     if (!userAddress) {
       return
     }
@@ -438,10 +504,21 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
         setUserEntry(null)
       })
 
-    return () => controller.abort()
+    return function abortLeaderboardUserEntryRequest() {
+      controller.abort()
+    }
   }, [filters.category, filters.period, filters.order, userAddress, currentFilters])
 
-  useEffect(() => {
+  return userEntry
+}
+
+function useBiggestWins(initialFilters: LeaderboardFilters, filters: LeaderboardFilters) {
+  const initialBiggestWinsKey = `${resolveCategoryApiValue(initialFilters.category)}:${resolvePeriodApiValue(initialFilters.period)}`
+  const initialBiggestWins = BIGGEST_WINS_CACHE.get(initialBiggestWinsKey) ?? []
+  const [biggestWins, setBiggestWins] = useState<BiggestWinEntry[]>(initialBiggestWins)
+  const [isBiggestWinsLoading, setIsBiggestWinsLoading] = useState(!BIGGEST_WINS_CACHE.has(initialBiggestWinsKey))
+
+  useEffect(function loadBiggestWins() {
     const category = resolveCategoryApiValue(filters.category)
     const period = resolvePeriodApiValue(filters.period)
     const cacheKey = `${category}:${period}`
@@ -481,35 +558,107 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
         }
       })
 
-    return () => {
+    return function cancelBiggestWinsRequest() {
       isActive = false
     }
   }, [filters.category, filters.period])
 
-  const categoryLabel = useMemo(
-    () => CATEGORY_OPTIONS.find(option => option.value === filters.category)?.label ?? 'All Categories',
-    [filters.category],
+  return { biggestWins, isBiggestWinsLoading }
+}
+
+function useLeaderboardCategoryLabel(category: LeaderboardFilters['category']) {
+  return useMemo(
+    () => CATEGORY_OPTIONS.find(option => option.value === category)?.label ?? 'All Categories',
+    [category],
   )
+}
 
-  function updateFilters(next: LeaderboardFilters) {
-    setFiltersState({
-      key: initialFiltersKey,
-      value: next,
-    })
-    const nextPath = buildLeaderboardPath(next) as Route
-    router.push(nextPath)
-  }
+function useBiggestWinsPeriodLabel(period: LeaderboardFilters['period']) {
+  return useMemo(() => {
+    switch (period) {
+      case 'today':
+        return 'today'
+      case 'weekly':
+        return 'this week'
+      case 'monthly':
+        return 'this month'
+      case 'all':
+        return 'all time'
+      default:
+        return 'this month'
+    }
+  }, [period])
+}
 
-  function setPageValue(nextPage: number | ((currentPage: number) => number)) {
-    setPageState((currentState) => {
-      const currentPage = currentState.key === leaderboardScopeKey ? currentState.value : 1
-      const resolvedPage = typeof nextPage === 'function' ? nextPage(currentPage) : nextPage
-      return {
-        key: leaderboardScopeKey,
-        value: Math.max(1, resolvedPage),
-      }
-    })
-  }
+function usePinnedLeaderboardEntry({
+  entries,
+  userAddress,
+  userEntry,
+  user,
+}: {
+  entries: LeaderboardEntry[]
+  userAddress: string
+  userEntry: LeaderboardEntry | null
+  user: User | null
+}) {
+  return useMemo(() => {
+    if (!userAddress) {
+      return null
+    }
+
+    const normalizedUserAddress = normalizeWalletAddress(userAddress)
+    const visibleEntry = entries.find(entry => normalizeWalletAddress(entry.proxyWallet) === normalizedUserAddress)
+    const sourceEntry = visibleEntry ?? userEntry
+    const address = sourceEntry?.proxyWallet || userAddress
+    const rawUsername = sourceEntry?.userName || sourceEntry?.xUsername || user?.username || ''
+    const username = rawUsername || address
+    const rankNumber = Number(sourceEntry?.rank ?? Number.NaN)
+    const medalSrc = rankNumber === 1
+      ? '/images/medals/gold.svg'
+      : rankNumber === 2
+        ? '/images/medals/silver.svg'
+        : rankNumber === 3
+          ? '/images/medals/bronze.svg'
+          : null
+    const medalAlt = rankNumber === 1
+      ? 'Gold medal'
+      : rankNumber === 2
+        ? 'Silver medal'
+        : rankNumber === 3
+          ? 'Bronze medal'
+          : ''
+
+    return {
+      rank: sourceEntry?.rank ?? '—',
+      address,
+      username,
+      profileImage: sourceEntry?.profileImage || user?.image || '',
+      pnl: sourceEntry?.pnl,
+      vol: sourceEntry?.vol,
+      medalSrc,
+      medalAlt,
+    }
+  }, [entries, userAddress, userEntry, user?.image, user?.username])
+}
+
+export default function LeaderboardClient({ initialFilters }: { initialFilters: LeaderboardFilters }) {
+  const { filters, updateFilters } = useLeaderboardFilters(initialFilters)
+  const { user, userAddress } = useLeaderboardUserAddress()
+  const { searchInput, setSearchInput, searchQuery } = useDebouncedLeaderboardSearch()
+  const leaderboardScopeKey = buildLeaderboardScopeKey(filters, searchQuery)
+  const { page, setPageValue } = useLeaderboardPagination(leaderboardScopeKey)
+  const leaderboardRequestKey = `${leaderboardScopeKey}:${page}`
+  const currentFilters = useCurrentLeaderboardFilters(filters)
+  const { entries, isLoading } = useLeaderboardEntries({
+    filters,
+    currentFilters,
+    searchQuery,
+    page,
+    leaderboardRequestKey,
+  })
+  const userEntry = useLeaderboardUserEntry({ filters, currentFilters, userAddress })
+  const { biggestWins, isBiggestWinsLoading } = useBiggestWins(initialFilters, filters)
+  const categoryLabel = useLeaderboardCategoryLabel(filters.category)
 
   const rowClassName = cn(
     `
@@ -551,58 +700,8 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
   )
 
   const selectedPeriod = filters.period
-  const biggestWinsPeriodLabel = useMemo(() => {
-    switch (filters.period) {
-      case 'today':
-        return 'today'
-      case 'weekly':
-        return 'this week'
-      case 'monthly':
-        return 'this month'
-      case 'all':
-        return 'all time'
-      default:
-        return 'this month'
-    }
-  }, [filters.period])
-  const pinnedEntry = useMemo(() => {
-    if (!userAddress) {
-      return null
-    }
-
-    const normalizedUserAddress = normalizeWalletAddress(userAddress)
-    const visibleEntry = entries.find(entry => normalizeWalletAddress(entry.proxyWallet) === normalizedUserAddress)
-    const sourceEntry = visibleEntry ?? userEntry
-    const address = sourceEntry?.proxyWallet || userAddress
-    const rawUsername = sourceEntry?.userName || sourceEntry?.xUsername || user?.username || ''
-    const username = rawUsername || address
-    const rankNumber = Number(sourceEntry?.rank ?? Number.NaN)
-    const medalSrc = rankNumber === 1
-      ? '/images/medals/gold.svg'
-      : rankNumber === 2
-        ? '/images/medals/silver.svg'
-        : rankNumber === 3
-          ? '/images/medals/bronze.svg'
-          : null
-    const medalAlt = rankNumber === 1
-      ? 'Gold medal'
-      : rankNumber === 2
-        ? 'Silver medal'
-        : rankNumber === 3
-          ? 'Bronze medal'
-          : ''
-
-    return {
-      rank: sourceEntry?.rank ?? '—',
-      address,
-      username,
-      profileImage: sourceEntry?.profileImage || user?.image || '',
-      pnl: sourceEntry?.pnl,
-      vol: sourceEntry?.vol,
-      medalSrc,
-      medalAlt,
-    }
-  }, [entries, userAddress, userEntry, user?.image, user?.username])
+  const biggestWinsPeriodLabel = useBiggestWinsPeriodLabel(filters.period)
+  const pinnedEntry = usePinnedLeaderboardEntry({ entries, userAddress, userEntry, user })
   const pinnedProfitValue = pinnedEntry?.pnl
   const pinnedVolumeValue = pinnedEntry?.vol
   const pinnedProfitLabel = Number.isFinite(pinnedProfitValue)


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855) to `LeaderboardClient.tsx` — on your split-components follow-up list; this PR is hook-refactor only, splitting happens later.

Follow-up to #866, #867, #868, #869, #870, #871, #872, #873, #874, #875, #876, #877, #878, #879, #881.

## Scope

Single file: `src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx` (~1150 LOC).

**Lint impact:** `use-encapsulation/prefer-custom-hooks` on this file: **18 → 0 (100% reduction)**. 4 `useEffect`s now named.

## Extracted hooks (all file-local)

- `useLeaderboardFilters(initialFilters)` — owns filter state, router push on change, returns `{ filters, updateFilters }`.
- `useDebouncedLeaderboardSearch()` — owns search input + 300 ms debounced search query with named effect `syncDebouncedSearchQuery` (+ cleanup `cancelDebouncedSearchTimeout`).
- `useLeaderboardPagination(scopeKey)` — page state scoped to the current filter + query key.
- `useCurrentLeaderboardFilters(filters)` — memoized stable `LeaderboardFilters` object for downstream effects.
- `useLeaderboardUserAddress()` — wraps `useUser` + memoized `userAddress`.
- `useLeaderboardEntries({...})` — fetches paged leaderboard rows with hydration + sort. Named effect `loadLeaderboardEntries` (+ cleanup `abortLeaderboardEntriesRequest`).
- `useLeaderboardUserEntry({...})` — fetches the current user's row. Named effect `loadLeaderboardUserEntry` (+ cleanup `abortLeaderboardUserEntryRequest`).
- `useBiggestWins(initialFilters, filters)` — biggest-wins cache + in-flight lookup. Named effect `loadBiggestWins` (+ cleanup `cancelBiggestWinsRequest`).
- `useLeaderboardCategoryLabel(category)` — human label for the selected category.
- `useBiggestWinsPeriodLabel(period)` — human label for the "Biggest wins" heading period.
- `usePinnedLeaderboardEntry({...})` — memoized pinned-entry view model (rank / medal / username / image fallback).

## Shared-hook audit

- `useDebounce` (`src/hooks/useDebounce.ts`) was considered for the search debounce but the existing behaviour restarts the 300 ms timer on every `searchInput` keystroke (including whitespace-only changes). Switching to `useDebounce(searchInput.trim(), 300)` would skip the restart when the trimmed value is unchanged — a subtle behaviour change. Preserved with the explicit file-local timer.
- `useFilters` already exists in `_providers/FilterProvider` but is scoped to the global platform filter context, distinct from `LeaderboardFilters`. Named file-local hook `useLeaderboardFilters` to avoid collision.
- All other new hooks grep-audited across `src/` — zero external references. Kept file-local per Bruno's rule.

## Remaining warnings

Zero `use-encapsulation/prefer-custom-hooks`. The file has 3 pre-existing `react/set-state-in-effect` warnings inside `useBiggestWins` — left as-is; different rule family, out of scope for this refactor, mirrors the trade-off accepted in prior PRs.

## Test plan

- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: leaderboard landing (all categories / period filters), debounced search, pagination, pinned current-user row, biggest-wins panel (category + period)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `LeaderboardClient` to use file-local custom hooks for state, data fetching, and view models to improve readability and encapsulation with no behavior changes. Eliminates all `use-encapsulation/prefer-custom-hooks` lint violations and adds names to key effects.

- **Refactors**
  - Scoped to `src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx` (+197/−98).
  - Added hooks for filters, debounced search (300 ms), and pagination.
  - Moved entries, user entry, and biggest-wins fetching into hooks with named effects and cleanups.
  - Added hooks for category/period labels and the pinned entry view model.
  - Lint impact: `use-encapsulation/prefer-custom-hooks` 18 → 0; 4 effects now named.
  - Preserved existing debounce behavior (avoids `useDebounce` behavior change). Left 3 pre-existing `react/set-state-in-effect` warnings as-is.

<sup>Written for commit 1d89d4f5d452d2162261f0dc9875030654a03d35. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

