### PR TITLE
refactor: split EventOrderPanelForm into focused sub-components

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -1,13 +1,10 @@
 import type { InfiniteData } from '@tanstack/react-query'
-import type { ReactNode } from 'react'
-import type { EventOrderPanelOutcomeSelectedAccent } from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton'
+import type { ConditionSharesMap, EventOrderPanelFormProps, ResolveDisplayOutcomeLabel } from '@/app/[locale]/(platform)/event/[slug]/_types/EventOrderPanelTypes'
 import type { PortfolioUserOpenOrder } from '@/app/[locale]/(platform)/portfolio/_types/PortfolioOpenOrdersTypes'
-import type { OddsFormat } from '@/lib/odds-format'
 import type { SafeTransactionRequestPayload } from '@/lib/safe/transactions'
 import type { Event, Market, Outcome, UserPosition } from '@/types'
 import { useAppKitAccount } from '@reown/appkit/react'
 import { useQueryClient } from '@tanstack/react-query'
-import { CheckIcon, TriangleAlertIcon } from 'lucide-react'
 import { useExtracted, useLocale } from 'next-intl'
 import Form from 'next/form'
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
@@ -18,14 +15,11 @@ import { getSafeNonceAction, submitSafeTransactionAction } from '@/app/[locale]/
 import { useTradingOnboarding } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { useOrderBookSummaries } from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook'
 import EventOrderPanelBuySellTabs from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs'
-import EventOrderPanelEarnings from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelEarnings'
-import EventOrderPanelInput from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput'
-import EventOrderPanelLimitControls from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls'
 import EventOrderPanelMarketInfo from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelMarketInfo'
 import EventOrderPanelMobileMarketInfo from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelMobileMarketInfo'
-import EventOrderPanelOutcomeButton from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton'
-import EventOrderPanelSubmitButton from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelSubmitButton'
-import EventOrderPanelUserShares from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelUserShares'
+import EventOrderPanelOrderInput from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOrderInput'
+import EventOrderPanelOutcomeSelector from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeSelector'
+import EventOrderPanelResolvedMarketDisplay from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelResolvedMarketDisplay'
 import { handleOrderCancelledFeedback, handleOrderErrorFeedback, handleOrderSuccessFeedback, handleValidationError } from '@/app/[locale]/(platform)/event/[slug]/_components/feedback'
 import { useEventOrderPanelOpenOrders } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventOrderPanelOpenOrders'
 import { useEventOrderPanelPositions } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventOrderPanelPositions'
