### PR TITLE
fix: use cache timeout event metadata

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
@@ -1,8 +1,6 @@
 import type { SupportedLocale } from '@/i18n/locales'
 import type { Event } from '@/types'
-import { cacheTag } from 'next/cache'
 import HomeClient from '@/app/[locale]/(platform)/(home)/_components/HomeClient'
-import { cacheTags } from '@/lib/cache-tags'
 import { listHomeEventsPage } from '@/lib/home-events-page'
 
 interface HomeContentProps {
@@ -11,21 +9,15 @@ interface HomeContentProps {
   initialMainTag?: string
 }
 
-function getServerCurrentTimestamp() {
-  return Date.now()
-}
-
 export default async function HomeContent({
   locale,
   initialTag,
   initialMainTag,
 }: HomeContentProps) {
-  cacheTag(cacheTags.eventsList)
   const resolvedLocale = locale as SupportedLocale
   const initialTagSlug = initialTag ?? 'trending'
   const initialMainTagSlug = initialMainTag ?? initialTagSlug
-  const serverCurrentTimestamp = getServerCurrentTimestamp()
-  let initialCurrentTimestamp: number | null = serverCurrentTimestamp
+  let initialCurrentTimestamp: number | null = null
 
   let initialEvents: Event[] = []
 
@@ -37,10 +29,10 @@ export default async function HomeContent({
       userId: '',
       bookmarked: false,
       locale: resolvedLocale,
-      currentTimestamp: serverCurrentTimestamp,
+      currentTimestamp: null,
     })
 
-    initialCurrentTimestamp = currentTimestamp ?? serverCurrentTimestamp
+    initialCurrentTimestamp = currentTimestamp ?? null
 
     if (!error) {
       initialEvents = events ?? []

--- a/src/app/[locale]/(platform)/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/page.tsx
@@ -21,8 +21,6 @@ async function generatePlatformSlugMetadata({
   locale: SupportedLocale
   slug: string
 }): Promise<Metadata> {
-  'use cache'
-
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     notFound()
   }
@@ -49,8 +47,6 @@ async function renderPlatformSlugPage({
   locale: SupportedLocale
   slug: string
 }) {
-  'use cache'
-
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
     notFound()
   }

--- a/src/lib/event-page-data.ts
+++ b/src/lib/event-page-data.ts
@@ -141,10 +141,6 @@ export async function loadEventPageShellData(
   eventSlug: string,
   locale: SupportedLocale,
 ): Promise<EventPageShellData> {
-  'use cache'
-  cacheTag(cacheTags.event(eventSlug))
-  cacheTag(cacheTags.settings)
-
   const [route, title, runtimeTheme] = await Promise.all([
     getEventRouteBySlug(eventSlug),
     getEventTitleBySlug(eventSlug, locale),

--- a/tests/unit/homeContent.test.ts
+++ b/tests/unit/homeContent.test.ts
@@ -1,12 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  cacheTag: vi.fn(),
   listHomeEventsPage: vi.fn(),
-}))
-
-vi.mock('next/cache', () => ({
-  cacheTag: (...args: any[]) => mocks.cacheTag(...args),
 }))
 
 vi.mock('@/lib/home-events-page', () => ({
@@ -19,7 +14,6 @@ vi.mock('@/app/[locale]/(platform)/(home)/_components/HomeClient', () => ({
 
 describe('homeContent', () => {
   beforeEach(() => {
-    mocks.cacheTag.mockReset()
     mocks.listHomeEventsPage.mockReset()
   })
 
@@ -37,7 +31,7 @@ describe('homeContent', () => {
       tag: 'ai',
       mainTag: 'tech',
       locale: 'en',
-      currentTimestamp: expect.any(Number),
+      currentTimestamp: null,
     }))
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch caching to use event metadata for timeouts, removing `next/cache` directives and server timestamps that caused premature revalidation. Prevents cache timeout conflicts on event pages and the home feed.

- **Bug Fixes**
  - Removed `cacheTag` and `'use cache'` from event shell and platform slug pages to avoid forced TTL from `next/cache`.
  - HomeContent no longer computes a server timestamp; passes `currentTimestamp: null` to rely on event metadata.
  - Updated unit test to expect `currentTimestamp: null` and dropped `next/cache` mocks.

<sup>Written for commit 0bdca96013bae3a515b44c79f475db7647c43244. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

