### PR TITLE
fix: stabilize sports date rendering to prevent hydration mismatch

### DIFF
--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -427,10 +427,10 @@ export default function SportsEventCenter({
         : Number.NaN
   const startTimestamp = Number.isFinite(parsedStartTimestamp) ? parsedStartTimestamp : null
   const timeLabel = startTimestamp !== null
-    ? new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' }).format(startTimestamp)
+    ? new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' }).format(startTimestamp)
     : 'TBD'
   const dayLabel = startTimestamp !== null
-    ? new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric' }).format(startTimestamp)
+    ? new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric', timeZone: 'UTC' }).format(startTimestamp)
     : 'Date TBD'
 
   const team1 = heroCard.teams[0] ?? null

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventRelatedGames.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventRelatedGames.tsx
@@ -30,6 +30,7 @@ function SportsEventRelatedGames({
       day: 'numeric',
       hour: 'numeric',
       minute: '2-digit',
+      timeZone: 'UTC',
     }),
     [locale],
   )

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
@@ -313,9 +313,9 @@ export function groupButtonsByMarketType(buttons: SportsGamesButton[]) {
 }
 
 export function toDateGroupKey(date: Date) {
-  const year = date.getFullYear()
-  const month = String(date.getMonth() + 1).padStart(2, '0')
-  const day = String(date.getDate()).padStart(2, '0')
+  const year = date.getUTCFullYear()
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(date.getUTCDate()).padStart(2, '0')
   return `${year}-${month}-${day}`
 }
 

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGamesCenter.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGamesCenter.ts
@@ -507,6 +507,7 @@ export function useLocaleDateTimeFormatters(locale: string) {
       weekday: 'short',
       month: 'long',
       day: 'numeric',
+      timeZone: 'UTC',
     }),
     [locale],
   )
@@ -515,6 +516,7 @@ export function useLocaleDateTimeFormatters(locale: string) {
     () => new Intl.DateTimeFormat(locale, {
       hour: 'numeric',
       minute: '2-digit',
+      timeZone: 'UTC',
     }),
     [locale],
   )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes sports date/time rendering by forcing UTC so server and client output match. Fixes hydration warnings and prevents unexpected MPA fallback.

- **Bug Fixes**
  - Set `timeZone: 'UTC'` in all sports date/time formatters (event center, related games, hooks).
  - Use `getUTCFullYear`/`getUTCMonth`/`getUTCDate` in `toDateGroupKey` to prevent local TZ shifts.
  - Result: consistent labels and grouping across SSR/CSR.

<sup>Written for commit d7d4b62e575a193872f87c56af8ef587ee5122a8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

