### PR TITLE
chore: remove duplicated docs openapi url

### DIFF
--- a/src/app/api/proxy/route.ts
+++ b/src/app/api/proxy/route.ts
@@ -1,1 +1,0 @@
-export { DELETE, GET, HEAD, PATCH, POST, PUT } from '@/lib/openapi-proxy'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the duplicate OpenAPI docs proxy route by deleting `src/app/api/proxy/route.ts`, which re-exported handlers from `@/lib/openapi-proxy`. This removes the extra docs URL and keeps a single canonical endpoint.

<sup>Written for commit e931f7cdf49bec8378798d5171ca1896c4c34813. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

