### PR TITLE
fix: eliminate sports hydration mismatches causing MPA fallback

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
@@ -129,6 +129,7 @@ export default function EventRules({ event, mode = 'accordion', showEndDate = fa
       month: 'short',
       day: 'numeric',
       year: 'numeric',
+      timeZone: 'UTC',
     }).format(date)
   }
 

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -14,27 +14,33 @@ function subscribeToWindowSizeStore(onStoreChange: () => void) {
     return function unsubscribeFromWindowSizeStore() {}
   }
 
-  window.addEventListener('resize', onStoreChange)
+  function publishWindowSizeIfChanged() {
+    const nextWindowSize = {
+      width: window.innerWidth,
+      height: window.innerHeight,
+    }
+
+    if (
+      cachedWindowSize.width === nextWindowSize.width
+      && cachedWindowSize.height === nextWindowSize.height
+    ) {
+      return
+    }
+
+    cachedWindowSize = nextWindowSize
+    onStoreChange()
+  }
+
+  window.addEventListener('resize', publishWindowSizeIfChanged)
+  const initialFrame = window.requestAnimationFrame(publishWindowSizeIfChanged)
 
   return function unsubscribeFromWindowSizeStore() {
-    window.removeEventListener('resize', onStoreChange)
+    window.cancelAnimationFrame(initialFrame)
+    window.removeEventListener('resize', publishWindowSizeIfChanged)
   }
 }
 
 function getWindowSizeClientSnapshot() {
-  const nextWindowSize = {
-    width: window.innerWidth,
-    height: window.innerHeight,
-  }
-
-  if (
-    cachedWindowSize.width === nextWindowSize.width
-    && cachedWindowSize.height === nextWindowSize.height
-  ) {
-    return cachedWindowSize
-  }
-
-  cachedWindowSize = nextWindowSize
   return cachedWindowSize
 }
 

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -8,35 +8,61 @@ interface WindowSize {
 const INITIAL_WINDOW_SIZE: WindowSize = { width: 0, height: 0 }
 
 let cachedWindowSize = INITIAL_WINDOW_SIZE
+const subscribers = new Set<() => void>()
+let isListeningForWindowResize = false
+let initialWindowSizeFrame: number | null = null
+
+function readWindowSize() {
+  return {
+    width: window.innerWidth,
+    height: window.innerHeight,
+  }
+}
+
+function publishWindowSizeIfChanged() {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  const nextWindowSize = readWindowSize()
+  if (
+    cachedWindowSize.width === nextWindowSize.width
+    && cachedWindowSize.height === nextWindowSize.height
+  ) {
+    return
+  }
+
+  cachedWindowSize = nextWindowSize
+  subscribers.forEach(subscriber => subscriber())
+}
 
 function subscribeToWindowSizeStore(onStoreChange: () => void) {
   if (typeof window === 'undefined') {
     return function unsubscribeFromWindowSizeStore() {}
   }
 
-  function publishWindowSizeIfChanged() {
-    const nextWindowSize = {
-      width: window.innerWidth,
-      height: window.innerHeight,
-    }
+  subscribers.add(onStoreChange)
 
-    if (
-      cachedWindowSize.width === nextWindowSize.width
-      && cachedWindowSize.height === nextWindowSize.height
-    ) {
+  if (!isListeningForWindowResize) {
+    isListeningForWindowResize = true
+    window.addEventListener('resize', publishWindowSizeIfChanged)
+    initialWindowSizeFrame = window.requestAnimationFrame(publishWindowSizeIfChanged)
+  }
+
+  return function unsubscribeFromWindowSizeStore() {
+    subscribers.delete(onStoreChange)
+
+    if (subscribers.size > 0 || !isListeningForWindowResize) {
       return
     }
 
-    cachedWindowSize = nextWindowSize
-    onStoreChange()
-  }
+    if (initialWindowSizeFrame != null) {
+      window.cancelAnimationFrame(initialWindowSizeFrame)
+      initialWindowSizeFrame = null
+    }
 
-  window.addEventListener('resize', publishWindowSizeIfChanged)
-  const initialFrame = window.requestAnimationFrame(publishWindowSizeIfChanged)
-
-  return function unsubscribeFromWindowSizeStore() {
-    window.cancelAnimationFrame(initialFrame)
     window.removeEventListener('resize', publishWindowSizeIfChanged)
+    isListeningForWindowResize = false
   }
 }
 

--- a/tests/unit/useWindowSize.test.tsx
+++ b/tests/unit/useWindowSize.test.tsx
@@ -1,0 +1,38 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useWindowSize } from '@/hooks/useWindowSize'
+
+function setWindowSize(width: number, height: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+  Object.defineProperty(window, 'innerHeight', {
+    configurable: true,
+    writable: true,
+    value: height,
+  })
+}
+
+describe('useWindowSize', () => {
+  it('notifies every subscriber when the viewport changes', async () => {
+    const first = renderHook(() => useWindowSize())
+    const second = renderHook(() => useWindowSize())
+
+    act(() => {
+      setWindowSize(1111, 777)
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    act(() => {
+      setWindowSize(2222, 888)
+      window.dispatchEvent(new Event('resize'))
+    })
+
+    await waitFor(() => {
+      expect(first.result.current).toEqual({ width: 2222, height: 888 })
+      expect(second.result.current).toEqual({ width: 2222, height: 888 })
+    })
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes hydration mismatches on sports event pages that triggered MPA fallback by aligning date formatting and making window size updates consistent across components.

- **Bug Fixes**
  - Set UTC in `EventRules` date formatter so server and client render the same dates.
  - Reworked `useWindowSize` to cache and publish only on real changes, trigger an initial rAF publish, broadcast updates to all subscribers, avoid mutating snapshots, and clean up listeners; added a unit test to verify multi-subscriber updates.

<sup>Written for commit 436bc5190786487c9bf8e251ce961435d83d6a5a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

