### PR TITLE
fix: stuck onboarding modal on step 3

### DIFF
--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -484,6 +484,9 @@ function useTokenApprovalsFlow({
   refreshSessionUserState,
   setApprovalsStep,
   setTokenApprovalError,
+  setRequiresTradingAuthRefresh,
+  setTradingAuthStep,
+  setTradingAuthError,
 }: {
   user: User | null
   tradingAuthSatisfied: boolean
@@ -491,6 +494,9 @@ function useTokenApprovalsFlow({
   refreshSessionUserState: () => Promise<void>
   setApprovalsStep: (value: ApprovalsStep) => void
   setTokenApprovalError: (value: string | null) => void
+  setRequiresTradingAuthRefresh: (value: boolean) => void
+  setTradingAuthStep: (value: TradingAuthStep) => void
+  setTradingAuthError: (value: string | null) => void
 }) {
   const { signMessageAsync } = useSignMessage()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
@@ -513,6 +519,15 @@ function useTokenApprovalsFlow({
       setApprovalsStep('signing')
       const nonceResult = await getSafeNonceAction()
       if (nonceResult.error || !nonceResult.nonce) {
+        if (isTradingAuthRequiredError(nonceResult.error)) {
+          setRequiresTradingAuthRefresh(true)
+          setTradingAuthStep('idle')
+          setTradingAuthError(null)
+          setTokenApprovalError(null)
+          setApprovalsStep('idle')
+          void refreshSessionUserState()
+          return
+        }
         setTokenApprovalError(nonceResult.error ?? DEFAULT_ERROR_MESSAGE)
         setApprovalsStep('idle')
         return
@@ -575,6 +590,15 @@ function useTokenApprovalsFlow({
 
       const submitResult = await submitSafeTransactionAction(requestPayload)
       if (submitResult.error) {
+        if (isTradingAuthRequiredError(submitResult.error)) {
+          setRequiresTradingAuthRefresh(true)
+          setTradingAuthStep('idle')
+          setTradingAuthError(null)
+          setTokenApprovalError(null)
+          setApprovalsStep('idle')
+          void refreshSessionUserState()
+          return
+        }
         setTokenApprovalError(submitResult.error)
         setApprovalsStep('idle')
         return
@@ -617,7 +641,10 @@ function useTokenApprovalsFlow({
     resolveReferralExchanges,
     runWithSignaturePrompt,
     setApprovalsStep,
+    setRequiresTradingAuthRefresh,
     setTokenApprovalError,
+    setTradingAuthError,
+    setTradingAuthStep,
     signMessageAsync,
     tradingAuthSatisfied,
     user,
@@ -962,6 +989,9 @@ function TradingOnboardingProviderContent({
     refreshSessionUserState,
     setApprovalsStep,
     setTokenApprovalError,
+    setRequiresTradingAuthRefresh,
+    setTradingAuthStep,
+    setTradingAuthError,
   })
 
   const { ensureTradingReady, openTradeRequirements, openAppKit } = useTradingReadyGate({


### PR DESCRIPTION
<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the onboarding modal getting stuck on step 3 by detecting when trading auth is required and redirecting users back to the trading auth step. Users now see the correct step instead of a frozen approvals screen.

- **Bug Fixes**
  - Detect “trading auth required” errors during nonce fetch and transaction submit in `useTokenApprovalsFlow`.
  - Reset approvals to `idle`, clear token approval errors, set `requiresTradingAuthRefresh`, set trading auth step to `idle`, and refresh session user state.
  - Pass `setRequiresTradingAuthRefresh`, `setTradingAuthStep`, and `setTradingAuthError` through the provider.

<sup>Written for commit 1605aceb1c04b80b66fcc37676cbc1aaa66a28b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

