### PR TITLE
fix: use cache timeout homepage

### DIFF
--- a/src/app/[locale]/(platform)/(home)/page.tsx
+++ b/src/app/[locale]/(platform)/(home)/page.tsx
@@ -1,10 +1,16 @@
-'use cache'
-
+import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
+
+async function CachedHomePageContent({ locale }: { locale: SupportedLocale }) {
+  'use cache'
+
+  return <HomeContent locale={locale} />
+}
 
 export default async function HomePage({ params }: PageProps<'/[locale]'>) {
   const { locale } = await params
   setRequestLocale(locale)
-  return <HomeContent locale={locale} />
+  const resolvedLocale = locale as SupportedLocale
+  return <CachedHomePageContent locale={resolvedLocale} />
 }

--- a/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
@@ -3,7 +3,6 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import EventContent from '@/app/[locale]/(platform)/event/[slug]/_components/EventContent'
-import RequestTimeDynamicMarker from '@/components/RequestTimeDynamicMarker'
 import EventStructuredData from '@/components/seo/EventStructuredData'
 import { redirect } from '@/i18n/navigation'
 import { buildEventPageMetadata } from '@/lib/event-open-graph'
@@ -94,10 +93,5 @@ export default async function EventMarketPage({ params }: PageProps<'/[locale]/e
     notFound()
   }
 
-  return (
-    <>
-      <RequestTimeDynamicMarker />
-      <CachedEventMarketPageContent locale={resolvedLocale} slug={slug} market={market} />
-    </>
-  )
+  return <CachedEventMarketPageContent locale={resolvedLocale} slug={slug} market={market} />
 }

--- a/src/app/[locale]/(platform)/event/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/page.tsx
@@ -3,7 +3,6 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import EventContent from '@/app/[locale]/(platform)/event/[slug]/_components/EventContent'
-import RequestTimeDynamicMarker from '@/components/RequestTimeDynamicMarker'
 import EventStructuredData from '@/components/seo/EventStructuredData'
 import { redirect } from '@/i18n/navigation'
 import { buildEventPageMetadata } from '@/lib/event-open-graph'
@@ -88,10 +87,5 @@ export default async function EventPage({ params }: PageProps<'/[locale]/event/[
     notFound()
   }
 
-  return (
-    <>
-      <RequestTimeDynamicMarker />
-      <CachedEventPageContent locale={resolvedLocale} slug={slug} />
-    </>
-  )
+  return <CachedEventPageContent locale={resolvedLocale} slug={slug} />
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Scoped caching to the homepage content component to prevent cache timeouts, and removed the dynamic marker from event pages to stop unwanted MPA fallback when navigating.

- **Bug Fixes**
  - Moved `'use cache'` into `CachedHomePageContent` and passed `SupportedLocale` to avoid cache timeout in the params flow.
  - Removed `RequestTimeDynamicMarker` from event pages and returned cached content directly to prevent MPA fallback.

<sup>Written for commit 16c771eb87e91dbdb1f0edf80e2cf8e5a71f4267. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

