### PR TITLE
fix: sports chart labels position

### DIFF
--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -1264,19 +1264,19 @@ export default function SportsEventCenter({
       <Suspense fallback={null}>
         <SportsEventQuerySync onSelectionChange={handleQuerySelectionChange} />
       </Suspense>
-      <div className="
+      <div className={cn(`
         min-[1200px]:grid min-[1200px]:h-full min-[1200px]:min-h-0 min-[1200px]:grid-cols-[minmax(0,1fr)_21.25rem]
         min-[1200px]:[align-content:start] min-[1200px]:[align-items:start] min-[1200px]:gap-6
-      "
+      `)}
       >
         <section
           data-sports-scroll-pane="center"
-          className="
+          className={cn(`
             min-w-0
             min-[1200px]:min-h-0 min-[1200px]:self-stretch min-[1200px]:overflow-y-auto min-[1200px]:overscroll-contain
             min-[1200px]:pr-1
             lg:ml-4
-          "
+          `)}
         >
           <div className="mb-4">
             <div className="relative mb-1 flex min-h-9 items-center justify-center">
@@ -1292,10 +1292,10 @@ export default function SportsEventCenter({
               </AppLink>
 
               <div
-                className="
+                className={cn(`
                   flex min-w-0 items-center justify-center gap-1 px-14 text-center text-sm text-muted-foreground
                   sm:px-22
-                "
+                `)}
               >
                 <AppLink href={verticalConfig.livePath} className="hover:text-foreground">
                   {verticalConfig.label}
@@ -1425,7 +1425,7 @@ export default function SportsEventCenter({
             {showFinalScore || showLiveScore
               ? (
                   <div className="flex flex-col items-center">
-                    <div className="flex items-center gap-2 text-3xl leading-none font-semibold tabular-nums">
+                    <div className="flex items-center gap-2 text-3xl/none font-semibold tabular-nums">
                       <span
                         className={team1Won
                           ? 'text-foreground'

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameGraph.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameGraph.tsx
@@ -4,6 +4,7 @@ import type { SportsGameGraphVariant, SportsGamesMarketType } from './sports-gam
 import type { SportsGamesCard } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 import type { PredictionChartProps } from '@/types/PredictionChartTypes'
 import dynamic from 'next/dynamic'
+import { useCallback, useState, useSyncExternalStore } from 'react'
 import EventChartControls from '@/app/[locale]/(platform)/event/[slug]/_components/EventChartControls'
 import EventChartEmbedDialog from '@/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog'
 import EventChartExportDialog from '@/app/[locale]/(platform)/event/[slug]/_components/EventChartExportDialog'
@@ -26,6 +27,56 @@ const PredictionChart = dynamic<PredictionChartProps>(
   { ssr: false },
 )
 
+function useElementWidth<T extends HTMLElement>() {
+  const [element, setElement] = useState<T | null>(null)
+
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    if (!element) {
+      return function noopElementWidthSubscription() {}
+    }
+
+    function notifyElementWidthChange() {
+      onStoreChange()
+    }
+
+    if (typeof ResizeObserver === 'undefined') {
+      window.addEventListener('resize', notifyElementWidthChange)
+
+      return function removeElementWidthResizeListener() {
+        window.removeEventListener('resize', notifyElementWidthChange)
+      }
+    }
+
+    const observer = new ResizeObserver(notifyElementWidthChange)
+    observer.observe(element)
+
+    return function disconnectElementWidthObserver() {
+      observer.disconnect()
+    }
+  }, [element])
+
+  const getSnapshot = useCallback(() => {
+    if (!element) {
+      return undefined
+    }
+
+    const nextWidth = Math.round(element.getBoundingClientRect().width)
+    if (!Number.isFinite(nextWidth) || nextWidth <= 0) {
+      return undefined
+    }
+
+    return nextWidth
+  }, [element])
+
+  const width = useSyncExternalStore(subscribe, getSnapshot, () => undefined)
+
+  const ref = useCallback((node: T | null) => {
+    setElement(currentElement => currentElement === node ? currentElement : node)
+  }, [])
+
+  return [ref, width] as const
+}
+
 export default function SportsGameGraph({
   card,
   selectedMarketType,
@@ -40,6 +91,7 @@ export default function SportsGameGraph({
   variant?: SportsGameGraphVariant
 }) {
   const { width: windowWidth } = useWindowSize()
+  const [chartContainerRef, chartContainerWidth] = useElementWidth<HTMLDivElement>()
   const {
     cursorSnapshot,
     setCursorSnapshot,
@@ -58,10 +110,15 @@ export default function SportsGameGraph({
     isSportsEventHeroVariant,
     usesPositionedSeriesLegend,
     canRenderPositionedSeriesLegend,
+    positionedLegendLayout,
     chartHeight,
     chartMargin,
     chartWidth,
-  } = useSportsGameGraphChartDimensions({ windowWidth, variant })
+  } = useSportsGameGraphChartDimensions({
+    containerWidth: chartContainerWidth,
+    windowWidth,
+    variant,
+  })
 
   const { graphSeriesTargets, tradeFlowSeriesByTokenId, marketTargets, chartSeries } = useSportsGameGraphSeries({
     card,
@@ -92,6 +149,7 @@ export default function SportsGameGraph({
     chartMargin,
     cursorSnapshot,
     latestSnapshot,
+    positionedLegendLayout,
     usesPositionedSeriesLegend,
   })
 
@@ -134,7 +192,7 @@ export default function SportsGameGraph({
   return (
     <>
       <div style={usesPositionedSeriesLegend ? { minHeight: `${chartHeight + 56}px` } : undefined}>
-        <div className="relative">
+        <div ref={chartContainerRef} className="relative">
           <PredictionChart
             data={chartData}
             series={chartSeries}
@@ -151,9 +209,9 @@ export default function SportsGameGraph({
             showTooltipSeriesLabels={!usesPositionedSeriesLegend}
             disableCursorSplit={false}
             clampCursorToDataExtent={usesPositionedSeriesLegend}
-            markerOuterRadius={usesPositionedSeriesLegend ? 10 : undefined}
-            markerInnerRadius={usesPositionedSeriesLegend ? 4.2 : undefined}
-            markerPulseStyle={usesPositionedSeriesLegend ? 'ring' : undefined}
+            markerOuterRadius={usesPositionedSeriesLegend ? (isSportsEventHeroVariant ? 15 : 10) : undefined}
+            markerInnerRadius={usesPositionedSeriesLegend ? (isSportsEventHeroVariant ? 5.2 : 4.2) : undefined}
+            markerPulseStyle={usesPositionedSeriesLegend ? (isSportsEventHeroVariant ? 'filled' : 'ring') : undefined}
             lineCurve="monotoneX"
             tooltipValueFormatter={value => `${Math.round(value)}%`}
             autoscale={chartSettings.autoscale}
@@ -166,31 +224,69 @@ export default function SportsGameGraph({
           />
 
           {canRenderPositionedSeriesLegend && heroLegendPositionedEntries.length > 0 && (
-            <div className="pointer-events-none absolute inset-0 overflow-hidden">
+            <div
+              className={cn(
+                'pointer-events-none absolute inset-0',
+                isSportsEventHeroVariant ? 'overflow-visible' : 'overflow-hidden',
+              )}
+            >
               {heroLegendPositionedEntries.map(entry => (
                 <div
                   key={entry.key}
-                  className="absolute"
+                  className={cn(
+                    'absolute flex flex-col',
+                    isSportsEventHeroVariant ? 'overflow-visible' : 'overflow-hidden',
+                  )}
                   style={{
                     top: `${entry.top}px`,
-                    left: `${entry.left}px`,
+                    left: `${(entry.left / chartWidth) * 100}%`,
+                    width: `${(entry.width / chartWidth) * 100}%`,
+                    height: `${entry.height}px`,
                   }}
                 >
-                  <p
+                  <div
                     className={cn(
-                      'text-[13px] leading-snug font-medium tracking-tight',
-                      (windowWidth ?? 1024) >= 768 && 'truncate',
+                      isSportsEventHeroVariant ? 'whitespace-nowrap' : 'truncate',
+                      isSportsEventHeroVariant
+                        ? undefined
+                        : 'text-[13px] leading-snug font-medium tracking-tight',
                     )}
-                    style={{ color: entry.color }}
+                    style={{
+                      color: entry.color,
+                      lineHeight: isSportsEventHeroVariant
+                        ? `${positionedLegendLayout.nameLineHeightPx}px`
+                        : undefined,
+                      font: isSportsEventHeroVariant
+                        ? positionedLegendLayout.nameFont
+                        : undefined,
+                      letterSpacing: isSportsEventHeroVariant ? '0' : undefined,
+                      margin: 0,
+                    }}
                   >
                     {entry.name}
-                  </p>
-                  <p
-                    className="text-2xl/tight font-semibold tabular-nums"
-                    style={{ color: entry.color }}
+                  </div>
+                  <div
+                    className={cn(
+                      'whitespace-nowrap tabular-nums',
+                      isSportsEventHeroVariant
+                        ? undefined
+                        : 'text-2xl/tight',
+                    )}
+                    style={{
+                      color: entry.color,
+                      lineHeight: isSportsEventHeroVariant
+                        ? `${positionedLegendLayout.valueLineHeightPx}px`
+                        : undefined,
+                      font: isSportsEventHeroVariant
+                        ? positionedLegendLayout.valueFont
+                        : undefined,
+                      letterSpacing: isSportsEventHeroVariant ? '0' : undefined,
+                      marginTop: `${Math.max(0, positionedLegendLayout.nameLineHeightPx - 14)}px`,
+                      marginBottom: 0,
+                    }}
                   >
                     {`${Math.round(entry.value)}%`}
-                  </p>
+                  </div>
                 </div>
               ))}
             </div>

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-constants.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-constants.ts
@@ -28,14 +28,44 @@ export const SPORTS_EVENT_ODDS_FORMAT_STORAGE_KEY = 'sports:event:odds-format'
 export const SPORTS_GAMES_SHOW_SPREADS_TOTALS_STORAGE_KEY = 'sports:games:show-spreads-totals'
 export const SPORTS_LIVE_FALLBACK_WINDOW_MS = 2 * 60 * 60 * 1000
 
-export const HERO_LEGEND_LABEL_GAP_PX = 8
-export const HERO_LEGEND_RIGHT_INSET_PX = 4
-export const HERO_LEGEND_MIN_WIDTH_PX = 72
-export const HERO_LEGEND_NAME_PADDING_PX = 10
-export const HERO_LEGEND_NAME_LINE_HEIGHT_PX = 18
-export const HERO_LEGEND_VALUE_LINE_HEIGHT_PX = 32
-export const HERO_LEGEND_MIN_HEIGHT_PX = 56
-export const HERO_LEGEND_VERTICAL_GAP_PX = 10
+export interface SportsPositionedLegendLayout {
+  labelGapPx: number
+  rightInsetPx: number
+  minWidthPx: number
+  horizontalPaddingPx: number
+  nameLineHeightPx: number
+  valueLineHeightPx: number
+  minHeightPx: number
+  verticalGapPx: number
+  nameFont: string
+  valueFont: string
+}
+
+export const SPORTS_CARD_POSITIONED_LEGEND_LAYOUT: SportsPositionedLegendLayout = {
+  labelGapPx: 8,
+  rightInsetPx: 4,
+  minWidthPx: 72,
+  horizontalPaddingPx: 10,
+  nameLineHeightPx: 18,
+  valueLineHeightPx: 32,
+  minHeightPx: 56,
+  verticalGapPx: 10,
+  nameFont: '500 13px ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+  valueFont: '600 24px ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+}
+
+export const SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT: SportsPositionedLegendLayout = {
+  labelGapPx: 12,
+  rightInsetPx: 6,
+  minWidthPx: 84,
+  horizontalPaddingPx: 10,
+  nameLineHeightPx: 15,
+  valueLineHeightPx: 24,
+  minHeightPx: 40,
+  verticalGapPx: 8,
+  nameFont: '600 12px ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+  valueFont: '600 24px ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
+}
 
 export const TRADE_FLOW_MAX_ITEMS = 6
 export const TRADE_FLOW_TTL_MS = 8000

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
@@ -1,3 +1,4 @@
+import type { SportsPositionedLegendLayout } from './sports-games-center-constants'
 import type { SportsGameGraphVariant, SportsGraphSeriesTarget, SportsTradeFlowLabelItem } from './sports-games-center-types'
 import type { TIME_RANGES } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory'
 import type { SportsGamesCard } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
@@ -9,14 +10,8 @@ import { loadStoredChartSettings, storeChartSettings } from '@/app/[locale]/(pla
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { calculateYAxisBounds } from '@/lib/prediction-chart'
 import {
-  HERO_LEGEND_LABEL_GAP_PX,
-  HERO_LEGEND_MIN_HEIGHT_PX,
-  HERO_LEGEND_MIN_WIDTH_PX,
-  HERO_LEGEND_NAME_LINE_HEIGHT_PX,
-  HERO_LEGEND_NAME_PADDING_PX,
-  HERO_LEGEND_RIGHT_INSET_PX,
-  HERO_LEGEND_VALUE_LINE_HEIGHT_PX,
-  HERO_LEGEND_VERTICAL_GAP_PX,
+  SPORTS_CARD_POSITIONED_LEGEND_LAYOUT,
+  SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT,
   TRADE_FLOW_CLEANUP_INTERVAL_MS,
 } from './sports-games-center-constants'
 import {
@@ -44,20 +39,29 @@ export function useSportsGameGraphChartSettings() {
 }
 
 export function useSportsGameGraphChartDimensions({
+  containerWidth,
   windowWidth,
   variant,
 }: {
+  containerWidth?: number | null
   windowWidth: number | undefined
   variant: SportsGameGraphVariant
 }) {
   const isSportsEventHeroVariant = variant === 'sportsEventHero'
   const usesPositionedSeriesLegend = variant === 'sportsEventHero' || variant === 'sportsCardLegend'
+  const positionedLegendLayout = isSportsEventHeroVariant
+    ? SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT
+    : SPORTS_CARD_POSITIONED_LEGEND_LAYOUT
   const chartHeight = isSportsEventHeroVariant ? 332 : 300
   const chartMargin = usesPositionedSeriesLegend
     ? { top: 12, right: 46, bottom: 40, left: 0 }
     : { top: 12, right: 30, bottom: 40, left: 0 }
 
   const chartWidth = useMemo(() => {
+    if (typeof containerWidth === 'number' && Number.isFinite(containerWidth) && containerWidth > 0) {
+      return Math.max(1, Math.round(containerWidth))
+    }
+
     const viewportWidth = windowWidth ?? 1200
 
     if (viewportWidth < 768) {
@@ -65,12 +69,13 @@ export function useSportsGameGraphChartDimensions({
     }
 
     return Math.min(860, viewportWidth - 520)
-  }, [windowWidth])
+  }, [containerWidth, windowWidth])
 
   return {
     isSportsEventHeroVariant,
     usesPositionedSeriesLegend,
     canRenderPositionedSeriesLegend: usesPositionedSeriesLegend,
+    positionedLegendLayout,
     chartHeight,
     chartMargin,
     chartWidth,
@@ -381,6 +386,7 @@ export function useSportsGameGraphHeroLegend({
   chartMargin,
   cursorSnapshot,
   latestSnapshot,
+  positionedLegendLayout,
   usesPositionedSeriesLegend,
 }: {
   canRenderPositionedSeriesLegend: boolean
@@ -391,80 +397,9 @@ export function useSportsGameGraphHeroLegend({
   chartMargin: { top: number, right: number, bottom: number, left: number }
   cursorSnapshot: PredictionChartCursorSnapshot | null
   latestSnapshot: Record<string, number>
+  positionedLegendLayout: SportsPositionedLegendLayout
   usesPositionedSeriesLegend: boolean
 }) {
-  const heroLegendRenderedWidth = useMemo(() => {
-    if (!canRenderPositionedSeriesLegend || chartSeries.length === 0) {
-      return HERO_LEGEND_MIN_WIDTH_PX
-    }
-
-    if (typeof document === 'undefined') {
-      return HERO_LEGEND_MIN_WIDTH_PX
-    }
-
-    const context = document.createElement('canvas').getContext('2d')
-    if (!context) {
-      return HERO_LEGEND_MIN_WIDTH_PX
-    }
-
-    context.font = '500 13px ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif'
-
-    const longestLabelWidth = chartSeries.reduce((maxWidth, seriesItem) => {
-      const label = seriesItem.name.trim()
-      if (!label) {
-        return maxWidth
-      }
-
-      return Math.max(maxWidth, context.measureText(label).width)
-    }, 0)
-
-    const targetWidth = Math.ceil(longestLabelWidth + HERO_LEGEND_NAME_PADDING_PX)
-    return Math.max(HERO_LEGEND_MIN_WIDTH_PX, targetWidth)
-  }, [canRenderPositionedSeriesLegend, chartSeries])
-
-  const chartXDomain = useMemo(() => {
-    if (!usesPositionedSeriesLegend || chartData.length < 2) {
-      return undefined
-    }
-
-    const firstPoint = chartData[0]
-    const lastPoint = chartData.at(-1)
-    if (!firstPoint || !lastPoint) {
-      return undefined
-    }
-
-    const firstTimestamp = firstPoint.date.getTime()
-    const lastTimestamp = lastPoint.date.getTime()
-    if (!Number.isFinite(firstTimestamp) || !Number.isFinite(lastTimestamp) || lastTimestamp <= firstTimestamp) {
-      return undefined
-    }
-
-    const dataSpanMs = Math.max(1, lastTimestamp - firstTimestamp)
-    const plotWidthPx = Math.max(1, chartWidth - chartMargin.left - chartMargin.right)
-    const reservedRightPx = Math.max(0, heroLegendRenderedWidth + HERO_LEGEND_LABEL_GAP_PX + HERO_LEGEND_RIGHT_INSET_PX)
-
-    // Keep enough fixed room on the right for legend so the plotted line ends before chart edge.
-    if (reservedRightPx >= plotWidthPx - 1) {
-      return {
-        start: firstTimestamp,
-        end: lastTimestamp,
-      }
-    }
-
-    const domainSpanMs = Math.round((dataSpanMs * plotWidthPx) / (plotWidthPx - reservedRightPx))
-    return {
-      start: firstTimestamp,
-      end: firstTimestamp + domainSpanMs,
-    }
-  }, [
-    chartData,
-    chartMargin.left,
-    chartMargin.right,
-    chartWidth,
-    heroLegendRenderedWidth,
-    usesPositionedSeriesLegend,
-  ])
-
   const heroLegendSeriesWithValues = useMemo(
     () => {
       if (!canRenderPositionedSeriesLegend) {
@@ -488,6 +423,93 @@ export function useSportsGameGraphHeroLegend({
     [canRenderPositionedSeriesLegend, chartSeries, cursorSnapshot, latestSnapshot],
   )
 
+  const heroLegendRenderedWidth = useMemo(() => {
+    if (!canRenderPositionedSeriesLegend || chartSeries.length === 0) {
+      return positionedLegendLayout.minWidthPx
+    }
+
+    if (typeof document === 'undefined') {
+      return positionedLegendLayout.minWidthPx
+    }
+
+    const context = document.createElement('canvas').getContext('2d')
+    if (!context) {
+      return positionedLegendLayout.minWidthPx
+    }
+
+    context.font = positionedLegendLayout.nameFont
+
+    const longestLabelWidth = chartSeries.reduce((maxWidth, seriesItem) => {
+      const label = seriesItem.name.trim()
+      if (!label) {
+        return maxWidth
+      }
+
+      return Math.max(maxWidth, context.measureText(label).width)
+    }, 0)
+
+    context.font = positionedLegendLayout.valueFont
+    const widestValueWidth = heroLegendSeriesWithValues.reduce((maxWidth, entry) => {
+      const label = `${Math.round(entry.value)}%`
+      return Math.max(maxWidth, context.measureText(label).width)
+    }, context.measureText('100%').width)
+
+    const targetWidth = Math.ceil(
+      Math.max(longestLabelWidth, widestValueWidth)
+      + positionedLegendLayout.horizontalPaddingPx,
+    )
+    return Math.max(positionedLegendLayout.minWidthPx, targetWidth)
+  }, [canRenderPositionedSeriesLegend, chartSeries, heroLegendSeriesWithValues, positionedLegendLayout])
+
+  const chartXDomain = useMemo(() => {
+    if (!usesPositionedSeriesLegend || chartData.length < 2) {
+      return undefined
+    }
+
+    const firstPoint = chartData[0]
+    const lastPoint = chartData.at(-1)
+    if (!firstPoint || !lastPoint) {
+      return undefined
+    }
+
+    const firstTimestamp = firstPoint.date.getTime()
+    const lastTimestamp = lastPoint.date.getTime()
+    if (!Number.isFinite(firstTimestamp) || !Number.isFinite(lastTimestamp) || lastTimestamp <= firstTimestamp) {
+      return undefined
+    }
+
+    const dataSpanMs = Math.max(1, lastTimestamp - firstTimestamp)
+    const plotWidthPx = Math.max(1, chartWidth - chartMargin.left - chartMargin.right)
+    const reservedRightPx = Math.max(
+      0,
+      heroLegendRenderedWidth
+      + positionedLegendLayout.labelGapPx
+      + positionedLegendLayout.rightInsetPx,
+    )
+
+    // Keep enough fixed room on the right for legend so the plotted line ends before chart edge.
+    if (reservedRightPx >= plotWidthPx - 1) {
+      return {
+        start: firstTimestamp,
+        end: lastTimestamp,
+      }
+    }
+
+    const domainSpanMs = Math.round((dataSpanMs * plotWidthPx) / (plotWidthPx - reservedRightPx))
+    return {
+      start: firstTimestamp,
+      end: firstTimestamp + domainSpanMs,
+    }
+  }, [
+    chartData,
+    chartMargin.left,
+    chartMargin.right,
+    chartWidth,
+    heroLegendRenderedWidth,
+    positionedLegendLayout,
+    usesPositionedSeriesLegend,
+  ])
+
   const heroLegendPositionedEntries = useMemo(
     () => {
       if (!canRenderPositionedSeriesLegend || heroLegendSeriesWithValues.length === 0 || chartData.length === 0) {
@@ -498,6 +520,8 @@ export function useSportsGameGraphHeroLegend({
           value: number
           left: number
           top: number
+          width: number
+          height: number
         }>
       }
 
@@ -525,29 +549,30 @@ export function useSportsGameGraphHeroLegend({
       const hoveredTimestampRaw = cursorSnapshot?.date.getTime() ?? lastTimestamp
       const hoveredTimestamp = Math.max(firstTimestamp, Math.min(lastTimestamp, hoveredTimestampRaw))
 
-      const yBounds = calculateYAxisBounds(chartData, chartSeries)
-      const ySpan = Math.max(1, yBounds.max - yBounds.min)
       const xSpan = Math.max(1, domainEnd - domainStart)
       const plotWidth = Math.max(1, chartWidth - chartMargin.left - chartMargin.right)
       const plotHeight = Math.max(1, chartHeight - chartMargin.top - chartMargin.bottom)
+      const yAxisMinTicks = Math.max(3, Math.min(5, Math.round(plotHeight / 56)))
       const chartTop = chartMargin.top
       const chartBottom = chartMargin.top + plotHeight
       const dotX = chartMargin.left + ((hoveredTimestamp - domainStart) / xSpan) * plotWidth
       const plotLeft = chartMargin.left
       const plotRight = chartWidth - chartMargin.right
-      const availableFullWidth = plotRight - plotLeft - HERO_LEGEND_RIGHT_INSET_PX
+      const availableFullWidth = plotRight - plotLeft - positionedLegendLayout.rightInsetPx
       const effectiveLabelWidth = Math.max(0, Math.min(heroLegendRenderedWidth, availableFullWidth))
-      const maxLeft = plotRight - effectiveLabelWidth - HERO_LEGEND_RIGHT_INSET_PX
-      const labelLeft = Math.max(plotLeft, Math.min(maxLeft, dotX + HERO_LEGEND_LABEL_GAP_PX))
-      const availableLabelWidth = Math.max(1, chartWidth - labelLeft - HERO_LEGEND_RIGHT_INSET_PX)
+      const maxLeft = plotRight - effectiveLabelWidth - positionedLegendLayout.rightInsetPx
+      const labelLeft = Math.max(plotLeft, Math.min(maxLeft, dotX + positionedLegendLayout.labelGapPx))
+      const availableLabelWidth = Math.max(1, chartWidth - labelLeft - positionedLegendLayout.rightInsetPx)
 
       const labelMeasureContext = typeof document !== 'undefined'
         ? document.createElement('canvas').getContext('2d')
         : null
       if (labelMeasureContext) {
-        labelMeasureContext.font = '500 13px ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif'
+        labelMeasureContext.font = positionedLegendLayout.nameFont
       }
 
+      const yBounds = calculateYAxisBounds(chartData, chartSeries, yAxisMinTicks, 6)
+      const ySpan = Math.max(1, yBounds.max - yBounds.min)
       const preferredEntries = heroLegendSeriesWithValues.map((entry) => {
         const clampedValue = Math.max(yBounds.min, Math.min(yBounds.max, entry.value))
         const dotY = chartMargin.top + ((yBounds.max - clampedValue) / ySpan) * plotHeight
@@ -557,8 +582,8 @@ export function useSportsGameGraphHeroLegend({
           : 0
         const wrappedNameLineCount = Math.max(1, Math.ceil(measuredNameWidth / availableLabelWidth))
         const labelHeight = Math.max(
-          HERO_LEGEND_MIN_HEIGHT_PX,
-          (wrappedNameLineCount * HERO_LEGEND_NAME_LINE_HEIGHT_PX) + HERO_LEGEND_VALUE_LINE_HEIGHT_PX,
+          positionedLegendLayout.minHeightPx,
+          (wrappedNameLineCount * positionedLegendLayout.nameLineHeightPx) + positionedLegendLayout.valueLineHeightPx,
         )
         const anchorOffset = labelHeight / 2
         const preferredTop = dotY - anchorOffset
@@ -568,6 +593,8 @@ export function useSportsGameGraphHeroLegend({
           ...entry,
           dotY,
           left: labelLeft,
+          width: effectiveLabelWidth,
+          height: labelHeight,
           labelHeight,
           preferredTop: Math.max(chartTop, Math.min(maxTopForEntry, preferredTop)),
         }
@@ -583,7 +610,7 @@ export function useSportsGameGraphHeroLegend({
           : null
         const top = previousBottom == null
           ? entry.preferredTop
-          : Math.max(entry.preferredTop, previousBottom + HERO_LEGEND_VERTICAL_GAP_PX)
+          : Math.max(entry.preferredTop, previousBottom + positionedLegendLayout.verticalGapPx)
         const maxTopForEntry = chartBottom - entry.labelHeight
         stacked.push({ ...entry, top: Math.max(chartTop, Math.min(maxTopForEntry, top)) })
       })
@@ -592,7 +619,7 @@ export function useSportsGameGraphHeroLegend({
         const entry = stacked[index]!
         const next = stacked[index + 1]!
         const maxTopForEntry = chartBottom - entry.labelHeight
-        const highestTopAllowedByNext = next.top - HERO_LEGEND_VERTICAL_GAP_PX - entry.labelHeight
+        const highestTopAllowedByNext = next.top - positionedLegendLayout.verticalGapPx - entry.labelHeight
         entry.top = Math.max(
           chartTop,
           Math.min(maxTopForEntry, Math.min(entry.top, highestTopAllowedByNext)),
@@ -619,6 +646,7 @@ export function useSportsGameGraphHeroLegend({
       cursorSnapshot?.date,
       heroLegendSeriesWithValues,
       canRenderPositionedSeriesLegend,
+      positionedLegendLayout,
     ],
   )
 

--- a/tests/unit/sportsGameGraphHeroLegend.test.tsx
+++ b/tests/unit/sportsGameGraphHeroLegend.test.tsx
@@ -1,0 +1,85 @@
+import { renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-constants'
+import { useSportsGameGraphHeroLegend } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph'
+
+const chartSeries = [
+  { key: 'chiefs', name: 'Chiefs', color: '#f4c400' },
+  { key: 'gloucester', name: 'Gloucester', color: '#c91f32' },
+  { key: 'draw', name: 'Draw', color: '#79818d' },
+]
+
+const chartData = [
+  { date: new Date('2026-04-01T00:00:00.000Z'), chiefs: 50, gloucester: 47, draw: 3 },
+  { date: new Date('2026-04-26T11:30:00.000Z'), chiefs: 66, gloucester: 39, draw: 8 },
+]
+
+describe('sportsGameGraphHeroLegend', () => {
+  let getContextSpy: { mockRestore: () => void }
+
+  function measureTextWidth(text: string, font: string) {
+    const fontSizeMatch = font.match(/(\d+)px/)
+    const fontSize = fontSizeMatch ? Number(fontSizeMatch[1]) : 16
+    const widthMultiplier = text.endsWith('%') ? 0.58 : 0.56
+
+    return Math.ceil(text.length * fontSize * widthMultiplier)
+  }
+
+  beforeEach(() => {
+    getContextSpy = vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockImplementation((() => {
+      let currentFont = ''
+
+      return {
+        get font() {
+          return currentFont
+        },
+        set font(value: string) {
+          currentFont = value
+        },
+        measureText: (text: string) => ({
+          width: measureTextWidth(text, currentFont),
+        }),
+      }
+    }) as any)
+  })
+
+  afterEach(() => {
+    getContextSpy.mockRestore()
+  })
+
+  it('reserves enough right-side room for large hero percent labels', () => {
+    const { result } = renderHook(() => useSportsGameGraphHeroLegend({
+      canRenderPositionedSeriesLegend: true,
+      chartSeries,
+      chartData,
+      chartWidth: 860,
+      chartHeight: 332,
+      chartMargin: { top: 12, right: 46, bottom: 40, left: 0 },
+      cursorSnapshot: null,
+      latestSnapshot: { chiefs: 66, gloucester: 39, draw: 8 },
+      positionedLegendLayout: SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT,
+      usesPositionedSeriesLegend: true,
+    }))
+
+    const entry = result.current.heroLegendPositionedEntries[0]
+    const expectedWidth = Math.max(
+      SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT.minWidthPx,
+      Math.ceil(
+        Math.max(
+          ...chartSeries.map(seriesItem => measureTextWidth(
+            seriesItem.name,
+            SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT.nameFont,
+          )),
+          measureTextWidth('100%', SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT.valueFont),
+        ) + SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT.horizontalPaddingPx,
+      ),
+    )
+
+    expect(result.current.heroLegendRenderedWidth).toBe(expectedWidth)
+    expect(entry?.left).toBeGreaterThan(0)
+    expect(entry?.width).toBe(result.current.heroLegendRenderedWidth)
+    expect((entry?.left ?? 0) + (entry?.width ?? 0)).toBeLessThanOrEqual(
+      860 - 46 - SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT.rightInsetPx,
+    )
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes positioned legend labels in sports charts so team names and percentages stay aligned, readable, and within bounds across screen sizes. Improves the sports event hero layout and prevents overflow/clipping.

- **Bug Fixes**
  - Measure label widths (names and percentages) and reserve right-side space so the chart line never runs under labels.
  - Position labels using the chart container width with a `ResizeObserver`; use percentage-based left/width for stable responsiveness.
  - Apply per-variant legend layout (fonts, line heights, padding, gaps) and enable `overflow-visible` on the hero to prevent clipping.
  - Tune hero markers (larger radii, filled pulse) and adjust text wrapping/truncation to fit within available space.
  - Add unit test for hero legend width reservation and placement.
  - Minor: fix className composition with `cn` in `SportsEventCenter` and update y-axis bounds calc to improve label placement.

<sup>Written for commit 6d07b06b4a1365efe169b76b4dd47f3624b2a62b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

