### PR TITLE
refactor: use custom hooks for WalletModal

### DIFF
--- a/src/app/[locale]/(platform)/_components/WalletModal.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletModal.tsx
@@ -142,6 +142,82 @@ interface WalletWithdrawModalProps {
   pendingWithdrawals?: PendingWithdrawalItem[]
 }
 
+function useWithdrawFormSelections() {
+  const [receiveToken, setReceiveToken] = useState<string>('USDC.e')
+  const [receiveChain, setReceiveChain] = useState<string>('Polygon')
+  const [isBreakdownOpen, setIsBreakdownOpen] = useState(false)
+  return { receiveToken, setReceiveToken, receiveChain, setReceiveChain, isBreakdownOpen, setIsBreakdownOpen }
+}
+
+function useCountdownTimer(seconds: number, onReset?: () => void) {
+  const [remaining, setRemaining] = useState(seconds)
+  const endTimeRef = useRef(0)
+  const hasTriggeredResetRef = useRef(false)
+  const onResetRef = useRef(onReset)
+
+  useEffect(function syncOnResetRef() {
+    onResetRef.current = onReset
+  }, [onReset])
+
+  useEffect(function runCountdownInterval() {
+    endTimeRef.current = Date.now() + seconds * 1000
+    hasTriggeredResetRef.current = false
+    const cleanupOnResetRef = onResetRef
+    const interval = setInterval(() => {
+      const now = Date.now()
+      let diff = endTimeRef.current - now
+      if (diff <= 0) {
+        if (!hasTriggeredResetRef.current) {
+          hasTriggeredResetRef.current = true
+          cleanupOnResetRef.current?.()
+        }
+        endTimeRef.current = Date.now() + seconds * 1000
+        diff = endTimeRef.current - now
+        hasTriggeredResetRef.current = false
+      }
+      const next = Math.max(0, Math.ceil(diff / 1000))
+      setRemaining(next)
+    }, 250)
+
+    return function cleanupCountdownInterval() {
+      clearInterval(interval)
+    }
+  }, [seconds])
+
+  return { remaining }
+}
+
+function useConfirmStepLocalState() {
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [isBreakdownOpen, setIsBreakdownOpen] = useState(false)
+  return { isSubmitting, setIsSubmitting, isBreakdownOpen, setIsBreakdownOpen }
+}
+
+function useDepositModalState(
+  walletEoaAddress: string | null | undefined,
+  open: boolean,
+  view: WalletDepositView,
+) {
+  const [copied, setCopied] = useState(false)
+  const tokensQueryEnabled = open && (view === 'wallets' || view === 'amount' || view === 'confirm')
+  const { items: walletTokenItems, isLoadingTokens } = useLiFiWalletTokens(walletEoaAddress, { enabled: tokensQueryEnabled })
+  const [preferredSelectedTokenId, setPreferredSelectedTokenId] = useState('')
+  const [amountValue, setAmountValue] = useState('')
+  const [confirmRefreshIndex, setConfirmRefreshIndex] = useState(0)
+  return {
+    copied,
+    setCopied,
+    walletTokenItems,
+    isLoadingTokens,
+    preferredSelectedTokenId,
+    setPreferredSelectedTokenId,
+    amountValue,
+    setAmountValue,
+    confirmRefreshIndex,
+    setConfirmRefreshIndex,
+  }
+}
+
 function WalletAddressCard({
   walletAddress,
   onCopy,
@@ -283,9 +359,7 @@ function WalletSendForm({
   const trimmedRecipient = sendTo.trim()
   const isRecipientAddress = /^0x[a-fA-F0-9]{40}$/.test(trimmedRecipient)
   const parsedAmount = Number(sendAmount)
-  const [receiveToken, setReceiveToken] = useState<string>('USDC.e')
-  const [receiveChain, setReceiveChain] = useState<string>('Polygon')
-  const [isBreakdownOpen, setIsBreakdownOpen] = useState(false)
+  const { receiveToken, setReceiveToken, receiveChain, setReceiveChain, isBreakdownOpen, setIsBreakdownOpen } = useWithdrawFormSelections()
   const inputValue = formatDisplayAmount(sendAmount)
   const isSubmitDisabled = (
     isSending
@@ -1257,36 +1331,7 @@ function CountdownBadgeContent({
   seconds,
   onReset,
 }: CountdownBadgeContentProps) {
-  const [remaining, setRemaining] = useState(seconds)
-  const endTimeRef = useRef(0)
-  const hasTriggeredResetRef = useRef(false)
-  const onResetRef = useRef(onReset)
-
-  useEffect(() => {
-    onResetRef.current = onReset
-  }, [onReset])
-
-  useEffect(() => {
-    endTimeRef.current = Date.now() + seconds * 1000
-    hasTriggeredResetRef.current = false
-    const interval = setInterval(() => {
-      const now = Date.now()
-      let diff = endTimeRef.current - now
-      if (diff <= 0) {
-        if (!hasTriggeredResetRef.current) {
-          hasTriggeredResetRef.current = true
-          onResetRef.current?.()
-        }
-        endTimeRef.current = Date.now() + seconds * 1000
-        diff = endTimeRef.current - now
-        hasTriggeredResetRef.current = false
-      }
-      const next = Math.max(0, Math.ceil(diff / 1000))
-      setRemaining(next)
-    }, 250)
-
-    return () => clearInterval(interval)
-  }, [seconds])
+  const { remaining } = useCountdownTimer(seconds, onReset)
 
   const size = 36
   const strokeWidth = 3
@@ -1358,9 +1403,8 @@ function WalletConfirmStep({
   quote?: { toAmountDisplay: string | null, gasUsdDisplay: string | null } | null
   refreshIndex: number
 }) {
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const { isSubmitting, setIsSubmitting, isBreakdownOpen, setIsBreakdownOpen } = useConfirmStepLocalState()
   const eoaSuffix = walletEoaAddress?.slice(-4) ?? '542d'
-  const [isBreakdownOpen, setIsBreakdownOpen] = useState(false)
   const site = useSiteIdentity()
   const formattedAmount = formatDisplayAmount(amountValue)
   const displayAmount = formattedAmount && formattedAmount.trim() !== '' ? formattedAmount : '0.00'
@@ -1823,14 +1867,20 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
     isBalanceLoading = false,
   } = props
 
-  const [copied, setCopied] = useState(false)
+  const {
+    copied,
+    setCopied,
+    walletTokenItems,
+    isLoadingTokens,
+    preferredSelectedTokenId,
+    setPreferredSelectedTokenId,
+    amountValue,
+    setAmountValue,
+    confirmRefreshIndex,
+    setConfirmRefreshIndex,
+  } = useDepositModalState(walletEoaAddress, open, view)
   const site = useSiteIdentity()
   const siteLabel = siteName ?? site.name
-  const tokensQueryEnabled = open && (view === 'wallets' || view === 'amount' || view === 'confirm')
-  const { items: walletTokenItems, isLoadingTokens } = useLiFiWalletTokens(walletEoaAddress, { enabled: tokensQueryEnabled })
-  const [preferredSelectedTokenId, setPreferredSelectedTokenId] = useState('')
-  const [amountValue, setAmountValue] = useState('')
-  const [confirmRefreshIndex, setConfirmRefreshIndex] = useState(0)
   const formattedBalance = walletBalance && walletBalance !== ''
     ? walletBalance
     : '0.00'


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855) to `WalletModal.tsx` — on your split-components follow-up list; this PR is hook-refactor only, splitting happens later.

Follow-up to #866, #867, #868, #869, #870, #871, #872, #873, #874, #875, #876, #877, #878, #879, #881, #882, #883.

## Scope

Single file: `src/app/[locale]/(platform)/_components/WalletModal.tsx` (~2130 LOC).

**Lint impact:** `use-encapsulation/prefer-custom-hooks`: **15 → 0 (100% reduction)**.

## Extracted hooks (all file-local)

- `useWithdrawFormSelections` — manages receive-token, chain, and breakdown-toggle state for the withdraw form.
- `useCountdownTimer(seconds, onReset)` — encapsulates the countdown interval logic with auto-reset callback.
- `useConfirmStepLocalState` — manages `isSubmitting` and `isBreakdownOpen` state for the confirm step.
- `useDepositModalState(walletEoaAddress, open, view)` — manages copied state, wallet-token fetching, selected token, amount, and refresh index for the deposit modal.

## Shared-hook audit

Grepped all 4 hook names across `src/` — zero cross-file usage. Kept file-local per Bruno's rule.

## Kept inline (per the \"2–3 sec rule\")

Trivial single-line derivations: `isDepositView`, `isWithdrawView`, format helpers, direct boolean flags — all readable in under 3 seconds.

## Test plan

- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: deposit modal (token select + amount + copy address + refresh), withdraw form (token + chain + breakdown), confirm step (submitting + countdown timer + auto-reset), wallet view switching

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored `WalletModal.tsx` to encapsulate state and effects in local custom hooks. No UI or behavior changes; improves readability and drops `use-encapsulation/prefer-custom-hooks` violations to zero.

- **Refactors**
  - Added file-local hooks: `useWithdrawFormSelections`, `useCountdownTimer`, `useConfirmStepLocalState`, `useDepositModalState`.
  - Moved countdown logic into `useCountdownTimer` and reused in `CountdownBadgeContent`.
  - Consolidated deposit modal state (copied, tokens query enablement, selected token, amount, refresh index) into `useDepositModalState`.
  - Lint: `use-encapsulation/prefer-custom-hooks` 15 → 0 in `WalletModal.tsx`.

<sup>Written for commit e22dba01ca9f16d3a488c86b0d2c7e680d4b9e2b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

