### PR TITLE
fix: N+1 api call to prices-history

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -59,6 +59,69 @@ import EventChartLayout from './EventChartLayout'
 import EventChartLegend from './EventChartLegend'
 import EventMetaInformation from './EventMetaInformation'
 
+function buildHistoryWithLatestPointOverride(
+  normalizedHistory: Array<Record<string, number | Date> & { date: Date }>,
+  valueByKey: Record<string, number>,
+  nowMs: number | null,
+) {
+  const fallbackTimestamp = normalizedHistory.at(-1)?.date.getTime()
+  if (!Number.isFinite(nowMs) && !Number.isFinite(fallbackTimestamp)) {
+    return normalizedHistory
+  }
+  const nextTimestamp = Number.isFinite(nowMs)
+    ? (nowMs as number)
+    : (fallbackTimestamp as number)
+  const nextDate = new Date(nextTimestamp)
+  const sanitizedEntries = Object.entries(valueByKey)
+    .filter(([, value]) => typeof value === 'number' && Number.isFinite(value))
+    .map(([key, value]) => [key, Math.max(0, Math.min(100, value))] as const)
+
+  if (!sanitizedEntries.length) {
+    return normalizedHistory
+  }
+
+  if (normalizedHistory.length === 0) {
+    return [
+      Object.fromEntries([['date', nextDate], ...sanitizedEntries]) as Record<string, number | Date> & { date: Date },
+    ]
+  }
+
+  const lastPoint = normalizedHistory.at(-1)
+  if (!lastPoint) {
+    return normalizedHistory
+  }
+
+  const hasSameLatestValues = sanitizedEntries.every(([key, value]) => {
+    const lastValue = lastPoint[key]
+    return typeof lastValue === 'number'
+      && Number.isFinite(lastValue)
+      && Math.abs(lastValue - value) < 0.0001
+  })
+
+  if (hasSameLatestValues) {
+    return normalizedHistory
+  }
+
+  const lastTimestamp = lastPoint.date.getTime()
+  if (Number.isFinite(lastTimestamp) && lastTimestamp >= nextTimestamp) {
+    return [
+      ...normalizedHistory.slice(0, -1),
+      {
+        ...lastPoint,
+        ...Object.fromEntries(sanitizedEntries),
+      },
+    ]
+  }
+
+  return [
+    ...normalizedHistory,
+    {
+      date: nextDate,
+      ...Object.fromEntries(sanitizedEntries),
+    },
+  ]
+}
+
 function EventChartComponent({
   event,
   isMobile,
@@ -424,17 +487,81 @@ function EventChartComponent({
   const normalizedHistory = showBothOutcomes
     ? bothOutcomeHistory.points
     : chartHistory.normalizedHistory
-  const leadingGapStart = normalizedHistory[0]?.date ?? null
+  const latestPointOverrides = useMemo(() => {
+    if (showBothOutcomes && primaryConditionId && yesSeriesKey && noSeriesKey) {
+      const liveYesChance = displayChanceByMarket[primaryConditionId]
+      if (typeof liveYesChance !== 'number' || !Number.isFinite(liveYesChance)) {
+        return {}
+      }
+
+      return {
+        [yesSeriesKey]: liveYesChance,
+        [noSeriesKey]: 100 - liveYesChance,
+      }
+    }
+
+    if (isSingleMarket && primaryConditionId) {
+      const liveYesChance = displayChanceByMarket[primaryConditionId]
+      if (typeof liveYesChance !== 'number' || !Number.isFinite(liveYesChance)) {
+        return {}
+      }
+
+      const activeValue = activeOutcomeIndex === OUTCOME_INDEX.NO
+        ? (100 - liveYesChance)
+        : liveYesChance
+
+      return {
+        [primaryConditionId]: activeValue,
+      }
+    }
+
+    const entries = effectiveSeries
+      .map((seriesItem) => {
+        const liveValue = displayChanceByMarket[seriesItem.key]
+        if (typeof liveValue !== 'number' || !Number.isFinite(liveValue)) {
+          return null
+        }
+        return [seriesItem.key, liveValue] as const
+      })
+      .filter((entry): entry is readonly [string, number] => entry !== null)
+
+    return Object.fromEntries(entries)
+  }, [
+    activeOutcomeIndex,
+    displayChanceByMarket,
+    effectiveSeries,
+    isSingleMarket,
+    noSeriesKey,
+    primaryConditionId,
+    showBothOutcomes,
+    yesSeriesKey,
+  ])
+  const normalizedHistoryForChart = useMemo(() => {
+    if (Object.keys(latestPointOverrides).length === 0) {
+      return normalizedHistory
+    }
+
+    return buildHistoryWithLatestPointOverride(
+      normalizedHistory,
+      latestPointOverrides,
+      nowMs,
+    )
+  }, [
+    latestPointOverrides,
+    normalizedHistory,
+    nowMs,
+  ])
+  const leadingGapStart = normalizedHistoryForChart[0]?.date ?? null
   const latestSnapshot = showBothOutcomes
     ? bothOutcomeHistory.latestSnapshot
     : chartHistory.latestSnapshot
 
   const chartData = useMemo(
     () => filterChartDataForSeries(
-      normalizedHistory,
+      normalizedHistoryForChart,
       effectiveSeries.map(series => series.key),
     ),
-    [normalizedHistory, effectiveSeries],
+    [normalizedHistoryForChart, effectiveSeries],
   )
   const hasChartData = chartData.length > 0
   const chartScopeKey = useMemo(() => {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -72,6 +72,7 @@ function EventChartComponent({
   const isSingleMarket = useIsSingleMarket()
   const isNegRiskEnabled = Boolean(event.enable_neg_risk || event.neg_risk)
   const shouldHideChart = !isSingleMarket && !isNegRiskEnabled
+  const shouldFetchChartData = !shouldHideChart
   const chartSettings = useSyncExternalStore(
     subscribeToChartSettings,
     loadStoredChartSettings,
@@ -153,6 +154,7 @@ function EventChartComponent({
   } = useEventMarketChanceData({
     event,
     range: activeTimeRange,
+    enabled: shouldFetchChartData,
   })
   const noMarketTargets = useMemo(
     () => (shouldHideChart || !isSingleMarket ? [] : buildMarketTargets(event.markets, OUTCOME_INDEX.NO)),

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartHeader.tsx
@@ -103,6 +103,11 @@ export default function EventChartHeader({
       </div>
     )
   })()
+  const roundedYesChanceValue = (
+    typeof yesChanceValue === 'number' && Number.isFinite(yesChanceValue)
+      ? Math.round(yesChanceValue)
+      : null
+  )
 
   return (
     <div className="flex flex-col gap-2">
@@ -124,7 +129,7 @@ export default function EventChartHeader({
               {typeof yesChanceValue === 'number'
                 ? (
                     <AnimatedCounter
-                      value={yesChanceValue}
+                      value={roundedYesChanceValue ?? 0}
                       color="currentColor"
                       fontSize="24px"
                       includeCommas={false}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventFaq.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventFaq.tsx
@@ -82,10 +82,10 @@ export default function EventFaq({ event, commentsCount }: EventFaqProps) {
       {items.length > DEFAULT_VISIBLE_ITEMS && (
         <button
           type="button"
-          className="
+          className={cn(`
             mt-4 flex cursor-pointer items-center gap-2 text-[14px] text-muted-foreground transition-colors
             hover:text-foreground
-          "
+          `)}
           onClick={() => setIsExpanded(current => !current)}
         >
           <span>{isExpanded ? t('View less') : t('View more')}</span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChance.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChance.tsx
@@ -57,7 +57,7 @@ export default function EventMarketChance({
           key={`${layout}-chance-${highlightKey}`}
           className={cn(
             baseClass,
-            chanceMeta.isSubOnePercent ? 'text-muted-foreground' : 'text-foreground',
+            chanceMeta.isSubOnePercent ? 'text-muted-foreground opacity-25' : 'text-foreground',
             'motion-safe:animate-[pulse_0.8s_ease-out] motion-reduce:animate-none',
             'inline-block w-[4ch] text-right tabular-nums',
           )}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -725,8 +725,9 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
     range: 'ALL',
     targets: rowChartDeltaTargets,
     eventCreatedAt: event.created_at,
+    refetchIntervalMs: false,
   })
-  const rowChartDeltaQuotesByMarket = useEventMarketQuotes(rowChartDeltaTargets)
+  const rowChartDeltaQuotesByMarket = useEventMarketQuotes(rowChartDeltaTargets, { refetchIntervalMs: false })
   const rowChartDeltaLiveYesChanceByMarket = useMemo(() => {
     if (!shouldHydrateChartDeltas) {
       return {}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -7,7 +7,7 @@ import type { Event, UserPosition } from '@/types'
 import { useQuery } from '@tanstack/react-query'
 import { ChevronDownIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useMemo, useRef, useState } from 'react'
 import SellPositionModal from '@/app/[locale]/(platform)/_components/SellPositionModal'
 import EventMarketCard from '@/app/[locale]/(platform)/event/[slug]/_components/EventMarketCard'
 import { useOrderBookSummaries } from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook'
@@ -16,6 +16,8 @@ import OtherOutcomeRow from '@/app/[locale]/(platform)/event/[slug]/_components/
 import ResolvedMarketRow from '@/app/[locale]/(platform)/event/[slug]/_components/ResolvedMarketRow'
 import { useChanceRefresh } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useChanceRefresh'
 import { useEventMarketRows } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows'
+import { useEventMarketQuotes } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMidPrices'
+import { buildMarketTargets, useEventPriceHistory } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory'
 import { useMarketDetailController } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useMarketDetailController'
 import { useUserOpenOrdersQuery } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserOpenOrdersQuery'
 import { useUserShareBalances } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances'
@@ -31,6 +33,7 @@ import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { ORDER_SIDE, ORDER_TYPE, OUTCOME_INDEX } from '@/lib/constants'
 import { fetchUserOtherBalance, fetchUserPositionsForMarket } from '@/lib/data-api/user'
 import { formatAmountInputValue, fromMicro } from '@/lib/formatters'
+import { resolveDisplayPrice } from '@/lib/market-chance'
 import { resolveOutcomeUnitPrice } from '@/lib/market-pricing'
 import { applyPositionDeltasToUserPositions } from '@/lib/optimistic-trading'
 import { calculateMarketFill, normalizeBookLevels } from '@/lib/order-panel-utils'
@@ -43,6 +46,26 @@ export { resolveWinningOutcomeIndex } from '@/app/[locale]/(platform)/event/[slu
 interface EventMarketsProps {
   event: Event
   isMobile: boolean
+}
+
+function resolveChanceMetaForOpenedChart(
+  chanceMeta: EventMarketRow['chanceMeta'],
+  chanceDelta: number | null,
+) {
+  if (typeof chanceDelta !== 'number' || !Number.isFinite(chanceDelta)) {
+    return chanceMeta
+  }
+
+  const roundedChanceDelta = Math.round(chanceDelta)
+  const absoluteChanceDelta = Math.abs(roundedChanceDelta)
+  const shouldShowChanceChange = absoluteChanceDelta >= 1
+
+  return {
+    ...chanceMeta,
+    shouldShowChanceChange,
+    chanceChangeLabel: shouldShowChanceChange ? `${absoluteChanceDelta}%` : '',
+    isChanceChangePositive: roundedChanceDelta > 0,
+  }
 }
 
 function toNumber(value: unknown) {
@@ -680,6 +703,116 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
     selectDetailTab,
     getSelectedDetailTab,
   } = useMarketDetailController(event.id)
+  const rowChartDeltaCacheRef = useRef<{ eventId: string, values: Record<string, number> }>({
+    eventId: event.id,
+    values: {},
+  })
+  if (rowChartDeltaCacheRef.current.eventId !== event.id) {
+    rowChartDeltaCacheRef.current = {
+      eventId: event.id,
+      values: {},
+    }
+  }
+  const shouldHydrateChartDeltas = true
+  const rowChartDeltaTargets = useMemo(
+    () => (shouldHydrateChartDeltas
+      ? buildMarketTargets(event.markets.filter(market => !isMarketResolved(market)))
+      : []),
+    [event.markets, shouldHydrateChartDeltas],
+  )
+  const rowChartDeltaPriceHistory = useEventPriceHistory({
+    eventId: event.id,
+    range: 'ALL',
+    targets: rowChartDeltaTargets,
+    eventCreatedAt: event.created_at,
+  })
+  const rowChartDeltaQuotesByMarket = useEventMarketQuotes(rowChartDeltaTargets)
+  const rowChartDeltaLiveYesChanceByMarket = useMemo(() => {
+    if (!shouldHydrateChartDeltas) {
+      return {}
+    }
+
+    return rowChartDeltaTargets.reduce<Record<string, number>>((acc, target) => {
+      const quote = rowChartDeltaQuotesByMarket[target.conditionId]
+      const lastTrade = rowChartDeltaPriceHistory.latestRawPrices[target.conditionId]
+      const displayPrice = resolveDisplayPrice({
+        bid: quote?.bid ?? null,
+        ask: quote?.ask ?? null,
+        midpoint: quote?.mid ?? null,
+        lastTrade,
+      })
+
+      if (typeof displayPrice === 'number' && Number.isFinite(displayPrice)) {
+        acc[target.conditionId] = displayPrice * 100
+      }
+
+      return acc
+    }, {})
+  }, [rowChartDeltaPriceHistory.latestRawPrices, rowChartDeltaQuotesByMarket, rowChartDeltaTargets, shouldHydrateChartDeltas])
+  const rowChartDeltaBaselineYesChanceByMarket = useMemo(() => {
+    if (!shouldHydrateChartDeltas) {
+      return {}
+    }
+
+    const baselineByMarket: Record<string, number> = {}
+    const unresolvedConditionIds = new Set(rowChartDeltaTargets.map(target => target.conditionId))
+
+    for (const point of rowChartDeltaPriceHistory.normalizedHistory) {
+      if (unresolvedConditionIds.size === 0) {
+        break
+      }
+
+      Array.from(unresolvedConditionIds).forEach((conditionId) => {
+        const value = point[conditionId]
+        if (typeof value === 'number' && Number.isFinite(value)) {
+          baselineByMarket[conditionId] = value
+          unresolvedConditionIds.delete(conditionId)
+        }
+      })
+    }
+
+    return baselineByMarket
+  }, [rowChartDeltaPriceHistory.normalizedHistory, rowChartDeltaTargets, shouldHydrateChartDeltas])
+  const rowChartDeltaYesByMarket = useMemo(() => {
+    if (!shouldHydrateChartDeltas) {
+      return {}
+    }
+
+    return rowChartDeltaTargets.reduce<Record<string, number>>((acc, target) => {
+      const baseline = rowChartDeltaBaselineYesChanceByMarket[target.conditionId]
+      const live = rowChartDeltaLiveYesChanceByMarket[target.conditionId]
+
+      if (
+        typeof baseline === 'number'
+        && Number.isFinite(baseline)
+        && typeof live === 'number'
+        && Number.isFinite(live)
+      ) {
+        acc[target.conditionId] = live - baseline
+      }
+
+      return acc
+    }, {})
+  }, [rowChartDeltaBaselineYesChanceByMarket, rowChartDeltaLiveYesChanceByMarket, rowChartDeltaTargets, shouldHydrateChartDeltas])
+  const stableRowChartDeltaYesByMarket = useMemo(() => {
+    if (!shouldHydrateChartDeltas) {
+      return rowChartDeltaCacheRef.current.values
+    }
+
+    const mergedDeltas = { ...rowChartDeltaCacheRef.current.values }
+    rowChartDeltaTargets.forEach((target) => {
+      const delta = rowChartDeltaYesByMarket[target.conditionId]
+      if (typeof delta === 'number' && Number.isFinite(delta)) {
+        mergedDeltas[target.conditionId] = delta
+      }
+    })
+    rowChartDeltaCacheRef.current = {
+      eventId: event.id,
+      values: mergedDeltas,
+    }
+
+    return mergedDeltas
+  }, [event.id, rowChartDeltaTargets, rowChartDeltaYesByMarket, shouldHydrateChartDeltas])
   const reviewConditionIds = useReviewConditionIds({ markets: event.markets, currentTimestamp })
   const { resolveResolvedOutcomeIndex } = useTweetMarketResolution({ event, currentTimestamp })
   const chanceRefreshQueryKeys = useMemo(
@@ -761,6 +894,13 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
         {primaryMarketRows
           .map((row, index, orderedMarkets) => {
             const { market } = row
+            const chartDeltaForMarket = stableRowChartDeltaYesByMarket[market.condition_id] ?? null
+            const resolvedChanceMeta = shouldHydrateChartDeltas
+              ? resolveChanceMetaForOpenedChart(row.chanceMeta, chartDeltaForMarket)
+              : row.chanceMeta
+            const resolvedRow = resolvedChanceMeta === row.chanceMeta
+              ? row
+              : { ...row, chanceMeta: resolvedChanceMeta }
             const isExpanded = expandedMarketId === market.condition_id
             const activeOutcomeForMarket = selectedOutcome && selectedOutcome.condition_id === market.condition_id
               ? selectedOutcome
@@ -791,7 +931,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
                     )
                   : (
                       <EventMarketCard
-                        row={row}
+                        row={resolvedRow}
                         showMarketIcon={Boolean(event.show_market_icons)}
                         isExpanded={isExpanded}
                         isActiveMarket={selectedMarketId === market.condition_id}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
@@ -14,6 +14,7 @@ import EventChartEmbedDialog from '@/app/[locale]/(platform)/event/[slug]/_compo
 import EventChartExportDialog from '@/app/[locale]/(platform)/event/[slug]/_components/EventChartExportDialog'
 import EventChartHeader from '@/app/[locale]/(platform)/event/[slug]/_components/EventChartHeader'
 import EventChartLayout from '@/app/[locale]/(platform)/event/[slug]/_components/EventChartLayout'
+import { useEventMarketQuotes } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMidPrices'
 import {
   buildMarketTargets,
   TIME_RANGES,
@@ -32,6 +33,7 @@ import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import { useWindowSize } from '@/hooks/useWindowSize'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { formatDate } from '@/lib/formatters'
+import { resolveDisplayPrice } from '@/lib/market-chance'
 import { isMarketNew } from '@/lib/utils'
 
 interface MarketOutcomeGraphProps {
@@ -228,7 +230,7 @@ export default function MarketOutcomeGraph({
   const [activeTimeRange, setActiveTimeRange] = useState<TimeRange>('ALL')
   const [exportDialogOpen, setExportDialogOpen] = useState(false)
   const [embedDialogOpen, setEmbedDialogOpen] = useState(false)
-  const marketTargets = useMemo(() => buildMarketTargets(allMarkets), [allMarkets])
+  const marketTargets = useMemo(() => buildMarketTargets([market]), [market])
   const { width: windowWidth } = useWindowSize()
   const chartWidth = isMobile ? ((windowWidth || 400) * 0.84) : Math.min((windowWidth ?? 1440) * 0.55, 900)
   const { chartSettings, handleChartSettingsChange } = useChartSettingsStore()
@@ -243,20 +245,95 @@ export default function MarketOutcomeGraph({
     market.outcomes.find(item => item.outcome_index === OUTCOME_INDEX.NO)?.outcome_text,
   ) ?? t('No')
 
-  const { normalizedHistory } = useEventPriceHistory({
+  const {
+    normalizedHistory,
+    latestRawPrices,
+  } = useEventPriceHistory({
     eventId: market.event_id,
     range: activeTimeRange,
     targets: marketTargets,
     eventCreatedAt,
   })
-  const leadingGapStart = normalizedHistory[0]?.date ?? null
+  const marketQuotesByMarket = useEventMarketQuotes(marketTargets)
+  const liveYesChance = useMemo(() => {
+    const quote = marketQuotesByMarket[market.condition_id]
+    const lastTrade = latestRawPrices[market.condition_id]
+    const displayPrice = resolveDisplayPrice({
+      bid: quote?.bid ?? null,
+      ask: quote?.ask ?? null,
+      midpoint: quote?.mid ?? null,
+      lastTrade,
+    })
+
+    return typeof displayPrice === 'number' && Number.isFinite(displayPrice)
+      ? displayPrice * 100
+      : null
+  }, [latestRawPrices, market.condition_id, marketQuotesByMarket])
+  const normalizedHistoryForChart = useMemo(() => {
+    if (typeof liveYesChance !== 'number' || !Number.isFinite(liveYesChance)) {
+      return normalizedHistory
+    }
+
+    const clampedLiveYesChance = Math.max(0, Math.min(100, liveYesChance))
+    const fallbackTimestamp = normalizedHistory.at(-1)?.date.getTime()
+    if (!Number.isFinite(currentTimestamp) && !Number.isFinite(fallbackTimestamp)) {
+      return normalizedHistory
+    }
+    const nextTimestamp = Number.isFinite(currentTimestamp)
+      ? (currentTimestamp as number)
+      : (fallbackTimestamp as number)
+    const nextDate = new Date(nextTimestamp)
+
+    if (normalizedHistory.length === 0) {
+      return [{
+        date: nextDate,
+        [market.condition_id]: clampedLiveYesChance,
+      }]
+    }
+
+    const lastPoint = normalizedHistory.at(-1)
+    if (!lastPoint) {
+      return normalizedHistory
+    }
+
+    const lastTimestamp = lastPoint.date.getTime()
+    const lastPointValue = lastPoint[market.condition_id]
+    const hasSameLatestValue = (
+      typeof lastPointValue === 'number'
+      && Number.isFinite(lastPointValue)
+      && Math.abs(lastPointValue - clampedLiveYesChance) < 0.0001
+    )
+
+    if (hasSameLatestValue) {
+      return normalizedHistory
+    }
+
+    if (Number.isFinite(lastTimestamp) && lastTimestamp >= nextTimestamp) {
+      return [
+        ...normalizedHistory.slice(0, -1),
+        {
+          ...lastPoint,
+          [market.condition_id]: clampedLiveYesChance,
+        },
+      ]
+    }
+
+    return [
+      ...normalizedHistory,
+      {
+        date: nextDate,
+        [market.condition_id]: clampedLiveYesChance,
+      },
+    ]
+  }, [currentTimestamp, liveYesChance, market.condition_id, normalizedHistory])
+  const leadingGapStart = normalizedHistoryForChart[0]?.date ?? null
 
   const activeSeriesKey: 'yes' | 'no' | 'value' = showBothOutcomes
     ? (activeOutcomeIndex === OUTCOME_INDEX.NO ? 'no' : 'yes')
     : 'value'
 
   const { chartData, series, chartSignature, latestValue, baselineValue } = useChartDataValues({
-    normalizedHistory,
+    normalizedHistory: normalizedHistoryForChart,
     conditionId: market.condition_id,
     activeOutcomeIndex,
     activeTimeRange,
@@ -280,10 +357,26 @@ export default function MarketOutcomeGraph({
   const primarySeriesColor = showBothOutcomes
     ? (activeOutcomeIndex === OUTCOME_INDEX.NO ? NO_SERIES_COLOR : YES_SERIES_COLOR)
     : (series[0]?.color ?? YES_SERIES_COLOR)
+  const liveActiveChance = useMemo(() => {
+    if (typeof liveYesChance !== 'number' || !Number.isFinite(liveYesChance)) {
+      return null
+    }
+
+    const normalizedYesChance = Math.max(0, Math.min(100, liveYesChance))
+    if (showBothOutcomes) {
+      return activeSeriesKey === 'no'
+        ? Math.max(0, Math.min(100, 100 - normalizedYesChance))
+        : normalizedYesChance
+    }
+
+    return activeOutcomeIndex === OUTCOME_INDEX.NO
+      ? Math.max(0, Math.min(100, 100 - normalizedYesChance))
+      : normalizedYesChance
+  }, [activeOutcomeIndex, activeSeriesKey, liveYesChance, showBothOutcomes])
   const hoveredValue = cursorSnapshot?.values?.[activeSeriesKey]
   const resolvedValue = typeof hoveredValue === 'number' && Number.isFinite(hoveredValue)
     ? hoveredValue
-    : latestValue
+    : (liveActiveChance ?? latestValue)
   const currentValue = resolvedValue
 
   return (

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData.ts
@@ -15,28 +15,32 @@ import { resolveDisplayPrice } from '@/lib/market-chance'
 interface UseEventMarketChanceDataParams {
   event: Event
   range: TimeRange
+  enabled?: boolean
+  includePriceHistory?: boolean
 }
 
 export function useEventMarketChanceData({
   event,
   range,
+  enabled = true,
+  includePriceHistory = true,
 }: UseEventMarketChanceDataParams) {
   const eventHistoryEndAt = useMemo(
     () => resolveEventHistoryEndAt(event),
     [event],
   )
   const yesMarketTargets = useMemo(
-    () => buildMarketTargets(event.markets),
-    [event.markets],
+    () => (enabled ? buildMarketTargets(event.markets) : []),
+    [enabled, event.markets],
   )
   const yesPriceHistory = useEventPriceHistory({
     eventId: event.id,
     range,
-    targets: yesMarketTargets,
+    targets: includePriceHistory ? yesMarketTargets : [],
     eventCreatedAt: event.created_at,
     eventResolvedAt: eventHistoryEndAt,
   })
-  const marketQuotesByMarket = useEventMarketQuotes(yesMarketTargets)
+  const marketQuotesByMarket = useEventMarketQuotes(yesMarketTargets, { enabled })
   const displayChanceByMarket = useMemo(() => {
     const marketIds = new Set([
       ...Object.keys(marketQuotesByMarket),
@@ -61,10 +65,13 @@ export function useEventMarketChanceData({
 
     return Object.fromEntries(entries)
   }, [marketQuotesByMarket, yesPriceHistory.latestRawPrices])
-  const chanceChangeByMarket = useMemo(
-    () => computeChanceChanges(yesPriceHistory.normalizedHistory),
-    [yesPriceHistory.normalizedHistory],
-  )
+  const chanceChangeByMarket = useMemo(() => {
+    if (!includePriceHistory) {
+      return {}
+    }
+
+    return computeChanceChanges(yesPriceHistory.normalizedHistory)
+  }, [includePriceHistory, yesPriceHistory.normalizedHistory])
 
   return {
     displayChanceByMarket,

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData.ts
@@ -30,13 +30,13 @@ export function useEventMarketChanceData({
     [event],
   )
   const yesMarketTargets = useMemo(
-    () => (enabled ? buildMarketTargets(event.markets) : []),
-    [enabled, event.markets],
+    () => buildMarketTargets(event.markets),
+    [event.markets],
   )
   const yesPriceHistory = useEventPriceHistory({
     eventId: event.id,
     range,
-    targets: includePriceHistory ? yesMarketTargets : [],
+    targets: includePriceHistory && enabled ? yesMarketTargets : [],
     eventCreatedAt: event.created_at,
     eventResolvedAt: eventHistoryEndAt,
   })

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData.ts
@@ -1,6 +1,7 @@
 import type { TimeRange } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory'
 import type { Event } from '@/types'
 import { useMemo } from 'react'
+import { useEventLastTrades } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventLastTrades'
 import { useEventMarketQuotes } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMidPrices'
 import {
   buildMarketTargets,
@@ -40,17 +41,23 @@ export function useEventMarketChanceData({
     eventCreatedAt: event.created_at,
     eventResolvedAt: eventHistoryEndAt,
   })
+  const fallbackLastTradesByMarket = useEventLastTrades(
+    enabled && !includePriceHistory ? yesMarketTargets : [],
+  )
+  const marketLastTradesByMarket = includePriceHistory
+    ? yesPriceHistory.latestRawPrices
+    : fallbackLastTradesByMarket
   const marketQuotesByMarket = useEventMarketQuotes(yesMarketTargets, { enabled })
   const displayChanceByMarket = useMemo(() => {
     const marketIds = new Set([
       ...Object.keys(marketQuotesByMarket),
-      ...Object.keys(yesPriceHistory.latestRawPrices),
+      ...Object.keys(marketLastTradesByMarket),
     ])
     const entries: Array<[string, number]> = []
 
     marketIds.forEach((marketId) => {
       const quote = marketQuotesByMarket[marketId]
-      const lastTrade = yesPriceHistory.latestRawPrices[marketId]
+      const lastTrade = marketLastTradesByMarket[marketId]
       const displayPrice = resolveDisplayPrice({
         bid: quote?.bid ?? null,
         ask: quote?.ask ?? null,
@@ -64,7 +71,7 @@ export function useEventMarketChanceData({
     })
 
     return Object.fromEntries(entries)
-  }, [marketQuotesByMarket, yesPriceHistory.latestRawPrices])
+  }, [marketLastTradesByMarket, marketQuotesByMarket])
   const chanceChangeByMarket = useMemo(() => {
     if (!includePriceHistory) {
       return {}

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
@@ -1,5 +1,5 @@
 import type { Event, Outcome } from '@/types'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { useEventMarketChanceData } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketChanceData'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { toCents } from '@/lib/formatters'
@@ -122,37 +122,80 @@ export function useEventMarketRows(event: Event): EventMarketRowsResult {
     range: 'ALL',
     includePriceHistory: false,
   })
+  const displayChanceCacheRef = useRef<{ eventId: string, values: Record<string, number> }>({
+    eventId: event.id,
+    values: {},
+  })
+  const chanceChangeCacheRef = useRef<{ eventId: string, values: Record<string, number> }>({
+    eventId: event.id,
+    values: {},
+  })
+  if (displayChanceCacheRef.current.eventId !== event.id) {
+    displayChanceCacheRef.current = { eventId: event.id, values: {} }
+  }
+  if (chanceChangeCacheRef.current.eventId !== event.id) {
+    chanceChangeCacheRef.current = { eventId: event.id, values: {} }
+  }
+
+  const stableDisplayChanceByMarket = useMemo(() => {
+    const mergedDisplayChanceByMarket = { ...displayChanceCacheRef.current.values }
+
+    event.markets.forEach((market) => {
+      const chance = displayChanceByMarket[market.condition_id]
+      if (typeof chance === 'number' && Number.isFinite(chance)) {
+        mergedDisplayChanceByMarket[market.condition_id] = chance
+      }
+    })
+
+    displayChanceCacheRef.current = {
+      eventId: event.id,
+      values: mergedDisplayChanceByMarket,
+    }
+
+    return mergedDisplayChanceByMarket
+  }, [displayChanceByMarket, event.id, event.markets])
+
   const chanceChangeByMarket = useMemo(() => {
     if (Object.keys(historicalChanceChangeByMarket).length > 0) {
       return historicalChanceChangeByMarket
     }
 
-    const entries = event.markets.map((market) => {
+    const mergedChanceChangeByMarket = { ...chanceChangeCacheRef.current.values }
+
+    event.markets.forEach((market) => {
       const baselineChance = Number.isFinite(market.probability)
         ? market.probability
         : null
-      const liveChance = displayChanceByMarket[market.condition_id]
+      const liveChance = stableDisplayChanceByMarket[market.condition_id]
 
       if (
         baselineChance == null
         || typeof liveChance !== 'number'
         || !Number.isFinite(liveChance)
       ) {
-        return [market.condition_id, 0] as const
+        if (!(market.condition_id in mergedChanceChangeByMarket)) {
+          mergedChanceChangeByMarket[market.condition_id] = 0
+        }
+        return
       }
 
-      return [market.condition_id, liveChance - baselineChance] as const
+      mergedChanceChangeByMarket[market.condition_id] = liveChance - baselineChance
     })
 
-    return Object.fromEntries(entries)
-  }, [displayChanceByMarket, event.markets, historicalChanceChangeByMarket])
+    chanceChangeCacheRef.current = {
+      eventId: event.id,
+      values: mergedChanceChangeByMarket,
+    }
+
+    return mergedChanceChangeByMarket
+  }, [event.id, event.markets, historicalChanceChangeByMarket, stableDisplayChanceByMarket])
 
   return useMemo(
     () => buildEventMarketRows(event, {
-      outcomeChances: displayChanceByMarket,
+      outcomeChances: stableDisplayChanceByMarket,
       outcomeChanceChanges: chanceChangeByMarket,
       marketYesPrices: yesPriceHistory.latestRawPrices,
     }),
-    [chanceChangeByMarket, displayChanceByMarket, event, yesPriceHistory.latestRawPrices],
+    [chanceChangeByMarket, event, stableDisplayChanceByMarket, yesPriceHistory.latestRawPrices],
   )
 }

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
@@ -141,10 +141,14 @@ export function useEventMarketRows(event: Event): EventMarketRowsResult {
     const mergedDisplayChanceByMarket = { ...displayChanceCacheRef.current.values }
 
     event.markets.forEach((market) => {
+      const conditionId = market.condition_id
       const chance = displayChanceByMarket[market.condition_id]
       if (typeof chance === 'number' && Number.isFinite(chance)) {
-        mergedDisplayChanceByMarket[market.condition_id] = chance
+        mergedDisplayChanceByMarket[conditionId] = chance
+        return
       }
+
+      delete mergedDisplayChanceByMarket[conditionId]
     })
 
     displayChanceCacheRef.current = {
@@ -173,9 +177,7 @@ export function useEventMarketRows(event: Event): EventMarketRowsResult {
         || typeof liveChance !== 'number'
         || !Number.isFinite(liveChance)
       ) {
-        if (!(market.condition_id in mergedChanceChangeByMarket)) {
-          mergedChanceChangeByMarket[market.condition_id] = 0
-        }
+        mergedChanceChangeByMarket[market.condition_id] = 0
         return
       }
 

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
@@ -122,23 +122,6 @@ export function useEventMarketRows(event: Event): EventMarketRowsResult {
     range: 'ALL',
     includePriceHistory: false,
   })
-  const outcomeChances = useMemo(() => {
-    const entries = event.markets.map((market) => {
-      const liveChance = displayChanceByMarket[market.condition_id]
-      const fallbackChance = Number.isFinite(market.probability)
-        ? market.probability
-        : 0
-
-      return [
-        market.condition_id,
-        typeof liveChance === 'number' && Number.isFinite(liveChance)
-          ? liveChance
-          : fallbackChance,
-      ] as const
-    })
-
-    return Object.fromEntries(entries)
-  }, [displayChanceByMarket, event.markets])
   const chanceChangeByMarket = useMemo(() => {
     if (Object.keys(historicalChanceChangeByMarket).length > 0) {
       return historicalChanceChangeByMarket
@@ -166,10 +149,10 @@ export function useEventMarketRows(event: Event): EventMarketRowsResult {
 
   return useMemo(
     () => buildEventMarketRows(event, {
-      outcomeChances,
+      outcomeChances: displayChanceByMarket,
       outcomeChanceChanges: chanceChangeByMarket,
       marketYesPrices: yesPriceHistory.latestRawPrices,
     }),
-    [chanceChangeByMarket, event, outcomeChances, yesPriceHistory.latestRawPrices],
+    [chanceChangeByMarket, displayChanceByMarket, event, yesPriceHistory.latestRawPrices],
   )
 }

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
@@ -114,7 +114,6 @@ export function buildEventMarketRows(
 
 export function useEventMarketRows(event: Event): EventMarketRowsResult {
   const {
-    chanceChangeByMarket: historicalChanceChangeByMarket,
     displayChanceByMarket,
     yesPriceHistory,
   } = useEventMarketChanceData({
@@ -160,10 +159,6 @@ export function useEventMarketRows(event: Event): EventMarketRowsResult {
   }, [displayChanceByMarket, event.id, event.markets])
 
   const chanceChangeByMarket = useMemo(() => {
-    if (Object.keys(historicalChanceChangeByMarket).length > 0) {
-      return historicalChanceChangeByMarket
-    }
-
     const mergedChanceChangeByMarket = { ...chanceChangeCacheRef.current.values }
 
     event.markets.forEach((market) => {
@@ -190,7 +185,7 @@ export function useEventMarketRows(event: Event): EventMarketRowsResult {
     }
 
     return mergedChanceChangeByMarket
-  }, [event.id, event.markets, historicalChanceChangeByMarket, stableDisplayChanceByMarket])
+  }, [event.id, event.markets, stableDisplayChanceByMarket])
 
   return useMemo(
     () => buildEventMarketRows(event, {

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows.ts
@@ -114,20 +114,62 @@ export function buildEventMarketRows(
 
 export function useEventMarketRows(event: Event): EventMarketRowsResult {
   const {
-    chanceChangeByMarket,
+    chanceChangeByMarket: historicalChanceChangeByMarket,
     displayChanceByMarket,
     yesPriceHistory,
   } = useEventMarketChanceData({
     event,
     range: 'ALL',
+    includePriceHistory: false,
   })
+  const outcomeChances = useMemo(() => {
+    const entries = event.markets.map((market) => {
+      const liveChance = displayChanceByMarket[market.condition_id]
+      const fallbackChance = Number.isFinite(market.probability)
+        ? market.probability
+        : 0
+
+      return [
+        market.condition_id,
+        typeof liveChance === 'number' && Number.isFinite(liveChance)
+          ? liveChance
+          : fallbackChance,
+      ] as const
+    })
+
+    return Object.fromEntries(entries)
+  }, [displayChanceByMarket, event.markets])
+  const chanceChangeByMarket = useMemo(() => {
+    if (Object.keys(historicalChanceChangeByMarket).length > 0) {
+      return historicalChanceChangeByMarket
+    }
+
+    const entries = event.markets.map((market) => {
+      const baselineChance = Number.isFinite(market.probability)
+        ? market.probability
+        : null
+      const liveChance = displayChanceByMarket[market.condition_id]
+
+      if (
+        baselineChance == null
+        || typeof liveChance !== 'number'
+        || !Number.isFinite(liveChance)
+      ) {
+        return [market.condition_id, 0] as const
+      }
+
+      return [market.condition_id, liveChance - baselineChance] as const
+    })
+
+    return Object.fromEntries(entries)
+  }, [displayChanceByMarket, event.markets, historicalChanceChangeByMarket])
 
   return useMemo(
     () => buildEventMarketRows(event, {
-      outcomeChances: displayChanceByMarket,
+      outcomeChances,
       outcomeChanceChanges: chanceChangeByMarket,
       marketYesPrices: yesPriceHistory.latestRawPrices,
     }),
-    [chanceChangeByMarket, displayChanceByMarket, event, yesPriceHistory.latestRawPrices],
+    [chanceChangeByMarket, event, outcomeChances, yesPriceHistory.latestRawPrices],
   )
 }

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMidPrices.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMidPrices.ts
@@ -113,7 +113,15 @@ async function fetchQuotesByMarket(targets: MarketTokenTarget[]): Promise<Market
   }, {})
 }
 
-export function useEventMarketQuotes(targets: MarketTokenTarget[]) {
+interface UseEventMarketQuotesOptions {
+  enabled?: boolean
+}
+
+export function useEventMarketQuotes(
+  targets: MarketTokenTarget[],
+  options: UseEventMarketQuotesOptions = {},
+) {
+  const { enabled = true } = options
   const tokenSignature = useMemo(
     () => targets.map(target => `${target.conditionId}:${target.tokenId}`).sort().join(','),
     [targets],
@@ -122,7 +130,7 @@ export function useEventMarketQuotes(targets: MarketTokenTarget[]) {
   const { data } = useQuery({
     queryKey: ['event-market-quotes', tokenSignature],
     queryFn: () => fetchQuotesByMarket(targets),
-    enabled: targets.length > 0,
+    enabled: enabled && targets.length > 0,
     staleTime: 'static',
     gcTime: PRICE_REFRESH_INTERVAL_MS,
     refetchInterval: PRICE_REFRESH_INTERVAL_MS,

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMidPrices.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventMidPrices.ts
@@ -115,13 +115,14 @@ async function fetchQuotesByMarket(targets: MarketTokenTarget[]): Promise<Market
 
 interface UseEventMarketQuotesOptions {
   enabled?: boolean
+  refetchIntervalMs?: number | false
 }
 
 export function useEventMarketQuotes(
   targets: MarketTokenTarget[],
   options: UseEventMarketQuotesOptions = {},
 ) {
-  const { enabled = true } = options
+  const { enabled = true, refetchIntervalMs = PRICE_REFRESH_INTERVAL_MS } = options
   const tokenSignature = useMemo(
     () => targets.map(target => `${target.conditionId}:${target.tokenId}`).sort().join(','),
     [targets],
@@ -133,8 +134,8 @@ export function useEventMarketQuotes(
     enabled: enabled && targets.length > 0,
     staleTime: 'static',
     gcTime: PRICE_REFRESH_INTERVAL_MS,
-    refetchInterval: PRICE_REFRESH_INTERVAL_MS,
-    refetchIntervalInBackground: true,
+    refetchInterval: refetchIntervalMs,
+    refetchIntervalInBackground: refetchIntervalMs !== false,
     placeholderData: keepPreviousData,
   })
 

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory.ts
@@ -310,6 +310,8 @@ interface UseEventPriceHistoryParams {
   targets: MarketTokenTarget[]
   eventCreatedAt: string
   eventResolvedAt?: string | null
+  enabled?: boolean
+  refetchIntervalMs?: number | false
 }
 
 export function useEventPriceHistory({
@@ -318,6 +320,8 @@ export function useEventPriceHistory({
   targets,
   eventCreatedAt,
   eventResolvedAt,
+  enabled = true,
+  refetchIntervalMs = PRICE_REFRESH_INTERVAL_MS,
 }: UseEventPriceHistoryParams) {
   const tokenSignature = useMemo(
     () => targets.map(target => `${target.conditionId}:${target.tokenId}`).sort().join(','),
@@ -327,11 +331,11 @@ export function useEventPriceHistory({
   const { data: priceHistoryByMarket } = useQuery({
     queryKey: ['event-price-history', eventId, range, tokenSignature, eventResolvedAt ?? ''],
     queryFn: () => fetchEventPriceHistory(targets, range, eventCreatedAt, eventResolvedAt),
-    enabled: targets.length > 0,
+    enabled: enabled && targets.length > 0,
     staleTime: PRICE_REFRESH_INTERVAL_MS,
     gcTime: PRICE_REFRESH_INTERVAL_MS,
-    refetchInterval: PRICE_REFRESH_INTERVAL_MS,
-    refetchIntervalInBackground: true,
+    refetchInterval: refetchIntervalMs,
+    refetchIntervalInBackground: refetchIntervalMs !== false,
     placeholderData: keepPreviousData,
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops N+1 requests to the price history API and aligns charts with live market chances. Fetches only what’s visible and restores stable row deltas without background polling.

- **Bug Fixes**
  - Fetch chart data only when shown; scope market chart targets to the active market.
  - Add `enabled`/`includePriceHistory` to `useEventPriceHistory` and `useEventMarketQuotes`; skip queries when disabled/empty and use `useEventLastTrades` when history is off.
  - Inject a live point from quotes/last trade into chart series and round header values so charts and headers match in single‑market and YES/NO views.
  - Stabilize market row deltas without polling: baseline from first history point, compute via live quotes, cache per event, clear on event change; keep — for missing chances and dim sub‑1% labels.

<sup>Written for commit 7cb4f5c6c8fb896f3eab4ea9bbbd7cf13e56f078. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

