### PR TITLE
fix: route market context through api endpoint

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
@@ -1,8 +1,7 @@
 import type { Event } from '@/types'
 import { LoaderIcon, SparkleIcon } from 'lucide-react'
-import { useExtracted } from 'next-intl'
+import { useExtracted, useLocale } from 'next-intl'
 import { useEffect, useMemo, useRef, useState, useTransition } from 'react'
-import { generateMarketContextAction } from '@/app/[locale]/(platform)/event/[slug]/_actions/generate-market-context'
 import { cn } from '@/lib/utils'
 import { useOrder } from '@/stores/useOrder'
 
@@ -62,8 +61,58 @@ interface EventMarketContextContentProps {
   resolvedMarketConditionId?: string
 }
 
+interface MarketContextResponse {
+  error?: string
+  context?: string | null
+  expiresAt?: string | null
+  updatedAt?: string | null
+}
+
+async function requestMarketContext({
+  slug,
+  marketConditionId,
+  readOnly = false,
+  locale,
+  signal,
+}: {
+  slug: string
+  marketConditionId: string
+  readOnly?: boolean
+  locale: string
+  signal?: AbortSignal
+}): Promise<MarketContextResponse> {
+  const response = await fetch('/api/market-context', {
+    method: 'POST',
+    headers: {
+      'Accept': 'application/json',
+      'Content-Type': 'application/json',
+      'X-Kuest-Locale': locale,
+    },
+    body: JSON.stringify({
+      slug,
+      marketConditionId,
+      readOnly,
+      locale,
+    }),
+    signal,
+  })
+
+  const payload = await response.json().catch(() => null) as MarketContextResponse | null
+
+  if (!payload || typeof payload !== 'object') {
+    throw new Error('Invalid market context response payload.')
+  }
+
+  if (!response.ok && !payload.error) {
+    throw new Error(`Failed to fetch market context (${response.status}).`)
+  }
+
+  return payload
+}
+
 function useMarketContextState(event: Event, resolvedMarketConditionId: string | undefined) {
   const t = useExtracted()
+  const locale = useLocale()
   const [isExpanded, setIsExpanded] = useState(false)
   const [context, setContext] = useState<string | null>(null)
   const [displayedContext, setDisplayedContext] = useState('')
@@ -82,13 +131,16 @@ function useMarketContextState(event: Event, resolvedMarketConditionId: string |
     }
 
     let isActive = true
+    const abortController = new AbortController()
 
     async function preloadCachedContext() {
       try {
-        const response = await generateMarketContextAction({
+        const response = await requestMarketContext({
           slug: event.slug,
-          marketConditionId: resolvedMarketConditionId,
+          marketConditionId: `${resolvedMarketConditionId}`,
           readOnly: true,
+          locale,
+          signal: abortController.signal,
         })
 
         if (!isActive || response?.error || !response?.context) {
@@ -101,6 +153,10 @@ function useMarketContextState(event: Event, resolvedMarketConditionId: string |
         setContextUpdatedAtMs(parseTimestamp(response.updatedAt) ?? Date.now())
       }
       catch (caughtError) {
+        if (caughtError instanceof DOMException && caughtError.name === 'AbortError') {
+          return
+        }
+
         console.error('Failed to fetch cached market context.', caughtError)
       }
     }
@@ -109,8 +165,9 @@ function useMarketContextState(event: Event, resolvedMarketConditionId: string |
 
     return function cleanupPreload() {
       isActive = false
+      abortController.abort()
     }
-  }, [event.slug, resolvedMarketConditionId])
+  }, [event.slug, locale, resolvedMarketConditionId])
 
   useEffect(function cacheExpirationEffect() {
     if (!cacheExpiresAtMs) {
@@ -238,9 +295,10 @@ function useMarketContextState(event: Event, resolvedMarketConditionId: string |
       setError(null)
 
       try {
-        const response = await generateMarketContextAction({
+        const response = await requestMarketContext({
           slug: event.slug,
           marketConditionId: resolvedMarketConditionId,
+          locale,
         })
 
         if (response?.error) {

--- a/src/app/api/market-context/route.ts
+++ b/src/app/api/market-context/route.ts
@@ -1,13 +1,17 @@
-import { resolveMarketContextRequest } from '@/lib/market-context-service'
+import { MarketContextRequestSchema, resolveMarketContextRequest } from '@/lib/market-context-service'
 
 export async function POST(request: Request) {
   const payload = await request.json().catch(() => null)
-  const localeHeader = request.headers.get('x-kuest-locale')
-  const result = await resolveMarketContextRequest(payload, localeHeader)
-
-  if (result.error && payload == null) {
-    return Response.json(result, { status: 400 })
+  const parsedPayload = MarketContextRequestSchema.safeParse(payload)
+  if (!parsedPayload.success) {
+    return Response.json(
+      { error: parsedPayload.error.issues[0]?.message ?? 'Invalid request.' },
+      { status: 400 },
+    )
   }
+
+  const localeHeader = request.headers.get('x-kuest-locale')
+  const result = await resolveMarketContextRequest(parsedPayload.data, localeHeader)
 
   return Response.json(result)
 }

--- a/src/app/api/market-context/route.ts
+++ b/src/app/api/market-context/route.ts
@@ -1,0 +1,13 @@
+import { resolveMarketContextRequest } from '@/lib/market-context-service'
+
+export async function POST(request: Request) {
+  const payload = await request.json().catch(() => null)
+  const localeHeader = request.headers.get('x-kuest-locale')
+  const result = await resolveMarketContextRequest(payload, localeHeader)
+
+  if (result.error && payload == null) {
+    return Response.json(result, { status: 400 })
+  }
+
+  return Response.json(result)
+}

--- a/src/lib/market-context-service.ts
+++ b/src/lib/market-context-service.ts
@@ -1,7 +1,4 @@
-'use server'
-
 import type { SupportedLocale } from '@/i18n/locales'
-import { getLocale } from 'next-intl/server'
 import { z } from 'zod'
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/i18n/locales'
 import { generateMarketContext } from '@/lib/ai/market-context'
@@ -12,27 +9,44 @@ import { MarketContextCacheRepository } from '@/lib/db/queries/market-context-ca
 
 const MARKET_CONTEXT_CACHE_WINDOW_MS = 30 * 60 * 1000
 
-const GenerateMarketContextSchema = z.object({
+export const MarketContextRequestSchema = z.object({
   slug: z.string(),
   marketConditionId: z.string().optional(),
   readOnly: z.boolean().optional(),
+  locale: z.string().optional(),
 })
 
-type GenerateMarketContextInput = z.infer<typeof GenerateMarketContextSchema>
+export interface MarketContextResponse {
+  error?: string
+  context?: string | null
+  expiresAt?: string | null
+  updatedAt?: string | null
+  cached?: boolean
+}
 
-export async function generateMarketContextAction(input: GenerateMarketContextInput) {
-  const parsed = GenerateMarketContextSchema.safeParse(input)
+function resolveSupportedLocale(locale: string | null | undefined): SupportedLocale {
+  const normalizedLocale = locale?.trim().toLowerCase()
+
+  if (normalizedLocale && SUPPORTED_LOCALES.includes(normalizedLocale as SupportedLocale)) {
+    return normalizedLocale as SupportedLocale
+  }
+
+  return DEFAULT_LOCALE
+}
+
+export async function resolveMarketContextRequest(
+  input: unknown,
+  fallbackLocale?: string | null,
+): Promise<MarketContextResponse> {
+  const parsed = MarketContextRequestSchema.safeParse(input)
 
   if (!parsed.success) {
     return { error: parsed.error.issues[0]?.message ?? 'Invalid request.' }
   }
 
   try {
-    const { slug, marketConditionId, readOnly = false } = parsed.data
-    const locale = await getLocale()
-    const resolvedLocale = SUPPORTED_LOCALES.includes(locale as SupportedLocale)
-      ? locale as SupportedLocale
-      : DEFAULT_LOCALE
+    const { slug, marketConditionId, readOnly = false, locale } = parsed.data
+    const resolvedLocale = resolveSupportedLocale(locale ?? fallbackLocale)
     const { data: event, error } = await EventRepository.getEventBySlug(slug, '', resolvedLocale)
 
     if (error || !event) {
@@ -74,7 +88,7 @@ export async function generateMarketContextAction(input: GenerateMarketContextIn
       return { error: 'Market context generation is not configured.' }
     }
 
-    const context = await generateMarketContext(event, market, settings, locale)
+    const context = await generateMarketContext(event, market, settings, resolvedLocale)
     const expiresAt = new Date(Date.now() + MARKET_CONTEXT_CACHE_WINDOW_MS)
     const persistedCache = await MarketContextCacheRepository.upsertContext(
       market.condition_id,

--- a/tests/unit/generateMarketContextAction.test.ts
+++ b/tests/unit/generateMarketContextAction.test.ts
@@ -1,16 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  getLocale: vi.fn(),
   loadMarketContextSettings: vi.fn(),
   getEventBySlug: vi.fn(),
   generateMarketContext: vi.fn(),
   getValidContext: vi.fn(),
   upsertContext: vi.fn(),
-}))
-
-vi.mock('next-intl/server', () => ({
-  getLocale: mocks.getLocale,
 }))
 
 vi.mock('@/lib/ai/market-context-config', () => ({
@@ -50,17 +45,14 @@ function makeEvent() {
   } as any
 }
 
-describe('generateMarketContextAction', () => {
+describe('resolveMarketContextRequest', () => {
   beforeEach(() => {
     vi.resetModules()
-    mocks.getLocale.mockReset()
     mocks.loadMarketContextSettings.mockReset()
     mocks.getEventBySlug.mockReset()
     mocks.generateMarketContext.mockReset()
     mocks.getValidContext.mockReset()
     mocks.upsertContext.mockReset()
-
-    mocks.getLocale.mockResolvedValue('en')
   })
 
   it('returns cached context when a valid cache entry exists', async () => {
@@ -75,12 +67,15 @@ describe('generateMarketContextAction', () => {
       error: null,
     })
 
-    const { generateMarketContextAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/generate-market-context')
+    const { resolveMarketContextRequest } = await import('@/lib/market-context-service')
 
-    const result = await generateMarketContextAction({
-      slug: 'event-slug',
-      marketConditionId: 'condition-1',
-    })
+    const result = await resolveMarketContextRequest(
+      {
+        slug: 'event-slug',
+        marketConditionId: 'condition-1',
+      },
+      'en',
+    )
 
     expect(result).toEqual({
       context: 'cached market summary',
@@ -96,13 +91,16 @@ describe('generateMarketContextAction', () => {
     mocks.getEventBySlug.mockResolvedValue({ data: makeEvent(), error: null })
     mocks.getValidContext.mockResolvedValue({ data: null, error: null })
 
-    const { generateMarketContextAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/generate-market-context')
+    const { resolveMarketContextRequest } = await import('@/lib/market-context-service')
 
-    const result = await generateMarketContextAction({
-      slug: 'event-slug',
-      marketConditionId: 'condition-1',
-      readOnly: true,
-    })
+    const result = await resolveMarketContextRequest(
+      {
+        slug: 'event-slug',
+        marketConditionId: 'condition-1',
+        readOnly: true,
+      },
+      'en',
+    )
 
     expect(result).toEqual({
       context: null,
@@ -129,12 +127,15 @@ describe('generateMarketContextAction', () => {
       error: null,
     })
 
-    const { generateMarketContextAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/generate-market-context')
+    const { resolveMarketContextRequest } = await import('@/lib/market-context-service')
 
-    const result = await generateMarketContextAction({
-      slug: 'event-slug',
-      marketConditionId: 'condition-1',
-    })
+    const result = await resolveMarketContextRequest(
+      {
+        slug: 'event-slug',
+        marketConditionId: 'condition-1',
+      },
+      'en',
+    )
 
     expect(result).toEqual({
       context: 'fresh market summary',

--- a/tests/unit/marketContextRoute.test.ts
+++ b/tests/unit/marketContextRoute.test.ts
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  safeParse: vi.fn(),
+  resolveMarketContextRequest: vi.fn(),
+}))
+
+vi.mock('@/lib/market-context-service', () => ({
+  MarketContextRequestSchema: {
+    safeParse: (...args: any[]) => mocks.safeParse(...args),
+  },
+  resolveMarketContextRequest: (...args: any[]) => mocks.resolveMarketContextRequest(...args),
+}))
+
+const { POST } = await import('@/app/api/market-context/route')
+
+describe('market context route', () => {
+  beforeEach(() => {
+    mocks.safeParse.mockReset()
+    mocks.resolveMarketContextRequest.mockReset()
+  })
+
+  it('returns 400 for schema-invalid payloads', async () => {
+    mocks.safeParse.mockReturnValue({
+      success: false,
+      error: { issues: [{ message: 'Invalid request.' }] },
+    })
+
+    const response = await POST(new Request('https://example.com/api/market-context', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    }))
+
+    expect(response.status).toBe(400)
+    await expect(response.json()).resolves.toEqual({ error: 'Invalid request.' })
+    expect(mocks.resolveMarketContextRequest).not.toHaveBeenCalled()
+  })
+
+  it('delegates validated payloads to the service', async () => {
+    const payload = {
+      slug: 'event-slug',
+      marketConditionId: 'condition-1',
+      readOnly: true,
+    }
+
+    mocks.safeParse.mockReturnValue({
+      success: true,
+      data: payload,
+    })
+    mocks.resolveMarketContextRequest.mockResolvedValue({
+      context: null,
+      expiresAt: null,
+      updatedAt: null,
+      cached: false,
+    })
+
+    const response = await POST(new Request('https://example.com/api/market-context', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-kuest-locale': 'pt',
+      },
+      body: JSON.stringify(payload),
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      context: null,
+      expiresAt: null,
+      updatedAt: null,
+      cached: false,
+    })
+    expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload, 'pt')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Route market context fetching through a new `/api/market-context` POST endpoint to fix server action parse errors and make preloading reliable. The client now sends locale and uses abortable requests; the API returns clear 400s for invalid payloads, and the service resolves locale server-side.

- **Bug Fixes**
  - Fixed parse errors and added proper 400 JSON responses for schema-invalid requests.
  - Locale is always respected; passed from the client and validated on the server.
  - Preload requests are abortable to prevent race conditions and UI warnings.

- **Refactors**
  - Added `/api/market-context` route and `resolveMarketContextRequest` with `zod` validation and locale resolution.
  - Removed server-action dependency; UI uses a `requestMarketContext` helper with explicit response handling.
  - Updated tests for the service and the API route.

<sup>Written for commit 3b9417741120fb3fb5e0ce83e651568ca63c7dac. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

