### PR TITLE
refactor: use custom hooks for remaining event page, docs, 2FA + misc

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChangeLog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChangeLog.tsx
@@ -65,9 +65,7 @@ function formatConditionLabel(conditionId: string, market?: Market) {
   return `${prefix}...${suffix}`
 }
 
-export default function EventChangeLog({ entries, markets }: EventChangeLogProps) {
-  const t = useExtracted()
-  const locale = useLocale()
+function useChangeLogData(entries: ConditionChangeLogEntry[], markets: Market[]) {
   const marketLookup = useMemo(() => {
     return new Map(markets.map(market => [market.condition_id, market]))
   }, [markets])
@@ -85,6 +83,14 @@ export default function EventChangeLog({ entries, markets }: EventChangeLogProps
       }))
     })
   }, [entries])
+
+  return { marketLookup, rows }
+}
+
+export default function EventChangeLog({ entries, markets }: EventChangeLogProps) {
+  const t = useExtracted()
+  const locale = useLocale()
+  const { marketLookup, rows } = useChangeLogData(entries, markets)
 
   if (entries.length === 0) {
     return null

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartControls.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartControls.tsx
@@ -48,6 +48,11 @@ interface EventChartControlsProps {
   onEmbed?: () => void
 }
 
+function useSettingsMenu() {
+  const [settingsOpen, setSettingsOpen] = useState(false)
+  return { settingsOpen, setSettingsOpen }
+}
+
 export default function EventChartControls({
   timeRanges,
   activeTimeRange,
@@ -67,7 +72,7 @@ export default function EventChartControls({
 }: EventChartControlsProps) {
   const t = useExtracted()
   const normalizeOutcomeLabel = useOutcomeLabel()
-  const [settingsOpen, setSettingsOpen] = useState(false)
+  const { settingsOpen, setSettingsOpen } = useSettingsMenu()
   const selectedSet = new Set(selectedMarketIds)
   const selectedOptions = marketOptions.filter(option => selectedSet.has(option.key))
   const unselectedOptions = marketOptions.filter(option => !selectedSet.has(option.key))

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentForm.tsx
@@ -15,6 +15,11 @@ interface EventCommentFormProps {
   isCreatingComment: boolean
 }
 
+function useCommentFormContent() {
+  const [content, setContent] = useState('')
+  return { content, setContent }
+}
+
 export default function EventCommentForm({
   user,
   onCommentAddedAction,
@@ -23,7 +28,7 @@ export default function EventCommentForm({
 }: EventCommentFormProps) {
   const t = useExtracted()
   const { open } = useAppKit()
-  const [content, setContent] = useState('')
+  const { content, setContent } = useCommentFormContent()
 
   async function handleSubmit(event: React.FormEvent) {
     event.preventDefault()

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentMenu.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentMenu.tsx
@@ -11,8 +11,13 @@ interface CommentMenuProps {
   isDeleting?: boolean
 }
 
-export default function EventCommentMenu({ comment, onDelete, isDeleting }: CommentMenuProps) {
+function useDeleteDialog() {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false)
+  return { isDeleteOpen, setIsDeleteOpen }
+}
+
+export default function EventCommentMenu({ comment, onDelete, isDeleting }: CommentMenuProps) {
+  const { isDeleteOpen, setIsDeleteOpen } = useDeleteDialog()
   const t = useExtracted()
 
   return (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentPositionsIndicator.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentPositionsIndicator.tsx
@@ -198,6 +198,11 @@ export function CommentPositionBadge({
   )
 }
 
+function usePositionsDropdown() {
+  const [open, setOpen] = useState(false)
+  return { open, setOpen }
+}
+
 export function CommentPositionsIndicator({
   positions,
   isSingleMarket = false,
@@ -211,7 +216,7 @@ export function CommentPositionsIndicator({
 }) {
   const normalizeOutcomeLabel = useOutcomeLabel()
   const entries = getCommentPositionEntries(positions, marketsByConditionId, isSingleMarket)
-  const [open, setOpen] = useState(false)
+  const { open, setOpen } = usePositionsDropdown()
 
   const primaryPosition = entries[0]
   const primaryInlineLabel = primaryPosition

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyForm.tsx
@@ -19,6 +19,12 @@ interface EventCommentReplyFormProps {
   isCreatingComment: boolean
 }
 
+function useReplyFormState(initialValue?: string) {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [content, setContent] = useState(initialValue || '')
+  return { inputRef, content, setContent }
+}
+
 export default function EventCommentReplyForm({
   user,
   parentCommentId,
@@ -28,8 +34,7 @@ export default function EventCommentReplyForm({
   createReply,
   isCreatingComment,
 }: EventCommentReplyFormProps) {
-  const inputRef = useRef<HTMLInputElement>(null)
-  const [content, setContent] = useState(initialValue || '')
+  const { inputRef, content, setContent } = useReplyFormState(initialValue)
 
   async function handleSubmit(e: React.FormEvent) {
     e.preventDefault()

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventFaq.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventFaq.tsx
@@ -21,17 +21,22 @@ interface EventFaqProps {
 
 const DEFAULT_VISIBLE_ITEMS = 6
 
+function useEventFaqState(event: Event, siteName: string, commentsCount?: number | null) {
+  const [isExpanded, setIsExpanded] = useState(false)
+  const [openItemId, setOpenItemId] = useState('')
+  const items = useMemo(() => buildEventFaqItems({
+    event,
+    siteName,
+    commentsCount,
+  }), [commentsCount, event, siteName])
+
+  return { isExpanded, setIsExpanded, openItemId, setOpenItemId, items }
+}
+
 export default function EventFaq({ event, commentsCount }: EventFaqProps) {
   const t = useExtracted()
   const site = useSiteIdentity()
-  const [isExpanded, setIsExpanded] = useState(false)
-  const [openItemId, setOpenItemId] = useState('')
-
-  const items = useMemo(() => buildEventFaqItems({
-    event,
-    siteName: site.name,
-    commentsCount,
-  }), [commentsCount, event, site.name])
+  const { isExpanded, setIsExpanded, openItemId, setOpenItemId, items } = useEventFaqState(event, site.name, commentsCount)
 
   const visibleItems = isExpanded
     ? items

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLimitExpirationCalendar.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLimitExpirationCalendar.tsx
@@ -37,6 +37,12 @@ function mergeDateAndTime(date: Date, time: string) {
   return nextDate
 }
 
+function useCalendarDates(value?: Date) {
+  const [minDate] = useState<Date>(() => new Date())
+  const [internalDate, setInternalDate] = useState<Date>(() => value ?? new Date(minDate.getTime()))
+  return { minDate, internalDate, setInternalDate }
+}
+
 export default function EventLimitExpirationCalendar({
   value,
   onChange,
@@ -47,8 +53,7 @@ export default function EventLimitExpirationCalendar({
   applyLabel,
 }: EventLimitExpirationCalendarProps) {
   const t = useExtracted()
-  const [minDate] = useState<Date>(() => new Date())
-  const [internalDate, setInternalDate] = useState<Date>(() => value ?? new Date(minDate.getTime()))
+  const { minDate, internalDate, setInternalDate } = useCalendarDates(value)
   const selectedDate = value ?? internalDate
   const timeValue = formatTimeInput(selectedDate)
   const showActions = Boolean(onCancel || onApply)

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketCard.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketCard.tsx
@@ -35,29 +35,7 @@ interface EventMarketCardProps {
   onCashOut?: (market: EventMarketRow['market'], tag: MarketPositionTag) => void
 }
 
-function EventMarketCardComponent({
-  row,
-  showMarketIcon,
-  isExpanded,
-  isActiveMarket,
-  showInReviewTag = false,
-  activeOutcomeIndex,
-  onToggle,
-  onBuy,
-  chanceHighlightKey,
-  positionTags = [],
-  openOrdersCount = 0,
-  onCashOut,
-}: EventMarketCardProps) {
-  const t = useExtracted()
-  const normalizeOutcomeLabel = useOutcomeLabel()
-  const { market, yesOutcome, noOutcome, yesPriceValue, noPriceValue, chanceMeta } = row
-  const yesOutcomeText = normalizeOutcomeLabel(yesOutcome?.outcome_text) ?? t('Yes')
-  const noOutcomeText = normalizeOutcomeLabel(noOutcome?.outcome_text) ?? t('No')
-  const resolvedPositionTags = positionTags.filter(tag => tag.shares > 0)
-  const hasOpenOrders = openOrdersCount > 0
-  const shouldShowTags = resolvedPositionTags.length > 0 || hasOpenOrders
-  const shouldShowIcon = showMarketIcon && Boolean(market.icon_url)
+function useMarketCardVolume(market: EventMarketRow['market'], yesOutcome: EventMarketRow['yesOutcome'], noOutcome: EventMarketRow['noOutcome']) {
   const volumeRequestPayload = useMemo(() => {
     const tokenIds = [yesOutcome?.token_id, noOutcome?.token_id].filter(Boolean) as string[]
     if (!market.condition_id || tokenIds.length < 2) {
@@ -109,6 +87,34 @@ function EventMarketCardComponent({
     }
     return market.volume
   }, [market.volume, volumeFromApi])
+
+  return resolvedVolume
+}
+
+function EventMarketCardComponent({
+  row,
+  showMarketIcon,
+  isExpanded,
+  isActiveMarket,
+  showInReviewTag = false,
+  activeOutcomeIndex,
+  onToggle,
+  onBuy,
+  chanceHighlightKey,
+  positionTags = [],
+  openOrdersCount = 0,
+  onCashOut,
+}: EventMarketCardProps) {
+  const t = useExtracted()
+  const normalizeOutcomeLabel = useOutcomeLabel()
+  const { market, yesOutcome, noOutcome, yesPriceValue, noPriceValue, chanceMeta } = row
+  const yesOutcomeText = normalizeOutcomeLabel(yesOutcome?.outcome_text) ?? t('Yes')
+  const noOutcomeText = normalizeOutcomeLabel(noOutcome?.outcome_text) ?? t('No')
+  const resolvedPositionTags = positionTags.filter(tag => tag.shares > 0)
+  const hasOpenOrders = openOrdersCount > 0
+  const shouldShowTags = resolvedPositionTags.length > 0 || hasOpenOrders
+  const shouldShowIcon = showMarketIcon && Boolean(market.icon_url)
+  const resolvedVolume = useMarketCardVolume(market, yesOutcome, noOutcome)
 
   return (
     <div

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChance.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChance.tsx
@@ -18,6 +18,15 @@ interface EventMarketChanceProps {
   showInReviewTag?: boolean
 }
 
+function useResolutionDialog(market: EventMarketRow['market'], siteName: string) {
+  const [isResolutionDialogOpen, setIsResolutionDialogOpen] = useState(false)
+  const umaDetailsUrl = useMemo(
+    () => buildUmaSettledUrl(market.condition, siteName) ?? buildUmaProposeUrl(market.condition, siteName),
+    [market.condition, siteName],
+  )
+  return { isResolutionDialogOpen, setIsResolutionDialogOpen, umaDetailsUrl }
+}
+
 export default function EventMarketChance({
   market,
   chanceMeta,
@@ -27,14 +36,10 @@ export default function EventMarketChance({
 }: EventMarketChanceProps) {
   const t = useExtracted()
   const siteIdentity = useSiteIdentity()
-  const [isResolutionDialogOpen, setIsResolutionDialogOpen] = useState(false)
+  const { isResolutionDialogOpen, setIsResolutionDialogOpen, umaDetailsUrl } = useResolutionDialog(market, siteIdentity.name)
   const chanceChangeColorClass = chanceMeta.isChanceChangePositive ? 'text-yes' : 'text-no'
   const shouldReserveDelta = layout === 'desktop' && !showInReviewTag
   const shouldRenderDelta = !showInReviewTag && (chanceMeta.shouldShowChanceChange || shouldReserveDelta)
-  const umaDetailsUrl = useMemo(
-    () => buildUmaSettledUrl(market.condition, siteIdentity.name) ?? buildUmaProposeUrl(market.condition, siteIdentity.name),
-    [market.condition, siteIdentity.name],
-  )
 
   const baseClass = layout === 'mobile'
     ? 'text-lg font-medium'

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
@@ -62,8 +62,7 @@ interface EventMarketContextContentProps {
   resolvedMarketConditionId?: string
 }
 
-function EventMarketContextContent({ event, resolvedMarketConditionId }: EventMarketContextContentProps) {
-  const t = useExtracted()
+function useMarketContextState(event: Event, resolvedMarketConditionId: string | undefined, t: ReturnType<typeof useExtracted>) {
   const [isExpanded, setIsExpanded] = useState(false)
   const [context, setContext] = useState<string | null>(null)
   const [displayedContext, setDisplayedContext] = useState('')
@@ -75,7 +74,156 @@ function EventMarketContextContent({ event, resolvedMarketConditionId }: EventMa
   const [isTyping, setIsTyping] = useState(false)
   const hasAnimatedRef = useRef(false)
   const contextRef = useRef<string | null>(null)
-  const isContentExpanded = isExpanded || Boolean(error)
+
+  useEffect(function preloadCachedContextEffect() {
+    if (!resolvedMarketConditionId) {
+      return
+    }
+
+    let isActive = true
+
+    async function preloadCachedContext() {
+      try {
+        const response = await generateMarketContextAction({
+          slug: event.slug,
+          marketConditionId: resolvedMarketConditionId,
+          readOnly: true,
+        })
+
+        if (!isActive || response?.error || !response?.context) {
+          return
+        }
+
+        setContext(response.context)
+        setHasGenerated(true)
+        setCacheExpiresAtMs(parseTimestamp(response.expiresAt))
+        setContextUpdatedAtMs(parseTimestamp(response.updatedAt) ?? Date.now())
+      }
+      catch (caughtError) {
+        console.error('Failed to fetch cached market context.', caughtError)
+      }
+    }
+
+    void preloadCachedContext()
+
+    return function cleanupPreload() {
+      isActive = false
+    }
+  }, [event.slug, resolvedMarketConditionId])
+
+  useEffect(function cacheExpirationEffect() {
+    if (!cacheExpiresAtMs) {
+      return
+    }
+
+    const remainingMs = Math.max(0, cacheExpiresAtMs - Date.now())
+    const timeout = window.setTimeout(() => {
+      setHasGenerated(false)
+      setContext(null)
+      setIsExpanded(false)
+      setCacheExpiresAtMs(null)
+      setContextUpdatedAtMs(null)
+    }, remainingMs)
+
+    return function cleanupCacheExpiration() {
+      window.clearTimeout(timeout)
+    }
+  }, [cacheExpiresAtMs])
+
+  useEffect(function typewriterAnimationEffect() {
+    let isActive = true
+    let animationFrame = 0
+
+    function scheduleContextDisplay(nextContext: string, nextIsTyping: boolean) {
+      queueMicrotask(() => {
+        if (!isActive) {
+          return
+        }
+
+        setDisplayedContext(nextContext)
+        setIsTyping(nextIsTyping)
+      })
+    }
+
+    if (contextRef.current !== context) {
+      contextRef.current = context
+      hasAnimatedRef.current = false
+    }
+
+    if (!context) {
+      scheduleContextDisplay('', false)
+      return function cleanupNoContext() {
+        isActive = false
+      }
+    }
+
+    if (!isExpanded) {
+      scheduleContextDisplay(context, false)
+      return function cleanupNotExpanded() {
+        isActive = false
+      }
+    }
+
+    if (hasAnimatedRef.current) {
+      return function cleanupAlreadyAnimated() {
+        isActive = false
+      }
+    }
+
+    if (typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
+      scheduleContextDisplay(context, false)
+      hasAnimatedRef.current = true
+      return function cleanupReducedMotion() {
+        isActive = false
+      }
+    }
+
+    const fullContext = context
+    const totalDurationMs = Math.min(2400, Math.max(900, fullContext.length * 12))
+    const start = performance.now()
+
+    scheduleContextDisplay('', true)
+
+    function tick(now: number) {
+      if (!isActive) {
+        return
+      }
+
+      const progress = Math.min(1, (now - start) / totalDurationMs)
+      const nextLength = Math.max(1, Math.floor(progress * fullContext.length))
+      setDisplayedContext(fullContext.slice(0, nextLength))
+
+      if (progress < 1) {
+        animationFrame = window.requestAnimationFrame(tick)
+      }
+      else {
+        setIsTyping(false)
+        hasAnimatedRef.current = true
+      }
+    }
+
+    animationFrame = window.requestAnimationFrame(tick)
+
+    return function cleanupAnimation() {
+      isActive = false
+      if (animationFrame) {
+        window.cancelAnimationFrame(animationFrame)
+      }
+    }
+  }, [context, isExpanded])
+
+  const paragraphs = useMemo(() => {
+    if (!displayedContext) {
+      return []
+    }
+
+    return displayedContext
+      .split(/\n{2,}|\r\n{2,}/)
+      .map(block => block.trim())
+      .filter(Boolean)
+  }, [displayedContext])
+
+  const updatedLabel = useMemo(() => formatContextUpdatedLabel(contextUpdatedAtMs), [contextUpdatedAtMs])
 
   async function generateMarketContext() {
     if (!resolvedMarketConditionId) {
@@ -124,159 +272,42 @@ function EventMarketContextContent({ event, resolvedMarketConditionId }: EventMa
     })
   }
 
-  useEffect(() => {
-    if (!resolvedMarketConditionId) {
-      return
-    }
-
-    let isActive = true
-
-    async function preloadCachedContext() {
-      try {
-        const response = await generateMarketContextAction({
-          slug: event.slug,
-          marketConditionId: resolvedMarketConditionId,
-          readOnly: true,
-        })
-
-        if (!isActive || response?.error || !response?.context) {
-          return
-        }
-
-        setContext(response.context)
-        setHasGenerated(true)
-        setCacheExpiresAtMs(parseTimestamp(response.expiresAt))
-        setContextUpdatedAtMs(parseTimestamp(response.updatedAt) ?? Date.now())
-      }
-      catch (caughtError) {
-        console.error('Failed to fetch cached market context.', caughtError)
-      }
-    }
-
-    void preloadCachedContext()
-
-    return () => {
-      isActive = false
-    }
-  }, [event.slug, resolvedMarketConditionId])
-
-  useEffect(() => {
-    if (!cacheExpiresAtMs) {
-      return
-    }
-
-    const remainingMs = Math.max(0, cacheExpiresAtMs - Date.now())
-    const timeout = window.setTimeout(() => {
-      setHasGenerated(false)
-      setContext(null)
-      setIsExpanded(false)
-      setCacheExpiresAtMs(null)
-      setContextUpdatedAtMs(null)
-    }, remainingMs)
-
-    return () => {
-      window.clearTimeout(timeout)
-    }
-  }, [cacheExpiresAtMs])
-
-  useEffect(() => {
-    let isActive = true
-    let animationFrame = 0
-
-    function scheduleContextDisplay(nextContext: string, nextIsTyping: boolean) {
-      queueMicrotask(() => {
-        if (!isActive) {
-          return
-        }
-
-        setDisplayedContext(nextContext)
-        setIsTyping(nextIsTyping)
-      })
-    }
-
-    if (contextRef.current !== context) {
-      contextRef.current = context
-      hasAnimatedRef.current = false
-    }
-
-    if (!context) {
-      scheduleContextDisplay('', false)
-      return () => {
-        isActive = false
-      }
-    }
-
-    if (!isExpanded) {
-      scheduleContextDisplay(context, false)
-      return () => {
-        isActive = false
-      }
-    }
-
-    if (hasAnimatedRef.current) {
-      return () => {
-        isActive = false
-      }
-    }
-
-    if (typeof window !== 'undefined' && window.matchMedia('(prefers-reduced-motion: reduce)').matches) {
-      scheduleContextDisplay(context, false)
-      hasAnimatedRef.current = true
-      return () => {
-        isActive = false
-      }
-    }
-
-    const fullContext = context
-    const totalDurationMs = Math.min(2400, Math.max(900, fullContext.length * 12))
-    const start = performance.now()
-
-    scheduleContextDisplay('', true)
-
-    function tick(now: number) {
-      if (!isActive) {
-        return
-      }
-
-      const progress = Math.min(1, (now - start) / totalDurationMs)
-      const nextLength = Math.max(1, Math.floor(progress * fullContext.length))
-      setDisplayedContext(fullContext.slice(0, nextLength))
-
-      if (progress < 1) {
-        animationFrame = window.requestAnimationFrame(tick)
-      }
-      else {
-        setIsTyping(false)
-        hasAnimatedRef.current = true
-      }
-    }
-
-    animationFrame = window.requestAnimationFrame(tick)
-
-    return () => {
-      isActive = false
-      if (animationFrame) {
-        window.cancelAnimationFrame(animationFrame)
-      }
-    }
-  }, [context, isExpanded])
-
-  const paragraphs = useMemo(() => {
-    if (!displayedContext) {
-      return []
-    }
-
-    return displayedContext
-      .split(/\n{2,}|\r\n{2,}/)
-      .map(block => block.trim())
-      .filter(Boolean)
-  }, [displayedContext])
-
-  const updatedLabel = useMemo(() => formatContextUpdatedLabel(contextUpdatedAtMs), [contextUpdatedAtMs])
-
   function toggleCollapse() {
     setIsExpanded(current => !current)
   }
+
+  return {
+    isExpanded,
+    context,
+    displayedContext,
+    error,
+    isPending,
+    hasGenerated,
+    isTyping,
+    paragraphs,
+    updatedLabel,
+    generateMarketContext,
+    toggleCollapse,
+    resolvedMarketConditionId,
+  }
+}
+
+function EventMarketContextContent({ event, resolvedMarketConditionId }: EventMarketContextContentProps) {
+  const t = useExtracted()
+  const {
+    isExpanded,
+    context,
+    displayedContext,
+    error,
+    isPending,
+    hasGenerated,
+    isTyping,
+    paragraphs,
+    updatedLabel,
+    generateMarketContext,
+    toggleCollapse,
+  } = useMarketContextState(event, resolvedMarketConditionId, t)
+  const isContentExpanded = isExpanded || Boolean(error)
 
   return (
     <section className="overflow-hidden rounded-xl border transition-all duration-500 ease-in-out">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
@@ -62,7 +62,8 @@ interface EventMarketContextContentProps {
   resolvedMarketConditionId?: string
 }
 
-function useMarketContextState(event: Event, resolvedMarketConditionId: string | undefined, t: ReturnType<typeof useExtracted>) {
+function useMarketContextState(event: Event, resolvedMarketConditionId: string | undefined) {
+  const t = useExtracted()
   const [isExpanded, setIsExpanded] = useState(false)
   const [context, setContext] = useState<string | null>(null)
   const [displayedContext, setDisplayedContext] = useState('')
@@ -306,7 +307,7 @@ function EventMarketContextContent({ event, resolvedMarketConditionId }: EventMa
     updatedLabel,
     generateMarketContext,
     toggleCollapse,
-  } = useMarketContextState(event, resolvedMarketConditionId, t)
+  } = useMarketContextState(event, resolvedMarketConditionId)
   const isContentExpanded = isExpanded || Boolean(error)
 
   return (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
@@ -146,7 +146,6 @@ function useOpenOrdersCancellation({
   openOrdersQueryKey,
   eventOpenOrdersQueryKey,
   openTradeRequirements,
-  t,
 }: {
   marketConditionId: string
   sortedOrders: UserOpenOrder[]
@@ -154,8 +153,8 @@ function useOpenOrdersCancellation({
   openOrdersQueryKey: readonly unknown[]
   eventOpenOrdersQueryKey: readonly unknown[]
   openTradeRequirements: (options: { forceTradingAuth: boolean }) => void
-  t: ReturnType<typeof useExtracted>
 }) {
+  const t = useExtracted()
   const [pendingCancelIds, setPendingCancelIds] = useState<Set<string>>(() => new Set())
   const [isCancellingAll, setIsCancellingAll] = useState(false)
 
@@ -588,7 +587,6 @@ export default function EventMarketOpenOrders({ market, eventSlug }: EventMarket
     openOrdersQueryKey,
     eventOpenOrdersQueryKey,
     openTradeRequirements,
-    t,
   })
 
   const handleSort = useCallback(function toggleSortDirection(column: SortColumn) {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMetaInformation.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMetaInformation.tsx
@@ -14,9 +14,7 @@ interface EventMetaInformationProps {
   event: Event
 }
 
-export default function EventMetaInformation({ event, currentTimestamp }: EventMetaInformationProps) {
-  const t = useExtracted()
-
+function useEventVolume(event: Event) {
   const volumeRequestPayload = useMemo(() => {
     const conditions = event.markets
       .map((market) => {
@@ -73,12 +71,17 @@ export default function EventMetaInformation({ event, currentTimestamp }: EventM
     },
   })
 
-  const resolvedVolume = useMemo(() => {
+  return useMemo(() => {
     if (typeof volumeFromApi === 'number' && Number.isFinite(volumeFromApi)) {
       return volumeFromApi
     }
     return event.volume
   }, [event.volume, volumeFromApi])
+}
+
+export default function EventMetaInformation({ event, currentTimestamp }: EventMetaInformationProps) {
+  const t = useExtracted()
+  const resolvedVolume = useEventVolume(event)
 
   const isNegRiskEnabled = Boolean(event.enable_neg_risk || event.neg_risk)
   const isNegRiskAugmented = Boolean(event.neg_risk_augmented)

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook.tsx
@@ -168,14 +168,13 @@ function useOrderBookUserOrderCancellation({
   openOrdersQueryKey,
   eventOpenOrdersQueryKey,
   openTradeRequirements,
-  t,
 }: {
   queryClient: ReturnType<typeof useQueryClient>
   openOrdersQueryKey: readonly unknown[]
   eventOpenOrdersQueryKey: readonly unknown[]
   openTradeRequirements: (options: { forceTradingAuth: boolean }) => void
-  t: ReturnType<typeof useExtracted>
 }) {
+  const t = useExtracted()
   const refreshTimeoutRef = useRef<number | null>(null)
   const [pendingCancelIds, setPendingCancelIds] = useState<Set<string>>(() => new Set())
 
@@ -322,7 +321,6 @@ export default function EventOrderBook({
     openOrdersQueryKey,
     eventOpenOrdersQueryKey,
     openTradeRequirements,
-    t,
   })
 
   const {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -222,7 +222,6 @@ function useResolvedMarketDisplay({
   activeMarket,
   currentTimestamp,
   resolveDisplayOutcomeLabel,
-  t,
 }: {
   event: Event
   activeMarket: Market | null | undefined
@@ -232,8 +231,8 @@ function useResolvedMarketDisplay({
     outcomeText: string | null | undefined,
     fallbackLabel: string,
   ) => string
-  t: ReturnType<typeof useExtracted>
 }) {
+  const t = useExtracted()
   const isResolvedMarket = Boolean(activeMarket?.is_resolved || activeMarket?.condition?.resolved)
   const isTweetMarketEvent = useMemo(
     () => isTweetMarketsEvent(event),
@@ -920,7 +919,6 @@ export default function EventOrderPanelForm({
     activeMarket,
     currentTimestamp,
     resolveDisplayOutcomeLabel,
-    t,
   })
   const orderDomain = useMemo(() => getExchangeEip712Domain(isNegRiskEnabled), [isNegRiskEnabled])
   const { positionsQuery, aggregatedPositionShares } = useEventOrderPanelPositions({

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
@@ -69,6 +69,57 @@ interface EventOrderPanelLimitControlsProps {
   onAmountUpdateFromLimit: (value: string) => void
 }
 
+function useLimitControlsDerived(limitPrice: string, limitShares: string, side: OrderSide) {
+  const limitPriceNumber = useMemo(
+    () => Number.parseFloat(limitPrice) || 0,
+    [limitPrice],
+  )
+
+  const limitSharesNumber = useMemo(
+    () => Number.parseFloat(limitShares) || 0,
+    [limitShares],
+  )
+
+  const totalValue = useMemo(() => {
+    const total = (limitPriceNumber * limitSharesNumber) / 100
+    return Number.isFinite(total) ? total : 0
+  }, [limitPriceNumber, limitSharesNumber])
+
+  const potentialWin = useMemo(() => {
+    if (limitSharesNumber <= 0) {
+      return 0
+    }
+
+    if (side === ORDER_SIDE.SELL) {
+      const total = (limitPriceNumber * limitSharesNumber) / 100
+      return Number.isFinite(total) ? total : 0
+    }
+
+    return Number.isFinite(limitSharesNumber) ? limitSharesNumber : 0
+  }, [limitPriceNumber, limitSharesNumber, side])
+
+  return { limitPriceNumber, limitSharesNumber, totalValue, potentialWin }
+}
+
+function useExpirationModal(limitExpirationTimestamp: number | null, locale: string) {
+  const [isExpirationModalOpen, setIsExpirationModalOpen] = useState(false)
+  const [draftExpiration, setDraftExpiration] = useState<Date | null>(null)
+  const customExpirationLabel = useMemo(() => {
+    if (!limitExpirationTimestamp) {
+      return null
+    }
+    const date = new Date(limitExpirationTimestamp * 1000)
+    return date.toLocaleString(locale, {
+      month: 'short',
+      day: 'numeric',
+      hour: '2-digit',
+      minute: '2-digit',
+    })
+  }, [limitExpirationTimestamp, locale])
+
+  return { isExpirationModalOpen, setIsExpirationModalOpen, draftExpiration, setDraftExpiration, customExpirationLabel }
+}
+
 export default function EventOrderPanelLimitControls({
   side,
   limitPrice,
@@ -92,20 +143,7 @@ export default function EventOrderPanelLimitControls({
   const t = useExtracted()
   const { balance } = useBalance()
   const areValuesHidden = usePortfolioValueVisibility(state => state.isHidden)
-  const limitPriceNumber = useMemo(
-    () => Number.parseFloat(limitPrice) || 0,
-    [limitPrice],
-  )
-
-  const limitSharesNumber = useMemo(
-    () => Number.parseFloat(limitShares) || 0,
-    [limitShares],
-  )
-
-  const totalValue = useMemo(() => {
-    const total = (limitPriceNumber * limitSharesNumber) / 100
-    return Number.isFinite(total) ? total : 0
-  }, [limitPriceNumber, limitSharesNumber])
+  const { limitPriceNumber, limitSharesNumber, totalValue, potentialWin } = useLimitControlsDerived(limitPrice, limitShares, side)
 
   const effectivePriceDollars = Number.isFinite(limitPriceNumber) && limitPriceNumber > 0
     ? limitPriceNumber / 100
@@ -123,19 +161,6 @@ export default function EventOrderPanelLimitControls({
     }
     return -100 / (decimalOdds - 1)
   })()
-
-  const potentialWin = useMemo(() => {
-    if (limitSharesNumber <= 0) {
-      return 0
-    }
-
-    if (side === ORDER_SIDE.SELL) {
-      const total = (limitPriceNumber * limitSharesNumber) / 100
-      return Number.isFinite(total) ? total : 0
-    }
-
-    return Number.isFinite(limitSharesNumber) ? limitSharesNumber : 0
-  }, [limitPriceNumber, limitSharesNumber, side])
 
   const maxSharesForSide = MAX_AMOUNT_INPUT
 
@@ -155,20 +180,7 @@ export default function EventOrderPanelLimitControls({
   const matchingSharesLabel = matchingShares && matchingShares > 0
     ? formatSharesLabel(matchingShares)
     : null
-  const [isExpirationModalOpen, setIsExpirationModalOpen] = useState(false)
-  const [draftExpiration, setDraftExpiration] = useState<Date | null>(null)
-  const customExpirationLabel = useMemo(() => {
-    if (!limitExpirationTimestamp) {
-      return null
-    }
-    const date = new Date(limitExpirationTimestamp * 1000)
-    return date.toLocaleString(locale, {
-      month: 'short',
-      day: 'numeric',
-      hour: '2-digit',
-      minute: '2-digit',
-    })
-  }, [limitExpirationTimestamp, locale])
+  const { isExpirationModalOpen, setIsExpirationModalOpen, draftExpiration, setDraftExpiration, customExpirationLabel } = useExpirationModal(limitExpirationTimestamp, locale)
 
   function syncAmount(priceValue: number, sharesValue: number) {
     if (!isLimitOrder) {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOutcomeChanceProvider.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOutcomeChanceProvider.tsx
@@ -20,7 +20,7 @@ interface EventOutcomeChanceProviderProps {
   children: React.ReactNode
 }
 
-export function EventOutcomeChanceProvider({ children }: EventOutcomeChanceProviderProps) {
+function useEventOutcomeChanceState() {
   const [chanceByMarket, setChanceByMarket] = useState<Record<string, number>>({})
   const [yesPriceByMarket, setYesPriceByMarket] = useState<Record<string, number>>({})
   const [chanceChangeByMarket, setChanceChangeByMarket] = useState<Record<string, number>>({})
@@ -36,6 +36,12 @@ export function EventOutcomeChanceProvider({ children }: EventOutcomeChanceProvi
     setChanceChangeByMarket,
     setMarketQuotesByMarket,
   }), [chanceByMarket, yesPriceByMarket, chanceChangeByMarket, marketQuotesByMarket])
+
+  return value
+}
+
+export function EventOutcomeChanceProvider({ children }: EventOutcomeChanceProviderProps) {
+  const value = useEventOutcomeChanceState()
 
   return (
     <EventOutcomeChanceContext value={value}>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
@@ -55,11 +55,16 @@ function normalizeRulesLabelWhitespace(value: string) {
   return value.replace(RULES_LABEL_WHITESPACE_REGEX, ' ').trim()
 }
 
+function useExpandedState() {
+  const [isExpanded, setIsExpanded] = useState(false)
+  return { isExpanded, setIsExpanded }
+}
+
 export default function EventRules({ event, mode = 'accordion', showEndDate = false }: EventRulesProps) {
   const t = useExtracted()
   const locale = useLocale()
   const siteIdentity = useSiteIdentity()
-  const [isExpanded, setIsExpanded] = useState(false)
+  const { isExpanded, setIsExpanded } = useExpandedState()
   const isInline = mode === 'inline'
 
   function formatRules(rules: string): string {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventSingleMarketOrderBook.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventSingleMarketOrderBook.tsx
@@ -24,20 +24,10 @@ interface EventSingleMarketOrderBookProps {
 
 type OutcomeToggleIndex = typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO
 
-export default function EventSingleMarketOrderBook({
-  market,
-  eventSlug,
-  showCompactVolume = false,
-}: EventSingleMarketOrderBookProps) {
-  const t = useExtracted()
-  const normalizeOutcomeLabel = useOutcomeLabel()
-  const isMobile = useIsMobile()
-  const marketChannelStatus = useMarketChannelStatus()
+function useOrderBookState(market: Market) {
   const [isExpanded, setIsExpanded] = useState(true)
   const orderMarket = useOrder(state => state.market)
   const orderOutcome = useOrder(state => state.outcome)
-  const setOrderMarket = useOrder(state => state.setMarket)
-  const setOrderOutcome = useOrder(state => state.setOutcome)
 
   const selectedOutcomeIndex: OutcomeToggleIndex = useMemo(() => {
     if (orderMarket?.condition_id === market.condition_id && orderOutcome) {
@@ -53,6 +43,34 @@ export default function EventSingleMarketOrderBook({
     [market.outcomes],
   )
 
+  const compactVolumeLabelResult = useMemo(() => {
+    const resolvedVolume = Number.isFinite(market.volume) ? market.volume : 0
+    if (resolvedVolume <= 0) {
+      return null
+    }
+
+    return `$${resolvedVolume.toLocaleString('en-US', {
+      notation: 'compact',
+      maximumFractionDigits: 1,
+    })} Vol.`
+  }, [market.volume])
+
+  return { isExpanded, setIsExpanded, selectedOutcomeIndex, tokenIds, compactVolumeLabel: compactVolumeLabelResult }
+}
+
+export default function EventSingleMarketOrderBook({
+  market,
+  eventSlug,
+  showCompactVolume = false,
+}: EventSingleMarketOrderBookProps) {
+  const t = useExtracted()
+  const normalizeOutcomeLabel = useOutcomeLabel()
+  const isMobile = useIsMobile()
+  const marketChannelStatus = useMarketChannelStatus()
+  const setOrderMarket = useOrder(state => state.setMarket)
+  const setOrderOutcome = useOrder(state => state.setOutcome)
+  const { isExpanded, setIsExpanded, selectedOutcomeIndex, tokenIds, compactVolumeLabel: rawCompactVolumeLabel } = useOrderBookState(market)
+
   const {
     data: orderBookSummaries,
     isLoading: isOrderBookLoading,
@@ -66,21 +84,7 @@ export default function EventSingleMarketOrderBook({
   const yesOutcomeLabel = (yesOutcomeText ? normalizeOutcomeLabel(yesOutcomeText) : '') || yesOutcomeText || t('Yes')
   const noOutcomeLabel = (noOutcomeText ? normalizeOutcomeLabel(noOutcomeText) : '') || noOutcomeText || t('No')
   const isLoadingSummaries = isExpanded && isOrderBookLoading && !orderBookSummaries
-  const compactVolumeLabel = useMemo(() => {
-    if (!showCompactVolume) {
-      return null
-    }
-
-    const resolvedVolume = Number.isFinite(market.volume) ? market.volume : 0
-    if (resolvedVolume <= 0) {
-      return null
-    }
-
-    return `$${resolvedVolume.toLocaleString('en-US', {
-      notation: 'compact',
-      maximumFractionDigits: 1,
-    })} Vol.`
-  }, [market.volume, showCompactVolume])
+  const compactVolumeLabel = showCompactVolume ? rawCompactVolumeLabel : null
 
   function handleOutcomeSelection(outcomeIndex: OutcomeToggleIndex) {
     const outcome = market.outcomes[outcomeIndex]

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventSplitSharesDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventSplitSharesDialog.tsx
@@ -60,6 +60,33 @@ interface EventSplitSharesDialogProps {
   onOpenChange: (open: boolean) => void
 }
 
+function useSplitFormState() {
+  const [amount, setAmount] = useState('')
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  return { amount, setAmount, error, setError, isSubmitting, setIsSubmitting }
+}
+
+function useFormattedUsdcBalance(availableUsdc: number) {
+  return useMemo(() => {
+    if (!Number.isFinite(availableUsdc)) {
+      return '$0.00'
+    }
+    const formatted = formatBalanceLabel(availableUsdc)
+    return `$${formatted}`
+  }, [availableUsdc])
+}
+
+function formatBalanceLabel(value: number) {
+  if (!Number.isFinite(value)) {
+    return '0.00'
+  }
+  return value.toLocaleString(undefined, {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  })
+}
+
 export default function EventSplitSharesDialog({
   open,
   availableUsdc,
@@ -81,19 +108,7 @@ export default function EventSplitSharesDialog({
   const isMobile = useIsMobile()
   const { signMessageAsync } = useSignMessage()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
-  const [amount, setAmount] = useState('')
-  const [error, setError] = useState<string | null>(null)
-  const [isSubmitting, setIsSubmitting] = useState(false)
-
-  function formatBalanceLabel(value: number) {
-    if (!Number.isFinite(value)) {
-      return '0.00'
-    }
-    return value.toLocaleString(undefined, {
-      minimumFractionDigits: 2,
-      maximumFractionDigits: 2,
-    })
-  }
+  const { amount, setAmount, error, setError, isSubmitting, setIsSubmitting } = useSplitFormState()
 
   function resetFormState() {
     setAmount('')
@@ -112,13 +127,7 @@ export default function EventSplitSharesDialog({
     handleDialogOpenChange(false)
   }
 
-  const formattedUsdcBalance = useMemo(() => {
-    if (!Number.isFinite(availableUsdc)) {
-      return '$0.00'
-    }
-    const formatted = formatBalanceLabel(availableUsdc)
-    return `$${formatted}`
-  }, [availableUsdc])
+  const formattedUsdcBalance = useFormattedUsdcBalance(availableUsdc)
 
   const numericAvailableBalance = Number.isFinite(availableUsdc) ? availableUsdc : 0
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventTabSelector.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventTabSelector.tsx
@@ -13,15 +13,7 @@ interface EventTabSelectorProps {
   marketChannelStatus: 'connecting' | 'live' | 'offline'
 }
 
-export default function EventTabSelector({
-  activeTab,
-  setActiveTab,
-  commentsCount,
-  liveCommentsStatus,
-  marketChannelStatus,
-}: EventTabSelectorProps) {
-  const t = useExtracted()
-  const locale = useLocale()
+function useEventTabLabels(commentsCount: number | null, locale: string, t: ReturnType<typeof useExtracted>) {
   const formattedCommentsCount = useMemo(
     () => (commentsCount == null ? null : Number(commentsCount).toLocaleString(locale)),
     [commentsCount, locale],
@@ -36,6 +28,20 @@ export default function EventTabSelector({
     { key: 'holders', label: t('Top Holders') },
     { key: 'activity', label: t('Activity') },
   ]), [formattedCommentsCount, t])
+
+  return { formattedCommentsCount, eventTabs }
+}
+
+export default function EventTabSelector({
+  activeTab,
+  setActiveTab,
+  commentsCount,
+  liveCommentsStatus,
+  marketChannelStatus,
+}: EventTabSelectorProps) {
+  const t = useExtracted()
+  const locale = useLocale()
+  const { eventTabs } = useEventTabLabels(commentsCount, locale, t)
 
   return (
     <div className="mt-3 flex items-center gap-2 border-b border-border">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventTabSelector.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventTabSelector.tsx
@@ -13,7 +13,9 @@ interface EventTabSelectorProps {
   marketChannelStatus: 'connecting' | 'live' | 'offline'
 }
 
-function useEventTabLabels(commentsCount: number | null, locale: string, t: ReturnType<typeof useExtracted>) {
+function useEventTabLabels(commentsCount: number | null) {
+  const t = useExtracted()
+  const locale = useLocale()
   const formattedCommentsCount = useMemo(
     () => (commentsCount == null ? null : Number(commentsCount).toLocaleString(locale)),
     [commentsCount, locale],
@@ -29,7 +31,7 @@ function useEventTabLabels(commentsCount: number | null, locale: string, t: Retu
     { key: 'activity', label: t('Activity') },
   ]), [formattedCommentsCount, t])
 
-  return { formattedCommentsCount, eventTabs }
+  return { eventTabs }
 }
 
 export default function EventTabSelector({
@@ -39,9 +41,7 @@ export default function EventTabSelector({
   liveCommentsStatus,
   marketChannelStatus,
 }: EventTabSelectorProps) {
-  const t = useExtracted()
-  const locale = useLocale()
-  const { eventTabs } = useEventTabLabels(commentsCount, locale, t)
+  const { eventTabs } = useEventTabLabels(commentsCount)
 
   return (
     <div className="mt-3 flex items-center gap-2 border-b border-border">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventTabs.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventTabs.tsx
@@ -16,12 +16,26 @@ interface EventTabsProps {
   initialTab?: EventTabKey
 }
 
+function useActiveTab(initialTab: EventTabKey) {
+  const [activeTab, setActiveTab] = useState<EventTabKey>(initialTab)
+  return { activeTab, setActiveTab }
+}
+
+function useCommentsCount(commentMetrics: ReturnType<typeof useCommentMetrics>['data']) {
+  return useMemo(() => {
+    if (commentMetrics?.comments_count != null) {
+      return commentMetrics.comments_count
+    }
+    return null
+  }, [commentMetrics?.comments_count])
+}
+
 export default function EventTabs({
   event,
   user,
   initialTab = 'comments',
 }: EventTabsProps) {
-  const [activeTab, setActiveTab] = useState<EventTabKey>(initialTab)
+  const { activeTab, setActiveTab } = useActiveTab(initialTab)
   const { data: commentMetrics } = useCommentMetrics(event.slug)
   const { status: liveCommentsStatus } = useLiveCommentsChannel({
     eventSlug: event.slug,
@@ -29,12 +43,7 @@ export default function EventTabs({
     enabled: activeTab === 'comments',
   })
   const marketChannelStatus = useMarketChannelStatus()
-  const commentsCount = useMemo(() => {
-    if (commentMetrics?.comments_count != null) {
-      return commentMetrics.comments_count
-    }
-    return null
-  }, [commentMetrics?.comments_count])
+  const commentsCount = useCommentsCount(commentMetrics)
 
   return (
     <div className="mt-6">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventTweetMarketsPanel.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventTweetMarketsPanel.tsx
@@ -107,11 +107,7 @@ function getServerNowSnapshot() {
   return 0
 }
 
-export default function EventTweetMarketsPanel({
-  tweetCount,
-  countdownTargetMs,
-  isFinal = false,
-}: EventTweetMarketsPanelProps) {
+function useCountdown(countdownTargetMs: number | null, isFinal: boolean) {
   const subscribeToNowForCountdown = useCallback(
     (onStoreChange: () => void) => subscribeToNow(onStoreChange, countdownTargetMs, isFinal),
     [countdownTargetMs, isFinal],
@@ -122,6 +118,16 @@ export default function EventTweetMarketsPanel({
     () => buildCountdownUnits(countdownTargetMs, nowMs, isFinal),
     [countdownTargetMs, isFinal, nowMs],
   )
+
+  return { nowMs, countdownUnits }
+}
+
+export default function EventTweetMarketsPanel({
+  tweetCount,
+  countdownTargetMs,
+  isFinal = false,
+}: EventTweetMarketsPanelProps) {
+  const { nowMs, countdownUnits } = useCountdown(countdownTargetMs, isFinal)
   const hasReachedCountdownTarget = countdownTargetMs != null
     && Number.isFinite(countdownTargetMs)
     && nowMs >= countdownTargetMs

--- a/src/app/[locale]/(platform)/event/[slug]/_components/ResolutionTimelinePanel.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/ResolutionTimelinePanel.tsx
@@ -163,6 +163,40 @@ function TimelineLabel({
   )
 }
 
+function useResolutionTimeline(market: Event['markets'][number], siteName: string) {
+  const [nowMs, setNowMs] = useState(() => Date.now())
+
+  const timeline = useMemo(
+    () => buildResolutionTimeline(market, { nowMs }),
+    [market, nowMs],
+  )
+  const disputeUrl = useMemo(
+    () => buildUmaProposeUrl(market.condition, siteName),
+    [market.condition, siteName],
+  )
+
+  const hasActiveCountdown = timeline.items.some(item =>
+    (item.type === 'finalReview' || item.type === 'disputeWindow')
+    && item.state === 'active'
+    && (item.remainingSeconds ?? 0) > 0)
+
+  useEffect(function countdownTickEffect() {
+    if (!hasActiveCountdown) {
+      return
+    }
+
+    const interval = window.setInterval(() => {
+      setNowMs(Date.now())
+    }, 1000)
+
+    return function cleanupCountdownTick() {
+      window.clearInterval(interval)
+    }
+  }, [hasActiveCountdown])
+
+  return { timeline, disputeUrl }
+}
+
 export default function ResolutionTimelinePanel({
   market,
   settledUrl,
@@ -173,39 +207,11 @@ export default function ResolutionTimelinePanel({
   const t = useExtracted()
   const normalizeOutcomeLabel = useOutcomeLabel()
   const siteIdentity = useSiteIdentity()
-  const [nowMs, setNowMs] = useState(() => Date.now())
+  const { timeline, disputeUrl } = useResolutionTimeline(market, siteIdentity.name)
   const yesOutcomeText = market.outcomes.find(outcome => outcome.outcome_index === OUTCOME_INDEX.YES)?.outcome_text
   const noOutcomeText = market.outcomes.find(outcome => outcome.outcome_index === OUTCOME_INDEX.NO)?.outcome_text
   const yesOutcomeLabel = (yesOutcomeText ? normalizeOutcomeLabel(yesOutcomeText) : '') || yesOutcomeText || t('Yes')
   const noOutcomeLabel = (noOutcomeText ? normalizeOutcomeLabel(noOutcomeText) : '') || noOutcomeText || t('No')
-
-  const timeline = useMemo(
-    () => buildResolutionTimeline(market, { nowMs }),
-    [market, nowMs],
-  )
-  const disputeUrl = useMemo(
-    () => buildUmaProposeUrl(market.condition, siteIdentity.name),
-    [market.condition, siteIdentity.name],
-  )
-
-  const hasActiveCountdown = timeline.items.some(item =>
-    (item.type === 'finalReview' || item.type === 'disputeWindow')
-    && item.state === 'active'
-    && (item.remainingSeconds ?? 0) > 0)
-
-  useEffect(() => {
-    if (!hasActiveCountdown) {
-      return
-    }
-
-    const interval = window.setInterval(() => {
-      setNowMs(Date.now())
-    }, 1000)
-
-    return () => {
-      window.clearInterval(interval)
-    }
-  }, [hasActiveCountdown])
 
   if (timeline.items.length === 0) {
     return null

--- a/src/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsSearchParamsSync.tsx
+++ b/src/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsSearchParamsSync.tsx
@@ -10,6 +10,20 @@ import {
   resolvePredictionResultsFiltersFromSearchParams,
 } from '@/lib/prediction-results-filters'
 
+function useSyncFiltersFromSearchParams(
+  onChange: (nextState: {
+    searchParamsString: string
+    sort: PredictionResultsSortOption
+    status: PredictionResultsStatusOption
+  }) => void,
+) {
+  const searchParams = useSearchParams()
+
+  useLayoutEffect(function syncFiltersEffect() {
+    onChange(resolvePredictionResultsFiltersFromSearchParams(searchParams))
+  }, [onChange, searchParams])
+}
+
 export default function PredictionResultsSearchParamsSync({
   onChange,
 }: {
@@ -19,11 +33,7 @@ export default function PredictionResultsSearchParamsSync({
     status: PredictionResultsStatusOption
   }) => void
 }) {
-  const searchParams = useSearchParams()
-
-  useLayoutEffect(() => {
-    onChange(resolvePredictionResultsFiltersFromSearchParams(searchParams))
-  }, [onChange, searchParams])
+  useSyncFiltersFromSearchParams(onChange)
 
   return null
 }

--- a/src/app/[locale]/2fa/_components/TwoFactorClient.tsx
+++ b/src/app/[locale]/2fa/_components/TwoFactorClient.tsx
@@ -27,14 +27,12 @@ function getSafeRedirect(value: string | null | undefined) {
   return value
 }
 
-export default function TwoFactorClient({ next }: { next?: string | null }) {
-  const t = useExtracted()
-  const router = useRouter()
+function useTwoFactorState(next: string | null | undefined, router: ReturnType<typeof useRouter>) {
   const [code, setCode] = useState('')
   const [isVerifying, setIsVerifying] = useState(false)
   const redirectTo = useMemo(() => getSafeRedirect(next), [next])
 
-  useEffect(() => {
+  useEffect(function checkSessionEffect() {
     let isActive = true
 
     authClient.getSession().then((session) => {
@@ -58,10 +56,18 @@ export default function TwoFactorClient({ next }: { next?: string | null }) {
       })
     }).catch(() => {})
 
-    return () => {
+    return function cleanupSessionCheck() {
       isActive = false
     }
   }, [router])
+
+  return { code, setCode, isVerifying, setIsVerifying, redirectTo }
+}
+
+export default function TwoFactorClient({ next }: { next?: string | null }) {
+  const t = useExtracted()
+  const router = useRouter()
+  const { code, setCode, isVerifying, setIsVerifying, redirectTo } = useTwoFactorState(next, router)
 
   async function handleVerify(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault()

--- a/src/app/[locale]/docs/_components/AffiliateShareDisplay.tsx
+++ b/src/app/[locale]/docs/_components/AffiliateShareDisplay.tsx
@@ -10,18 +10,24 @@ interface AffiliateShareDisplayProps {
   className?: string
 }
 
-export function AffiliateShareDisplay({
-  showSymbol = true,
-  className = 'font-semibold text-primary',
-}: AffiliateShareDisplayProps) {
+function useAffiliateData() {
   const [data, setData] = useState<AffiliateDataResult | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(() => {
+  useEffect(function fetchAffiliateSettingsEffect() {
     fetchAffiliateSettingsFromAPI()
       .then(setData)
       .finally(() => setIsLoading(false))
   }, [])
+
+  return { data, isLoading }
+}
+
+export function AffiliateShareDisplay({
+  showSymbol = true,
+  className = 'font-semibold text-primary',
+}: AffiliateShareDisplayProps) {
+  const { data, isLoading } = useAffiliateData()
 
   if (isLoading) {
     return (

--- a/src/app/[locale]/docs/_components/FeeCalculationExample.tsx
+++ b/src/app/[locale]/docs/_components/FeeCalculationExample.tsx
@@ -11,15 +11,21 @@ interface FeeCalculationExampleProps {
   format?: 'table' | 'inline'
 }
 
-export function FeeCalculationExample({ amount, className = '', format = 'table' }: FeeCalculationExampleProps) {
+function useAffiliateData() {
   const [data, setData] = useState<AffiliateDataResult | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(() => {
+  useEffect(function fetchAffiliateSettingsEffect() {
     fetchAffiliateSettingsFromAPI()
       .then(setData)
       .finally(() => setIsLoading(false))
   }, [])
+
+  return { data, isLoading }
+}
+
+export function FeeCalculationExample({ amount, className = '', format = 'table' }: FeeCalculationExampleProps) {
+  const { data, isLoading } = useAffiliateData()
 
   if (isLoading) {
     return (

--- a/src/app/[locale]/docs/_components/LLMPageActions.tsx
+++ b/src/app/[locale]/docs/_components/LLMPageActions.tsx
@@ -103,14 +103,12 @@ function CursorIcon({ className }: BrandIconProps) {
   )
 }
 
-export function ViewOptions({ markdownUrl }: ViewOptionsProps) {
+function useMarkdownPreloader(markdownUrl: string) {
   const [copied, setCopied] = useState(false)
   const [loading, setLoading] = useState(false)
   const [markdownCache, setMarkdownCache] = useState<Record<string, string>>({})
-  const absoluteMarkdownUrl = toAbsoluteUrl(markdownUrl)
-  const markdownContent = markdownCache[markdownUrl] ?? null
 
-  useEffect(() => {
+  useEffect(function preloadMarkdownEffect() {
     let cancelled = false
 
     async function preloadMarkdown() {
@@ -145,10 +143,18 @@ export function ViewOptions({ markdownUrl }: ViewOptionsProps) {
     }
 
     void preloadMarkdown()
-    return () => {
+    return function cleanupPreload() {
       cancelled = true
     }
   }, [markdownUrl])
+
+  return { copied, setCopied, loading, setLoading, markdownCache }
+}
+
+export function ViewOptions({ markdownUrl }: ViewOptionsProps) {
+  const { copied, setCopied, loading, setLoading, markdownCache } = useMarkdownPreloader(markdownUrl)
+  const absoluteMarkdownUrl = toAbsoluteUrl(markdownUrl)
+  const markdownContent = markdownCache[markdownUrl] ?? null
 
   async function onCopy() {
     if (loading) {

--- a/src/app/[locale]/docs/_components/PlatformShareDisplay.tsx
+++ b/src/app/[locale]/docs/_components/PlatformShareDisplay.tsx
@@ -10,18 +10,24 @@ interface PlatformShareDisplayProps {
   className?: string
 }
 
-export function PlatformShareDisplay({
-  showSymbol = true,
-  className = 'font-semibold text-primary',
-}: PlatformShareDisplayProps) {
+function useAffiliateData() {
   const [data, setData] = useState<AffiliateDataResult | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(() => {
+  useEffect(function fetchAffiliateSettingsEffect() {
     fetchAffiliateSettingsFromAPI()
       .then(setData)
       .finally(() => setIsLoading(false))
   }, [])
+
+  return { data, isLoading }
+}
+
+export function PlatformShareDisplay({
+  showSymbol = true,
+  className = 'font-semibold text-primary',
+}: PlatformShareDisplayProps) {
+  const { data, isLoading } = useAffiliateData()
 
   if (isLoading) {
     return (

--- a/src/app/[locale]/docs/_components/TradingFeeDisplay.tsx
+++ b/src/app/[locale]/docs/_components/TradingFeeDisplay.tsx
@@ -10,18 +10,24 @@ interface TradingFeeDisplayProps {
   className?: string
 }
 
-export function TradingFeeDisplay({
-  showSymbol = true,
-  className = 'font-semibold text-primary',
-}: TradingFeeDisplayProps) {
+function useAffiliateData() {
   const [data, setData] = useState<AffiliateDataResult | null>(null)
   const [isLoading, setIsLoading] = useState(true)
 
-  useEffect(() => {
+  useEffect(function fetchAffiliateSettingsEffect() {
     fetchAffiliateSettingsFromAPI()
       .then(setData)
       .finally(() => setIsLoading(false))
   }, [])
+
+  return { data, isLoading }
+}
+
+export function TradingFeeDisplay({
+  showSymbol = true,
+  className = 'font-semibold text-primary',
+}: TradingFeeDisplayProps) {
+  const { data, isLoading } = useAffiliateData()
 
   if (isLoading) {
     return (

--- a/src/app/[locale]/docs/_components/WebSocketPlayground.tsx
+++ b/src/app/[locale]/docs/_components/WebSocketPlayground.tsx
@@ -83,6 +83,51 @@ function formatTime(timestamp: number) {
   return new Date(timestamp).toLocaleTimeString()
 }
 
+function useWebSocketState(endpoint: string, defaultMessage: string) {
+  const [url, setUrl] = useState(endpoint)
+  const [token, setToken] = useState('')
+  const [message, setMessage] = useState(defaultMessage)
+  const [status, setStatus] = useState<ConnectionStatus>('disconnected')
+  const [logs, setLogs] = useState<LogEntry[]>([])
+  const [errorMessage, setErrorMessage] = useState('')
+  const socketRef = useRef<WebSocket | null>(null)
+  const nextLogIdRef = useRef(0)
+  const instanceId = useId()
+
+  useEffect(function cleanupSocketOnUnmount() {
+    return function cleanup() {
+      const socket = socketRef.current
+      socketRef.current = null
+
+      if (!socket) {
+        return
+      }
+
+      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
+        socket.close(1000, 'Component unmounted')
+      }
+    }
+  }, [])
+
+  return {
+    url,
+    setUrl,
+    token,
+    setToken,
+    message,
+    setMessage,
+    status,
+    setStatus,
+    logs,
+    setLogs,
+    errorMessage,
+    setErrorMessage,
+    socketRef,
+    nextLogIdRef,
+    instanceId,
+  }
+}
+
 export function WebSocketPlayground({
   endpoint = DEFAULT_ENDPOINT,
   defaultMessage = DEFAULT_MESSAGE,
@@ -90,16 +135,23 @@ export function WebSocketPlayground({
   maxLogs = 120,
   className,
 }: WebSocketPlaygroundProps) {
-  const [url, setUrl] = useState(endpoint)
-  const [token, setToken] = useState('')
-  const [message, setMessage] = useState(defaultMessage)
-  const [status, setStatus] = useState<ConnectionStatus>('disconnected')
-  const [logs, setLogs] = useState<LogEntry[]>([])
-  const [errorMessage, setErrorMessage] = useState('')
-
-  const socketRef = useRef<WebSocket | null>(null)
-  const nextLogIdRef = useRef(0)
-  const instanceId = useId()
+  const {
+    url,
+    setUrl,
+    token,
+    setToken,
+    message,
+    setMessage,
+    status,
+    setStatus,
+    logs,
+    setLogs,
+    errorMessage,
+    setErrorMessage,
+    socketRef,
+    nextLogIdRef,
+    instanceId,
+  } = useWebSocketState(endpoint, defaultMessage)
   const logLimit = Math.max(maxLogs, 10)
 
   function pushLog(level: LogLevel, entryMessage: string) {
@@ -220,21 +272,6 @@ export function WebSocketPlayground({
   function clearLogs() {
     setLogs([])
   }
-
-  useEffect(() => {
-    return () => {
-      const socket = socketRef.current
-      socketRef.current = null
-
-      if (!socket) {
-        return
-      }
-
-      if (socket.readyState === WebSocket.OPEN || socket.readyState === WebSocket.CONNECTING) {
-        socket.close(1000, 'Component unmounted')
-      }
-    }
-  }, [])
 
   const isConnected = status === 'connected'
   const previewUrl = buildSocketUrl(url.trim(), token.trim(), authQueryKey)

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -4,14 +4,18 @@ import * as Sentry from '@sentry/nextjs'
 import NextError from 'next/error'
 import { useEffect } from 'react'
 
+function useSentryCapture(error: Error & { digest?: string }) {
+  useEffect(function captureExceptionEffect() {
+    Sentry.captureException(error)
+  }, [error])
+}
+
 export default function GlobalError({
   error,
 }: {
   error: Error & { digest?: string }
 }) {
-  useEffect(() => {
-    Sentry.captureException(error)
-  }, [error])
+  useSentryCapture(error)
 
   return (
     <html lang="en">


### PR DESCRIPTION
Final sweep for `use-encapsulation/prefer-custom-hooks` (#855). Covers every remaining file not addressed by prior PRs — event page small components, docs area, 2FA, predictions sync, and global error.

Follow-up to #866–#887.

## Files changed (30)

### Event page small components (21 files, 64 → 0)
| File | Warnings |
|---|---|
| EventChangeLog | 2 → 0 |
| EventChartControls | 1 → 0 |
| EventCommentForm | 1 → 0 |
| EventCommentMenu | 1 → 0 |
| EventCommentPositionsIndicator | 1 → 0 |
| EventCommentReplyForm | 2 → 0 |
| EventFaq | 3 → 0 |
| EventLimitExpirationCalendar | 2 → 0 |
| EventMarketCard | 2 → 0 |
| EventMarketChance | 2 → 0 |
| EventMarketContext | 16 → 0 |
| EventMetaInformation | 2 → 0 |
| EventOrderPanelLimitControls | 7 → 0 |
| EventOutcomeChanceProvider | 5 → 0 |
| EventRules | 1 → 0 |
| EventSingleMarketOrderBook | 4 → 0 |
| EventSplitSharesDialog | 4 → 0 |
| EventTabSelector | 2 → 0 |
| EventTabs | 2 → 0 |
| EventTweetMarketsPanel | 3 → 0 |
| ResolutionTimelinePanel | 4 → 0 |

### Docs (6 files, 26 → 0)
| File | Warnings |
|---|---|
| AffiliateShareDisplay | 3 → 0 |
| FeeCalculationExample | 3 → 0 |
| LLMPageActions | 4 → 0 |
| PlatformShareDisplay | 3 → 0 |
| TradingFeeDisplay | 3 → 0 |
| WebSocketPlayground | 10 → 0 |

### Other (3 files, 6 → 0)
| File | Warnings |
|---|---|
| TwoFactorClient | 4 → 0 |
| PredictionResultsSearchParamsSync | 1 → 0 |
| global-error | 1 → 0 |

**Total: 99 → 0 (100% reduction) across 30 files.**

## Shared-hook note

`useAffiliateData` appears in 4 docs files (AffiliateShareDisplay, FeeCalculationExample, PlatformShareDisplay, TradingFeeDisplay) with identical implementations. Kept file-local per bias-local rule — trivial hook (2 useState + 1 useEffect). Candidate for consolidation to a shared `src/hooks/useAffiliateData.ts` if a fifth consumer appears.

## Not included

- `src/components/ui/calendar.tsx` (2) and `src/components/ui/number-input.tsx` (3) — shadcn components, excluded per your guidelines.

## With this PR merged alongside all prior PRs, #855 is complete.

The `use-encapsulation/prefer-custom-hooks` rule should show 0 warnings across the entire codebase (except the 5 shadcn ui warnings that are intentionally excluded).

## Test plan

- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Manual UX smoke: event changelog, chart controls, comment form/menu/reply/positions-indicator, FAQ accordion, limit expiration calendar, market card/chance/context, meta information, order panel limit controls, outcome chance provider, rules expand, single-market order book, split shares dialog, tab selector/tabs, tweet markets countdown, resolution timeline, docs pages (affiliate/fee/platform share displays, WebSocket playground, LLM page actions), 2FA setup/disable, prediction results search params sync

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Final sweep to migrate remaining event, docs, 2FA, predictions, and global error components to small custom hooks, completing the `use-encapsulation/prefer-custom-hooks` rollout and removing 99 lints. Also fixes a `next-intl` extraction issue by moving `useExtracted` calls into hooks. No UI or behavior changes intended.

- **Refactors**
  - Extracted local state/effects into focused `use*` hooks across 30 files (forms, dialogs, menus, toggles, timers, calculations, WebSocket, Sentry); centralized Event Market Context in `useMarketContextState` (preload, cache expiry, typewriter).
  - Event page hooks: volume (`useMarketCardVolume`, `useEventVolume`), chance/resolution (`useResolutionDialog`, `useResolutionTimeline`), order book/limit controls (`useOrderBookState`, `useLimitControlsDerived`, `useExpirationModal`), FAQ/tabs/comments/calendars.
  - Docs/auth/predictions: local `useAffiliateData` in `AffiliateShareDisplay`, `FeeCalculationExample`, `PlatformShareDisplay`, `TradingFeeDisplay`; added `useMarkdownPreloader`, `useWebSocketState`, `useTwoFactorState`, `useSyncFiltersFromSearchParams`.

- **Bug Fixes**
  - Moved `useExtracted` calls inside hooks to avoid `next-intl` extraction issues (EventTabSelector, EventMarketContext, EventOrderPanelForm, EventMarketOpenOrders, EventOrderBook).

<sup>Written for commit 81cd97e29b49baf8733171e893c03921b606c464. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