@@ -36,7 +30,6 @@ import { inferResolvedTweetMarketOutcome, isTweetMarketsEvent } from '@/app/[loc
 import {
   resolveResolvedOrderPanelDisplay,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/resolved-order-panel-market'
-import { Button } from '@/components/ui/button'
 import { useAffiliateOrderMetadata } from '@/hooks/useAffiliateOrderMetadata'
 import { useAppKit } from '@/hooks/useAppKit'
 import { SAFE_BALANCE_QUERY_KEY, useBalance } from '@/hooks/useBalance'
@@ -74,21 +67,6 @@ import { isUserRejectedRequestError, normalizeAddress } from '@/lib/wallet'
 import { useNotifications } from '@/stores/useNotifications'
 import { useAmountAsNumber, useIsLimitOrder, useNoPrice, useOrder, useYesPrice } from '@/stores/useOrder'
 import { useUser } from '@/stores/useUser'
-
-interface EventOrderPanelFormProps {
-  isMobile: boolean
-  event: Event
-  initialMarket?: Market | null
-  initialOutcome?: Outcome | null
-  desktopMarketInfo?: ReactNode
-  mobileMarketInfo?: ReactNode
-  primaryOutcomeIndex?: number | null
-  oddsFormat?: OddsFormat
-  outcomeButtonStyleVariant?: 'default' | 'sports3d'
-  outcomeLabelOverrides?: Partial<Record<number, string>>
-  outcomeAccentOverrides?: Partial<Record<number, EventOrderPanelOutcomeSelectedAccent>>
-  optimisticallyClaimedConditionIds?: Record<string, true>
-}
 
 function resolveIndexSetFromOutcomeIndex(outcomeIndex: number | undefined) {
   if (outcomeIndex === OUTCOME_INDEX.YES) {
@@ -165,8 +143,6 @@ function getHydratedClientSnapshot() {
 function getHydratedServerSnapshot() {
   return false
 }
-
-type ConditionSharesMap = Record<string, Record<typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO, number>>
 
 function useUserSharesStoreSync({
   makerAddress,
@@ -546,12 +522,6 @@ function useOrderBookComputations({
     buyPayoutSummary,
   }
 }
-
-type ResolveDisplayOutcomeLabel = (
-  outcomeIndex: number | null | undefined,
-  outcomeText: string | null | undefined,
-  fallbackLabel: string,
-) => string
 
 function useClaimablePositions({
   activeMarket,
@@ -1783,47 +1753,19 @@ export default function EventOrderPanelForm({
       )}
       {isResolvedMarket
         ? (
-            <div className="flex flex-col items-center gap-3 px-2 py-4 text-center">
-              <div className="flex size-10 items-center justify-center rounded-full bg-primary">
-                <CheckIcon className="size-7 text-background" strokeWidth={3} />
-              </div>
-              <div className="text-lg font-bold text-primary">
-                {t('Outcome:')}
-                {' '}
-                {resolvedOutcomeLabel}
-              </div>
-              {((!isSingleMarket || shouldShowResolvedSportsSubtitle) && resolvedMarketTitle) && (
-                <div className="text-sm text-muted-foreground">{resolvedMarketTitle}</div>
-              )}
-              {hasClaimableWinnings && (
-                <div className="mt-2 w-full space-y-3 text-left">
-                  <div className="w-full border-t border-border" />
-                  <p className="text-center text-base font-semibold text-foreground">{t('Your Earnings')}</p>
-                  <div className="space-y-1.5 text-sm">
-                    <div className="flex items-center justify-between gap-4">
-                      <span className="text-muted-foreground">{t('Position')}</span>
-                      <span className="text-right font-medium text-foreground">{claimPositionLabel}</span>
-                    </div>
-                    <div className="flex items-center justify-between gap-4">
-                      <span className="text-muted-foreground">{t('Value per share')}</span>
-                      <span className="text-right font-medium text-foreground">{claimValuePerShareLabel}</span>
-                    </div>
-                    <div className="flex items-center justify-between gap-4">
-                      <span className="text-muted-foreground">{t('Total')}</span>
-                      <span className="text-right font-medium text-foreground">{claimTotalLabel}</span>
-                    </div>
-                  </div>
-                  <Button
-                    type="button"
-                    className="h-10 w-full"
-                    onClick={handleClaimWinnings}
-                    disabled={isClaimSubmitting || positionsQuery.isLoading}
-                  >
-                    {isClaimSubmitting ? t('Submitting...') : t('Claim winnings')}
-                  </Button>
-                </div>
-              )}
-            </div>
+            <EventOrderPanelResolvedMarketDisplay
+              resolvedOutcomeLabel={resolvedOutcomeLabel}
+              isSingleMarket={isSingleMarket}
+              shouldShowResolvedSportsSubtitle={shouldShowResolvedSportsSubtitle}
+              resolvedMarketTitle={resolvedMarketTitle}
+              hasClaimableWinnings={hasClaimableWinnings}
+              claimPositionLabel={claimPositionLabel}
+              claimValuePerShareLabel={claimValuePerShareLabel}
+              claimTotalLabel={claimTotalLabel}
+              isClaimSubmitting={isClaimSubmitting}
+              isPositionsLoading={positionsQuery.isLoading}
+              onClaimWinnings={handleClaimWinnings}
+            />
           )
         : (
             <>
@@ -1846,163 +1788,80 @@ export default function EventOrderPanelForm({
                 onFocusInput={focusInput}
               />
 
-              <div className="mb-2 flex gap-2">
-                <EventOrderPanelOutcomeButton
-                  variant="yes"
-                  price={primaryPrice}
-                  label={resolveDisplayOutcomeLabel(
-                    normalizedPrimaryOutcomeIndex,
-                    primaryOutcome?.outcome_text,
-                    t('Yes'),
-                  )}
-                  isSelected={activeOutcome?.outcome_index === normalizedPrimaryOutcomeIndex}
-                  oddsFormat={oddsFormat}
-                  styleVariant={outcomeButtonStyleVariant}
-                  selectedAccent={outcomeAccentOverrides[normalizedPrimaryOutcomeIndex] ?? null}
-                  onSelect={() => handleOutcomeSelect(primaryOutcome)}
-                />
-                <EventOrderPanelOutcomeButton
-                  variant="no"
-                  price={secondaryPrice}
-                  label={resolveDisplayOutcomeLabel(
-                    normalizedSecondaryOutcomeIndex,
-                    secondaryOutcome?.outcome_text,
-                    t('No'),
-                  )}
-                  isSelected={activeOutcome?.outcome_index === normalizedSecondaryOutcomeIndex}
-                  oddsFormat={oddsFormat}
-                  styleVariant={outcomeButtonStyleVariant}
-                  selectedAccent={outcomeAccentOverrides[normalizedSecondaryOutcomeIndex] ?? null}
-                  onSelect={() => handleOutcomeSelect(secondaryOutcome)}
-                />
-              </div>
-
-              {isLimitOrder
-                ? (
-                    <div className="mb-4">
-                      {state.side === ORDER_SIDE.SELL && (
-                        <EventOrderPanelUserShares
-                          yesShares={availableYesTokenShares}
-                          noShares={availableNoTokenShares}
-                          activeOutcome={outcomeIndex}
-                        />
-                      )}
-                      <EventOrderPanelLimitControls
-                        side={state.side}
-                        limitPrice={state.limitPrice}
-                        limitShares={state.limitShares}
-                        limitExpirationEnabled={state.limitExpirationEnabled}
-                        limitExpirationOption={state.limitExpirationOption}
-                        limitExpirationTimestamp={state.limitExpirationTimestamp}
-                        isLimitOrder={isLimitOrder}
-                        matchingShares={limitMatchingShares}
-                        availableShares={selectedShares}
-                        showLimitMinimumWarning={shouldShowLimitMinimumWarning}
-                        shouldShakeShares={shouldShakeLimitShares}
-                        limitSharesRef={limitSharesInputRef}
-                        onLimitPriceChange={handleLimitPriceChange}
-                        onLimitSharesChange={handleLimitSharesChange}
-                        onLimitExpirationEnabledChange={state.setLimitExpirationEnabled}
-                        onLimitExpirationOptionChange={state.setLimitExpirationOption}
-                        onLimitExpirationTimestampChange={state.setLimitExpirationTimestamp}
-                        onAmountUpdateFromLimit={state.setAmount}
-                      />
-                    </div>
-                  )
-                : (
-                    <>
-                      {state.side === ORDER_SIDE.SELL
-                        ? (
-                            <EventOrderPanelUserShares
-                              yesShares={availableYesPositionShares}
-                              noShares={availableNoPositionShares}
-                              activeOutcome={outcomeIndex}
-                            />
-                          )
-                        : <div className="mb-4"></div>}
-                      <EventOrderPanelInput
-                        isMobile={isMobile}
-                        side={state.side}
-                        amount={state.amount}
-                        amountNumber={amountNumber}
-                        availableShares={selectedShares}
-                        balance={balance}
-                        isBalanceLoading={isLoadingBalance}
-                        inputRef={state.inputRef}
-                        onAmountChange={handleAmountChange}
-                        shouldShake={shouldShakeInput}
-                      />
-                      <div
-                        className={cn(
-                          'overflow-hidden transition-all duration-500 ease-in-out',
-                          shouldShowEarnings
-                            ? 'max-h-96 translate-y-0 opacity-100'
-                            : 'pointer-events-none max-h-0 -translate-y-2 opacity-0',
-                        )}
-                        aria-hidden={!shouldShowEarnings}
-                      >
-                        <EventOrderPanelEarnings
-                          isMobile={isMobile}
-                          side={state.side}
-                          sellAmountLabel={sellAmountLabel}
-                          avgSellPriceLabel={avgSellPriceLabel}
-                          avgBuyPriceLabel={avgBuyPriceLabel}
-                          avgSellPriceCents={avgSellPriceCentsValue}
-                          avgBuyPriceCents={avgBuyPriceCentsValue}
-                          buyPayout={buyPayoutSummary.payout}
-                          buyProfit={buyPayoutSummary.profit}
-                          buyChangePct={buyPayoutSummary.changePct}
-                          buyMultiplier={buyPayoutSummary.multiplier}
-                        />
-                      </div>
-                      {shouldShowResolvedMarketMinimumWarning && (
-                        <div
-                          className={`
-                            mt-3 flex animate-order-shake items-center justify-center gap-2 pb-1 text-sm font-semibold
-                            text-orange-500
-                          `}
-                        >
-                          <TriangleAlertIcon className="size-4" />
-                          {t('Market buys must be at least $1')}
-                        </div>
-                      )}
-                      {shouldShowResolvedNoLiquidityWarning && (
-                        <div
-                          className={`
-                            mt-3 flex animate-order-shake items-center justify-center gap-2 pb-1 text-sm font-semibold
-                            text-orange-500
-                          `}
-                        >
-                          <TriangleAlertIcon className="size-4" />
-                          {t('No liquidity for this market order')}
-                        </div>
-                      )}
-                    </>
-                  )}
-
-              {(showInsufficientSharesWarning || showInsufficientBalanceWarning || showAmountTooLowWarning) && (
-                <div
-                  className={`
-                    mt-2 mb-3 flex animate-order-shake items-center justify-center gap-2 text-sm font-semibold
-                    text-orange-500
-                  `}
-                >
-                  <TriangleAlertIcon className="size-4" />
-                  {showAmountTooLowWarning
-                    ? t('Amount too low')
-                    : showInsufficientBalanceWarning
-                      ? t('Insufficient USDC balance')
-                      : t('Insufficient shares for this order')}
-                </div>
-              )}
-
-              <EventOrderPanelSubmitButton
-                type={!isInteractiveWalletReady || shouldShowDepositCta ? 'button' : 'submit'}
-                isLoading={state.isLoading}
-                isDisabled={state.isLoading}
-                selectedAccent={selectedSubmitAccent}
+              <EventOrderPanelOutcomeSelector
+                primaryPrice={primaryPrice}
+                secondaryPrice={secondaryPrice}
+                primaryLabel={resolveDisplayOutcomeLabel(
+                  normalizedPrimaryOutcomeIndex,
+                  primaryOutcome?.outcome_text,
+                  t('Yes'),
+                )}
+                secondaryLabel={resolveDisplayOutcomeLabel(
+                  normalizedSecondaryOutcomeIndex,
+                  secondaryOutcome?.outcome_text,
+                  t('No'),
+                )}
+                primaryIsSelected={activeOutcome?.outcome_index === normalizedPrimaryOutcomeIndex}
+                secondaryIsSelected={activeOutcome?.outcome_index === normalizedSecondaryOutcomeIndex}
+                oddsFormat={oddsFormat}
                 styleVariant={outcomeButtonStyleVariant}
-                onClick={(event) => {
+                primarySelectedAccent={outcomeAccentOverrides[normalizedPrimaryOutcomeIndex] ?? null}
+                secondarySelectedAccent={outcomeAccentOverrides[normalizedSecondaryOutcomeIndex] ?? null}
+                onSelectPrimary={() => handleOutcomeSelect(primaryOutcome)}
+                onSelectSecondary={() => handleOutcomeSelect(secondaryOutcome)}
+              />
+
+              <EventOrderPanelOrderInput
+                isMobile={isMobile}
+                side={state.side}
+                isLimitOrder={isLimitOrder}
+                amount={state.amount}
+                amountNumber={amountNumber}
+                availableShares={selectedShares}
+                availableYesTokenShares={availableYesTokenShares}
+                availableNoTokenShares={availableNoTokenShares}
+                availableYesPositionShares={availableYesPositionShares}
+                availableNoPositionShares={availableNoPositionShares}
+                outcomeIndex={outcomeIndex}
+                balance={balance}
+                isBalanceLoading={isLoadingBalance}
+                inputRef={state.inputRef}
+                shouldShakeInput={shouldShakeInput}
+                shouldShowEarnings={shouldShowEarnings}
+                sellAmountLabel={sellAmountLabel}
+                avgSellPriceLabel={avgSellPriceLabel}
+                avgBuyPriceLabel={avgBuyPriceLabel}
+                avgSellPriceCentsValue={avgSellPriceCentsValue}
+                avgBuyPriceCentsValue={avgBuyPriceCentsValue}
+                buyPayoutSummary={buyPayoutSummary}
+                shouldShowResolvedMarketMinimumWarning={shouldShowResolvedMarketMinimumWarning}
+                shouldShowResolvedNoLiquidityWarning={shouldShowResolvedNoLiquidityWarning}
+                showInsufficientSharesWarning={showInsufficientSharesWarning}
+                showInsufficientBalanceWarning={showInsufficientBalanceWarning}
+                showAmountTooLowWarning={showAmountTooLowWarning}
+                limitPrice={state.limitPrice}
+                limitShares={state.limitShares}
+                limitExpirationEnabled={state.limitExpirationEnabled}
+                limitExpirationOption={state.limitExpirationOption}
+                limitExpirationTimestamp={state.limitExpirationTimestamp}
+                limitMatchingShares={limitMatchingShares}
+                shouldShowLimitMinimumWarning={shouldShowLimitMinimumWarning}
+                shouldShakeLimitShares={shouldShakeLimitShares}
+                limitSharesRef={limitSharesInputRef}
+                onAmountChange={handleAmountChange}
+                onLimitPriceChange={handleLimitPriceChange}
+                onLimitSharesChange={handleLimitSharesChange}
+                onLimitExpirationEnabledChange={state.setLimitExpirationEnabled}
+                onLimitExpirationOptionChange={state.setLimitExpirationOption}
+                onLimitExpirationTimestampChange={state.setLimitExpirationTimestamp}
+                onAmountUpdateFromLimit={state.setAmount}
+                isInteractiveWalletReady={isInteractiveWalletReady}
+                shouldShowDepositCta={shouldShowDepositCta}
+                isLoading={state.isLoading}
+                selectedSubmitAccent={selectedSubmitAccent}
+                outcomeButtonStyleVariant={outcomeButtonStyleVariant}
+                submitButtonLabel={submitButtonLabel}
+                onSubmitButtonClick={(event) => {
                   if (!isInteractiveWalletReady) {
                     void open()
                     return
@@ -2014,7 +1873,6 @@ export default function EventOrderPanelForm({
                   }
                   state.setLastMouseEvent(event)
                 }}
-                label={submitButtonLabel}
               />
             </>
           )}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOrderInput.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOrderInput.tsx
@@ -1,0 +1,262 @@
+'use client'
+
+import type { RefObject } from 'react'
+import type { EventOrderPanelOutcomeSelectedAccent } from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton'
+import type { useBalance } from '@/hooks/useBalance'
+import type { OUTCOME_INDEX } from '@/lib/constants'
+import type { LimitExpirationOption } from '@/stores/useOrder'
+import { TriangleAlertIcon } from 'lucide-react'
+import { useExtracted } from 'next-intl'
+import EventOrderPanelEarnings from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelEarnings'
+import EventOrderPanelInput from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput'
+import EventOrderPanelLimitControls from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls'
+import EventOrderPanelSubmitButton from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelSubmitButton'
+import EventOrderPanelUserShares from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelUserShares'
+import { ORDER_SIDE } from '@/lib/constants'
+import { cn } from '@/lib/utils'
+
+interface EventOrderPanelOrderInputProps {
+  isMobile: boolean
+  side: typeof ORDER_SIDE.BUY | typeof ORDER_SIDE.SELL
+  isLimitOrder: boolean
+  amount: string
+  amountNumber: number
+  availableShares: number
+  availableYesTokenShares: number
+  availableNoTokenShares: number
+  availableYesPositionShares: number
+  availableNoPositionShares: number
+  outcomeIndex: typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO | undefined
+  balance: ReturnType<typeof useBalance>['balance']
+  isBalanceLoading: boolean
+  inputRef: RefObject<HTMLInputElement | null>
+  shouldShakeInput: boolean
+  shouldShowEarnings: boolean
+  sellAmountLabel: string
+  avgSellPriceLabel: string
+  avgBuyPriceLabel: string
+  avgSellPriceCentsValue: number | null
+  avgBuyPriceCentsValue: number | null
+  buyPayoutSummary: {
+    payout: number
+    cost: number
+    profit: number
+    changePct: number
+    multiplier: number
+  }
+  shouldShowResolvedMarketMinimumWarning: boolean
+  shouldShowResolvedNoLiquidityWarning: boolean
+  showInsufficientSharesWarning: boolean
+  showInsufficientBalanceWarning: boolean
+  showAmountTooLowWarning: boolean
+  limitPrice: string
+  limitShares: string
+  limitExpirationEnabled: boolean
+  limitExpirationOption: LimitExpirationOption
+  limitExpirationTimestamp: number | null
+  limitMatchingShares: number | null
+  shouldShowLimitMinimumWarning: boolean
+  shouldShakeLimitShares: boolean
+  limitSharesRef: RefObject<HTMLInputElement | null>
+  onAmountChange: (nextAmount: string) => void
+  onLimitPriceChange: (nextLimitPrice: string) => void
+  onLimitSharesChange: (nextLimitShares: string) => void
+  onLimitExpirationEnabledChange: (enabled: boolean) => void
+  onLimitExpirationOptionChange: (option: LimitExpirationOption) => void
+  onLimitExpirationTimestampChange: (timestamp: number | null) => void
+  onAmountUpdateFromLimit: (amount: string) => void
+  isInteractiveWalletReady: boolean
+  shouldShowDepositCta: boolean
+  isLoading: boolean
+  selectedSubmitAccent: EventOrderPanelOutcomeSelectedAccent | null
+  outcomeButtonStyleVariant: 'default' | 'sports3d'
+  submitButtonLabel: string
+  onSubmitButtonClick: (event: React.MouseEvent<HTMLButtonElement>) => void
+}
+
+export default function EventOrderPanelOrderInput({
+  isMobile,
+  side,
+  isLimitOrder,
+  amount,
+  amountNumber,
+  availableShares,
+  availableYesTokenShares,
+  availableNoTokenShares,
+  availableYesPositionShares,
+  availableNoPositionShares,
+  outcomeIndex,
+  balance,
+  isBalanceLoading,
+  inputRef,
+  shouldShakeInput,
+  shouldShowEarnings,
+  sellAmountLabel,
+  avgSellPriceLabel,
+  avgBuyPriceLabel,
+  avgSellPriceCentsValue,
+  avgBuyPriceCentsValue,
+  buyPayoutSummary,
+  shouldShowResolvedMarketMinimumWarning,
+  shouldShowResolvedNoLiquidityWarning,
+  showInsufficientSharesWarning,
+  showInsufficientBalanceWarning,
+  showAmountTooLowWarning,
+  limitPrice,
+  limitShares,
+  limitExpirationEnabled,
+  limitExpirationOption,
+  limitExpirationTimestamp,
+  limitMatchingShares,
+  shouldShowLimitMinimumWarning,
+  shouldShakeLimitShares,
+  limitSharesRef,
+  onAmountChange,
+  onLimitPriceChange,
+  onLimitSharesChange,
+  onLimitExpirationEnabledChange,
+  onLimitExpirationOptionChange,
+  onLimitExpirationTimestampChange,
+  onAmountUpdateFromLimit,
+  isInteractiveWalletReady,
+  shouldShowDepositCta,
+  isLoading,
+  selectedSubmitAccent,
+  outcomeButtonStyleVariant,
+  submitButtonLabel,
+  onSubmitButtonClick,
+}: EventOrderPanelOrderInputProps) {
+  const t = useExtracted()
+
+  return (
+    <>
+      {isLimitOrder
+        ? (
+            <div className="mb-4">
+              {side === ORDER_SIDE.SELL && (
+                <EventOrderPanelUserShares
+                  yesShares={availableYesTokenShares}
+                  noShares={availableNoTokenShares}
+                  activeOutcome={outcomeIndex}
+                />
+              )}
+              <EventOrderPanelLimitControls
+                side={side}
+                limitPrice={limitPrice}
+                limitShares={limitShares}
+                limitExpirationEnabled={limitExpirationEnabled}
+                limitExpirationOption={limitExpirationOption}
+                limitExpirationTimestamp={limitExpirationTimestamp}
+                isLimitOrder={isLimitOrder}
+                matchingShares={limitMatchingShares}
+                availableShares={availableShares}
+                showLimitMinimumWarning={shouldShowLimitMinimumWarning}
+                shouldShakeShares={shouldShakeLimitShares}
+                limitSharesRef={limitSharesRef}
+                onLimitPriceChange={onLimitPriceChange}
+                onLimitSharesChange={onLimitSharesChange}
+                onLimitExpirationEnabledChange={onLimitExpirationEnabledChange}
+                onLimitExpirationOptionChange={onLimitExpirationOptionChange}
+                onLimitExpirationTimestampChange={onLimitExpirationTimestampChange}
+                onAmountUpdateFromLimit={onAmountUpdateFromLimit}
+              />
+            </div>
+          )
+        : (
+            <>
+              {side === ORDER_SIDE.SELL
+                ? (
+                    <EventOrderPanelUserShares
+                      yesShares={availableYesPositionShares}
+                      noShares={availableNoPositionShares}
+                      activeOutcome={outcomeIndex}
+                    />
+                  )
+                : <div className="mb-4"></div>}
+              <EventOrderPanelInput
+                isMobile={isMobile}
+                side={side}
+                amount={amount}
+                amountNumber={amountNumber}
+                availableShares={availableShares}
+                balance={balance}
+                isBalanceLoading={isBalanceLoading}
+                inputRef={inputRef}
+                onAmountChange={onAmountChange}
+                shouldShake={shouldShakeInput}
+              />
+              <div
+                className={cn(
+                  'overflow-hidden transition-all duration-500 ease-in-out',
+                  shouldShowEarnings
+                    ? 'max-h-96 translate-y-0 opacity-100'
+                    : 'pointer-events-none max-h-0 -translate-y-2 opacity-0',
+                )}
+                aria-hidden={!shouldShowEarnings}
+              >
+                <EventOrderPanelEarnings
+                  isMobile={isMobile}
+                  side={side}
+                  sellAmountLabel={sellAmountLabel}
+                  avgSellPriceLabel={avgSellPriceLabel}
+                  avgBuyPriceLabel={avgBuyPriceLabel}
+                  avgSellPriceCents={avgSellPriceCentsValue}
+                  avgBuyPriceCents={avgBuyPriceCentsValue}
+                  buyPayout={buyPayoutSummary.payout}
+                  buyProfit={buyPayoutSummary.profit}
+                  buyChangePct={buyPayoutSummary.changePct}
+                  buyMultiplier={buyPayoutSummary.multiplier}
+                />
+              </div>
+              {shouldShowResolvedMarketMinimumWarning && (
+                <div
+                  className={`
+                    mt-3 flex animate-order-shake items-center justify-center gap-2 pb-1 text-sm font-semibold
+                    text-orange-500
+                  `}
+                >
+                  <TriangleAlertIcon className="size-4" />
+                  {t('Market buys must be at least $1')}
+                </div>
+              )}
+              {shouldShowResolvedNoLiquidityWarning && (
+                <div
+                  className={`
+                    mt-3 flex animate-order-shake items-center justify-center gap-2 pb-1 text-sm font-semibold
+                    text-orange-500
+                  `}
+                >
+                  <TriangleAlertIcon className="size-4" />
+                  {t('No liquidity for this market order')}
+                </div>
+              )}
+            </>
+          )}
+
+      {(showInsufficientSharesWarning || showInsufficientBalanceWarning || showAmountTooLowWarning) && (
+        <div
+          className={`
+            mt-2 mb-3 flex animate-order-shake items-center justify-center gap-2 text-sm font-semibold text-orange-500
+          `}
+        >
+          <TriangleAlertIcon className="size-4" />
+          {showAmountTooLowWarning
+            ? t('Amount too low')
+            : showInsufficientBalanceWarning
+              ? t('Insufficient USDC balance')
+              : t('Insufficient shares for this order')}
+        </div>
+      )}
+
+      <EventOrderPanelSubmitButton
+        type={!isInteractiveWalletReady || shouldShowDepositCta ? 'button' : 'submit'}
+        isLoading={isLoading}
+        isDisabled={isLoading}
+        selectedAccent={selectedSubmitAccent}
+        styleVariant={outcomeButtonStyleVariant}
+        onClick={onSubmitButtonClick}
+        label={submitButtonLabel}
+      />
+    </>
+  )
+}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeSelector.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeSelector.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import type { EventOrderPanelOutcomeSelectedAccent } from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton'
+import type { OddsFormat } from '@/lib/odds-format'
+import EventOrderPanelOutcomeButton from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton'
+
+interface EventOrderPanelOutcomeSelectorProps {
+  primaryPrice: number | null
+  secondaryPrice: number | null
+  primaryLabel: string
+  secondaryLabel: string
+  primaryIsSelected: boolean
+  secondaryIsSelected: boolean
+  oddsFormat: OddsFormat
+  styleVariant: 'default' | 'sports3d'
+  primarySelectedAccent: EventOrderPanelOutcomeSelectedAccent | null
+  secondarySelectedAccent: EventOrderPanelOutcomeSelectedAccent | null
+  onSelectPrimary: () => void
+  onSelectSecondary: () => void
+}
+
+export default function EventOrderPanelOutcomeSelector({
+  primaryPrice,
+  secondaryPrice,
+  primaryLabel,
+  secondaryLabel,
+  primaryIsSelected,
+  secondaryIsSelected,
+  oddsFormat,
+  styleVariant,
+  primarySelectedAccent,
+  secondarySelectedAccent,
+  onSelectPrimary,
+  onSelectSecondary,
+}: EventOrderPanelOutcomeSelectorProps) {
+  return (
+    <div className="mb-2 flex gap-2">
+      <EventOrderPanelOutcomeButton
+        variant="yes"
+        price={primaryPrice}
+        label={primaryLabel}
+        isSelected={primaryIsSelected}
+        oddsFormat={oddsFormat}
+        styleVariant={styleVariant}
+        selectedAccent={primarySelectedAccent}
+        onSelect={onSelectPrimary}
+      />
+      <EventOrderPanelOutcomeButton
+        variant="no"
+        price={secondaryPrice}
+        label={secondaryLabel}
+        isSelected={secondaryIsSelected}
+        oddsFormat={oddsFormat}
+        styleVariant={styleVariant}
+        selectedAccent={secondarySelectedAccent}
+        onSelect={onSelectSecondary}
+      />
+    </div>
+  )
+}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelResolvedMarketDisplay.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelResolvedMarketDisplay.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { CheckIcon } from 'lucide-react'
+import { useExtracted } from 'next-intl'
+import { Button } from '@/components/ui/button'
+
+interface EventOrderPanelResolvedMarketDisplayProps {
+  resolvedOutcomeLabel: string | null
+  isSingleMarket: boolean
+  shouldShowResolvedSportsSubtitle: boolean
+  resolvedMarketTitle: string | null
+  hasClaimableWinnings: boolean
+  claimPositionLabel: string
+  claimValuePerShareLabel: string
+  claimTotalLabel: string
+  isClaimSubmitting: boolean
+  isPositionsLoading: boolean
+  onClaimWinnings: () => void
+}
+
+export default function EventOrderPanelResolvedMarketDisplay({
+  resolvedOutcomeLabel,
+  isSingleMarket,
+  shouldShowResolvedSportsSubtitle,
+  resolvedMarketTitle,
+  hasClaimableWinnings,
+  claimPositionLabel,
+  claimValuePerShareLabel,
+  claimTotalLabel,
+  isClaimSubmitting,
+  isPositionsLoading,
+  onClaimWinnings,
+}: EventOrderPanelResolvedMarketDisplayProps) {
+  const t = useExtracted()
+
+  return (
+    <div className="flex flex-col items-center gap-3 px-2 py-4 text-center">
+      <div className="flex size-10 items-center justify-center rounded-full bg-primary">
+        <CheckIcon className="size-7 text-background" strokeWidth={3} />
+      </div>
+      <div className="text-lg font-bold text-primary">
+        {t('Outcome:')}
+        {' '}
+        {resolvedOutcomeLabel}
+      </div>
+      {((!isSingleMarket || shouldShowResolvedSportsSubtitle) && resolvedMarketTitle) && (
+        <div className="text-sm text-muted-foreground">{resolvedMarketTitle}</div>
+      )}
+      {hasClaimableWinnings && (
+        <div className="mt-2 w-full space-y-3 text-left">
+          <div className="w-full border-t border-border" />
+          <p className="text-center text-base font-semibold text-foreground">{t('Your Earnings')}</p>
+          <div className="space-y-1.5 text-sm">
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">{t('Position')}</span>
+              <span className="text-right font-medium text-foreground">{claimPositionLabel}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">{t('Value per share')}</span>
+              <span className="text-right font-medium text-foreground">{claimValuePerShareLabel}</span>
+            </div>
+            <div className="flex items-center justify-between gap-4">
+              <span className="text-muted-foreground">{t('Total')}</span>
+              <span className="text-right font-medium text-foreground">{claimTotalLabel}</span>
+            </div>
+          </div>
+          <Button
+            type="button"
+            className="h-10 w-full"
+            onClick={onClaimWinnings}
+            disabled={isClaimSubmitting || isPositionsLoading}
+          >
+            {isClaimSubmitting ? t('Submitting...') : t('Claim winnings')}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/app/[locale]/(platform)/event/[slug]/_types/EventOrderPanelTypes.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_types/EventOrderPanelTypes.ts
@@ -1,0 +1,28 @@
+import type { ReactNode } from 'react'
+import type { EventOrderPanelOutcomeSelectedAccent } from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton'
+import type { OUTCOME_INDEX } from '@/lib/constants'
+import type { OddsFormat } from '@/lib/odds-format'
+import type { Event, Market, Outcome } from '@/types'
+
+export interface EventOrderPanelFormProps {
+  isMobile: boolean
+  event: Event
+  initialMarket?: Market | null
+  initialOutcome?: Outcome | null
+  desktopMarketInfo?: ReactNode
+  mobileMarketInfo?: ReactNode
+  primaryOutcomeIndex?: number | null
+  oddsFormat?: OddsFormat
+  outcomeButtonStyleVariant?: 'default' | 'sports3d'
+  outcomeLabelOverrides?: Partial<Record<number, string>>
+  outcomeAccentOverrides?: Partial<Record<number, EventOrderPanelOutcomeSelectedAccent>>
+  optimisticallyClaimedConditionIds?: Record<string, true>
+}
+
+export type ConditionSharesMap = Record<string, Record<typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO, number>>
+
+export type ResolveDisplayOutcomeLabel = (
+  outcomeIndex: number | null | undefined,
+  outcomeText: string | null | undefined,
+  fallbackLabel: string,
+) => string


### PR DESCRIPTION
First PR in the split-components follow-up project. Breaks `EventOrderPanelForm.tsx` (2023 LOC) into focused sub-components per your request on #855.

## New files

| File | LOC | Responsibility |
|---|---|---|
| `EventOrderPanelResolvedMarketDisplay.tsx` | 79 | Resolved market outcome display + claim winnings button |
| `EventOrderPanelOutcomeSelector.tsx` | 60 | Yes/No outcome buttons with dynamic prices |
| `EventOrderPanelOrderInput.tsx` | 262 | Market/limit order inputs + validation warnings + earnings preview + submit button |
| `_types/EventOrderPanelTypes.ts` | 28 | Shared types (EventOrderPanelFormProps, ConditionSharesMap, ResolveDisplayOutcomeLabel) |

## Refactored main file

`EventOrderPanelForm.tsx`: 2023 → 1881 LOC. Keeps all 5 custom hooks (useUserSharesStoreSync, useResolvedMarketDisplay, useOrderBookComputations, useClaimablePositions, useOrderValidationFeedback), all state management, and the `onSubmit` + `handleClaimWinnings` handlers. The component body is now a thin orchestrator that delegates rendering to the 3 sub-components.

Hooks remain in the main file because they're tightly coupled to submission logic (onSubmit needs computed fills, resolved market data, and validation state).

## Test plan
- [x] `npx vitest run` → 487 tests pass
- [x] `npx tsc --noEmit` clean
- [x] Manual UX smoke: market/limit order flow, buy/sell, outcome selection, resolved market claim, validation warnings, earnings preview

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split `EventOrderPanelForm` into three focused sub-components and moved shared types to reduce complexity and improve reuse. No behavior changes; all hooks and submission logic remain in the form orchestrator.

- **Refactors**
  - Extracted `EventOrderPanelResolvedMarketDisplay` (resolved outcome + claim UI), `EventOrderPanelOutcomeSelector` (Yes/No buttons), and `EventOrderPanelOrderInput` (market/limit inputs, validation, earnings).
  - Moved shared types to `_types/EventOrderPanelTypes.ts`.
  - Kept the five custom hooks, state, and submit/claim handlers in `EventOrderPanelForm`, passing props to the new components.
  - Reduced `EventOrderPanelForm.tsx` by ~142 LOC (2023 → 1881).

<sup>Written for commit 1a03bfec40c9887d93efea4cfbef5f9f72bc9b9c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

