### PR TITLE
fix: admin auth guard, xss in announcement banner, home feed scan, api rate limiting

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1004.0",
+    "lru-cache": "^11.1.0",
     "@better-auth/drizzle-adapter": "^1.5.6",
     "@bprogress/next": "^3.2.12",
     "@fullcalendar/core": "^6.1.20",

--- a/src/app/[locale]/admin/layout.tsx
+++ b/src/app/[locale]/admin/layout.tsx
@@ -1,10 +1,10 @@
-'use cache'
-
 import type { Metadata } from 'next'
+import { notFound } from 'next/navigation'
 import { setRequestLocale } from 'next-intl/server'
 import PlatformViewerState from '@/app/[locale]/(platform)/_components/PlatformViewerState'
 import AdminHeader from '@/app/[locale]/admin/_components/AdminHeader'
 import AdminSidebar from '@/app/[locale]/admin/_components/AdminSidebar'
+import { UserRepository } from '@/lib/db/queries/user'
 import AppKitProvider from '@/providers/AppKitProvider'
 
 export const metadata: Metadata = {
@@ -14,6 +14,11 @@ export const metadata: Metadata = {
 export default async function AdminLayout({ params, children }: LayoutProps<'/[locale]/admin'>) {
   const { locale } = await params
   setRequestLocale(locale)
+
+  const user = await UserRepository.getCurrentUser()
+  if (!user || !user.is_admin) {
+    notFound()
+  }
 
   return (
     <AppKitProvider>

--- a/src/app/api/open-orders/route.ts
+++ b/src/app/api/open-orders/route.ts
@@ -41,7 +41,7 @@ export async function GET(request: Request) {
   try {
     const user = await UserRepository.getCurrentUser()
     if (!user) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ error: 'Unauthorized.' }, { status: 401 })
     }
 
     if (!CLOB_URL) {

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -1,16 +1,43 @@
 import type { PublicProfile, User } from '@/types'
+import type { NextRequest } from 'next/server'
 import { NextResponse } from 'next/server'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { UserRepository } from '@/lib/db/queries/user'
+import { checkRateLimit } from '@/lib/rate-limit'
 import { getPublicAssetUrl } from '@/lib/storage'
 import { getUserPublicAddress } from '@/lib/user-address'
 
-export async function GET(request: Request) {
+export async function GET(request: NextRequest) {
+  const ip
+    = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim()
+    ?? request.headers.get('x-real-ip')
+    ?? 'unknown'
+
+  const { allowed, remaining } = checkRateLimit(`users-search:${ip}`, {
+    limit: 30,
+    windowMs: 60_000,
+  })
+
+  if (!allowed) {
+    return NextResponse.json(
+      { error: 'Too many requests. Please try again later.' },
+      {
+        status: 429,
+        headers: {
+          'Retry-After': '60',
+          'X-RateLimit-Remaining': '0',
+        },
+      },
+    )
+  }
+
   const { searchParams } = new URL(request.url)
   const query = searchParams.get('search')
 
   if (!query || query.length < 2) {
-    return NextResponse.json([])
+    return NextResponse.json([], {
+      headers: { 'X-RateLimit-Remaining': String(remaining) },
+    })
   }
 
   try {

--- a/src/components/GlobalAnnouncementBanner.tsx
+++ b/src/components/GlobalAnnouncementBanner.tsx
@@ -16,6 +16,11 @@ function isExternalHttpUrl(value: string) {
   return value.startsWith('https://') || value.startsWith('http://')
 }
 
+// only allow safe URL schemes — blocks javascript:, data:, vbscript:, etc.
+function isSafeUrl(value: string) {
+  return value.startsWith('https://') || value.startsWith('http://') || value.startsWith('/')
+}
+
 function stripLocalePrefix(pathname: string | null, locale: string) {
   if (!pathname) {
     return pathname
@@ -56,7 +61,7 @@ export default function GlobalAnnouncementBanner({
     </div>
   )
 
-  if (!linkUrl) {
+  if (!linkUrl || !isSafeUrl(linkUrl)) {
     return content
   }
 

--- a/src/lib/home-events-page.ts
+++ b/src/lib/home-events-page.ts
@@ -48,7 +48,14 @@ export async function listHomeEventsPage({
   const accumulatedEvents: Event[] = []
   let visibleEvents: Event[] = []
 
-  while (true) {
+  // cap the number of DB round-trips so a large catalog with aggressive tag
+  // filters can't turn a single page load into a full-table scan
+  const MAX_ITERATIONS = 10
+  let iterations = 0
+
+  while (iterations < MAX_ITERATIONS) {
+    iterations++
+
     const { data: rawEvents, error } = await EventRepository.listEvents({
       tag,
       mainTag,
@@ -83,7 +90,9 @@ export async function listHomeEventsPage({
       status,
     })
 
-    if (status === 'resolved' && visibleEvents.length >= targetVisibleCount) {
+    // stop as soon as we have gathered enough visible events for the requested page,
+    // regardless of status — previously this early-exit only applied to 'resolved'
+    if (visibleEvents.length >= targetVisibleCount) {
       break
     }
 

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,0 +1,48 @@
+import { LRUCache } from 'lru-cache'
+
+interface RateLimitEntry {
+  count: number
+  resetAt: number
+}
+
+// keyed by "<route>:<ip>", capped at 5 000 distinct callers in memory
+const store = new LRUCache<string, RateLimitEntry>({ max: 5_000 })
+
+interface RateLimitOptions {
+  /** number of allowed requests per window */
+  limit?: number
+  /** window size in milliseconds */
+  windowMs?: number
+}
+
+interface RateLimitResult {
+  allowed: boolean
+  remaining: number
+  resetAt: number
+}
+
+/**
+ * Simple fixed-window in-memory rate limiter.
+ * In a multi-instance deployment (e.g. Vercel serverless) each instance
+ * maintains its own counter — use a shared store (Redis / KV) for global limits.
+ */
+export function checkRateLimit(
+  key: string,
+  { limit = 30, windowMs = 60_000 }: RateLimitOptions = {},
+): RateLimitResult {
+  const now = Date.now()
+  const entry = store.get(key)
+
+  if (!entry || now >= entry.resetAt) {
+    const resetAt = now + windowMs
+    store.set(key, { count: 1, resetAt }, { ttl: windowMs })
+    return { allowed: true, remaining: limit - 1, resetAt }
+  }
+
+  if (entry.count >= limit) {
+    return { allowed: false, remaining: 0, resetAt: entry.resetAt }
+  }
+
+  entry.count++
+  return { allowed: true, remaining: limit - entry.count, resetAt: entry.resetAt }
+}


### PR DESCRIPTION
## summary

found a few security and performance issues while reading through the codebase — all in places that could cause real problems for anyone running a production deployment.

---

### 1. admin pages were accessible to everyone

`src/app/[locale]/admin/layout.tsx` had `'use cache'` at the top and zero auth check. any visitor who hit `/[locale]/admin/...` would get the full admin ui shell rendered by the server. all the *mutations* were guarded in individual server actions, but the read side (page data, settings previews) was completely open.

fixed by removing `'use cache'` (which blocks dynamic apis like `headers()` anyway) and adding a `getCurrentUser()` + `is_admin` check with `notFound()` as the fallback, matching the same pattern already used in every server action.

---

### 2. stored xss via announcement banner link url

`GlobalAnnouncementBanner.tsx` put the admin-configured `linkUrl` straight into `href` with no scheme validation. clicking a banner with `linkUrl` set to `javascript:...` would run arbitrary code in every visitor's browser.

the existing `isExternalHttpUrl` helper already existed but only determined whether to open in a new tab — it never blocked the render. added a small `isSafeUrl()` helper that allowlists `https://`, `http://`, and relative `/` paths, and short-circuits the link render for anything else.

---

### 3. home feed was scanning the entire events table on every page load

`listHomeEventsPage` in `src/lib/home-events-page.ts` had a `while (true)` loop that kept fetching batches from the db until the last batch came back short. the only early-exit was `status === 'resolved' && visibleEvents.length >= targetVisibleCount`. for `active` and `all` it would scan everything, which is fine with 100 events but catastrophic at scale when tag filters (hide sports, hide crypto, hide earnings) are discarding large chunks of each batch.

fixed by applying the same `visibleEvents.length >= targetVisibleCount` break to all statuses, plus adding a `MAX_ITERATIONS = 10` hard cap (max ~320 raw events inspected per page request).

---

### 4. open-orders returned 200 with an empty array when unauthenticated

clients that check `response.ok` would treat this as a successful "you have no orders" response rather than "you are not logged in". changed to `401` so the client can distinguish these two states.

---

### 5. public user search had no rate limiting (wallet enumeration)

`GET /api/users?search=...` returned wallet addresses and proxy wallet addresses for any two-character prefix with zero auth or throttling. trivial to enumerate the entire user base.

added a fixed-window ip-based rate limiter (30 req / 60 s) in a new `src/lib/rate-limit.ts` using `lru-cache`. the module is designed to be swapped out for a redis/kv backed store in multi-instance deployments — the interface stays the same.

---

made by mooncitydev


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Locks down admin pages, blocks unsafe banner links, rate‑limits public user search, fixes open‑orders auth response, and caps home feed scans for better performance.

- **Bug Fixes**
  - Admin layout now checks `getCurrentUser()` and `is_admin`; uses `notFound()` if unauthorized. Removed `'use cache'`.
  - Announcement banner only renders links with `https://`, `http://`, or `/` paths; blocks `javascript:` and other schemes.
  - Home feed stops after enough visible events are found and is capped at 10 iterations to avoid full‑table scans.
  - `/api/open-orders` returns `401` when unauthenticated (was `200` with empty data).
  - `/api/users` adds per‑IP fixed‑window rate limiting (30 req/60s) via `checkRateLimit`; returns `429` with `Retry-After` and `X-RateLimit-Remaining`.

- **Dependencies**
  - Added `lru-cache` for in‑memory rate limiting.

<sup>Written for commit 3dc45a0ce8b7d48129377045717f7e0e79cbafcf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

