### PR TITLE
docs: add batch prices history endpoint

### DIFF
--- a/docs/api-reference/markets/get-batch-prices-history.mdx
+++ b/docs/api-reference/markets/get-batch-prices-history.mdx
@@ -1,0 +1,14 @@
+---
+title: Get Batch Prices History
+description: "Get historical midpoint prices for many markets"
+full: true
+_openapi:
+  method: POST
+---
+
+<APIPage
+  document="clob"
+  operations={[
+    { path: '/batch-prices-history', method: 'post' }
+  ]}
+/>

--- a/docs/api-reference/markets/meta.json
+++ b/docs/api-reference/markets/meta.json
@@ -11,6 +11,7 @@
     "get-market-by-id",
     "get-market-by-slug",
     "get-prices-history",
+    "get-batch-prices-history",
     "get-sampling-markets",
     "get-sampling-simplified-markets",
     "get-simplified-markets",

--- a/docs/api-reference/rate-limits.mdx
+++ b/docs/api-reference/rate-limits.mdx
@@ -59,6 +59,7 @@ description: Request caps and throttling windows for CLOB endpoints
 | `POST /prices` | 80 requests / 10s | Throttled above configured maximum |
 | `GET /midpoint` | 200 requests / 10s | Throttled above configured maximum |
 | `GET /prices-history` | 100 requests / 10s | Throttled above configured maximum |
+| `POST /batch-prices-history` | 80 requests / 10s | Throttled above configured maximum |
 
 ### Ledger
 

--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -865,6 +865,40 @@
         }
       }
     },
+    "/batch-prices-history": {
+      "post": {
+        "tags": [
+          "Pricing"
+        ],
+        "summary": "Get historical midpoint prices for many markets",
+        "operationId": "postBatchPriceHistory",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/BatchPriceHistoryRequest"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Time series of midpoint prices per market",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/BatchPriceHistoryResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        }
+      }
+    },
     "/spreads": {
       "post": {
         "tags": [
@@ -5019,6 +5053,72 @@
             "type": "array",
             "items": {
               "$ref": "#/components/schemas/PriceHistoryPoint"
+            }
+          }
+        }
+      },
+      "BatchPriceHistoryRequest": {
+        "type": "object",
+        "required": [
+          "markets"
+        ],
+        "properties": {
+          "markets": {
+            "type": "array",
+            "description": "Token identifiers (markets) to query. Maximum 20.",
+            "minItems": 1,
+            "maxItems": 20,
+            "items": {
+              "type": "string"
+            }
+          },
+          "start_ts": {
+            "type": "integer",
+            "format": "int64",
+            "description": "Start of the time range (unix timestamp in seconds). Required when interval is absent."
+          },
+          "end_ts": {
+            "type": "integer",
+            "format": "int64",
+            "description": "End of the time range (unix timestamp in seconds). Defaults to now when omitted."
+          },
+          "interval": {
+            "type": "string",
+            "description": "Preset time window to query. Cannot be used with start_ts/end_ts. `all` is accepted as an alias for `max` and uses 12h buckets aligned to 00:00/12:00 UTC.",
+            "enum": [
+              "1m",
+              "5m",
+              "15m",
+              "1h",
+              "6h",
+              "1d",
+              "1w",
+              "max",
+              "all"
+            ]
+          },
+          "fidelity": {
+            "type": "integer",
+            "format": "int32",
+            "minimum": 1,
+            "description": "Bucket size in minutes when using explicit timestamps. Auto-calculated when omitted and rounded up to the nearest supported step (1m, 5m, 30m, 3h, 12h)."
+          }
+        }
+      },
+      "BatchPriceHistoryResponse": {
+        "type": "object",
+        "required": [
+          "history"
+        ],
+        "properties": {
+          "history": {
+            "type": "object",
+            "description": "Map of token identifier to historical midpoint price series.",
+            "additionalProperties": {
+              "type": "array",
+              "items": {
+                "$ref": "#/components/schemas/PriceHistoryPoint"
+              }
             }
           }
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds docs for `POST /batch-prices-history`, a new endpoint to fetch historical midpoint prices for multiple markets in one request. Updates the OpenAPI schema and rate limits to include this route.

- **New Features**
  - Added Markets page: Get Batch Prices History.
  - Updated `openapi-clob.json` with `POST /batch-prices-history`, `BatchPriceHistoryRequest` (markets up to 20, timestamps or interval, optional fidelity), and `BatchPriceHistoryResponse`.
  - Updated rate limits: `POST /batch-prices-history` set to 80 requests / 10s.

<sup>Written for commit 43b047f0e564e125ec65e4f72b07bf0883ecc2a2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

