### PR TITLE
fix: unwanted MPA fallback while navigating to an event page

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
@@ -3,7 +3,6 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import EventContent from '@/app/[locale]/(platform)/event/[slug]/_components/EventContent'
-import RequestTimeDynamicMarker from '@/components/RequestTimeDynamicMarker'
 import EventStructuredData from '@/components/seo/EventStructuredData'
 import { redirect } from '@/i18n/navigation'
 import { buildEventPageMetadata } from '@/lib/event-open-graph'
@@ -94,10 +93,5 @@ export default async function EventMarketPage({ params }: PageProps<'/[locale]/e
     notFound()
   }
 
-  return (
-    <>
-      <RequestTimeDynamicMarker />
-      <CachedEventMarketPageContent locale={resolvedLocale} slug={slug} market={market} />
-    </>
-  )
+  return <CachedEventMarketPageContent locale={resolvedLocale} slug={slug} market={market} />
 }

--- a/src/app/[locale]/(platform)/event/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/page.tsx
@@ -3,7 +3,6 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import EventContent from '@/app/[locale]/(platform)/event/[slug]/_components/EventContent'
-import RequestTimeDynamicMarker from '@/components/RequestTimeDynamicMarker'
 import EventStructuredData from '@/components/seo/EventStructuredData'
 import { redirect } from '@/i18n/navigation'
 import { buildEventPageMetadata } from '@/lib/event-open-graph'
@@ -88,10 +87,5 @@ export default async function EventPage({ params }: PageProps<'/[locale]/event/[
     notFound()
   }
 
-  return (
-    <>
-      <RequestTimeDynamicMarker />
-      <CachedEventPageContent locale={resolvedLocale} slug={slug} />
-    </>
-  )
+  return <CachedEventPageContent locale={resolvedLocale} slug={slug} />
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `RequestTimeDynamicMarker` from event pages to prevent unwanted MPA fallback during navigation. Event content now renders directly via `CachedEventPageContent` and `CachedEventMarketPageContent` for smooth SPA transitions.

<sup>Written for commit b34752f260c06fc5a662f4b30f53a5a1aba99f1d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

