### PR TITLE
refactor: use custom hooks for ActivityFeed

### DIFF
--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -218,34 +218,19 @@ function resolveActivityCreatorWallet(payload: LiveActivityPayload) {
   return normalizeWalletAddress(payload.creator)
 }
 
-export default function ActivityFeed() {
-  const t = useExtracted()
-  const normalizeOutcomeLabel = useOutcomeLabel()
-  const { tags } = usePlatformNavigationData()
-  const wsUrl = process.env.WS_LIVE_DATA_URL
-  const wsUrlRef = useRef<string | null>(wsUrl ?? null)
-  const router = useRouter()
-  const [categoryFilter, setCategoryFilter] = useState<string>('all')
-  const [minAmountFilter, setMinAmountFilter] = useState<string>('none')
-  const [items, setItems] = useState<LiveActivityItem[]>([])
-  const [allowedCreatorWallets, setAllowedCreatorWallets] = useState<ReadonlySet<string> | null>(null)
-  const [visibleWindow, setVisibleWindow] = useState<{ key: string, extra: number }>({ key: '', extra: 0 })
-  const loadMoreRef = useRef<HTMLDivElement | null>(null)
-  const seenIdsRef = useRef<Set<string>>(new Set())
-  const categoryValues = useMemo(() => buildActivityCategoryValues(tags), [tags])
-  const categoryOptions = useMemo(
-    () => buildActivityCategoryOptions(tags, t('All')),
-    [t, tags],
-  )
+function useBaseVisibleCount() {
   const viewportHeight = useSyncExternalStore(
     subscribeToViewportResize,
     getViewportHeightSnapshot,
     getServerViewportHeightSnapshot,
   )
-  const baseVisibleCount = useMemo(() => clampBaseVisibleCount(viewportHeight), [viewportHeight])
-  const activeCategoryFilter = categoryValues.has(categoryFilter) ? categoryFilter : 'all'
+  return useMemo(() => clampBaseVisibleCount(viewportHeight), [viewportHeight])
+}
 
-  useEffect(() => {
+function useAllowedCreatorWallets() {
+  const [allowedCreatorWallets, setAllowedCreatorWallets] = useState<ReadonlySet<string> | null>(null)
+
+  useEffect(function loadAllowedCreatorWalletsEffect() {
     const abortController = new AbortController()
 
     async function loadAllowedCreators() {
@@ -278,12 +263,28 @@ export default function ActivityFeed() {
 
     void loadAllowedCreators()
 
-    return () => {
+    return function abortLoadAllowedCreators() {
       abortController.abort()
     }
   }, [])
 
-  useEffect(() => {
+  return allowedCreatorWallets
+}
+
+function useLiveActivityStream({
+  wsUrl,
+  allowedCreatorWallets,
+  categoryValues,
+}: {
+  wsUrl: string | undefined
+  allowedCreatorWallets: ReadonlySet<string> | null
+  categoryValues: ReadonlySet<string>
+}) {
+  const [items, setItems] = useState<LiveActivityItem[]>([])
+  const wsUrlRef = useRef<string | null>(wsUrl ?? null)
+  const seenIdsRef = useRef<Set<string>>(new Set())
+
+  useEffect(function subscribeLiveActivityStream() {
     if (!wsUrl || !allowedCreatorWallets) {
       return
     }
@@ -445,7 +446,7 @@ export default function ActivityFeed() {
     connect()
     document.addEventListener('visibilitychange', handleVisibilityChange)
 
-    return () => {
+    return function teardownLiveActivityStream() {
       isActive = false
       clearReconnect()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
@@ -462,6 +463,18 @@ export default function ActivityFeed() {
     }
   }, [allowedCreatorWallets, categoryValues, wsUrl])
 
+  return items
+}
+
+function useFilteredActivityOrders({
+  items,
+  activeCategoryFilter,
+  minAmountFilter,
+}: {
+  items: LiveActivityItem[]
+  activeCategoryFilter: string
+  minAmountFilter: string
+}) {
   const minAmountMicro = useMemo(() => {
     const parsed = Number(minAmountFilter)
     if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -470,30 +483,70 @@ export default function ActivityFeed() {
     return Number(toMicro(parsed))
   }, [minAmountFilter])
 
-  const filteredOrders = useMemo(() => {
+  return useMemo(() => {
     let filtered = items
     if (activeCategoryFilter !== 'all') {
       filtered = filtered.filter(item => item.categories.includes(activeCategoryFilter))
     }
     return filterActivitiesByMinAmount(filtered.map(item => item.order), minAmountMicro)
   }, [activeCategoryFilter, items, minAmountMicro])
+}
 
+function useActivityCategoryOptions(tags: Array<{ slug: string, name: string }>, allLabel: string) {
+  const categoryValues = useMemo(() => buildActivityCategoryValues(tags), [tags])
+  const categoryOptions = useMemo(
+    () => buildActivityCategoryOptions(tags, allLabel),
+    [allLabel, tags],
+  )
+  return { categoryValues, categoryOptions }
+}
+
+function useActivityFilters() {
+  const [categoryFilter, setCategoryFilter] = useState<string>('all')
+  const [minAmountFilter, setMinAmountFilter] = useState<string>('none')
+  return { categoryFilter, setCategoryFilter, minAmountFilter, setMinAmountFilter }
+}
+
+function useActivityFilterLabels({
+  categoryOptions,
+  activeCategoryFilter,
+  minAmountFilter,
+  allLabel,
+}: {
+  categoryOptions: ActivityCategoryOption[]
+  activeCategoryFilter: string
+  minAmountFilter: string
+  allLabel: string
+}) {
   const minAmountDisplay = useMemo(() => {
     return MIN_AMOUNT_OPTIONS.find(option => option.value === minAmountFilter)?.display ?? 'Min amount'
   }, [minAmountFilter])
 
   const categoryDisplay = useMemo(() => {
-    return categoryOptions.find(option => option.value === activeCategoryFilter)?.label ?? t('All')
-  }, [activeCategoryFilter, categoryOptions, t])
+    return categoryOptions.find(option => option.value === activeCategoryFilter)?.label ?? allLabel
+  }, [activeCategoryFilter, allLabel, categoryOptions])
 
-  const visibleKey = `${activeCategoryFilter}:${minAmountFilter}:${baseVisibleCount}`
+  return { minAmountDisplay, categoryDisplay }
+}
+
+function useActivityVisibleWindow({
+  filteredOrdersLength,
+  baseVisibleCount,
+  visibleKey,
+}: {
+  filteredOrdersLength: number
+  baseVisibleCount: number
+  visibleKey: string
+}) {
+  const [visibleWindow, setVisibleWindow] = useState<{ key: string, extra: number }>({ key: '', extra: 0 })
+  const loadMoreRef = useRef<HTMLDivElement | null>(null)
+
   const visibleExtra = visibleWindow.key === visibleKey ? visibleWindow.extra : 0
-  const visibleCount = Math.min(filteredOrders.length, baseVisibleCount + visibleExtra)
+  const visibleCount = Math.min(filteredOrdersLength, baseVisibleCount + visibleExtra)
   const pageSize = Math.max(6, Math.round(baseVisibleCount * 0.6))
-  const hasHiddenItems = visibleCount < filteredOrders.length
-  const visibleOrders = filteredOrders.slice(0, visibleCount)
+  const hasHiddenItems = visibleCount < filteredOrdersLength
 
-  useEffect(() => {
+  useEffect(function observeActivityFeedSentinel() {
     const node = loadMoreRef.current
     if (!node || !hasHiddenItems) {
       return
@@ -514,8 +567,45 @@ export default function ActivityFeed() {
     )
 
     observer.observe(node)
-    return () => observer.disconnect()
+    return function unobserveActivityFeedSentinel() {
+      observer.disconnect()
+    }
   }, [hasHiddenItems, pageSize, visibleKey])
+
+  return { loadMoreRef, visibleCount, hasHiddenItems }
+}
+
+export default function ActivityFeed() {
+  const t = useExtracted()
+  const normalizeOutcomeLabel = useOutcomeLabel()
+  const { tags } = usePlatformNavigationData()
+  const wsUrl = process.env.WS_LIVE_DATA_URL
+  const router = useRouter()
+  const allLabel = t('All')
+  const { categoryFilter, setCategoryFilter, minAmountFilter, setMinAmountFilter } = useActivityFilters()
+  const { categoryValues, categoryOptions } = useActivityCategoryOptions(tags, allLabel)
+  const baseVisibleCount = useBaseVisibleCount()
+  const activeCategoryFilter = categoryValues.has(categoryFilter) ? categoryFilter : 'all'
+
+  const allowedCreatorWallets = useAllowedCreatorWallets()
+  const items = useLiveActivityStream({ wsUrl, allowedCreatorWallets, categoryValues })
+
+  const filteredOrders = useFilteredActivityOrders({ items, activeCategoryFilter, minAmountFilter })
+
+  const { minAmountDisplay, categoryDisplay } = useActivityFilterLabels({
+    categoryOptions,
+    activeCategoryFilter,
+    minAmountFilter,
+    allLabel,
+  })
+
+  const visibleKey = `${activeCategoryFilter}:${minAmountFilter}:${baseVisibleCount}`
+  const { loadMoreRef, visibleCount, hasHiddenItems } = useActivityVisibleWindow({
+    filteredOrdersLength: filteredOrders.length,
+    baseVisibleCount,
+    visibleKey,
+  })
+  const visibleOrders = filteredOrders.slice(0, visibleCount)
 
   const isLoading = items.length === 0
 


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855) to `ActivityFeed.tsx`.

Follow-up to #866, #867, #868, #869, #870, #871, #872, #873, #874, #875, #876, #877, #878, #879, #881, #882.

## Scope

Single file: `src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx` (~745 LOC).

**Lint impact:** `use-encapsulation/prefer-custom-hooks`: **19 → 0 (100% reduction)**. 3 effects named.

## Extracted hooks (all file-local)

- `useBaseVisibleCount` — subscribes to viewport resize via `useSyncExternalStore`, returns clamped base visible row count.
- `useAllowedCreatorWallets` — fetches the public allowed-creator wallet list once on mount. Named effect `loadAllowedCreatorWalletsEffect` (+ cleanup `abortLoadAllowedCreators`).
- `useLiveActivityStream({ wsUrl, allowedCreatorWallets, categoryValues })` — owns the WebSocket subscription, message parsing, dedupe via `seenIdsRef`, and trimmed items state. Named effect `subscribeLiveActivityStream` (+ cleanup `teardownLiveActivityStream`).
- `useFilteredActivityOrders({ items, activeCategoryFilter, minAmountFilter })` — derives `minAmountMicro` + the category + amount filtered order list.
- `useActivityCategoryOptions(tags, allLabel)` — memoizes `categoryValues` set + `categoryOptions` list.
- `useActivityFilters` — `categoryFilter` + `minAmountFilter` state and setters.
- `useActivityFilterLabels({...})` — memoized display labels for the two Select triggers.
- `useActivityVisibleWindow({ filteredOrdersLength, baseVisibleCount, visibleKey })` — owns `visibleWindow` state + `loadMoreRef`, installs the `IntersectionObserver`. Named effect `observeActivityFeedSentinel` (+ cleanup `unobserveActivityFeedSentinel`).

## Shared-hook audit

Grepped all new hook names across `src/` — zero cross-file usage. Kept file-local per Bruno's rule. The other existing `useInfiniteScrollSentinel` patterns in the repo have different error/retry semantics (e.g. `EventMarketOpenOrders`, `PortfolioOpenOrdersList`, `PublicActivityList`); consolidation is a post-merge cleanup candidate.

## Kept inline (per the \"2–3 sec rule\")

- `visibleOrders` (one-line slice), `displayedOrders`, `hasHiddenItems`, `shouldShowEmpty`, `handleShowAll` inline handler — single-line derivations.

## Test plan

- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: live activity stream (WebSocket + reconnect), category filter, minimum amount filter, infinite scroll sentinel loading more rows, viewport resize adjusting base visible count

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored ActivityFeed to use file-local custom hooks and named effects, simplifying the component with no behavior changes. Clears `use-encapsulation/prefer-custom-hooks` violations and makes side effects explicit.

- **Refactors**
  - Extracted hooks: viewport count, allowed creators fetch, live stream, filtered orders, category options, filter state/labels, and visible window (with IntersectionObserver). Named effects added for each side effect.
  - Lint: `use-encapsulation/prefer-custom-hooks` 19 → 0; 3 effects named.
  - Kept trivial derivations inline; WebSocket flow, filters, and infinite scroll unchanged.
  - Scope: `src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx` only (+124/−34).

<sup>Written for commit 0546284e61973089719c98d7e63bf3176d72a374. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

