### PR TITLE
refactor: use custom hooks for shared components

### DIFF
--- a/src/components/AppLink.tsx
+++ b/src/components/AppLink.tsx
@@ -12,7 +12,7 @@ type AppLinkProps = Omit<ComponentPropsWithoutRef<typeof Link>, 'prefetch'> & {
 }
 type AppLinkRef = ComponentRef<typeof Link>
 
-function AppLink({ ref, intentPrefetch = false, onFocus, onMouseEnter, onTouchStart, prefetch = false, ...props }: AppLinkProps) {
+function useIntentPrefetch(intentPrefetch: boolean, prefetch: NextLinkPrefetch | false) {
   const [shouldPrefetch, setShouldPrefetch] = useState(false)
   const nextPrefetch = prefetch === false ? null : prefetch
   const resolvedPrefetch = intentPrefetch
@@ -22,6 +22,12 @@ function AppLink({ ref, intentPrefetch = false, onFocus, onMouseEnter, onTouchSt
   function enableIntentPrefetch() {
     setShouldPrefetch(true)
   }
+
+  return { resolvedPrefetch, enableIntentPrefetch }
+}
+
+function AppLink({ ref, intentPrefetch = false, onFocus, onMouseEnter, onTouchStart, prefetch = false, ...props }: AppLinkProps) {
+  const { resolvedPrefetch, enableIntentPrefetch } = useIntentPrefetch(intentPrefetch, prefetch)
 
   return (
     <Link

--- a/src/components/CustomJavascriptCode.tsx
+++ b/src/components/CustomJavascriptCode.tsx
@@ -180,7 +180,7 @@ function executeCustomJavascriptCodes(codes: CustomJavascriptCodeConfig[]) {
   }
 }
 
-export default function CustomJavascriptCode({ locale, codes }: CustomJavascriptCodeProps) {
+function useCustomJavascriptCodeExecution(locale: string, codes: CustomJavascriptCodeConfig[]) {
   const pathname = usePathname()
   const localizedPathname = useMemo(() => stripLocalePrefix(pathname, locale), [locale, pathname])
   const activeCodes = useMemo(
@@ -194,7 +194,7 @@ export default function CustomJavascriptCode({ locale, codes }: CustomJavascript
   const previousActiveCodeSignatureRef = useRef<string | null>(null)
   const [interactionSignature, setInteractionSignature] = useState<string | null>(null)
 
-  useEffect(() => {
+  useEffect(function reloadOnCodeChange() {
     const previousActiveCodeSignature = previousActiveCodeSignatureRef.current
     previousActiveCodeSignatureRef.current = activeCodeSignature
 
@@ -213,7 +213,7 @@ export default function CustomJavascriptCode({ locale, codes }: CustomJavascript
     window.location.reload()
   }, [activeCodeSignature])
 
-  useEffect(() => {
+  useEffect(function executeCodesOnFirstInteraction() {
     if (interactionSignature === activeCodeSignature || activeCodes.length === 0) {
       return
     }
@@ -228,13 +228,17 @@ export default function CustomJavascriptCode({ locale, codes }: CustomJavascript
     window.addEventListener('touchstart', handleInteraction, { once: true, passive: true })
     window.addEventListener('scroll', handleInteraction, { once: true, passive: true })
 
-    return () => {
+    return function cleanupInteractionListeners() {
       window.removeEventListener('pointerdown', handleInteraction)
       window.removeEventListener('keydown', handleInteraction)
       window.removeEventListener('touchstart', handleInteraction)
       window.removeEventListener('scroll', handleInteraction)
     }
   }, [activeCodeSignature, activeCodes, interactionSignature])
+}
+
+export default function CustomJavascriptCode({ locale, codes }: CustomJavascriptCodeProps) {
+  useCustomJavascriptCodeExecution(locale, codes)
 
   return null
 }

--- a/src/components/GlobalAnnouncementBanner.tsx
+++ b/src/components/GlobalAnnouncementBanner.tsx
@@ -33,14 +33,18 @@ function stripLocalePrefix(pathname: string | null, locale: string) {
   return pathname
 }
 
+function useLocalizedPathname(locale: string) {
+  const pathname = usePathname()
+  return useMemo(() => stripLocalePrefix(pathname, locale), [locale, pathname])
+}
+
 export default function GlobalAnnouncementBanner({
   locale,
   message,
   linkUrl,
   disabledOn,
 }: GlobalAnnouncementBannerProps) {
-  const pathname = usePathname()
-  const localizedPathname = useMemo(() => stripLocalePrefix(pathname, locale), [locale, pathname])
+  const localizedPathname = useLocalizedPathname(locale)
   const hasMessage = message.trim().length > 0
   const isEnabled = isCustomJavascriptCodeEnabledOnPathname({ disabledOn }, localizedPathname)
 

--- a/src/components/HeaderDropdownUserMenuAuth.tsx
+++ b/src/components/HeaderDropdownUserMenuAuth.tsx
@@ -28,35 +28,20 @@ import { getAvatarPlaceholderStyle, shouldUseAvatarPlaceholder } from '@/lib/ava
 import { signOutAndRedirect } from '@/lib/logout'
 import { useUser } from '@/stores/useUser'
 
-export default function HeaderDropdownUserMenuAuth() {
-  const t = useExtracted()
-  const { isReady } = useAppKit()
-  const { disconnect } = useDisconnect()
-  const user = useUser()
-  const { canShowInstallUi, isIos, isPrompting, requestInstall } = usePwaInstall()
-  const pathname = usePathname()
-  const isAdmin = pathname.startsWith('/admin')
-  const isMobile = useIsMobile()
-  const enableHoverOpen = !isMobile
+function useHoverMenu(enableHoverOpen: boolean) {
   const [menuOpen, setMenuOpen] = useState(false)
   const wrapperRef = useRef<HTMLDivElement | null>(null)
   const closeTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const avatarUrl = user?.image?.trim() ?? ''
-  const avatarSeed = user?.proxy_wallet_address || user?.address || user?.username || 'user'
-  const showPlaceholder = shouldUseAvatarPlaceholder(avatarUrl)
-  const placeholderStyle = showPlaceholder
-    ? getAvatarPlaceholderStyle(avatarSeed)
-    : undefined
 
   useEffect(function clearMenuCloseTimeoutOnUnmount() {
-    function cleanupMenuCloseTimeout() {
-      if (closeTimeoutRef.current) {
-        clearTimeout(closeTimeoutRef.current)
-        closeTimeoutRef.current = null
+    const timeoutRef = closeTimeoutRef
+
+    return function cleanupMenuCloseTimeout() {
+      if (timeoutRef.current) {
+        clearTimeout(timeoutRef.current)
+        timeoutRef.current = null
       }
     }
-
-    return cleanupMenuCloseTimeout
   }, [])
 
   function relatedTargetIsWithin(ref: React.RefObject<HTMLElement | null>, relatedTarget: EventTarget | null) {
@@ -107,6 +92,27 @@ export default function HeaderDropdownUserMenuAuth() {
   function handleMenuClose() {
     setMenuOpen(false)
   }
+
+  return { menuOpen, setMenuOpen, wrapperRef, clearCloseTimeout, handleWrapperPointerEnter, handleWrapperPointerLeave, handleMenuClose }
+}
+
+export default function HeaderDropdownUserMenuAuth() {
+  const t = useExtracted()
+  const { isReady } = useAppKit()
+  const { disconnect } = useDisconnect()
+  const user = useUser()
+  const { canShowInstallUi, isIos, isPrompting, requestInstall } = usePwaInstall()
+  const pathname = usePathname()
+  const isAdmin = pathname.startsWith('/admin')
+  const isMobile = useIsMobile()
+  const enableHoverOpen = !isMobile
+  const { menuOpen, setMenuOpen, wrapperRef, clearCloseTimeout, handleWrapperPointerEnter, handleWrapperPointerLeave, handleMenuClose } = useHoverMenu(enableHoverOpen)
+  const avatarUrl = user?.image?.trim() ?? ''
+  const avatarSeed = user?.proxy_wallet_address || user?.address || user?.username || 'user'
+  const showPlaceholder = shouldUseAvatarPlaceholder(avatarUrl)
+  const placeholderStyle = showPlaceholder
+    ? getAvatarPlaceholderStyle(avatarSeed)
+    : undefined
 
   async function handleInstallAction() {
     handleMenuClose()

--- a/src/components/LocaleSwitcherMenuItem.tsx
+++ b/src/components/LocaleSwitcherMenuItem.tsx
@@ -15,8 +15,7 @@ import {
 import { LOCALE_LABELS, LOOP_LABELS, normalizeEnabledLocales, SUPPORTED_LOCALES } from '@/i18n/locales'
 import { stripLocalePrefix, withLocalePrefix } from '@/lib/locale-path'
 
-export default function LocaleSwitcherMenuItem() {
-  const locale = useLocale()
+function useLocaleCarousel() {
   const [isPending, setIsPending] = useState(false)
   const [enabledLocales, setEnabledLocales] = useState<SupportedLocale[] | null>(null)
   const [carouselState, setCarouselState] = useState({ index: 0, isSliding: true })
@@ -35,9 +34,8 @@ export default function LocaleSwitcherMenuItem() {
   const isSliding = carouselState.isSliding
   const displayDurationMs = 1800
   const transitionDurationMs = 240
-  const itemHeightRem = 1.25
 
-  useEffect(() => {
+  useEffect(function fetchEnabledLocales() {
     let isActive = true
 
     async function loadEnabledLocales() {
@@ -62,12 +60,12 @@ export default function LocaleSwitcherMenuItem() {
 
     void loadEnabledLocales()
 
-    return () => {
+    return function cleanupFetchEnabledLocales() {
       isActive = false
     }
   }, [])
 
-  useEffect(() => {
+  useEffect(function runCarouselInterval() {
     if (!shouldAnimate) {
       return
     }
@@ -79,7 +77,9 @@ export default function LocaleSwitcherMenuItem() {
       }))
     }, displayDurationMs + transitionDurationMs)
 
-    return () => window.clearInterval(interval)
+    return function cleanupCarouselInterval() {
+      window.clearInterval(interval)
+    }
   }, [shouldAnimate, displayDurationMs, transitionDurationMs, localeLabels.length])
 
   function handleCarouselTransitionEnd() {
@@ -94,6 +94,14 @@ export default function LocaleSwitcherMenuItem() {
       }
     })
   }
+
+  return { isPending, setIsPending, displayLocales, loopedLabels, shouldAnimate, carouselIndex, isSliding, handleCarouselTransitionEnd }
+}
+
+export default function LocaleSwitcherMenuItem() {
+  const locale = useLocale()
+  const { isPending, setIsPending, displayLocales, loopedLabels, shouldAnimate, carouselIndex, isSliding, handleCarouselTransitionEnd } = useLocaleCarousel()
+  const itemHeightRem = 1.25
 
   function handleValueChange(nextLocale: string) {
     const resolvedLocale = nextLocale as SupportedLocale

--- a/src/components/ProfileLink.tsx
+++ b/src/components/ProfileLink.tsx
@@ -41,6 +41,67 @@ interface ProfileLinkProps {
   joinedAt?: string | null
 }
 
+function useAvatarFallbackStyle(showPlaceholder: boolean, avatarSeed: string) {
+  return useMemo<CSSProperties | undefined>(() => {
+    if (!showPlaceholder) {
+      return undefined
+    }
+
+    return getAvatarPlaceholderStyle(avatarSeed)
+  }, [avatarSeed, showPlaceholder])
+}
+
+function useProfileTooltipStats(user: ProfileLinkProps['user']) {
+  const [isOpen, setIsOpen] = useState(false)
+  const [stats, setStats] = useState<Awaited<ReturnType<typeof fetchProfileLinkStats>>>(null)
+  const [loadedStatsAddress, setLoadedStatsAddress] = useState<string | null>(null)
+  const statsAddress = useMemo(
+    () => user.proxy_wallet_address ?? user.address,
+    [user.address, user.proxy_wallet_address],
+  )
+  const normalizedStatsAddress = statsAddress ?? null
+  const hasLoaded = normalizedStatsAddress === null || loadedStatsAddress === normalizedStatsAddress
+  const tooltipStats = loadedStatsAddress === normalizedStatsAddress ? stats : null
+
+  useEffect(function fetchStatsOnTooltipOpen() {
+    if (!isOpen || hasLoaded) {
+      return
+    }
+
+    if (!normalizedStatsAddress) {
+      return
+    }
+
+    const controller = new AbortController()
+    let isActive = true
+
+    fetchProfileLinkStats(normalizedStatsAddress, controller.signal)
+      .then((result) => {
+        if (!isActive || controller.signal.aborted) {
+          return
+        }
+        setStats(result)
+        setLoadedStatsAddress(normalizedStatsAddress)
+      })
+      .catch((error) => {
+        if (!isActive || controller.signal.aborted || error?.name === 'AbortError') {
+          return
+        }
+        setStats(null)
+        setLoadedStatsAddress(normalizedStatsAddress)
+      })
+
+    return function cleanupStatsFetch() {
+      isActive = false
+      controller.abort()
+    }
+  }, [hasLoaded, isOpen, normalizedStatsAddress])
+
+  const isTooltipLoading = isOpen && !hasLoaded
+
+  return { isOpen, setIsOpen, tooltipStats, isTooltipLoading }
+}
+
 export default function ProfileLink({
   user,
   layout = 'default',
@@ -60,9 +121,7 @@ export default function ProfileLink({
   avatarBadge,
   tooltipTrigger = 'all',
 }: ProfileLinkProps) {
-  const [isOpen, setIsOpen] = useState(false)
-  const [stats, setStats] = useState<Awaited<ReturnType<typeof fetchProfileLinkStats>>>(null)
-  const [loadedStatsAddress, setLoadedStatsAddress] = useState<string | null>(null)
+  const { setIsOpen, tooltipStats, isTooltipLoading } = useProfileTooltipStats(user)
   const isInline = layout === 'inline'
   const isStacked = layout === 'stacked'
   const inlineBody = inlineContent ?? children
@@ -100,56 +159,7 @@ export default function ProfileLink({
   const tooltipAvatarUrl = showPlaceholder
     ? null
     : rawAvatarUrl
-  const fallbackStyle = useMemo<CSSProperties | undefined>(() => {
-    if (!showPlaceholder) {
-      return undefined
-    }
-
-    return getAvatarPlaceholderStyle(avatarSeed)
-  }, [avatarSeed, showPlaceholder])
-  const statsAddress = useMemo(
-    () => user.proxy_wallet_address ?? user.address,
-    [user.address, user.proxy_wallet_address],
-  )
-  const normalizedStatsAddress = statsAddress ?? null
-  const hasLoaded = normalizedStatsAddress === null || loadedStatsAddress === normalizedStatsAddress
-  const tooltipStats = loadedStatsAddress === normalizedStatsAddress ? stats : null
-
-  useEffect(() => {
-    if (!isOpen || hasLoaded) {
-      return
-    }
-
-    if (!normalizedStatsAddress) {
-      return
-    }
-
-    const controller = new AbortController()
-    let isActive = true
-
-    fetchProfileLinkStats(normalizedStatsAddress, controller.signal)
-      .then((result) => {
-        if (!isActive || controller.signal.aborted) {
-          return
-        }
-        setStats(result)
-        setLoadedStatsAddress(normalizedStatsAddress)
-      })
-      .catch((error) => {
-        if (!isActive || controller.signal.aborted || error?.name === 'AbortError') {
-          return
-        }
-        setStats(null)
-        setLoadedStatsAddress(normalizedStatsAddress)
-      })
-
-    return () => {
-      isActive = false
-      controller.abort()
-    }
-  }, [hasLoaded, isOpen, normalizedStatsAddress])
-
-  const isTooltipLoading = isOpen && !hasLoaded
+  const fallbackStyle = useAvatarFallbackStyle(showPlaceholder, avatarSeed)
 
   const dateLabel = date
     ? (

--- a/src/components/PwaInstallStateSync.tsx
+++ b/src/components/PwaInstallStateSync.tsx
@@ -5,12 +5,12 @@ import { useEffect } from 'react'
 import { detectIos, detectStandaloneMode } from '@/lib/pwa-install'
 import { usePwaInstallStore } from '@/stores/usePwaInstall'
 
-export default function PwaInstallStateSync() {
+function usePwaInstallSync() {
   const setEnvironment = usePwaInstallStore(state => state.setEnvironment)
   const setDeferredPrompt = usePwaInstallStore(state => state.setDeferredPrompt)
   const setStandalone = usePwaInstallStore(state => state.setStandalone)
 
-  useEffect(() => {
+  useEffect(function syncPwaInstallState() {
     setEnvironment({
       isIos: detectIos(),
       isStandalone: detectStandaloneMode(),
@@ -42,7 +42,7 @@ export default function PwaInstallStateSync() {
       displayModeQuery.addListener(handleDisplayModeChange)
     }
 
-    return () => {
+    return function cleanupPwaInstallListeners() {
       window.removeEventListener('beforeinstallprompt', handleBeforeInstallPrompt)
       window.removeEventListener('appinstalled', handleAppInstalled)
 
@@ -54,6 +54,10 @@ export default function PwaInstallStateSync() {
       }
     }
   }, [setDeferredPrompt, setEnvironment, setStandalone])
+}
+
+export default function PwaInstallStateSync() {
+  usePwaInstallSync()
 
   return null
 }

--- a/src/components/PwaServiceWorker.tsx
+++ b/src/components/PwaServiceWorker.tsx
@@ -10,8 +10,8 @@ function isLocalhostHost(hostname: string) {
     || hostname === '0.0.0.0'
 }
 
-export default function PwaServiceWorker() {
-  useEffect(() => {
+function useServiceWorkerRegistration() {
+  useEffect(function manageServiceWorker() {
     if (!('serviceWorker' in navigator)) {
       return
     }
@@ -41,6 +41,10 @@ export default function PwaServiceWorker() {
         console.error('Failed to register service worker', error)
       })
   }, [])
+}
+
+export default function PwaServiceWorker() {
+  useServiceWorkerRegistration()
 
   return null
 }

--- a/src/components/SignaturePrompt.tsx
+++ b/src/components/SignaturePrompt.tsx
@@ -96,15 +96,21 @@ export function SignaturePrompt() {
   )
 }
 
-function SignatureWalletIcon() {
+function useWalletIcon() {
   const { walletInfo } = useWalletInfo()
   const [walletIconLoadFailed, setWalletIconLoadFailed] = useState(false)
   const walletName = typeof walletInfo?.name === 'string' ? walletInfo.name : undefined
   const walletIconUrl = typeof walletInfo?.icon === 'string' ? walletInfo.icon.trim() : ''
 
-  useEffect(() => {
+  useEffect(function resetIconLoadFailedOnUrlChange() {
     setWalletIconLoadFailed(false)
   }, [walletIconUrl])
+
+  return { walletName, walletIconUrl, walletIconLoadFailed, setWalletIconLoadFailed }
+}
+
+function SignatureWalletIcon() {
+  const { walletName, walletIconUrl, walletIconLoadFailed, setWalletIconLoadFailed } = useWalletIcon()
 
   if (!walletIconUrl || walletIconLoadFailed) {
     return <WalletIcon className="size-16 text-primary" strokeWidth={1.8} />


### PR DESCRIPTION
Continues the rollout of `use-encapsulation/prefer-custom-hooks` and named effects (#855) to shared `src/components/` (excluding `ui/` shadcn folder per your guidelines and `PredictionChart` covered by #885).

Follow-up to #866–#885.

## Files changed (9)

| File | Warnings |
|---|---|
| `AppLink` | 1 → 0 |
| `CustomJavascriptCode` | 7 → 0 |
| `GlobalAnnouncementBanner` | 1 → 0 |
| `HeaderDropdownUserMenuAuth` | 4 → 0 |
| `LocaleSwitcherMenuItem` | 5 → 0 |
| `ProfileLink` | 6 → 0 |
| `PwaInstallStateSync` | 1 → 0 |
| `PwaServiceWorker` | 1 → 0 |
| `SignaturePrompt` | 2 → 0 |

**Total: 28 → 0 (100% reduction).**

## Extracted hooks (all file-local)

- **AppLink**: `useIntentPrefetch` — prefetch-on-intent state + resolution logic.
- **CustomJavascriptCode**: `useCustomJavascriptCodeExecution` — tracks active codes by pathname, reloads on code changes, executes on first user interaction.
- **GlobalAnnouncementBanner**: `useLocalizedPathname` — strips locale prefix from current pathname.
- **HeaderDropdownUserMenuAuth**: `useHoverMenu` — hover-open dropdown state with delayed close timeout.
- **LocaleSwitcherMenuItem**: `useLocaleCarousel` — fetches enabled locales + drives the label carousel animation.
- **ProfileLink**: `useProfileTooltipStats` — lazily fetches profile stats when tooltip opens; `useAvatarFallbackStyle` — memoizes avatar placeholder gradient style.
- **PwaInstallStateSync**: `usePwaInstallSync` — detects PWA environment + listens for install / display-mode events.
- **PwaServiceWorker**: `useServiceWorkerRegistration` — registers or unregisters service worker based on environment.
- **SignaturePrompt**: `useWalletIcon` — resolves wallet icon URL + resets load-failed state on URL change.

## Shared-hook audit
All 10 new hooks grepped across `src/` — zero cross-file usage. Kept file-local.

## Not included
- `src/components/ui/calendar.tsx` (2 warnings) — shadcn component, excluded per your guidelines.
- `src/components/PredictionChart.tsx` — already covered by #885.

## Test plan
- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Pre-push hook ran the full test + production build pipeline
- [x] Manual UX smoke: AppLink prefetch on hover/focus, custom JS code injection on navigation, announcement banner localized pathname, auth user dropdown hover menu, locale switcher carousel, profile tooltip lazy stats, PWA install/SW registration, signature prompt wallet icon

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactored shared components to use file-local custom hooks that encapsulate state and side effects. Removes 28 ESLint warnings and keeps behavior unchanged. Excludes `src/components/ui/*` and `PredictionChart`.

- **Refactors**
  - Introduced file-local hooks: `useIntentPrefetch`, `useCustomJavascriptCodeExecution`, `useLocalizedPathname`, `useHoverMenu`, `useLocaleCarousel`, `useProfileTooltipStats`, `useAvatarFallbackStyle`, `usePwaInstallSync`, `useServiceWorkerRegistration`, `useWalletIcon`.
  - Named `useEffect` callbacks with clear cleanup functions for readability.
  - Kept all hooks private (no cross-file exports) to satisfy `use-encapsulation/prefer-custom-hooks`.

<sup>Written for commit 05ac0253bae0a4b30e9019dec589bc569336f2fb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

