### PR TITLE
fix: batch event price history requests

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -16,9 +16,11 @@ const config: NextConfig = {
   reactStrictMode: false,
   reactCompiler: true,
   experimental: {
+    optimizePackageImports: ['radix-ui'],
     serverActions: {
       bodySizeLimit: '2mb',
     },
+    typedEnv: true,
   },
   images: {
     unoptimized: process.env.DISABLE_IMAGE_OPTIMIZATION === 'true',

--- a/src/app/[locale]/(platform)/_lib/public-profile-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/public-profile-page.tsx
@@ -21,10 +21,6 @@ function buildLocalizedPagePath(path: string, locale: SupportedLocale) {
   return `/${locale}${path}`
 }
 
-function getFallbackChartEndDate() {
-  return new Date().toISOString()
-}
-
 function buildPublicProfileOgImageUrl({
   locale,
   slug,
@@ -143,7 +139,6 @@ export async function buildPublicProfileMetadata({
 }
 
 export async function PublicProfilePageContent({ slug }: { slug: string }) {
-  const fallbackChartEndDate = getFallbackChartEndDate()
   const normalized = normalizePublicProfileSlug(slug)
   if (normalized.type === 'invalid') {
     notFound()
@@ -157,6 +152,7 @@ export async function PublicProfilePageContent({ slug }: { slug: string }) {
     }
 
     const snapshot = await fetchPortfolioSnapshot(normalized.value)
+    const fallbackChartEndDate = new Date().toISOString()
 
     return (
       <>
@@ -177,6 +173,7 @@ export async function PublicProfilePageContent({ slug }: { slug: string }) {
 
   const userAddress = profile.proxy_wallet_address!
   const snapshot = await fetchPortfolioSnapshot(userAddress)
+  const fallbackChartEndDate = new Date().toISOString()
 
   return (
     <>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartExportDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartExportDialog.tsx
@@ -1,9 +1,17 @@
 'use client'
 
+import type {
+  PriceHistoryPoint,
+  RangeFilters,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/priceHistoryApi'
 import type { Market } from '@/types'
 import { CalendarIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useId, useMemo, useState, useSyncExternalStore } from 'react'
+import {
+  fetchBatchPriceHistoryByTokenIds,
+  mapTokenHistoryToConditionHistory,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/priceHistoryApi'
 import { Button } from '@/components/ui/button'
 import { Calendar } from '@/components/ui/calendar'
 import { Checkbox } from '@/components/ui/checkbox'
@@ -45,15 +53,6 @@ const FREQUENCY_FIDELITY_MINUTES: Record<Frequency, number> = {
   daily: 1440,
   weekly: 10080,
   monthly: 43200,
-}
-
-interface PriceHistoryPoint {
-  t: number
-  p: number
-}
-
-interface PriceHistoryResponse {
-  history?: PriceHistoryPoint[]
 }
 
 interface MarketTarget {
@@ -127,27 +126,6 @@ function buildMarketTarget(market: Market): MarketTarget | null {
     tokenId: String(yesOutcome.token_id),
     label: sanitizeTsvValue(market.short_title ?? ''),
   }
-}
-
-async function fetchTokenPriceHistory(
-  tokenId: string,
-  filters: Record<string, string>,
-): Promise<PriceHistoryPoint[]> {
-  const url = new URL(`${process.env.CLOB_URL!}/prices-history`)
-  url.searchParams.set('market', tokenId)
-  Object.entries(filters).forEach(([key, value]) => {
-    url.searchParams.set(key, value)
-  })
-
-  const response = await fetch(url.toString())
-  if (!response.ok) {
-    throw new Error('Failed to fetch price history')
-  }
-
-  const payload = await response.json() as PriceHistoryResponse
-  return (payload.history ?? [])
-    .map(point => ({ t: Number(point.t), p: Number(point.p) }))
-    .filter(point => Number.isFinite(point.t) && Number.isFinite(point.p))
 }
 
 function buildCsvContent(
@@ -331,7 +309,7 @@ function EventChartExportDialogBody({
       const toSeconds = Math.floor(toDate.getTime() / 1000)
       const startTs = Math.min(fromSeconds, toSeconds)
       const endTs = Math.max(fromSeconds, toSeconds)
-      const filters = {
+      const filters: RangeFilters = {
         fidelity: String(FREQUENCY_FIDELITY_MINUTES[frequency]),
         startTs: String(startTs),
         endTs: String(endTs),
@@ -355,18 +333,11 @@ function EventChartExportDialogBody({
         return
       }
 
-      const entries = await Promise.all(
-        targets.map(async (target) => {
-          try {
-            const history = await fetchTokenPriceHistory(target.tokenId, filters)
-            return [target.conditionId, history] as const
-          }
-          catch {
-            return [target.conditionId, []] as const
-          }
-        }),
+      const historyByToken = await fetchBatchPriceHistoryByTokenIds(
+        targets.map(target => target.tokenId),
+        filters,
       )
-      const historyByMarket = Object.fromEntries(entries)
+      const historyByMarket = mapTokenHistoryToConditionHistory(targets, historyByToken)
       const csv = buildCsvContent(historyByMarket, targets, isMultiMarket)
       const siteName = buildSiteSlug(site.name ?? '', { fallback: 'market' })
       const filename = `${siteName}-price-data-${formatFilenameDate(fromDate, locale)}-${formatFilenameDate(toDate, locale)}-${Date.now()}.csv`

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
@@ -11,7 +11,6 @@ import EventCategoryNote from '@/app/[locale]/(platform)/event/[slug]/_component
 import EventHeader from '@/app/[locale]/(platform)/event/[slug]/_components/EventHeader'
 import EventMarketChannelProvider from '@/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider'
 import EventMarkets from '@/app/[locale]/(platform)/event/[slug]/_components/EventMarkets'
-import EventOrderPanelForm from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm'
 import EventOrderPanelTermsDisclaimer from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelTermsDisclaimer'
 import { EventOutcomeChanceProvider } from '@/app/[locale]/(platform)/event/[slug]/_components/EventOutcomeChanceProvider'
 import EventRelatedSkeleton from '@/app/[locale]/(platform)/event/[slug]/_components/EventRelatedSkeleton'
@@ -53,6 +52,11 @@ const EventRelated = dynamic(
 const EventMarketPositions = dynamic(
   () => import('@/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions'),
   { ssr: false, loading: () => <Skeleton className="h-52" /> },
+)
+
+const EventOrderPanelDesktop = dynamic(
+  () => import('@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm'),
+  { ssr: false, loading: () => <Skeleton className="h-136 w-full rounded-xl" /> },
 )
 
 const EventMarketOpenOrders = dynamic(
@@ -638,7 +642,7 @@ export default function EventContent({
             `}
           >
             <div className="grid gap-6">
-              <EventOrderPanelForm
+              <EventOrderPanelDesktop
                 event={event}
                 isMobile={false}
                 initialMarket={initialMarket}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventContent.tsx
@@ -56,7 +56,7 @@ const EventMarketPositions = dynamic(
 
 const EventOrderPanelDesktop = dynamic(
   () => import('@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm'),
-  { ssr: false, loading: () => <Skeleton className="h-136 w-full rounded-xl" /> },
+  { ssr: false, loading: () => <Skeleton className="h-80 w-full rounded-xl" /> },
 )
 
 const EventMarketOpenOrders = dynamic(

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -17,15 +17,17 @@ import ResolvedMarketRow from '@/app/[locale]/(platform)/event/[slug]/_component
 import { useChanceRefresh } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useChanceRefresh'
 import { useEventMarketRows } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows'
 import { useEventMarketQuotes } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMidPrices'
-import { buildMarketTargets, useEventPriceHistory } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory'
+import { useEventPriceHistory } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory'
 import { useMarketDetailController } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useMarketDetailController'
 import { useUserOpenOrdersQuery } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserOpenOrdersQuery'
 import { useUserShareBalances } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances'
 import { useXTrackerTweetCount } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useXTrackerTweetCount'
+import { applyCachedChartDeltaToEventMarketRow } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventMarketChanceMeta'
 import { isMarketResolved, POSITION_VISIBILITY_THRESHOLD } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventMarketUtils'
 import {
   resolveEventResolvedOutcomeIndex,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventResolvedOutcome'
+import { buildRowChartDeltaTargets } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventRowChartDeltaTargets'
 import { isTweetMarketsEvent } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventTweetMarkets'
 import { isResolutionReviewActive } from '@/app/[locale]/(platform)/event/[slug]/_utils/resolution-timeline-builder'
 import { useCurrentTimestamp } from '@/hooks/useCurrentTimestamp'
@@ -46,26 +48,6 @@ export { resolveWinningOutcomeIndex } from '@/app/[locale]/(platform)/event/[slu
 interface EventMarketsProps {
   event: Event
   isMobile: boolean
-}
-
-function resolveChanceMetaForOpenedChart(
-  chanceMeta: EventMarketRow['chanceMeta'],
-  chanceDelta: number | null,
-) {
-  if (typeof chanceDelta !== 'number' || !Number.isFinite(chanceDelta)) {
-    return chanceMeta
-  }
-
-  const roundedChanceDelta = Math.round(chanceDelta)
-  const absoluteChanceDelta = Math.abs(roundedChanceDelta)
-  const shouldShowChanceChange = absoluteChanceDelta >= 1
-
-  return {
-    ...chanceMeta,
-    shouldShowChanceChange,
-    chanceChangeLabel: shouldShowChanceChange ? `${absoluteChanceDelta}%` : '',
-    isChanceChangePositive: roundedChanceDelta > 0,
-  }
 }
 
 function toNumber(value: unknown) {
@@ -713,26 +695,11 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
       values: {},
     }
   }
-  const shouldHydrateChartDeltas = Boolean(expandedMarketId)
   const rowChartDeltaTargets = useMemo(
-    () => {
-      if (!shouldHydrateChartDeltas || !expandedMarketId) {
-        return []
-      }
-
-      const expandedMarket = event.markets.find(market => market.condition_id === expandedMarketId)
-      if (!expandedMarket || isMarketResolved(expandedMarket)) {
-        return []
-      }
-
-      return buildMarketTargets([expandedMarket])
-    },
-    [event.markets, expandedMarketId, shouldHydrateChartDeltas],
+    () => buildRowChartDeltaTargets(event.markets),
+    [event.markets],
   )
-  const rowChartDeltaTargetConditionIds = useMemo(
-    () => new Set(rowChartDeltaTargets.map(target => target.conditionId)),
-    [rowChartDeltaTargets],
-  )
+  const shouldHydrateChartDeltas = rowChartDeltaTargets.length > 0
   const rowChartDeltaPriceHistory = useEventPriceHistory({
     eventId: event.id,
     range: 'ALL',
@@ -908,15 +875,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
         {primaryMarketRows
           .map((row, index, orderedMarkets) => {
             const { market } = row
-            const chartDeltaForMarket = rowChartDeltaTargetConditionIds.has(market.condition_id)
-              ? (stableRowChartDeltaYesByMarket[market.condition_id] ?? null)
-              : null
-            const resolvedChanceMeta = shouldHydrateChartDeltas
-              ? resolveChanceMetaForOpenedChart(row.chanceMeta, chartDeltaForMarket)
-              : row.chanceMeta
-            const resolvedRow = resolvedChanceMeta === row.chanceMeta
-              ? row
-              : { ...row, chanceMeta: resolvedChanceMeta }
+            const resolvedRow = applyCachedChartDeltaToEventMarketRow(row, stableRowChartDeltaYesByMarket)
             const isExpanded = expandedMarketId === market.condition_id
             const activeOutcomeForMarket = selectedOutcome && selectedOutcome.condition_id === market.condition_id
               ? selectedOutcome

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory.ts
@@ -1,32 +1,22 @@
+import type {
+  PriceHistoryByKey as PriceHistoryByMarket,
+  RangeFilters,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/priceHistoryApi'
 import type { Market } from '@/types'
 import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { useMemo } from 'react'
+import {
+  fetchBatchPriceHistoryByTokenIds,
+  mapTokenHistoryToConditionHistory,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/priceHistoryApi'
 import { OUTCOME_INDEX } from '@/lib/constants'
 
 export type TimeRange = '1H' | '6H' | '1D' | '1W' | '1M' | 'ALL'
-
-interface PriceHistoryPoint {
-  t: number
-  p: number
-}
-
-interface PriceHistoryResponse {
-  history?: PriceHistoryPoint[]
-}
 
 export interface MarketTokenTarget {
   conditionId: string
   tokenId: string
 }
-
-interface RangeFilters {
-  fidelity: string
-  interval?: string
-  startTs?: string
-  endTs?: string
-}
-
-type PriceHistoryByMarket = Record<string, PriceHistoryPoint[]>
 
 interface NormalizedHistoryResult {
   points: Array<Record<string, number | Date> & { date: Date }>
@@ -153,30 +143,6 @@ function buildTimeRangeFilters(range: TimeRange, createdAt: string, resolvedAt?:
   }
 }
 
-async function fetchTokenPriceHistory(tokenId: string, filters: RangeFilters): Promise<PriceHistoryPoint[]> {
-  const url = new URL(`${process.env.CLOB_URL!}/prices-history`)
-  url.searchParams.set('market', tokenId)
-
-  Object.entries(filters).forEach(([key, value]) => {
-    if (value !== undefined) {
-      url.searchParams.set(key, value)
-    }
-  })
-
-  const response = await fetch(url.toString())
-  if (!response.ok) {
-    throw new Error('Failed to fetch price history')
-  }
-
-  const payload = await response.json() as PriceHistoryResponse
-  return (payload.history ?? [])
-    .map(point => ({
-      t: Number(point.t),
-      p: Number(point.p),
-    }))
-    .filter(point => Number.isFinite(point.t) && Number.isFinite(point.p))
-}
-
 async function fetchEventPriceHistory(
   targets: MarketTokenTarget[],
   range: TimeRange,
@@ -188,19 +154,12 @@ async function fetchEventPriceHistory(
   }
 
   const filters = buildTimeRangeFilters(range, eventCreatedAt, eventResolvedAt)
-  const entries = await Promise.all(
-    targets.map(async (target) => {
-      try {
-        const history = await fetchTokenPriceHistory(target.tokenId, filters)
-        return [target.conditionId, history] as const
-      }
-      catch {
-        return [target.conditionId, []] as const
-      }
-    }),
+  const historyByToken = await fetchBatchPriceHistoryByTokenIds(
+    targets.map(target => target.tokenId),
+    filters,
   )
 
-  return Object.fromEntries(entries)
+  return mapTokenHistoryToConditionHistory(targets, historyByToken)
 }
 
 function clampPrice(value: number) {

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventMarketChanceMeta.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventMarketChanceMeta.ts
@@ -1,0 +1,40 @@
+import type { EventMarketRow } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows'
+
+export function resolveChanceMetaForChartDelta(
+  chanceMeta: EventMarketRow['chanceMeta'],
+  chanceDelta: number | null,
+) {
+  if (typeof chanceDelta !== 'number' || !Number.isFinite(chanceDelta)) {
+    return chanceMeta
+  }
+
+  const roundedChanceDelta = Math.round(chanceDelta)
+  const absoluteChanceDelta = Math.abs(roundedChanceDelta)
+  const shouldShowChanceChange = absoluteChanceDelta >= 1
+
+  return {
+    ...chanceMeta,
+    shouldShowChanceChange,
+    chanceChangeLabel: shouldShowChanceChange ? `${absoluteChanceDelta}%` : '',
+    isChanceChangePositive: roundedChanceDelta > 0,
+  }
+}
+
+interface EventMarketChanceMetaCarrier {
+  market: {
+    condition_id: string
+  }
+  chanceMeta: EventMarketRow['chanceMeta']
+}
+
+export function applyCachedChartDeltaToEventMarketRow<T extends EventMarketChanceMetaCarrier>(
+  row: T,
+  chartDeltaByMarket: Record<string, number>,
+): T {
+  const chanceDelta = chartDeltaByMarket[row.market.condition_id] ?? null
+  const resolvedChanceMeta = resolveChanceMetaForChartDelta(row.chanceMeta, chanceDelta)
+
+  return resolvedChanceMeta === row.chanceMeta
+    ? row
+    : { ...row, chanceMeta: resolvedChanceMeta } as T
+}

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventRowChartDeltaTargets.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventRowChartDeltaTargets.ts
@@ -1,0 +1,9 @@
+import type { Event } from '@/types'
+import { buildMarketTargets } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory'
+import { isMarketResolved } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventMarketUtils'
+
+export function buildRowChartDeltaTargets(markets: Event['markets']) {
+  return buildMarketTargets(
+    markets.filter(market => !isMarketResolved(market)),
+  )
+}

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/priceHistoryApi.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/priceHistoryApi.ts
@@ -1,0 +1,127 @@
+export interface PriceHistoryPoint {
+  t: number
+  p: number
+}
+
+export interface RangeFilters {
+  fidelity: string
+  interval?: string
+  startTs?: string
+  endTs?: string
+}
+
+export type PriceHistoryByKey = Record<string, PriceHistoryPoint[]>
+
+interface BatchPriceHistoryResponse {
+  history?: Record<string, unknown>
+}
+
+const MAX_BATCH_PRICE_HISTORY_MARKETS = 20
+
+function chunkValues<T>(values: T[], chunkSize: number) {
+  const chunks: T[][] = []
+
+  for (let index = 0; index < values.length; index += chunkSize) {
+    chunks.push(values.slice(index, index + chunkSize))
+  }
+
+  return chunks
+}
+
+function normalizePriceHistoryPoints(points: unknown): PriceHistoryPoint[] {
+  if (!Array.isArray(points)) {
+    return []
+  }
+
+  return points
+    .map((point) => {
+      if (!point || typeof point !== 'object') {
+        return null
+      }
+
+      return {
+        t: Number((point as { t?: unknown }).t),
+        p: Number((point as { p?: unknown }).p),
+      }
+    })
+    .filter((point): point is PriceHistoryPoint => {
+      return point !== null
+        && Number.isFinite(point.t)
+        && Number.isFinite(point.p)
+    })
+}
+
+export function buildBatchPriceHistoryRequestBody(tokenIds: string[], filters: RangeFilters) {
+  const requestBody: Record<string, unknown> = {
+    markets: tokenIds,
+  }
+
+  if (filters.interval) {
+    requestBody.interval = filters.interval
+  }
+
+  if (filters.fidelity) {
+    requestBody.fidelity = Number(filters.fidelity)
+  }
+
+  if (filters.startTs) {
+    requestBody.startTs = Number(filters.startTs)
+  }
+
+  if (filters.endTs) {
+    requestBody.endTs = Number(filters.endTs)
+  }
+
+  return requestBody
+}
+
+export async function fetchBatchPriceHistoryByTokenIds(tokenIds: string[], filters: RangeFilters): Promise<PriceHistoryByKey> {
+  const uniqueTokenIds = Array.from(new Set(tokenIds.filter(Boolean)))
+
+  if (!uniqueTokenIds.length) {
+    return {}
+  }
+
+  const tokenIdChunks = chunkValues(uniqueTokenIds, MAX_BATCH_PRICE_HISTORY_MARKETS)
+  const historyByChunk = await Promise.all(
+    tokenIdChunks.map(async (tokenIdChunk) => {
+      try {
+        const response = await fetch(`${process.env.CLOB_URL!}/batch-prices-history`, {
+          method: 'POST',
+          headers: {
+            'Accept': 'application/json',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(buildBatchPriceHistoryRequestBody(tokenIdChunk, filters)),
+        })
+
+        if (!response.ok) {
+          throw new Error('Failed to fetch price history')
+        }
+
+        const payload = await response.json() as BatchPriceHistoryResponse
+        return tokenIdChunk.reduce<PriceHistoryByKey>((acc, tokenId) => {
+          acc[tokenId] = normalizePriceHistoryPoints(payload.history?.[tokenId])
+          return acc
+        }, {})
+      }
+      catch {
+        return tokenIdChunk.reduce<PriceHistoryByKey>((acc, tokenId) => {
+          acc[tokenId] = []
+          return acc
+        }, {})
+      }
+    }),
+  )
+
+  return Object.assign({}, ...historyByChunk)
+}
+
+export function mapTokenHistoryToConditionHistory<T extends { conditionId: string, tokenId: string }>(
+  targets: T[],
+  historyByToken: PriceHistoryByKey,
+): PriceHistoryByKey {
+  return Object.fromEntries(
+    targets.map(target => [target.conditionId, historyByToken[target.tokenId] ?? []] as const),
+  )
+}

--- a/src/components/EventIconImage.tsx
+++ b/src/components/EventIconImage.tsx
@@ -20,11 +20,26 @@ export default function EventIconImage({
   imageClassName,
   ...props
 }: EventIconImageProps) {
+  const normalizedSrc = typeof src === 'string' ? src.trim() : src
+  const hasRenderableSrc = typeof normalizedSrc === 'string'
+    ? normalizedSrc.length > 0
+    : (
+        normalizedSrc != null
+        && typeof normalizedSrc === 'object'
+        && 'src' in normalizedSrc
+        && typeof normalizedSrc.src === 'string'
+        && normalizedSrc.src.trim().length > 0
+      )
+
+  if (!hasRenderableSrc) {
+    return <div className={cn('relative overflow-hidden', containerClassName)} aria-hidden="true" />
+  }
+
   return (
     <div className={cn('relative overflow-hidden', containerClassName)}>
       <Image
         {...props}
-        src={src}
+        src={normalizedSrc}
         alt={alt}
         fill
         sizes={sizes}

--- a/src/components/EventIconImage.tsx
+++ b/src/components/EventIconImage.tsx
@@ -43,7 +43,7 @@ export default function EventIconImage({
         alt={alt}
         fill
         sizes={sizes}
-        className={cn('object-cover object-center', imageClassName)}
+        className={cn('shrink-0 object-cover object-center', imageClassName)}
       />
     </div>
   )

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -2536,9 +2536,6 @@ export const EventRepository = {
     slug: string,
     locale: SupportedLocale = DEFAULT_LOCALE,
   ): Promise<QueryResult<{ title: string }>> {
-    'use cache'
-    cacheTag(cacheTags.event(slug))
-
     return runQuery(async () => {
       const result = await db
         .select({ id: events.id, title: events.title })

--- a/tests/unit/eventMarketChanceMeta.test.ts
+++ b/tests/unit/eventMarketChanceMeta.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest'
+import { applyCachedChartDeltaToEventMarketRow, resolveChanceMetaForChartDelta } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventMarketChanceMeta'
+
+describe('eventMarketChanceMeta', () => {
+  const baseRow = {
+    market: {
+      condition_id: 'market-1',
+    },
+    chanceMeta: {
+      chanceDisplay: '55%',
+      normalizedChance: 55,
+      isSubOnePercent: false,
+      shouldShowChanceChange: false,
+      chanceChangeLabel: '',
+      isChanceChangePositive: false,
+    },
+  } as const
+
+  it('keeps the original row when there is no cached chart delta', () => {
+    expect(applyCachedChartDeltaToEventMarketRow(baseRow, {})).toBe(baseRow)
+  })
+
+  it('reuses the cached chart delta after the row collapses', () => {
+    const resolvedRow = applyCachedChartDeltaToEventMarketRow(baseRow, {
+      'market-1': 3.2,
+    })
+
+    expect(resolvedRow).not.toBe(baseRow)
+    expect(resolvedRow.chanceMeta.shouldShowChanceChange).toBe(true)
+    expect(resolvedRow.chanceMeta.chanceChangeLabel).toBe('3%')
+    expect(resolvedRow.chanceMeta.isChanceChangePositive).toBe(true)
+  })
+
+  it('preserves the direction for negative chart deltas', () => {
+    const resolvedMeta = resolveChanceMetaForChartDelta(baseRow.chanceMeta, -4.6)
+
+    expect(resolvedMeta.shouldShowChanceChange).toBe(true)
+    expect(resolvedMeta.chanceChangeLabel).toBe('5%')
+    expect(resolvedMeta.isChanceChangePositive).toBe(false)
+  })
+})

--- a/tests/unit/eventRowChartDeltaTargets.test.ts
+++ b/tests/unit/eventRowChartDeltaTargets.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { buildRowChartDeltaTargets } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventRowChartDeltaTargets'
+
+describe('buildRowChartDeltaTargets', () => {
+  it('hydrates chart deltas for every unresolved market', () => {
+    const targets = buildRowChartDeltaTargets([
+      {
+        condition_id: 'market-open-1',
+        is_resolved: false,
+        outcomes: [
+          { outcome_index: 0, token_id: 'yes-1' },
+          { outcome_index: 1, token_id: 'no-1' },
+        ],
+      },
+      {
+        condition_id: 'market-resolved',
+        is_resolved: true,
+        outcomes: [
+          { outcome_index: 0, token_id: 'yes-resolved' },
+          { outcome_index: 1, token_id: 'no-resolved' },
+        ],
+      },
+      {
+        condition_id: 'market-open-2',
+        is_resolved: false,
+        outcomes: [
+          { outcome_index: 0, token_id: 'yes-2' },
+          { outcome_index: 1, token_id: 'no-2' },
+        ],
+      },
+    ] as any)
+
+    expect(targets).toEqual([
+      {
+        conditionId: 'market-open-1',
+        tokenId: 'yes-1',
+      },
+      {
+        conditionId: 'market-open-2',
+        tokenId: 'yes-2',
+      },
+    ])
+  })
+})

--- a/tests/unit/priceHistoryApi.test.ts
+++ b/tests/unit/priceHistoryApi.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildBatchPriceHistoryRequestBody,
+  mapTokenHistoryToConditionHistory,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/priceHistoryApi'
+
+describe('priceHistoryApi', () => {
+  it('builds a batch price history request body with numeric filters', () => {
+    expect(buildBatchPriceHistoryRequestBody(['token-1', 'token-2'], {
+      fidelity: '720',
+      startTs: '100',
+      endTs: '200',
+    })).toEqual({
+      markets: ['token-1', 'token-2'],
+      fidelity: 720,
+      startTs: 100,
+      endTs: 200,
+    })
+  })
+
+  it('maps token histories back to condition ids', () => {
+    expect(mapTokenHistoryToConditionHistory([
+      { conditionId: 'market-1', tokenId: 'token-1' },
+      { conditionId: 'market-2', tokenId: 'token-2' },
+    ], {
+      'token-1': [{ t: 1, p: 0.2 }],
+    })).toEqual({
+      'market-1': [{ t: 1, p: 0.2 }],
+      'market-2': [],
+    })
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Batch event price history fetching into a single endpoint to cut request volume and fix timeouts on event pages and CSV export. Also stabilizes market row chance deltas and hardens image rendering.

- **Bug Fixes**
  - Replace per-token requests with `batch-prices-history` POST (chunked to 20) via new `priceHistoryApi`; used by `useEventPriceHistory` and CSV export.
  - Normalize/validate points and map token histories back to condition IDs to reduce failures and prevent timeouts.
  - Cache and reapply market chance deltas for collapsed rows for a stable UI.

- **Refactors**
  - Added `priceHistoryApi`, `eventMarketChanceMeta`, and `eventRowChartDeltaTargets` utilities with unit tests.
  - Hardened `EventIconImage` for empty/invalid src; minor desktop order panel dynamic import rename.
  - Inline public profile fallback date and remove caching from the event title query to avoid prerender edge cases.
  - Enable Next.js `experimental.typedEnv` and `optimizePackageImports` for `radix-ui`.

<sup>Written for commit 32f542b14d59ed34083f7c11a8bae3619fe10792. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

