### PR TITLE
fix: event page use cache prerender timeout

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
@@ -1,5 +1,3 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
@@ -40,6 +38,8 @@ async function CachedEventMarketPageContent({
   slug: string
   market: string
 }) {
+  'use cache'
+
   const eventRoute = await getEventRouteBySlug(slug)
   if (!eventRoute) {
     notFound()

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventSeriesPills.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventSeriesPills.tsx
@@ -13,13 +13,17 @@ import { cn } from '@/lib/utils'
 const MAX_PAST_RESULT_BADGES = 5
 const LIVE_TRADING_WINDOW_MS = 24 * 60 * 60 * 1000
 const NOW_TICK_INTERVAL_MS = 1000
-let nowTimestampStore = Date.now()
+let nowTimestampStore = 0
 const nowTimestampListeners = new Set<() => void>()
 let nowTimestampInterval: number | null = null
 
 function subscribeToNowTimestamp(onStoreChange: () => void) {
   nowTimestampListeners.add(onStoreChange)
-  nowTimestampStore = Date.now()
+  const nextNowTimestamp = Date.now()
+  if (nextNowTimestamp !== nowTimestampStore) {
+    nowTimestampStore = nextNowTimestamp
+    onStoreChange()
+  }
 
   if (nowTimestampInterval === null) {
     nowTimestampInterval = window.setInterval(() => {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/ResolutionTimelinePanel.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/ResolutionTimelinePanel.tsx
@@ -2,7 +2,7 @@ import type { ResolutionTimelineItem, ResolutionTimelineOutcome } from '@/app/[l
 import type { Event } from '@/types'
 import { CheckIcon, GavelIcon, SquareArrowOutUpRightIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
-import { useEffect, useMemo, useState } from 'react'
+import { useMemo, useSyncExternalStore } from 'react'
 import {
   buildResolutionTimeline,
   formatResolutionCountdown,
@@ -20,6 +20,45 @@ interface ResolutionTimelinePanelProps {
   outcomeOverride?: ResolutionTimelineOutcome | null
   showLink?: boolean
   className?: string
+}
+
+const RESOLUTION_TIMELINE_TICK_INTERVAL_MS = 1000
+let resolutionTimelineNowMsStore = 0
+const resolutionTimelineNowMsListeners = new Set<() => void>()
+let resolutionTimelineNowMsInterval: number | null = null
+
+function subscribeToResolutionTimelineNowMs(onStoreChange: () => void) {
+  resolutionTimelineNowMsListeners.add(onStoreChange)
+  const nextNowTimestamp = Date.now()
+  if (nextNowTimestamp !== resolutionTimelineNowMsStore) {
+    resolutionTimelineNowMsStore = nextNowTimestamp
+    onStoreChange()
+  }
+
+  if (resolutionTimelineNowMsInterval === null) {
+    resolutionTimelineNowMsInterval = window.setInterval(() => {
+      resolutionTimelineNowMsStore = Date.now()
+      for (const listener of resolutionTimelineNowMsListeners) {
+        listener()
+      }
+    }, RESOLUTION_TIMELINE_TICK_INTERVAL_MS)
+  }
+
+  return () => {
+    resolutionTimelineNowMsListeners.delete(onStoreChange)
+    if (resolutionTimelineNowMsListeners.size === 0 && resolutionTimelineNowMsInterval !== null) {
+      window.clearInterval(resolutionTimelineNowMsInterval)
+      resolutionTimelineNowMsInterval = null
+    }
+  }
+}
+
+function getResolutionTimelineNowMsSnapshot() {
+  return resolutionTimelineNowMsStore
+}
+
+function getResolutionTimelineNowMsServerSnapshot() {
+  return 0
 }
 
 function TimelineIcon({ item }: { item: ResolutionTimelineItem }) {
@@ -164,35 +203,19 @@ function TimelineLabel({
 }
 
 function useResolutionTimeline(market: Event['markets'][number], siteName: string) {
-  const [nowMs, setNowMs] = useState(() => Date.now())
-
+  const nowMs = useSyncExternalStore(
+    subscribeToResolutionTimelineNowMs,
+    getResolutionTimelineNowMsSnapshot,
+    getResolutionTimelineNowMsServerSnapshot,
+  )
   const timeline = useMemo(
-    () => buildResolutionTimeline(market, { nowMs }),
+    () => (nowMs <= 0 ? null : buildResolutionTimeline(market, { nowMs })),
     [market, nowMs],
   )
   const disputeUrl = useMemo(
     () => buildUmaProposeUrl(market.condition, siteName),
     [market.condition, siteName],
   )
-
-  const hasActiveCountdown = timeline.items.some(item =>
-    (item.type === 'finalReview' || item.type === 'disputeWindow')
-    && item.state === 'active'
-    && (item.remainingSeconds ?? 0) > 0)
-
-  useEffect(function countdownTickEffect() {
-    if (!hasActiveCountdown) {
-      return
-    }
-
-    const interval = window.setInterval(() => {
-      setNowMs(Date.now())
-    }, 1000)
-
-    return function cleanupCountdownTick() {
-      window.clearInterval(interval)
-    }
-  }, [hasActiveCountdown])
 
   return { timeline, disputeUrl }
 }
@@ -213,7 +236,7 @@ export default function ResolutionTimelinePanel({
   const yesOutcomeLabel = (yesOutcomeText ? normalizeOutcomeLabel(yesOutcomeText) : '') || yesOutcomeText || t('Yes')
   const noOutcomeLabel = (noOutcomeText ? normalizeOutcomeLabel(noOutcomeText) : '') || noOutcomeText || t('No')
 
-  if (timeline.items.length === 0) {
+  if (!timeline || timeline.items.length === 0) {
     return null
   }
 

--- a/src/app/[locale]/(platform)/event/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/page.tsx
@@ -1,5 +1,3 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes event page prerender timeouts by scoping `use cache` to market content and replacing effect-based timers with a shared clock. Stabilizes countdowns and live badges without hydration flicker.

- **Bug Fixes**
  - Moved `use cache` into `CachedEventMarketPageContent` so route param parsing and `notFound()` run outside the cache boundary, preventing prerender timeouts.
  - Removed top-level `use cache` from event slug pages.
  - Replaced effect-based intervals with a `useSyncExternalStore` clock in `ResolutionTimelinePanel` (server-safe snapshot, starts/stops only when subscribed). Skips rendering until clock is ready to avoid SSR/CSR mismatch.
  - Updated `EventSeriesPills` timestamp store to initialize on subscribe, dedupe updates, and clean up intervals, fixing initial render flicker for live trading windows.

<sup>Written for commit f3a3989c3235a99d6d7cc0fe8a0803c90370ad77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

