### PR TITLE
fix: defer event metadata to request time to prevent use cache timeout

### DIFF
--- a/src/lib/event-open-graph.ts
+++ b/src/lib/event-open-graph.ts
@@ -2,6 +2,7 @@ import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import type { Event } from '@/types'
 import { notFound } from 'next/navigation'
+import { connection } from 'next/server'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { loadEventPageShellData } from '@/lib/event-page-data'
@@ -122,6 +123,8 @@ export async function buildEventPageMetadata({
   locale,
   marketSlug,
 }: BuildEventPageMetadataOptions): Promise<Metadata> {
+  await connection()
+
   const shellData = await loadEventPageShellData(eventSlug, locale)
   const title = shellData.title
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Defer event page metadata generation to request time to avoid the Next.js "use cache timeout" error. Adds `await connection()` from `next/server` before loading shell data in `buildEventPageMetadata`, preventing stale Open Graph metadata.

<sup>Written for commit f4263280c2caed26a95d95a77a49142891fc4466. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

