### PR TITLE
fix: keep useExtracted calls in local render scope to fix MISSING_MESSAGE

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeSecondaryNavigation.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeSecondaryNavigation.tsx
@@ -23,10 +23,10 @@ interface TagItem {
 interface UseResolvedTagItemsParams {
   tag: Pick<PlatformNavigationTag, 'childs' | 'sidebarItems' | 'slug'>
   activeSubtagSlug: string
-  t: ReturnType<typeof useExtracted>
 }
 
-function useResolvedTagItems({ tag, activeSubtagSlug, t }: UseResolvedTagItemsParams) {
+function useResolvedTagItems({ tag, activeSubtagSlug }: UseResolvedTagItemsParams) {
+  const t = useExtracted()
   const tagItems = useMemo<TagItem[]>(() => {
     if (tag.sidebarItems) {
       return tag.sidebarItems
@@ -214,8 +214,7 @@ export default function HomeSecondaryNavigation({
   showCategoryTitle = false,
   hideOnDesktop = false,
 }: HomeSecondaryNavigationProps) {
-  const t = useExtracted()
-  const { tagItems, resolvedActiveSubtagSlug } = useResolvedTagItems({ tag, activeSubtagSlug, t })
+  const { tagItems, resolvedActiveSubtagSlug } = useResolvedTagItems({ tag, activeSubtagSlug })
   const {
     scrollContainerRef,
     buttonRef,

--- a/src/app/[locale]/(platform)/_components/PositionShareDialog.tsx
+++ b/src/app/[locale]/(platform)/_components/PositionShareDialog.tsx
@@ -115,7 +115,8 @@ function useShareCardState(shareCardUrl: string) {
   return { shareCardStatus, setShareCardStatus, shareCardBlob }
 }
 
-function useShareOnXHandler(payload: ShareCardPayload | null, t: ReturnType<typeof useExtracted>) {
+function useShareOnXHandler(payload: ShareCardPayload | null) {
+  const t = useExtracted()
   const [isSharingOnX, setIsSharingOnX] = useState(false)
   const shareOnXTimeoutRef = useRef<number | null>(null)
 
@@ -167,12 +168,11 @@ function useShareOnXHandler(payload: ShareCardPayload | null, t: ReturnType<type
 function useCopyShareImage({
   shareCardBlob,
   shareCardUrl,
-  t,
 }: {
   shareCardBlob: Blob | null
   shareCardUrl: string
-  t: ReturnType<typeof useExtracted>
 }) {
+  const t = useExtracted()
   const [isCopyingShareImage, setIsCopyingShareImage] = useState(false)
 
   const handleCopyShareImage = useCallback(async () => {
@@ -224,7 +224,8 @@ function useCopyShareImage({
   return { isCopyingShareImage, handleCopyShareImage }
 }
 
-function useShareCardStatusHandlers(setShareCardStatus: (status: ShareCardStatus) => void, t: ReturnType<typeof useExtracted>) {
+function useShareCardStatusHandlers(setShareCardStatus: (status: ShareCardStatus) => void) {
+  const t = useExtracted()
   const handleShareCardLoaded = useCallback(() => {
     setShareCardStatus('ready')
   }, [setShareCardStatus])
@@ -243,9 +244,9 @@ function PositionShareDialogContent({
 }: PositionShareDialogContentProps) {
   const t = useExtracted()
   const { shareCardStatus, setShareCardStatus, shareCardBlob } = useShareCardState(shareCardUrl)
-  const { isCopyingShareImage, handleCopyShareImage } = useCopyShareImage({ shareCardBlob, shareCardUrl, t })
-  const { isSharingOnX, handleShareOnX } = useShareOnXHandler(payload, t)
-  const { handleShareCardLoaded, handleShareCardError } = useShareCardStatusHandlers(setShareCardStatus, t)
+  const { isCopyingShareImage, handleCopyShareImage } = useCopyShareImage({ shareCardBlob, shareCardUrl })
+  const { isSharingOnX, handleShareOnX } = useShareOnXHandler(payload)
+  const { handleShareCardLoaded, handleShareCardError } = useShareCardStatusHandlers(setShareCardStatus)
 
   const isShareReady = shareCardStatus === 'ready'
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -333,7 +333,6 @@ function useEventUserPositionsData({
   isNegRiskAugmented,
   userId,
   normalizeOutcomeLabel,
-  t,
 }: {
   event: Event
   ownerAddress: `0x${string}`
@@ -342,8 +341,8 @@ function useEventUserPositionsData({
   isNegRiskAugmented: boolean
   userId: string | undefined
   normalizeOutcomeLabel: (value: string | null | undefined) => string
-  t: ReturnType<typeof useExtracted>
 }) {
+  const t = useExtracted()
   const { data: userPositions } = useQuery<UserPosition[]>({
     queryKey: ['event-user-positions', ownerAddress, event.id],
     enabled: Boolean(ownerAddress),
@@ -738,7 +737,6 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
     isNegRiskAugmented,
     userId: user?.id,
     normalizeOutcomeLabel,
-    t,
   })
   const shouldShowOtherRow = isNegRiskAugmented && otherShares > 0
   const { cashOutPayload, handleCashOut, handleCashOutModalChange, handleCashOutSubmit, dismissCashOut } = useCashOutFlow({

--- a/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
+++ b/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
@@ -287,7 +287,6 @@ function useGeneralSettingsFormState({
   )
 
   return {
-    t,
     router,
     state,
     formAction,
@@ -386,8 +385,8 @@ function AdminGeneralSettingsFormInner({
   initialTermsOfServicePdfUrl,
   openRouterSettings,
 }: AdminGeneralSettingsFormProps) {
+  const t = useExtracted()
   const {
-    t,
     router,
     state,
     formAction,

--- a/src/app/[locale]/admin/(general)/_components/AllowedMarketCreatorsManager.tsx
+++ b/src/app/[locale]/admin/(general)/_components/AllowedMarketCreatorsManager.tsx
@@ -126,7 +126,6 @@ function useAllowedMarketCreatorsState(disabled: boolean) {
   }, [dialogMode, disabled, isSubmitting, siteUrl, walletAddress, walletName])
 
   return {
-    t,
     items,
     setItems,
     isLoading,
@@ -153,8 +152,8 @@ function useAllowedMarketCreatorsState(disabled: boolean) {
 export default function AllowedMarketCreatorsManager({
   disabled = false,
 }: AllowedMarketCreatorsManagerProps) {
+  const t = useExtracted()
   const {
-    t,
     items,
     setItems,
     isLoading,

--- a/src/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm.tsx
+++ b/src/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm.tsx
@@ -39,7 +39,7 @@ function useAffiliateSettingsForm() {
     wasPendingRef.current = isPending
   }, [isPending, state.error, t])
 
-  return { t, state, formAction, isPending }
+  return { state, formAction, isPending }
 }
 
 export default function AdminAffiliateSettingsForm({
@@ -48,7 +48,8 @@ export default function AdminAffiliateSettingsForm({
   minTradeFeeBps = 0,
   updatedAtLabel,
 }: AdminAffiliateSettingsFormProps) {
-  const { t, state, formAction, isPending } = useAffiliateSettingsForm()
+  const t = useExtracted()
+  const { state, formAction, isPending } = useAffiliateSettingsForm()
   const minTradeFeePercent = (minTradeFeeBps / 100).toFixed(2)
 
   return (

--- a/src/app/[locale]/admin/categories/_components/AdminCategoriesTable.tsx
+++ b/src/app/[locale]/admin/categories/_components/AdminCategoriesTable.tsx
@@ -276,7 +276,6 @@ function useAdminCategoriesTableState() {
   })
 
   return {
-    t,
     isMobile,
     categories,
     totalCount,
@@ -316,8 +315,8 @@ function useAdminCategoriesTableState() {
 }
 
 export default function AdminCategoriesTable() {
+  const t = useExtracted()
   const {
-    t,
     isMobile,
     categories,
     totalCount,

--- a/src/app/[locale]/admin/categories/_components/MainCategorySortDialog.tsx
+++ b/src/app/[locale]/admin/categories/_components/MainCategorySortDialog.tsx
@@ -144,7 +144,6 @@ function useMainCategorySortState({
   }, [handleOpenChange, onSaved, orderedCategories, queryClient, t])
 
   return {
-    t,
     isMobile,
     orderedCategories,
     error,
@@ -164,8 +163,8 @@ export default function MainCategorySortDialog({
   onOpenChange,
   onSaved,
 }: MainCategorySortDialogProps) {
+  const t = useExtracted()
   const {
-    t,
     isMobile,
     orderedCategories,
     error,

--- a/src/app/[locale]/admin/events/_components/AdminEventsTable.tsx
+++ b/src/app/[locale]/admin/events/_components/AdminEventsTable.tsx
@@ -367,7 +367,6 @@ function useAdminEventsTableState(initialAutoDeployNewEventsEnabled: boolean) {
   })
 
   return {
-    t,
     events,
     totalCount,
     isLoading,
@@ -434,8 +433,8 @@ export default function AdminEventsTable({
   initialAutoDeployNewEventsEnabled,
   mainCategoryOptions,
 }: AdminEventsTableProps) {
+  const t = useExtracted()
   const {
-    t,
     events,
     totalCount,
     isLoading,

--- a/src/app/[locale]/admin/locales/_components/AdminLocalesSettingsForm.tsx
+++ b/src/app/[locale]/admin/locales/_components/AdminLocalesSettingsForm.tsx
@@ -65,7 +65,6 @@ function useLocalesSettingsForm(
   }, [isPending, state.error, t])
 
   return {
-    t,
     state,
     formAction,
     isPending,
@@ -82,8 +81,8 @@ function AdminLocalesSettingsFormInner({
   automaticTranslationsEnabled,
   isOpenRouterConfigured,
 }: AdminLocalesSettingsFormProps) {
+  const t = useExtracted()
   const {
-    t,
     state,
     formAction,
     isPending,

--- a/src/app/[locale]/admin/market-context/_components/AdminMarketContextSettingsForm.tsx
+++ b/src/app/[locale]/admin/market-context/_components/AdminMarketContextSettingsForm.tsx
@@ -65,7 +65,6 @@ function useMarketContextSettingsForm(defaultPrompt: string, isEnabled: boolean)
   }, [isPending, state.error, t])
 
   return {
-    t,
     textareaRef,
     highlightTimeoutRef,
     variableLiftTimeoutRef,
@@ -88,8 +87,8 @@ function AdminMarketContextSettingsFormInner({
   isEnabled,
   variables,
 }: AdminMarketContextSettingsFormProps) {
+  const t = useExtracted()
   const {
-    t,
     textareaRef,
     highlightTimeoutRef,
     variableLiftTimeoutRef,

--- a/src/app/[locale]/admin/theme/_components/AdminThemeSettingsForm.tsx
+++ b/src/app/[locale]/admin/theme/_components/AdminThemeSettingsForm.tsx
@@ -278,7 +278,6 @@ function getRadiusPresetButtonStyle(presetValue: string): CSSProperties {
 }
 
 function useRadiusControlState(radiusValue: string) {
-  const t = useExtracted()
   const normalizedRadius = radiusValue.trim()
   const effectiveRadius = normalizedRadius || DEFAULT_RADIUS_VALUE
   const selectedPresetValue = useMemo(() => {
@@ -295,7 +294,7 @@ function useRadiusControlState(radiusValue: string) {
     return matchedPreset?.value ?? null
   }, [effectiveRadius])
 
-  return { t, normalizedRadius, selectedPresetValue }
+  return { normalizedRadius, selectedPresetValue }
 }
 
 function RadiusControl({
@@ -311,7 +310,8 @@ function RadiusControl({
   onRadiusReset: () => void
   error: string | null
 }) {
-  const { t, normalizedRadius, selectedPresetValue } = useRadiusControlState(radiusValue)
+  const t = useExtracted()
+  const { normalizedRadius, selectedPresetValue } = useRadiusControlState(radiusValue)
 
   return (
     <div className="grid gap-3 rounded-md border border-border p-3">
@@ -365,9 +365,8 @@ function RadiusControl({
 }
 
 function useThemePreviewCardState(overrides: ThemeOverrides, radius: string | null) {
-  const t = useExtracted()
   const style = useMemo(() => buildPreviewStyle(overrides, radius), [overrides, radius])
-  return { t, style }
+  return { style }
 }
 
 function ThemePreviewCard({
@@ -387,7 +386,8 @@ function ThemePreviewCard({
   logoSvg: string
   logoImageUrl: string | null
 }) {
-  const { t, style } = useThemePreviewCardState(overrides, radius)
+  const t = useExtracted()
+  const { style } = useThemePreviewCardState(overrides, radius)
 
   return (
     <div
@@ -613,7 +613,6 @@ function resolveBaseThemeValues(presetId: string) {
 }
 
 function useThemeTokenMatrixState(presetId: string) {
-  const t = useExtracted()
   const [baseThemeValues, setBaseThemeValues] = useState<{
     lightValues: ThemeOverrides
     darkValues: ThemeOverrides
@@ -635,7 +634,7 @@ function useThemeTokenMatrixState(presetId: string) {
     return initialState
   })
 
-  return { t, baseLightValues, baseDarkValues, openGroups, setOpenGroups }
+  return { baseLightValues, baseDarkValues, openGroups, setOpenGroups }
 }
 
 function ThemeTokenMatrix({
@@ -661,7 +660,8 @@ function ThemeTokenMatrix({
   lightParseError: string | null
   darkParseError: string | null
 }) {
-  const { t, baseLightValues, baseDarkValues, openGroups, setOpenGroups } = useThemeTokenMatrixState(presetId)
+  const t = useExtracted()
+  const { baseLightValues, baseDarkValues, openGroups, setOpenGroups } = useThemeTokenMatrixState(presetId)
 
   return (
     <div className="flex flex-col gap-3">
@@ -916,7 +916,6 @@ function useThemeSettingsForm(initialThemeSettings: AdminThemeSettingsInitialSta
   }, [draftCssText, isPending, parsedPreset, state.error, t])
 
   return {
-    t,
     state,
     formAction,
     isPending,
@@ -942,8 +941,8 @@ function AdminThemeSettingsFormInner({
   initialThemeSettings,
   initialThemeSiteSettings,
 }: AdminThemeSettingsFormProps) {
+  const t = useExtracted()
   const {
-    t,
     state,
     formAction,
     isPending,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes translation errors by keeping `useExtracted()` calls inside the local render scope. Removes threaded `t` params/returns across components to prevent `MISSING_MESSAGE`.

- **Bug Fixes**
  - Inline `useExtracted()` in local hooks/components (home nav, share dialog, event markets, admin forms/tables, theme settings).
  - Remove `t` from hook signatures and returns; read translations where used.
  - No UI changes; resolves runtime `MISSING_MESSAGE` in affected views.

<sup>Written for commit 9eafe40611ae63a8e761e763546f6151b0a9f065. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

