### PR TITLE
feat: docs sitemap

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -11,6 +11,7 @@ export default function robots(): MetadataRoute.Robots {
       {
         userAgent: '*',
         allow: '/',
+        disallow: ['/api/'],
       },
     ],
     sitemap: `${siteUrl}/sitemap.xml`,

--- a/src/app/sitemaps/sitemap.ts
+++ b/src/app/sitemaps/sitemap.ts
@@ -4,7 +4,7 @@ import { loadEnabledLocales } from '@/i18n/locale-settings'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
 import { withLocalePrefix } from '@/lib/locale-path'
 import siteUrlUtils from '@/lib/site-url'
-import { formatDateForSitemap, getDynamicSitemapEntriesById, getSitemapIds } from '@/lib/sitemap'
+import { DOCS_SITEMAP_ID, formatDateForSitemap, getDynamicSitemapEntriesById, getSitemapIds } from '@/lib/sitemap'
 
 const { resolveSiteUrl } = siteUrlUtils
 
@@ -44,6 +44,11 @@ async function buildSitemapEntries(
 ): Promise<MetadataRoute.Sitemap> {
   if (sitemapId === 'base') {
     return buildPathEntries(BASE_PATHS, siteUrl, lastModified, enabledLocales)
+  }
+
+  if (sitemapId === DOCS_SITEMAP_ID) {
+    const dynamicEntries = await getDynamicSitemapEntriesById(sitemapId)
+    return buildDynamicEntries(dynamicEntries, siteUrl, enabledLocales)
   }
 
   if (sitemapId === 'categories') {

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -10,6 +10,7 @@ import { db } from '@/lib/drizzle'
 import { buildPublicEventListVisibilityCondition } from '@/lib/event-visibility'
 import { resolveEventMarketPath, resolveEventPagePath } from '@/lib/events-routing'
 import { isDynamicHomeCategorySlug } from '@/lib/platform-routing'
+import { source } from '@/lib/source'
 import { isSportsAuxiliaryEventSlug } from '@/lib/sports-event-slugs'
 import { resolveCanonicalSportsSportSlug } from '@/lib/sports-slug-mapping'
 
@@ -18,6 +19,7 @@ const STATIC_SITEMAP_IDS = [
 ] as const
 
 const CATEGORIES_SITEMAP_ID = 'categories'
+export const DOCS_SITEMAP_ID = 'docs'
 const PREDICTIONS_SITEMAP_PREFIX = 'predictions-'
 const PREDICTIONS_SITEMAP_PATTERN = /^predictions-(\d{3})$/
 const ACTIVE_EVENTS_SITEMAP_PREFIX = 'events-active-'
@@ -73,6 +75,10 @@ interface PredictionSitemapRow {
   sports_tags: unknown
 }
 
+interface DocsSitemapPage {
+  url: string
+}
+
 function shouldIgnoreSportsSitemapSlug(slug: string | null | undefined) {
   return isSportsAuxiliaryEventSlug(slug)
 }
@@ -100,11 +106,16 @@ export async function getSitemapIds(): Promise<string[]> {
 export async function getSitemapIndexEntries(): Promise<SitemapIndexEntry[]> {
   const fallbackDate = formatDateForSitemap(new Date())
   const categoryEntries = await getCategorySitemapEntries()
+  const docsEntries = getDocsSitemapEntries(fallbackDate)
   const dynamicSitemaps = await getDynamicEventSitemaps()
   const predictionEntries = await getPredictionSitemapEntries()
   const chunkSize = await resolveLocalizedSitemapChunkSize()
   const entries: SitemapIndexEntry[] = [
     ...STATIC_SITEMAP_IDS.map(id => ({ id, lastmod: fallbackDate })),
+    {
+      id: DOCS_SITEMAP_ID,
+      lastmod: getLatestLastModified(docsEntries, fallbackDate),
+    },
     {
       id: CATEGORIES_SITEMAP_ID,
       lastmod: getLatestLastModified(categoryEntries, fallbackDate),
@@ -155,6 +166,10 @@ export async function getSitemapIndexEntries(): Promise<SitemapIndexEntry[]> {
 }
 
 export async function getDynamicSitemapEntriesById(id: string): Promise<SitemapRouteEntry[]> {
+  if (id === DOCS_SITEMAP_ID) {
+    return getDocsSitemapEntries(formatDateForSitemap(new Date()))
+  }
+
   if (id === CATEGORIES_SITEMAP_ID) {
     return getCategorySitemapEntries()
   }
@@ -183,6 +198,47 @@ export async function getDynamicSitemapEntriesById(id: string): Promise<SitemapR
   const monthEntries = dynamicSitemaps.closedByMonth[closedSitemapId.monthKey] ?? []
   const monthChunks = chunkSitemapEntries(monthEntries, chunkSize)
   return monthChunks[closedSitemapId.chunkIndex - 1] ?? []
+}
+
+export function buildDocsSitemapEntries(
+  pages: readonly DocsSitemapPage[],
+  lastModified: string,
+): SitemapRouteEntry[] {
+  const docsPathMap = new Map<string, SitemapRouteEntry>()
+
+  for (const page of pages) {
+    const path = normalizeDocsSitemapPath(page.url)
+    if (!path) {
+      continue
+    }
+
+    docsPathMap.set(path, {
+      path,
+      lastModified,
+    })
+  }
+
+  return Array.from(docsPathMap.values()).sort((a, b) => a.path.localeCompare(b.path))
+}
+
+function getDocsSitemapEntries(lastModified: string): SitemapRouteEntry[] {
+  return buildDocsSitemapEntries(source.getPages(), lastModified)
+}
+
+function normalizeDocsSitemapPath(url: string): string | null {
+  const normalizedUrl = url.trim()
+
+  if (normalizedUrl === '/docs') {
+    return normalizedUrl
+  }
+
+  if (!normalizedUrl.startsWith('/docs/')) {
+    return null
+  }
+
+  return normalizedUrl.endsWith('/')
+    ? normalizedUrl.slice(0, -1)
+    : normalizedUrl
 }
 
 async function getCategorySitemapEntries(): Promise<SitemapRouteEntry[]> {

--- a/tests/unit/sitemap.test.ts
+++ b/tests/unit/sitemap.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  cacheTag: vi.fn(),
+  getPages: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+  cacheTag: (...args: any[]) => mocks.cacheTag(...args),
+  unstable_cache: (callback: (...args: any[]) => unknown) => callback,
+}))
+
+vi.mock('@/lib/source', () => ({
+  source: {
+    getPages: (...args: any[]) => mocks.getPages(...args),
+  },
+}))
+
+const {
+  DOCS_SITEMAP_ID,
+  buildDocsSitemapEntries,
+  getDynamicSitemapEntriesById,
+} = await import('@/lib/sitemap')
+
+describe('sitemap docs entries', () => {
+  beforeEach(() => {
+    mocks.cacheTag.mockReset()
+    mocks.getPages.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps only canonical docs paths sorted and deduped', () => {
+    const entries = buildDocsSitemapEntries([
+      { url: '/docs/users/getting-started/' },
+      { url: '/activity' },
+      { url: ' /docs ' },
+      { url: '/docs/users/getting-started' },
+      { url: '/docs/api-reference' },
+    ], '2026-04-27')
+
+    expect(entries).toEqual([
+      { path: '/docs', lastModified: '2026-04-27' },
+      { path: '/docs/api-reference', lastModified: '2026-04-27' },
+      { path: '/docs/users/getting-started', lastModified: '2026-04-27' },
+    ])
+  })
+
+  it('serves the docs sitemap from the docs source', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-04-27T12:00:00.000Z'))
+    mocks.getPages.mockReturnValue([
+      { url: '/docs' },
+      { url: '/docs/api-reference/rate-limits' },
+    ])
+
+    await expect(getDynamicSitemapEntriesById(DOCS_SITEMAP_ID)).resolves.toEqual([
+      { path: '/docs', lastModified: '2026-04-27' },
+      { path: '/docs/api-reference/rate-limits', lastModified: '2026-04-27' },
+    ])
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a docs-specific sitemap built from our docs source and adds it to the sitemap index to improve discovery of `/docs` pages. Also blocks `/api/` in robots.

- **New Features**
  - Adds `DOCS_SITEMAP_ID` and dynamic entries from `source.getPages()`.
  - Canonicalizes `/docs` URLs (dedupe, trim, remove trailing slash; ignore non-docs).
  - Includes docs sitemap in the index with correct lastmod and locale-aware routes.
  - Disallows `/api/` in `robots.txt`.

<sup>Written for commit dfdc58ae5e538ca712274e15ec108701f7b6fc9f. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/948?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

