### PR TITLE
fix: move sports and esports event params resolution outside use cache

### DIFF
--- a/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/page.tsx
@@ -1,5 +1,3 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import { notFound } from 'next/navigation'
 import {
@@ -85,14 +83,12 @@ export async function generateMetadata({
   notFound()
 }
 
-export default async function EsportsSlugPartsPage({
-  params,
-}: PageProps<'/[locale]/esports/[sport]/[...slugParts]'>) {
-  const { locale, sport, slugParts } = await params
-
-  if (sport === STATIC_PARAMS_PLACEHOLDER || slugParts.includes(STATIC_PARAMS_PLACEHOLDER)) {
-    notFound()
-  }
+async function CachedEsportsSlugPartsPageContent({
+  locale,
+  sport,
+  slugParts,
+}: Awaited<PageProps<'/[locale]/esports/[sport]/[...slugParts]'>['params']>) {
+  'use cache'
 
   if (slugParts.length === 1) {
     return await renderSportsVerticalEventPage({
@@ -136,4 +132,17 @@ export default async function EsportsSlugPartsPage({
   }
 
   notFound()
+}
+
+export default async function EsportsSlugPartsPage({
+  params,
+}: PageProps<'/[locale]/esports/[sport]/[...slugParts]'>) {
+  const resolvedParams = await params
+  const { sport, slugParts } = resolvedParams
+
+  if (sport === STATIC_PARAMS_PLACEHOLDER || slugParts.includes(STATIC_PARAMS_PLACEHOLDER)) {
+    notFound()
+  }
+
+  return <CachedEsportsSlugPartsPageContent {...resolvedParams} />
 }

--- a/src/app/[locale]/(platform)/sports/[sport]/[event]/[market]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/[event]/[market]/page.tsx
@@ -1,5 +1,3 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
@@ -65,19 +63,16 @@ export async function generateMetadata({
   })
 }
 
-export default async function SportsEventMarketPage({
-  params,
-}: PageProps<'/[locale]/sports/[sport]/[event]/[market]'>) {
-  const { locale, sport, event, market } = await params
-  setRequestLocale(locale)
+async function CachedSportsEventMarketPageContent({
+  locale,
+  sport,
+  event,
+  market,
+}: Awaited<PageProps<'/[locale]/sports/[sport]/[event]/[market]'>['params']>) {
+  'use cache'
+
   const resolvedLocale = locale as SupportedLocale
-  if (
-    sport === STATIC_PARAMS_PLACEHOLDER
-    || event === STATIC_PARAMS_PLACEHOLDER
-    || market === STATIC_PARAMS_PLACEHOLDER
-  ) {
-    notFound()
-  }
+
   const canonicalEventSlug = await resolveCanonicalEventSlugFromSportsPath(sport, event)
   if (!canonicalEventSlug) {
     notFound()
@@ -164,4 +159,21 @@ export default async function SportsEventMarketPage({
       </EventMarketChannelProvider>
     </>
   )
+}
+
+export default async function SportsEventMarketPage({
+  params,
+}: PageProps<'/[locale]/sports/[sport]/[event]/[market]'>) {
+  const resolvedParams = await params
+  const { locale, sport, event, market } = resolvedParams
+  setRequestLocale(locale)
+  if (
+    sport === STATIC_PARAMS_PLACEHOLDER
+    || event === STATIC_PARAMS_PLACEHOLDER
+    || market === STATIC_PARAMS_PLACEHOLDER
+  ) {
+    notFound()
+  }
+
+  return <CachedSportsEventMarketPageContent {...resolvedParams} />
 }

--- a/src/app/[locale]/(platform)/sports/[sport]/[event]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/[event]/page.tsx
@@ -1,5 +1,3 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import {
   generateSportsVerticalEventMetadata,
@@ -17,11 +15,24 @@ export async function generateMetadata({
   return await generateSportsVerticalEventMetadata(await params)
 }
 
+async function CachedSportsEventPageContent({
+  locale,
+  sport,
+  event,
+}: Awaited<PageProps<'/[locale]/sports/[sport]/[event]'>['params']>) {
+  'use cache'
+
+  return await renderSportsVerticalEventPage({
+    locale,
+    sport,
+    event,
+    vertical: 'sports',
+  })
+}
+
 export default async function SportsEventPage({
   params,
 }: PageProps<'/[locale]/sports/[sport]/[event]'>) {
-  return await renderSportsVerticalEventPage({
-    ...(await params),
-    vertical: 'sports',
-  })
+  const resolvedParams = await params
+  return <CachedSportsEventPageContent {...resolvedParams} />
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Moved route param resolution for sports and esports event pages outside the `use cache` boundary to prevent caching placeholder params and 404 states. Keeps inner page content cached while ensuring correct validation and locale setup.

- **Bug Fixes**
  - Split pages into an outer resolver and inner `Cached*PageContent` with `use cache` for:
    - `/[locale]/esports/[sport]/[...slugParts]`
    - `/[locale]/sports/[sport]/[event]`
    - `/[locale]/sports/[sport]/[event]/[market]`
  - Resolve `params`, validate `STATIC_PARAMS_PLACEHOLDER`, and call `notFound()` before rendering cached content.
  - Call `setRequestLocale(locale)` before cache in the sports market route.

<sup>Written for commit a4d1bd09d83ab9300ab741625a9545eab6323a34. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

