### PR TITLE
fix: do not persist community avatar_url on username only updates

### DIFF
--- a/src/app/[locale]/(platform)/settings/_components/SettingsProfileContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsProfileContent.tsx
@@ -45,6 +45,10 @@ function useAvatarPreview() {
   return { previewImage, setPreviewImage }
 }
 
+function isSelectedImageFile(value: FormDataEntryValue | null): value is File {
+  return typeof File !== 'undefined' && value instanceof File && value.size > 0
+}
+
 export default function SettingsProfileContent({ user }: { user: User }) {
   const t = useExtracted()
   const queryClient = useQueryClient()
@@ -89,14 +93,14 @@ export default function SettingsProfileContent({ user }: { user: User }) {
     const email = (formData.get('email') as string | null)?.trim() ?? ''
     const emailValue = email.length > 0 ? email : undefined
     const username = (formData.get('username') as string | null)?.trim() || ''
-    const imageFile = formData.get('image') as File | null
+    const imageFile = formData.get('image')
+    const selectedImageFile = isSelectedImageFile(imageFile) ? imageFile : null
+    const hasUsernameChange = username.length > 0 && username !== user.username
 
-    const shouldUpdateCommunity = Boolean(
-      (username && username !== user.username) || (imageFile && imageFile.size > 0),
-    )
+    const shouldUpdateCommunity = hasUsernameChange || Boolean(selectedImageFile)
 
     let communityUsername = username
-    let avatarUrl: string | undefined
+    let updatedAvatarUrl: string | undefined
 
     try {
       if (shouldUpdateCommunity) {
@@ -108,11 +112,11 @@ export default function SettingsProfileContent({ user }: { user: User }) {
         })
 
         const communityForm = new FormData()
-        if (username && username !== user.username) {
+        if (hasUsernameChange) {
           communityForm.append('username', username)
         }
-        if (imageFile && imageFile.size > 0) {
-          communityForm.append('image', imageFile)
+        if (selectedImageFile) {
+          communityForm.append('image', selectedImageFile)
         }
 
         const response = await fetch(`${communityApiUrl}/profile`, {
@@ -139,7 +143,9 @@ export default function SettingsProfileContent({ user }: { user: User }) {
           avatar_url?: string
         }
         communityUsername = payload.username || username
-        avatarUrl = payload.avatar_url
+        if (selectedImageFile) {
+          updatedAvatarUrl = payload.avatar_url?.trim() || undefined
+        }
       }
 
       const localForm = new FormData()
@@ -147,8 +153,8 @@ export default function SettingsProfileContent({ user }: { user: User }) {
         localForm.set('email', emailValue)
       }
       localForm.set('username', communityUsername)
-      if (avatarUrl) {
-        localForm.set('avatar_url', avatarUrl)
+      if (updatedAvatarUrl) {
+        localForm.set('avatar_url', updatedAvatarUrl)
       }
 
       const result = await updateUserAction(localForm)
@@ -162,7 +168,7 @@ export default function SettingsProfileContent({ user }: { user: User }) {
         ...user,
         email: emailValue ?? user.email,
         username: communityUsername,
-        image: avatarUrl ?? user.image,
+        image: updatedAvatarUrl ?? user.image,
       })
       await queryClient.invalidateQueries({
         predicate: (query) => {

--- a/tests/unit/SettingsProfileContent.test.tsx
+++ b/tests/unit/SettingsProfileContent.test.tsx
@@ -1,0 +1,145 @@
+import type { User } from '@/types'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import * as React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SettingsProfileContent from '@/app/[locale]/(platform)/settings/_components/SettingsProfileContent'
+
+const mocks = vi.hoisted(() => ({
+  clearCommunityAuth: vi.fn(),
+  ensureCommunityToken: vi.fn(),
+  fetch: vi.fn(),
+  invalidateQueries: vi.fn(),
+  parseCommunityError: vi.fn(),
+  setUserState: vi.fn(),
+  signMessageAsync: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  updateUserAction: vi.fn(),
+}))
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({
+    invalidateQueries: mocks.invalidateQueries,
+  }),
+}))
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (value: string) => value,
+}))
+
+vi.mock('next/image', () => ({
+  __esModule: true,
+  default: (props: React.ImgHTMLAttributes<HTMLImageElement>) => React.createElement('img', props),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+  },
+}))
+
+vi.mock('wagmi', () => ({
+  useSignMessage: () => ({
+    signMessageAsync: mocks.signMessageAsync,
+  }),
+}))
+
+vi.mock('@/app/[locale]/(platform)/settings/_actions/update-profile', () => ({
+  updateUserAction: (formData: FormData) => mocks.updateUserAction(formData),
+}))
+
+vi.mock('@/components/AppLink', () => ({
+  __esModule: true,
+  default: ({ children, href, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement>) => (
+    <a href={String(href)} {...props}>{children}</a>
+  ),
+}))
+
+vi.mock('@/hooks/useSignaturePromptRunner', () => ({
+  useSignaturePromptRunner: () => ({
+    runWithSignaturePrompt: (callback: () => Promise<string>) => callback(),
+  }),
+}))
+
+vi.mock('@/lib/community-auth', () => ({
+  clearCommunityAuth: mocks.clearCommunityAuth,
+  ensureCommunityToken: (...args: unknown[]) => mocks.ensureCommunityToken(...args),
+  parseCommunityError: (...args: unknown[]) => mocks.parseCommunityError(...args),
+}))
+
+vi.mock('@/stores/useUser', () => ({
+  useUser: {
+    setState: mocks.setUserState,
+  },
+}))
+
+function createUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-1',
+    address: '0xabc',
+    email: 'user@example.com',
+    twoFactorEnabled: false,
+    username: 'oldname',
+    image: '',
+    settings: {},
+    is_admin: false,
+    ...overrides,
+  }
+}
+
+describe('SettingsProfileContent', () => {
+  beforeEach(() => {
+    mocks.clearCommunityAuth.mockReset()
+    mocks.ensureCommunityToken.mockReset()
+    mocks.fetch.mockReset()
+    mocks.invalidateQueries.mockReset()
+    mocks.parseCommunityError.mockReset()
+    mocks.setUserState.mockReset()
+    mocks.signMessageAsync.mockReset()
+    mocks.toastError.mockReset()
+    mocks.toastSuccess.mockReset()
+    mocks.updateUserAction.mockReset()
+
+    mocks.ensureCommunityToken.mockResolvedValue('community-token')
+    mocks.updateUserAction.mockResolvedValue({})
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({
+        username: 'newname',
+        avatar_url: 'https://community.example/avatar.png',
+      }),
+    })
+    vi.stubGlobal('fetch', mocks.fetch)
+    process.env.COMMUNITY_URL = 'https://community.example'
+  })
+
+  it('does not persist a community avatar_url on username-only saves', async () => {
+    const user = userEvent.setup()
+    render(<SettingsProfileContent user={createUser()} />)
+
+    const usernameInput = screen.getByLabelText('Username')
+    await user.clear(usernameInput)
+    await user.type(usernameInput, 'newname')
+    await user.click(screen.getByRole('button', { name: 'Save changes' }))
+
+    await waitFor(() => {
+      expect(mocks.updateUserAction).toHaveBeenCalledTimes(1)
+    })
+
+    const communityRequest = mocks.fetch.mock.calls[0][1] as RequestInit
+    const communityForm = communityRequest.body as FormData
+    const localForm = mocks.updateUserAction.mock.calls[0][0] as FormData
+
+    expect(communityForm.get('username')).toBe('newname')
+    expect(communityForm.get('image')).toBeNull()
+    expect(localForm.get('username')).toBe('newname')
+    expect(localForm.get('avatar_url')).toBeNull()
+    expect(mocks.setUserState).toHaveBeenCalledWith(expect.objectContaining({
+      image: '',
+      username: 'newname',
+    }))
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop persisting the community avatar_url when saving profile changes with only a username update. Avatar now updates only when a new image file is selected, preventing unintended avatar changes.

- **Bug Fixes**
  - Skip sending image to the community API unless a valid file is selected.
  - Persist avatar_url locally only when an image upload occurs.
  - Add `isSelectedImageFile` guard and a unit test for username-only saves.

<sup>Written for commit 60191809295d081efcba5da4dbe3e44431bbd4ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

