### PR TITLE
fix: cache timeout regression

### DIFF
--- a/src/lib/event-page-data.ts
+++ b/src/lib/event-page-data.ts
@@ -45,17 +45,11 @@ export async function resolveCanonicalEventSlugFromSportsPath(
 }
 
 export async function getEventTitleBySlug(eventSlug: string, locale: SupportedLocale) {
-  'use cache'
-  cacheTag(cacheTags.event(eventSlug))
-
   const { data } = await EventRepository.getEventTitleBySlug(eventSlug, locale)
   return data?.title ?? null
 }
 
 export async function getEventRouteBySlug(eventSlug: string) {
-  'use cache'
-  cacheTag(cacheTags.event(eventSlug))
-
   const { data, error } = await EventRepository.getEventRouteBySlug(eventSlug)
   if (error || !data) {
     return null


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed caching directives and tags from event slug lookups to fix a timeout regression that caused stale titles and routes to be served. Calls now skip tag-based caching and return fresh data using the repository defaults.

- **Bug Fixes**
  - Removed 'use cache' and `cacheTag(cacheTags.event(eventSlug))` in `getEventTitleBySlug` and `getEventRouteBySlug`.

<sup>Written for commit 312609d0a0538d278c4765c4a1453322ec0ec8c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

