### PR TITLE
fix: event metadata cache timeout

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -713,12 +713,25 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
       values: {},
     }
   }
-  const shouldHydrateChartDeltas = true
+  const shouldHydrateChartDeltas = Boolean(expandedMarketId)
   const rowChartDeltaTargets = useMemo(
-    () => (shouldHydrateChartDeltas
-      ? buildMarketTargets(event.markets.filter(market => !isMarketResolved(market)))
-      : []),
-    [event.markets, shouldHydrateChartDeltas],
+    () => {
+      if (!shouldHydrateChartDeltas || !expandedMarketId) {
+        return []
+      }
+
+      const expandedMarket = event.markets.find(market => market.condition_id === expandedMarketId)
+      if (!expandedMarket || isMarketResolved(expandedMarket)) {
+        return []
+      }
+
+      return buildMarketTargets([expandedMarket])
+    },
+    [event.markets, expandedMarketId, shouldHydrateChartDeltas],
+  )
+  const rowChartDeltaTargetConditionIds = useMemo(
+    () => new Set(rowChartDeltaTargets.map(target => target.conditionId)),
+    [rowChartDeltaTargets],
   )
   const rowChartDeltaPriceHistory = useEventPriceHistory({
     eventId: event.id,
@@ -895,7 +908,9 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
         {primaryMarketRows
           .map((row, index, orderedMarkets) => {
             const { market } = row
-            const chartDeltaForMarket = stableRowChartDeltaYesByMarket[market.condition_id] ?? null
+            const chartDeltaForMarket = rowChartDeltaTargetConditionIds.has(market.condition_id)
+              ? (stableRowChartDeltaYesByMarket[market.condition_id] ?? null)
+              : null
             const resolvedChanceMeta = shouldHydrateChartDeltas
               ? resolveChanceMetaForOpenedChart(row.chanceMeta, chartDeltaForMarket)
               : row.chanceMeta

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -2536,9 +2536,6 @@ export const EventRepository = {
     slug: string,
     locale: SupportedLocale = DEFAULT_LOCALE,
   ): Promise<QueryResult<{ title: string }>> {
-    'use cache'
-    cacheTag(cacheTags.event(slug))
-
     return runQuery(async () => {
       const result = await db
         .select({ id: events.id, title: events.title })

--- a/src/lib/db/queries/settings.ts
+++ b/src/lib/db/queries/settings.ts
@@ -32,8 +32,7 @@ export const SettingsRepository = {
 
         return { data: settingsByGroup, error: null }
       }
-      catch (error) {
-        console.error('Failed to fetch settings:', error)
+      catch {
         return { data: null, error: 'Failed to fetch settings.' }
       }
     })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes event metadata cache timeouts and reduces unnecessary price-history work on event pages. Removes caching from event title queries and hydrates chart deltas only for the opened market.

- **Bug Fixes**
  - Removed cache from event title lookup to eliminate metadata timeouts.
  - Hydrate chart deltas only for the expanded market to avoid price-history N+1.

- **Refactors**
  - Simplified settings fetch error handling (no console logging; return a generic error).

<sup>Written for commit e985e71a3d71b24e8b2058334f23f926cf5402ab. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

