### PR TITLE
perf: decrease homepage db hits

### DIFF
--- a/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
@@ -6,7 +6,7 @@ import {
   buildLocalizedPagePath,
   buildPredictionResultsOgImageUrl,
 } from '@/app/[locale]/(platform)/_lib/prediction-results-metadata'
-import { TagRepository } from '@/lib/db/queries/tag'
+import { loadPlatformMainTags } from '@/lib/platform-main-tags'
 import {
   findDynamicHomeCategoryBySlug,
   findDynamicHomeSubcategoryBySlug,
@@ -18,7 +18,7 @@ import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 const { resolveSiteUrl } = siteUrlUtils
 
 async function getMainTags(locale: SupportedLocale) {
-  const { data: mainTags } = await TagRepository.getMainTags(locale)
+  const { data: mainTags } = await loadPlatformMainTags(locale)
   return mainTags ?? []
 }
 

--- a/src/app/[locale]/(platform)/layout.tsx
+++ b/src/app/[locale]/(platform)/layout.tsx
@@ -7,7 +7,7 @@ import NavigationTabs from '@/app/[locale]/(platform)/_components/NavigationTabs
 import PlatformViewerState from '@/app/[locale]/(platform)/_components/PlatformViewerState'
 import { FilterProvider } from '@/app/[locale]/(platform)/_providers/FilterProvider'
 import PlatformNavigationProvider from '@/app/[locale]/(platform)/_providers/PlatformNavigationProvider'
-import { TagRepository } from '@/lib/db/queries/tag'
+import { loadPlatformMainTags } from '@/lib/platform-main-tags'
 import { buildChildParentMap, buildPlatformNavigationTags } from '@/lib/platform-navigation'
 import AppKitProvider from '@/providers/AppKitProvider'
 
@@ -16,7 +16,7 @@ export default async function PlatformLayout({ params, children }: LayoutProps<'
   const resolvedLocale = locale as SupportedLocale
   setRequestLocale(resolvedLocale)
   const t = await getExtracted()
-  const { data: mainTags, globalChilds = [] } = await TagRepository.getMainTags(resolvedLocale)
+  const { data: mainTags, globalChilds = [] } = await loadPlatformMainTags(resolvedLocale)
   const tags = buildPlatformNavigationTags({
     mainTags: mainTags ?? [],
     globalChilds,

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -1445,6 +1445,8 @@ export const EventRepository = {
     cacheTag(cacheTags.events(userId || 'guest'))
     cacheTag(cacheTags.eventsList)
 
+    console.log('DB HIT EventRepository.listEvents')
+
     return await runQuery(async () => {
       const safeLimit = normalizeEventListLimit(limit)
       const validOffset = normalizeEventListOffset(offset)
@@ -1830,6 +1832,8 @@ export const EventRepository = {
   }: ListEventMarketSlugsProps): Promise<QueryResult<string[]>> {
     'use cache'
     cacheTag(cacheTags.eventsList)
+
+    console.log('DB HIT EventRepository.listEventMarketSlugs')
 
     return await runQuery(async () => {
       const { baseWhere, empty } = await buildEventListQueryContext({
@@ -2538,6 +2542,8 @@ export const EventRepository = {
   ): Promise<QueryResult<{ title: string }>> {
     'use cache'
     cacheTag(cacheTags.event(slug))
+
+    console.log('DB HIT  EventRepository.getEventTitleBySlug')
 
     return runQuery(async () => {
       const result = await db

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -1445,8 +1445,6 @@ export const EventRepository = {
     cacheTag(cacheTags.events(userId || 'guest'))
     cacheTag(cacheTags.eventsList)
 
-    console.log('DB HIT EventRepository.listEvents')
-
     return await runQuery(async () => {
       const safeLimit = normalizeEventListLimit(limit)
       const validOffset = normalizeEventListOffset(offset)
@@ -1832,8 +1830,6 @@ export const EventRepository = {
   }: ListEventMarketSlugsProps): Promise<QueryResult<string[]>> {
     'use cache'
     cacheTag(cacheTags.eventsList)
-
-    console.log('DB HIT EventRepository.listEventMarketSlugs')
 
     return await runQuery(async () => {
       const { baseWhere, empty } = await buildEventListQueryContext({
@@ -2542,8 +2538,6 @@ export const EventRepository = {
   ): Promise<QueryResult<{ title: string }>> {
     'use cache'
     cacheTag(cacheTags.event(slug))
-
-    console.log('DB HIT  EventRepository.getEventTitleBySlug')
 
     return runQuery(async () => {
       const result = await db

--- a/src/lib/db/queries/tag.ts
+++ b/src/lib/db/queries/tag.ts
@@ -329,6 +329,9 @@ export const TagRepository = {
   async getMainTags(locale: SupportedLocale = DEFAULT_LOCALE): Promise<MainTagsResult> {
     'use cache'
     cacheTag(cacheTags.mainTags(locale))
+
+    console.log('DB HIT TagRepository.getMainTags')
+
     const { data: mainTagsResult, error } = await runQuery(async () => {
       const result = await db
         .select({

--- a/src/lib/db/queries/tag.ts
+++ b/src/lib/db/queries/tag.ts
@@ -330,8 +330,6 @@ export const TagRepository = {
     'use cache'
     cacheTag(cacheTags.mainTags(locale))
 
-    console.log('DB HIT TagRepository.getMainTags')
-
     const { data: mainTagsResult, error } = await runQuery(async () => {
       const result = await db
         .select({

--- a/src/lib/home-events-page.ts
+++ b/src/lib/home-events-page.ts
@@ -1,8 +1,12 @@
 import type { SupportedLocale } from '@/i18n/locales'
 import type { EventListSortBy, EventListStatusFilter } from '@/lib/event-list-filters'
 import type { Event } from '@/types'
+import { cacheTag } from 'next/cache'
+import { cacheTags } from '@/lib/cache-tags'
 import { EventRepository } from '@/lib/db/queries/event'
 import { filterHomeEvents, HOME_EVENTS_PAGE_SIZE } from '@/lib/home-events'
+
+const HOME_EVENTS_QUERY_BATCH_SIZE = 128
 
 interface ListHomeEventsPageOptions {
   bookmarked: boolean
@@ -23,9 +27,10 @@ interface ListHomeEventsPageOptions {
   userId: string
 }
 
-export async function listHomeEventsPage({
+interface LoadHomeEventCandidatesOptions extends Omit<ListHomeEventsPageOptions, 'currentTimestamp'> {}
+
+async function loadHomeEventCandidates({
   bookmarked,
-  currentTimestamp,
   frequency = 'all',
   hideCrypto = false,
   hideEarnings = false,
@@ -40,13 +45,15 @@ export async function listHomeEventsPage({
   status = 'active',
   tag,
   userId,
-}: ListHomeEventsPageOptions) {
+}: LoadHomeEventCandidatesOptions) {
+  'use cache'
+  cacheTag(cacheTags.events(userId || 'guest'))
+  cacheTag(cacheTags.eventsList)
+
   const targetOffset = Math.max(0, offset)
   const targetVisibleCount = targetOffset + HOME_EVENTS_PAGE_SIZE
-  const resolvedCurrentTimestamp = currentTimestamp ?? null
   let rawOffset = 0
   const accumulatedEvents: Event[] = []
-  let visibleEvents: Event[] = []
 
   while (true) {
     const { data: rawEvents, error } = await EventRepository.listEvents({
@@ -59,13 +66,14 @@ export async function listHomeEventsPage({
       frequency,
       status,
       offset: rawOffset,
+      limit: HOME_EVENTS_QUERY_BATCH_SIZE,
       locale,
       sportsSportSlug,
       sportsSection,
     })
 
     if (error) {
-      return { data: [], error, currentTimestamp: resolvedCurrentTimestamp ?? null }
+      return { data: [], error }
     }
 
     const batch = rawEvents ?? []
@@ -75,24 +83,67 @@ export async function listHomeEventsPage({
 
     accumulatedEvents.push(...batch)
 
-    visibleEvents = filterHomeEvents(accumulatedEvents, {
-      currentTimestamp: resolvedCurrentTimestamp ?? null,
-      hideSports,
-      hideCrypto,
-      hideEarnings,
-      status,
-    })
+    if (status === 'resolved') {
+      const visibleResolvedEvents = filterHomeEvents(accumulatedEvents, {
+        currentTimestamp: null,
+        hideSports,
+        hideCrypto,
+        hideEarnings,
+        status,
+      })
 
-    if (status === 'resolved' && visibleEvents.length >= targetVisibleCount) {
+      if (visibleResolvedEvents.length >= targetVisibleCount) {
+        break
+      }
+    }
+
+    if (batch.length < HOME_EVENTS_QUERY_BATCH_SIZE) {
       break
     }
 
-    if (batch.length < HOME_EVENTS_PAGE_SIZE) {
-      break
-    }
-
-    rawOffset += HOME_EVENTS_PAGE_SIZE
+    rawOffset += HOME_EVENTS_QUERY_BATCH_SIZE
   }
+
+  return {
+    data: accumulatedEvents,
+    error: null,
+  }
+}
+
+export async function listHomeEventsPage({
+  currentTimestamp,
+  hideCrypto = false,
+  hideEarnings = false,
+  hideSports = false,
+  offset = 0,
+  status = 'active',
+  ...options
+}: ListHomeEventsPageOptions) {
+  const targetOffset = Math.max(0, offset)
+  const resolvedCurrentTimestamp = currentTimestamp ?? null
+
+  const { data: rawEvents, error } = await loadHomeEventCandidates({
+    ...options,
+    hideCrypto,
+    hideEarnings,
+    hideSports,
+    offset,
+    status,
+  })
+
+  if (error) {
+    return { data: [], error, currentTimestamp: resolvedCurrentTimestamp ?? null }
+  }
+
+  const visibleEvents = (rawEvents?.length ?? 0) > 0
+    ? filterHomeEvents(rawEvents ?? [], {
+        currentTimestamp: resolvedCurrentTimestamp,
+        hideSports,
+        hideCrypto,
+        hideEarnings,
+        status,
+      })
+    : []
 
   return {
     data: visibleEvents.slice(targetOffset, targetOffset + HOME_EVENTS_PAGE_SIZE),

--- a/src/lib/platform-main-tags.ts
+++ b/src/lib/platform-main-tags.ts
@@ -1,0 +1,19 @@
+import type { SupportedLocale } from '@/i18n/locales'
+import { cacheTag } from 'next/cache'
+import { cacheTags } from '@/lib/cache-tags'
+import { TagRepository } from '@/lib/db/queries/tag'
+
+type PlatformMainTagsResult = Awaited<ReturnType<typeof TagRepository.getMainTags>>
+
+export async function loadPlatformMainTags(locale: SupportedLocale): Promise<PlatformMainTagsResult> {
+  'use cache'
+  cacheTag(cacheTags.mainTags(locale))
+
+  const result = await TagRepository.getMainTags(locale)
+
+  return {
+    ...result,
+    data: result.data ?? [],
+    globalChilds: result.globalChilds ?? [],
+  }
+}

--- a/tests/unit/homeEventsPage.test.ts
+++ b/tests/unit/homeEventsPage.test.ts
@@ -1,8 +1,13 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  cacheTag: vi.fn(),
   filterHomeEvents: vi.fn(),
   listEvents: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+  cacheTag: (...args: any[]) => mocks.cacheTag(...args),
 }))
 
 vi.mock('@/lib/db/queries/event', () => ({
@@ -21,14 +26,17 @@ vi.mock('@/lib/home-events', async () => {
 })
 
 describe('listHomeEventsPage', () => {
+  const queryBatchSize = 128
+
   beforeEach(() => {
+    mocks.cacheTag.mockReset()
     mocks.listEvents.mockReset()
     mocks.filterHomeEvents.mockReset()
   })
 
   it('stops fetching early for resolved pages once it has enough visible events', async () => {
-    const firstBatch = Array.from({ length: 32 }, (_, index) => ({ id: `batch-1-${index}` }))
-    const secondBatch = Array.from({ length: 32 }, (_, index) => ({ id: `batch-2-${index}` }))
+    const firstBatch = Array.from({ length: queryBatchSize }, (_, index) => ({ id: `batch-1-${index}` }))
+    const secondBatch = Array.from({ length: queryBatchSize }, (_, index) => ({ id: `batch-2-${index}` }))
     const visibleAfterFirstBatch = firstBatch.slice(0, 20)
     const visibleAfterSecondBatch = [...firstBatch, ...secondBatch].slice(0, 40)
 
@@ -38,6 +46,7 @@ describe('listHomeEventsPage', () => {
 
     mocks.filterHomeEvents
       .mockReturnValueOnce(visibleAfterFirstBatch)
+      .mockReturnValueOnce(visibleAfterSecondBatch)
       .mockReturnValueOnce(visibleAfterSecondBatch)
 
     const { listHomeEventsPage } = await import('@/lib/home-events-page')
@@ -50,7 +59,16 @@ describe('listHomeEventsPage', () => {
       userId: '',
     })
 
+    expect(mocks.filterHomeEvents).toHaveBeenCalledTimes(3)
     expect(mocks.listEvents).toHaveBeenCalledTimes(2)
+    expect(mocks.listEvents).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      limit: queryBatchSize,
+      offset: 0,
+    }))
+    expect(mocks.listEvents).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      limit: queryBatchSize,
+      offset: queryBatchSize,
+    }))
     expect(result).toEqual({
       data: visibleAfterSecondBatch.slice(0, 32),
       error: null,
@@ -59,22 +77,17 @@ describe('listHomeEventsPage', () => {
   })
 
   it('does not stop early for active pages because later batches can replace series entries', async () => {
-    const firstBatch = Array.from({ length: 32 }, (_, index) => ({ id: `batch-1-${index}` }))
-    const secondBatch = Array.from({ length: 32 }, (_, index) => ({ id: `batch-2-${index}` }))
+    const firstBatch = Array.from({ length: queryBatchSize }, (_, index) => ({ id: `batch-1-${index}` }))
+    const secondBatch = Array.from({ length: queryBatchSize }, (_, index) => ({ id: `batch-2-${index}` }))
     const thirdBatch: any[] = []
-    const visibleAfterFirstBatch = firstBatch
-    const visibleAfterSecondBatch = [...secondBatch.slice(0, 8), ...firstBatch.slice(8)]
-    const visibleAfterThirdBatch = visibleAfterSecondBatch
+    const visibleAfterAllBatches = [...secondBatch.slice(0, 8), ...firstBatch.slice(8)]
 
     mocks.listEvents
       .mockResolvedValueOnce({ data: firstBatch, error: null })
       .mockResolvedValueOnce({ data: secondBatch, error: null })
       .mockResolvedValueOnce({ data: thirdBatch, error: null })
 
-    mocks.filterHomeEvents
-      .mockReturnValueOnce(visibleAfterFirstBatch)
-      .mockReturnValueOnce(visibleAfterSecondBatch)
-      .mockReturnValueOnce(visibleAfterThirdBatch)
+    mocks.filterHomeEvents.mockReturnValueOnce(visibleAfterAllBatches)
 
     const { listHomeEventsPage } = await import('@/lib/home-events-page')
     const result = await listHomeEventsPage({
@@ -86,9 +99,22 @@ describe('listHomeEventsPage', () => {
       userId: '',
     })
 
+    expect(mocks.filterHomeEvents).toHaveBeenCalledTimes(1)
     expect(mocks.listEvents).toHaveBeenCalledTimes(3)
+    expect(mocks.listEvents).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      limit: queryBatchSize,
+      offset: 0,
+    }))
+    expect(mocks.listEvents).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      limit: queryBatchSize,
+      offset: queryBatchSize,
+    }))
+    expect(mocks.listEvents).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      limit: queryBatchSize,
+      offset: queryBatchSize * 2,
+    }))
     expect(result).toEqual({
-      data: visibleAfterThirdBatch.slice(0, 32),
+      data: visibleAfterAllBatches.slice(0, 32),
       error: null,
       currentTimestamp: null,
     })
@@ -110,6 +136,7 @@ describe('listHomeEventsPage', () => {
     })
 
     expect(mocks.listEvents).toHaveBeenCalledWith(expect.objectContaining({
+      limit: queryBatchSize,
       sortBy: 'trending',
     }))
   })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduce homepage DB queries by batching event fetches and caching main tags and event lists. This lowers backend load and speeds up the homepage.

- **Refactors**
  - Batch event queries to 128 via `loadHomeEventCandidates`, add `cacheTag` for per-user and global lists from `next/cache`, early-stop only for resolved pages, and run `filterHomeEvents` once for active pages.
  - Add `loadPlatformMainTags` with `cacheTag` and safe defaults; replace direct `TagRepository.getMainTags` usage in platform layout and dynamic category page.

<sup>Written for commit 886dd355ec9765ccafee18ef5665db6640d2d3fa. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/941?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

