### PR TITLE
fix: move event metadata dynamic marker to page boundary

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
@@ -3,6 +3,7 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import EventContent from '@/app/[locale]/(platform)/event/[slug]/_components/EventContent'
+import RequestTimeDynamicMarker from '@/components/RequestTimeDynamicMarker'
 import EventStructuredData from '@/components/seo/EventStructuredData'
 import { redirect } from '@/i18n/navigation'
 import { buildEventPageMetadata } from '@/lib/event-open-graph'
@@ -93,5 +94,10 @@ export default async function EventMarketPage({ params }: PageProps<'/[locale]/e
     notFound()
   }
 
-  return <CachedEventMarketPageContent locale={resolvedLocale} slug={slug} market={market} />
+  return (
+    <>
+      <RequestTimeDynamicMarker />
+      <CachedEventMarketPageContent locale={resolvedLocale} slug={slug} market={market} />
+    </>
+  )
 }

--- a/src/app/[locale]/(platform)/event/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/page.tsx
@@ -3,6 +3,7 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import EventContent from '@/app/[locale]/(platform)/event/[slug]/_components/EventContent'
+import RequestTimeDynamicMarker from '@/components/RequestTimeDynamicMarker'
 import EventStructuredData from '@/components/seo/EventStructuredData'
 import { redirect } from '@/i18n/navigation'
 import { buildEventPageMetadata } from '@/lib/event-open-graph'
@@ -87,5 +88,10 @@ export default async function EventPage({ params }: PageProps<'/[locale]/event/[
     notFound()
   }
 
-  return <CachedEventPageContent locale={resolvedLocale} slug={slug} />
+  return (
+    <>
+      <RequestTimeDynamicMarker />
+      <CachedEventPageContent locale={resolvedLocale} slug={slug} />
+    </>
+  )
 }

--- a/src/components/RequestTimeDynamicMarker.tsx
+++ b/src/components/RequestTimeDynamicMarker.tsx
@@ -1,0 +1,15 @@
+import { connection } from 'next/server'
+import { Suspense } from 'react'
+
+async function RequestTimeConnection() {
+  await connection()
+  return null
+}
+
+export default function RequestTimeDynamicMarker() {
+  return (
+    <Suspense>
+      <RequestTimeConnection />
+    </Suspense>
+  )
+}

--- a/src/lib/event-open-graph.ts
+++ b/src/lib/event-open-graph.ts
@@ -2,7 +2,6 @@ import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import type { Event } from '@/types'
 import { notFound } from 'next/navigation'
-import { connection } from 'next/server'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { loadEventPageShellData } from '@/lib/event-page-data'
@@ -123,8 +122,6 @@ export async function buildEventPageMetadata({
   locale,
   marketSlug,
 }: BuildEventPageMetadataOptions): Promise<Metadata> {
-  await connection()
-
   const shellData = await loadEventPageShellData(eventSlug, locale)
   const title = shellData.title
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved the request-time dynamic marker to the event page boundary. This fixes dynamic OG metadata and ensures per-request rendering with correct caching.

- **Bug Fixes**
  - Added `RequestTimeDynamicMarker` that awaits `connection()` from `next/server` inside `Suspense`.
  - Placed it at the top of event pages `[slug]` and `[slug]/[market]` before cached content.
  - Removed `connection()` from `buildEventPageMetadata` to keep dynamic markers at the page boundary.

<sup>Written for commit cc7979fbf63470d16f183b8201870f3cd40d2063. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

