### PR TITLE
fix: move params access outside use cache in platform slug routes

### DIFF
--- a/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
@@ -1,5 +1,3 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
@@ -14,10 +12,16 @@ import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export const generateStaticParams = generateDynamicHomeSubcategoryStaticParams
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]/[subcategory]'>): Promise<Metadata> {
-  const { locale, slug, subcategory } = await params
-  const resolvedLocale = locale as SupportedLocale
-  setRequestLocale(resolvedLocale)
+async function generatePlatformSubcategoryMetadata({
+  locale,
+  slug,
+  subcategory,
+}: {
+  locale: SupportedLocale
+  slug: string
+  subcategory: string
+}): Promise<Metadata> {
+  'use cache'
 
   if (slug === STATIC_PARAMS_PLACEHOLDER || subcategory === STATIC_PARAMS_PLACEHOLDER) {
     notFound()
@@ -27,7 +31,41 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]/[
     notFound()
   }
 
-  return buildDynamicHomeSubcategoryMetadata(resolvedLocale, slug, subcategory)
+  return buildDynamicHomeSubcategoryMetadata(locale, slug, subcategory)
+}
+
+async function renderPlatformSubcategoryPage({
+  locale,
+  slug,
+  subcategory,
+}: {
+  locale: SupportedLocale
+  slug: string
+  subcategory: string
+}) {
+  'use cache'
+
+  if (slug === STATIC_PARAMS_PLACEHOLDER || subcategory === STATIC_PARAMS_PLACEHOLDER) {
+    notFound()
+  }
+
+  if (normalizePublicProfileSlug(slug).type !== 'invalid' || isPlatformReservedRootSlug(slug)) {
+    notFound()
+  }
+
+  return <DynamicHomeSubcategoryPageContent locale={locale} slug={slug} subcategory={subcategory} />
+}
+
+export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]/[subcategory]'>): Promise<Metadata> {
+  const { locale, slug, subcategory } = await params
+  const resolvedLocale = locale as SupportedLocale
+  setRequestLocale(resolvedLocale)
+
+  return await generatePlatformSubcategoryMetadata({
+    locale: resolvedLocale,
+    slug,
+    subcategory,
+  })
 }
 
 export default async function PlatformSubcategoryPage({ params }: PageProps<'/[locale]/[slug]/[subcategory]'>) {
@@ -35,13 +73,9 @@ export default async function PlatformSubcategoryPage({ params }: PageProps<'/[l
   const resolvedLocale = locale as SupportedLocale
   setRequestLocale(resolvedLocale)
 
-  if (slug === STATIC_PARAMS_PLACEHOLDER || subcategory === STATIC_PARAMS_PLACEHOLDER) {
-    notFound()
-  }
-
-  if (normalizePublicProfileSlug(slug).type !== 'invalid' || isPlatformReservedRootSlug(slug)) {
-    notFound()
-  }
-
-  return <DynamicHomeSubcategoryPageContent locale={resolvedLocale} slug={slug} subcategory={subcategory} />
+  return await renderPlatformSubcategoryPage({
+    locale: resolvedLocale,
+    slug,
+    subcategory,
+  })
 }

--- a/src/app/[locale]/(platform)/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/page.tsx
@@ -1,5 +1,3 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
@@ -16,10 +14,14 @@ import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export const generateStaticParams = generateDynamicHomeCategoryStaticParams
 
-export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]'>): Promise<Metadata> {
-  const { locale, slug } = await params
-  const resolvedLocale = locale as SupportedLocale
-  setRequestLocale(resolvedLocale)
+async function generatePlatformSlugMetadata({
+  locale,
+  slug,
+}: {
+  locale: SupportedLocale
+  slug: string
+}): Promise<Metadata> {
+  'use cache'
 
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     notFound()
@@ -29,7 +31,7 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]'>
   if (profileSlug.type !== 'invalid') {
     return await buildPublicProfileMetadata({
       slug,
-      locale: resolvedLocale,
+      locale,
     })
   }
 
@@ -37,13 +39,17 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]'>
     notFound()
   }
 
-  return buildDynamicHomeCategoryMetadata(resolvedLocale, slug)
+  return buildDynamicHomeCategoryMetadata(locale, slug)
 }
 
-export default async function PlatformSlugPage({ params }: PageProps<'/[locale]/[slug]'>) {
-  const { locale, slug } = await params
-  const resolvedLocale = locale as SupportedLocale
-  setRequestLocale(resolvedLocale)
+async function renderPlatformSlugPage({
+  locale,
+  slug,
+}: {
+  locale: SupportedLocale
+  slug: string
+}) {
+  'use cache'
 
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     notFound()
@@ -66,5 +72,27 @@ export default async function PlatformSlugPage({ params }: PageProps<'/[locale]/
     notFound()
   }
 
-  return <DynamicHomeCategoryPageContent locale={resolvedLocale} slug={slug} />
+  return <DynamicHomeCategoryPageContent locale={locale} slug={slug} />
+}
+
+export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]'>): Promise<Metadata> {
+  const { locale, slug } = await params
+  const resolvedLocale = locale as SupportedLocale
+  setRequestLocale(resolvedLocale)
+
+  return await generatePlatformSlugMetadata({
+    locale: resolvedLocale,
+    slug,
+  })
+}
+
+export default async function PlatformSlugPage({ params }: PageProps<'/[locale]/[slug]'>) {
+  const { locale, slug } = await params
+  const resolvedLocale = locale as SupportedLocale
+  setRequestLocale(resolvedLocale)
+
+  return await renderPlatformSlugPage({
+    locale: resolvedLocale,
+    slug,
+  })
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes prerender timeouts on platform slug routes by reading `params` and setting the locale before any cached logic runs. Scopes `'use cache'` to metadata/render helpers so Next.js caching doesn’t capture unresolved `params`.

- **Bug Fixes**
  - Removed top-level `'use cache'` and extracted cached helpers: `generatePlatformSlugMetadata`/`renderPlatformSlugPage` and `generatePlatformSubcategoryMetadata`/`renderPlatformSubcategoryPage`.
  - Access `params` and call `setRequestLocale` first, then invoke the cached helpers; keeps existing `notFound()` guards and behavior unchanged while preventing prerender timeouts.

<sup>Written for commit d743b0307db9ff412670db2283fd3a7026067b4b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

