### PR TITLE
refactor(cache): scope cache tags per concern + remove redundant nuclear invalidations (closes #939)

### DIFF
--- a/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
+++ b/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
@@ -141,7 +141,6 @@ function revalidateGeneralSettingsPaths() {
   revalidatePath('/[locale]/admin/theme', 'page')
   revalidatePath('/[locale]/admin/market-context', 'page')
   revalidatePath('/[locale]/tos', 'page')
-  revalidatePath('/[locale]', 'layout')
 }
 
 async function syncGeoblockSettings() {

--- a/src/app/[locale]/admin/categories/_actions/main-category-order.ts
+++ b/src/app/[locale]/admin/categories/_actions/main-category-order.ts
@@ -27,7 +27,6 @@ export interface UpdateMainCategoryOrderResult {
 
 function revalidateCategoryCaches(userId: string) {
   revalidatePath('/[locale]/admin/categories', 'page')
-  revalidatePath('/[locale]', 'layout')
   updateTag(cacheTags.adminCategories)
   updateTag(cacheTags.eventsList)
   updateTag(cacheTags.events(userId))

--- a/src/app/[locale]/admin/categories/_actions/update-category-translations.ts
+++ b/src/app/[locale]/admin/categories/_actions/update-category-translations.ts
@@ -64,7 +64,6 @@ export async function updateCategoryTranslationsAction(
     }
 
     revalidatePath('/[locale]/admin/categories', 'page')
-    revalidatePath('/[locale]', 'layout')
     updateTag(cacheTags.adminCategories)
     updateTag(cacheTags.eventsList)
     updateTag(cacheTags.events(currentUser.id))

--- a/src/app/[locale]/admin/categories/_actions/update-category.ts
+++ b/src/app/[locale]/admin/categories/_actions/update-category.ts
@@ -93,7 +93,6 @@ export async function updateCategoryAction(
     }
 
     revalidatePath('/[locale]/admin/categories', 'page')
-    revalidatePath('/[locale]', 'layout')
     revalidatePath('/[locale]/event/[slug]', 'page')
     revalidatePath('/[locale]/event/[slug]/[market]', 'page')
     updateTag(cacheTags.adminCategories)

--- a/src/app/[locale]/admin/events/_actions/update-event-sports-final-state.ts
+++ b/src/app/[locale]/admin/events/_actions/update-event-sports-final-state.ts
@@ -68,6 +68,7 @@ export async function updateEventSportsFinalStateAction(
     revalidatePath('/[locale]/admin/events', 'page')
     updateTag(cacheTags.eventsList)
     updateTag(cacheTags.event(data.slug))
+    updateTag(cacheTags.sportsMenu)
 
     return {
       success: true,

--- a/src/app/[locale]/admin/events/_actions/update-event-visibility.ts
+++ b/src/app/[locale]/admin/events/_actions/update-event-visibility.ts
@@ -40,6 +40,8 @@ export async function updateEventVisibilityAction(
     revalidatePath('/[locale]/admin/events', 'page')
     updateTag(cacheTags.eventsList)
     updateTag(cacheTags.event(data.slug))
+    updateTag(cacheTags.sportsMenu)
+    updateTag(cacheTags.sitemap)
     for (const locale of SUPPORTED_LOCALES) {
       updateTag(cacheTags.mainTags(locale))
     }

--- a/src/app/[locale]/admin/theme/_actions/update-theme-settings.ts
+++ b/src/app/[locale]/admin/theme/_actions/update-theme-settings.ts
@@ -59,7 +59,6 @@ export async function updateThemeSettingsAction(
   }
 
   revalidatePath('/[locale]/admin/theme', 'page')
-  revalidatePath('/[locale]', 'layout')
 
   return { error: null }
 }

--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -116,12 +116,6 @@ interface ProcessMarketResult {
   eventIdForCacheInvalidation: string | null
   changed: boolean
   listAffectingChange: boolean
-  /**
-   * True when this market's processing produced a change to the public URL
-   * set (a new event was created). Used to scope sitemap invalidation to
-   * runs that actually altered the crawlable URL list, rather than every
-   * status flip.
-   */
   urlSetChanged: boolean
 }
 
@@ -129,13 +123,13 @@ interface ProcessEventResult {
   eventId: string
   eventChanged: boolean
   listAffectingChange: boolean
-  /** See {@link ProcessMarketResult.urlSetChanged}. */
   urlSetChanged: boolean
 }
 
 interface ProcessMarketDataResult {
   eventIdForStatusUpdate: string
   marketChanged: boolean
+  urlSetChanged: boolean
 }
 
 const PNL_CONDITIONS_PAGE_QUERY = `
@@ -424,6 +418,7 @@ async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): 
       }
       if (changedEventIds.length > 0) {
         shouldInvalidateListCache = true
+        shouldInvalidateSitemap = true
       }
       eventIdsNeedingStatusUpdate.clear()
     }
@@ -446,6 +441,7 @@ async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): 
     }
     if (changedEventIds.length > 0) {
       shouldInvalidateListCache = true
+      shouldInvalidateSitemap = true
     }
     eventIdsNeedingStatusUpdate.clear()
   }
@@ -598,7 +594,7 @@ async function processMarket(
     eventIdForCacheInvalidation: changed ? eventResult.eventId : null,
     changed,
     listAffectingChange: eventResult.listAffectingChange,
-    urlSetChanged: eventResult.urlSetChanged,
+    urlSetChanged: eventResult.urlSetChanged || marketResult.urlSetChanged,
   }
 }
 
@@ -1042,6 +1038,7 @@ async function processMarketData(
       event_id: marketsTable.event_id,
       is_resolved: marketsTable.is_resolved,
       updated_at: marketsTable.updated_at,
+      slug: marketsTable.slug,
     })
     .from(marketsTable)
     .where(eq(marketsTable.condition_id, market.id))
@@ -1068,6 +1065,7 @@ async function processMarketData(
     return {
       eventIdForStatusUpdate,
       marketChanged: false,
+      urlSetChanged: false,
     }
   }
 
@@ -1209,9 +1207,15 @@ async function processMarketData(
     await processOutcomes(market.id, metadata.outcomes)
   }
 
+  const incomingSlug = String(metadata.slug ?? '').trim()
+  const previousSlug = (existingMarket?.slug ?? '').trim()
+  const urlSetChanged = (!marketAlreadyExists && incomingSlug.length > 0)
+    || (marketAlreadyExists && incomingSlug !== previousSlug)
+
   return {
     eventIdForStatusUpdate,
     marketChanged: true,
+    urlSetChanged,
   }
 }
 

--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -116,12 +116,21 @@ interface ProcessMarketResult {
   eventIdForCacheInvalidation: string | null
   changed: boolean
   listAffectingChange: boolean
+  /**
+   * True when this market's processing produced a change to the public URL
+   * set (a new event was created). Used to scope sitemap invalidation to
+   * runs that actually altered the crawlable URL list, rather than every
+   * status flip.
+   */
+  urlSetChanged: boolean
 }
 
 interface ProcessEventResult {
   eventId: string
   eventChanged: boolean
   listAffectingChange: boolean
+  /** See {@link ProcessMarketResult.urlSetChanged}. */
+  urlSetChanged: boolean
 }
 
 interface ProcessMarketDataResult {
@@ -309,6 +318,7 @@ async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): 
   const eventIdsNeedingStatusUpdate = new Set<string>()
   const eventIdsNeedingCacheInvalidation = new Set<string>()
   let shouldInvalidateListCache = false
+  let shouldInvalidateSitemap = false
   const runtimeState: SyncRuntimeState = {
     eventTagSlugsByEventId: new Map(),
   }
@@ -368,6 +378,9 @@ async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): 
         }
         if (processResult.listAffectingChange) {
           shouldInvalidateListCache = true
+        }
+        if (processResult.urlSetChanged) {
+          shouldInvalidateSitemap = true
         }
         processedCount++
         lastPersistableCursor = conditionCursor
@@ -437,9 +450,10 @@ async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): 
     eventIdsNeedingStatusUpdate.clear()
   }
 
-  if (eventIdsNeedingCacheInvalidation.size > 0 || shouldInvalidateListCache) {
+  if (eventIdsNeedingCacheInvalidation.size > 0 || shouldInvalidateListCache || shouldInvalidateSitemap) {
     const invalidationSummary = await invalidateEventCaches(Array.from(eventIdsNeedingCacheInvalidation), {
       includeList: shouldInvalidateListCache,
+      includeSitemap: shouldInvalidateSitemap,
     })
     console.log('🧹 Event cache invalidation summary:', invalidationSummary)
   }
@@ -584,6 +598,7 @@ async function processMarket(
     eventIdForCacheInvalidation: changed ? eventResult.eventId : null,
     changed,
     listAffectingChange: eventResult.listAffectingChange,
+    urlSetChanged: eventResult.urlSetChanged,
   }
 }
 
@@ -923,6 +938,7 @@ async function processEvent(
       eventId: existingEvent.id,
       eventChanged,
       listAffectingChange,
+      urlSetChanged: false,
     }
   }
 
@@ -1006,6 +1022,7 @@ async function processEvent(
     eventId: newEvent.id,
     eventChanged: true,
     listAffectingChange: true,
+    urlSetChanged: true,
   }
 }
 
@@ -1301,17 +1318,22 @@ async function updateEventStatusesFromMarketsBatch(eventIds: string[]) {
 
 async function invalidateEventCaches(
   eventIds: string[],
-  options: { includeList?: boolean } = {},
+  options: { includeList?: boolean, includeSitemap?: boolean } = {},
 ) {
   const uniqueEventIds = Array.from(new Set(eventIds.filter(Boolean)))
   const listTagInvalidated = options.includeList === true
+  const sitemapTagInvalidated = options.includeSitemap === true
   if (listTagInvalidated) {
     revalidateTag(cacheTags.eventsList, 'max')
+  }
+  if (sitemapTagInvalidated) {
+    revalidateTag(cacheTags.sitemap, 'max')
   }
 
   if (uniqueEventIds.length === 0) {
     return {
       listTagInvalidated,
+      sitemapTagInvalidated,
       eventTagInvalidations: 0,
       uniqueEventIdsCount: 0,
     }
@@ -1334,6 +1356,7 @@ async function invalidateEventCaches(
 
   return {
     listTagInvalidated,
+    sitemapTagInvalidated,
     eventTagInvalidations,
     uniqueEventIdsCount: uniqueEventIds.length,
   }

--- a/src/lib/cache-tags.ts
+++ b/src/lib/cache-tags.ts
@@ -1,11 +1,32 @@
+/**
+ * Central registry of cache tags used with `cacheTag()` and `revalidateTag()`.
+ *
+ * Each tag must represent a single logical concern. Sharing one tag across
+ * unrelated cache surfaces causes invalidation fan-out: invalidating the tag
+ * for one concern wipes every other surface that happens to be tagged the
+ * same. Keep tags scoped to the data they describe.
+ */
 export const cacheTags = {
+  /** Per-user notifications inbox. */
   notifications: (key: string) => `notifications:${key}`,
+  /** Per-event public activity feed. */
   activity: (key: string) => `activity:${key}`,
+  /** Per-condition holders list. */
   holders: (key: string) => `holders:${key}`,
+  /** Per-user event lists (favorites, etc). */
   events: (key: string) => `events:${key}`,
+  /** Public event listing surfaces (homepage grid, market-slug routing list). */
   eventsList: 'events:list',
+  /** Per-event content surfaces (page data, title, route resolution). */
   event: (key: string) => `event:${key}`,
+  /** Admin categories table. */
   adminCategories: 'admin:categories',
+  /** Per-locale main navigation tags. */
   mainTags: (locale: string) => `main-tags:${locale}`,
+  /** Site settings (admin-edited identity, branding, integrations). */
   settings: 'settings',
+  /** Sports sidebar menu structure and counts (independent of homepage list). */
+  sportsMenu: 'sports:menu',
+  /** Public sitemap entries (event/market URL lists). */
+  sitemap: 'sitemap',
 }

--- a/src/lib/db/queries/sports-menu.ts
+++ b/src/lib/db/queries/sports-menu.ts
@@ -176,7 +176,7 @@ const getCachedSportsMenuRows = unstable_cache(
   ['sports-menu-items-v2'],
   {
     revalidate: 1800,
-    tags: [cacheTags.eventsList],
+    tags: [cacheTags.sportsMenu],
   },
 )
 
@@ -217,7 +217,7 @@ const getCachedActiveSportsCountRows = unstable_cache(
   ['sports-menu-active-count-rows-v4'],
   {
     revalidate: 300,
-    tags: [cacheTags.eventsList],
+    tags: [cacheTags.sportsMenu],
   },
 )
 
@@ -327,7 +327,7 @@ export async function getSportsCountsBySlugFromDb(vertical: SportsVertical = 'sp
 export const SportsMenuRepository = {
   async getMenuEntries(vertical: SportsVertical = 'sports'): Promise<QueryResult<SportsMenuEntry[]>> {
     'use cache'
-    cacheTag(cacheTags.eventsList)
+    cacheTag(cacheTags.sportsMenu)
 
     return runQuery(async () => {
       const rows = await getCachedSportsMenuRows()
@@ -341,7 +341,7 @@ export const SportsMenuRepository = {
 
   async getLayoutData(vertical: SportsVertical = 'sports'): Promise<QueryResult<SportsMenuLayoutData>> {
     'use cache'
-    cacheTag(cacheTags.eventsList)
+    cacheTag(cacheTags.sportsMenu)
 
     return runQuery(async () => {
       const [rows, activeCountRows] = await Promise.all([
@@ -367,7 +367,7 @@ export const SportsMenuRepository = {
 
   async resolveCanonicalSlugByAlias(alias: string): Promise<QueryResult<string | null>> {
     'use cache'
-    cacheTag(cacheTags.eventsList)
+    cacheTag(cacheTags.sportsMenu)
 
     return runQuery(async () => {
       const resolver = await getSportsSlugResolverFromDb()
@@ -381,7 +381,7 @@ export const SportsMenuRepository = {
 
   async getLandingHref(vertical: SportsVertical = 'sports'): Promise<QueryResult<string | null>> {
     'use cache'
-    cacheTag(cacheTags.eventsList)
+    cacheTag(cacheTags.sportsMenu)
 
     return runQuery(async () => {
       const rows = await getCachedSportsMenuRows()
@@ -396,7 +396,7 @@ export const SportsMenuRepository = {
 
   async getFuturesHref(vertical: SportsVertical = 'sports'): Promise<QueryResult<string | null>> {
     'use cache'
-    cacheTag(cacheTags.eventsList)
+    cacheTag(cacheTags.sportsMenu)
 
     return runQuery(async () => {
       const rows = await getCachedSportsMenuRows()

--- a/src/lib/db/queries/tag.ts
+++ b/src/lib/db/queries/tag.ts
@@ -3,7 +3,7 @@ import type { PlatformCategorySidebarItem, PlatformNavigationChild } from '@/lib
 import { createHash } from 'node:crypto'
 import { and, asc, count, desc, eq, exists, ilike, inArray, or, sql } from 'drizzle-orm'
 import { alias } from 'drizzle-orm/pg-core'
-import { cacheTag, revalidatePath } from 'next/cache'
+import { cacheTag } from 'next/cache'
 import { DEFAULT_LOCALE, NON_DEFAULT_LOCALES } from '@/i18n/locales'
 import { cacheTags } from '@/lib/cache-tags'
 import { resolveCategorySidebarData } from '@/lib/category-sidebar-config'
@@ -913,8 +913,6 @@ export const TagRepository = {
       return { data: null, error: visibleCountsError }
     }
 
-    revalidatePath('/')
-
     const row = selectResult[0]
     const formattedData: AdminTagRow = {
       id: row.id,
@@ -1018,8 +1016,6 @@ export const TagRepository = {
       }
     }
 
-    revalidatePath('/')
-
     return { error: null }
   },
 
@@ -1106,8 +1102,6 @@ export const TagRepository = {
         error: translationError,
       }
     }
-
-    revalidatePath('/')
 
     return {
       data: translationsByTagId.get(tagId) ?? {},

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -217,7 +217,7 @@ async function getCategorySitemapEntries(): Promise<SitemapRouteEntry[]> {
 async function getPredictionSitemapEntries(): Promise<SitemapRouteEntry[]> {
   'use cache'
 
-  cacheTag(cacheTags.eventsList)
+  cacheTag(cacheTags.sitemap)
 
   try {
     const sportsSlugResolver = await getSportsSlugResolverFromDb()
@@ -290,7 +290,7 @@ async function getPredictionSitemapEntries(): Promise<SitemapRouteEntry[]> {
 async function getDynamicEventSitemaps(): Promise<DynamicEventSitemaps> {
   'use cache'
 
-  cacheTag(cacheTags.eventsList)
+  cacheTag(cacheTags.sitemap)
 
   try {
     const sportsSlugResolver = await getSportsSlugResolverFromDb()

--- a/tests/unit/tagRepository.test.ts
+++ b/tests/unit/tagRepository.test.ts
@@ -539,6 +539,6 @@ describe('tagRepository.updateMainCategoriesDisplayOrder', () => {
 
     expect(result.error).toBeNull()
     expect(mocks.runQuery).toHaveBeenCalledTimes(1)
-    expect(mocks.revalidatePath).toHaveBeenCalledWith('/')
+    expect(mocks.revalidatePath).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/updateGeneralSettingsAction.test.ts
+++ b/tests/unit/updateGeneralSettingsAction.test.ts
@@ -160,7 +160,7 @@ describe('updateGeneralSettingsAction', () => {
     expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]/admin/theme', 'page')
     expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]/admin/market-context', 'page')
     expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]/tos', 'page')
-    expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]', 'layout')
+    expect(mocks.revalidatePath).not.toHaveBeenCalledWith('/[locale]', 'layout')
   })
 
   it('saves image-mode settings when an image path already exists', async () => {

--- a/tests/unit/updateThemeSettingsAction.test.ts
+++ b/tests/unit/updateThemeSettingsAction.test.ts
@@ -98,6 +98,6 @@ describe('updateThemeSettingsAction', () => {
     expect(JSON.parse(savedLight?.value || '{}')).toEqual({ primary: '#112233' })
     expect(JSON.parse(savedDark?.value || '{}')).toEqual({ primary: '#445566' })
     expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]/admin/theme', 'page')
-    expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]', 'layout')
+    expect(mocks.revalidatePath).not.toHaveBeenCalledWith('/[locale]', 'layout')
   })
 })


### PR DESCRIPTION
Fixes #939.

This PR addresses the two cache architecture issues called out in #939:
cacheTags.eventsList over-shared across 9 unrelated cache surfaces, and
8 nuclear revalidatePath calls in admin actions that wipe entire layout
trees on a single admin action. Net diff is overwhelmingly subtractive.

## What changed

### Commit 1: Tag scoping (cacheTags.eventsList split into 3 concerns)

Two new tags introduced in src/lib/cache-tags.ts:

* sportsMenu  -> sports sidebar menu structure and counts
* sitemap     -> public sitemap entries

Migration:

* src/lib/db/queries/sports-menu.ts: 7 cacheTag(eventsList) -> sportsMenu
  Inner unstable_cache helpers retain their 300s/1800s time based revalidate so menu freshness is unaffected when sportsMenu is not explicitly invalidated.
* src/lib/sitemap.ts: 2 cacheTag(eventsList) -> sitemap
* update-event-sports-final-state, update-event-visibility: add targeted updateTag(sportsMenu) and updateTag(sitemap) where freshness must be immediate

Sync routes intentionally NOT touched: they continue to invalidate eventsList on actual status changes via the existing guard. Sports menu and sitemap rely on built in TTLs for cron driven freshness, removing the cross surface fan out.

### Commit 2: Sitemap freshness preserved on new event creation

After decoupling sitemap from eventsList, new events created by /api/sync/events would not appear in the sitemap until the default 15 min revalidate ticks. ProcessEventResult / ProcessMarketResult gain a urlSetChanged: boolean field, set to true only in the new event creation return path. The sync loop tracks shouldInvalidateSitemap and invalidateEventCaches accepts an includeSitemap option.

Net effect: sitemap regenerates when the public URL set actually changes, not on every minor metadata tweak.

### Commit 3: Remove 8 redundant nuclear cache invalidations from admin actions

Each of these wipes the entire layout/site cache on a single admin action and is already covered by scoped tag invalidations in the same code path:

| Removed call | Already covered by |
|---|---|
| tag.ts:916,1021,1110 revalidatePath('/') | Caller actions invalidate adminCategories, eventsList, events(userId), mainTags(locale) x18 |
| update-theme-settings:62 revalidatePath('/[locale]','layout') | SettingsRepository.updateSettings invokes updateTag(cacheTags.settings) (settings.ts:74); loadRuntimeThemeState is tagged with cacheTags.settings |
| update-general-settings:144 same | Same as theme settings |
| update-category:96 revalidatePath('/[locale]','layout') | Same action invokes updateTag(cacheTags.mainTags(locale)) x18; platform layout is tagged with cacheTags.mainTags(resolvedLocale) |
| main-category-order:30 same | Same |
| update-category-translations:67 same | Same |

Architectural improvement: the three calls inside tag.ts:916/1021/1110 were a layering violation. The data repository should not know about HTTP route caching. That responsibility now lives entirely in the action layer where it belongs.

Per event page revalidations in update-category.ts:97-98 are KEPT because they propagate event_page_note (rendered by EventCategoryNote.tsx on event pages with the modified tag). Replacing them properly requires a new cacheTags.tagEvents(slug) infrastructure which is out of scope for this PR.

## Test plan

* tsc clean (the pre existing fumadocs-mdx:collections/server resolution error on src/lib/source.ts:3 is unrelated and reproduces on vanilla upstream/main)
* eslint clean on all changed source files
* vitest 505/505 pass
* 3 test assertions updated to assert the layout wide calls are NOT made:
  * tests/unit/updateThemeSettingsAction.test.ts:101
  * tests/unit/updateGeneralSettingsAction.test.ts:163
  * tests/unit/tagRepository.test.ts:542

## Cost impact

For our deployment this single architecture issue was responsible for ~\$25/mo of a \$40 Vercel bill (74% of infra cost was ISR Writes, ~7.35M writes/month). At higher traffic plus active admin work this would grow further. Net diff is overwhelmingly subtractive (15 deletions, 4 insertions across 9 files in commit 3 alone).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scoped cache tags by concern and removed layout-wide invalidations to stop cache fan‑out and cut ISR writes; sitemap now refreshes only when the public URL set changes (new events, new markets, slug rewrites, or draft/non‑draft flips). Closes #939.

- **Refactors**
  - Split `cacheTags.eventsList` across concerns: keep `eventsList` for listings; add `sportsMenu` for sports sidebar; add `sitemap` for public sitemaps.
  - Updated sports menu queries to tag `sportsMenu`; sitemap queries to tag `sitemap`.
  - Added targeted tag updates in admin actions: `update-event-sports-final-state` → `sportsMenu`; `update-event-visibility` → `sportsMenu` + `sitemap`.
  - Removed 8 root/layout `revalidatePath` calls in admin actions and `TagRepository`; rely on scoped tags. Kept per-event page revalidations in `update-category`.

- **Bug Fixes**
  - Sitemap invalidation is now tied to URL set changes: sync tracks `urlSetChanged` at event and market levels and revalidates `sitemap` on new events, new markets with slugs, slug updates, or draft ↔ non‑draft flips.

<sup>Written for commit 78d14e04bc6b6061c04ddbbc5825d1febdbac3c2. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/940?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

