### PR TITLE
fix: close header search on ESC

### DIFF
--- a/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
@@ -244,7 +244,7 @@ export default function HeaderSearch({
   }, [blurFrameRef])
 
   function handleSearchKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
-    if (event.key !== 'Escape' || !showAttachedDropdown) {
+    if (event.key !== 'Escape' || event.nativeEvent.isComposing || !showAttachedDropdown) {
       return
     }
 

--- a/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import type { Route } from 'next'
-import type { ReactNode, RefObject } from 'react'
+import type { KeyboardEvent as ReactKeyboardEvent, ReactNode, RefObject } from 'react'
 import { SearchIcon, XIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useCallback, useEffect, useRef, useState } from 'react'
@@ -190,7 +190,7 @@ export default function HeaderSearch({
   const hasActiveQuery = query.trim().length >= 2
   const showDropdown = hasActiveQuery
     && (showResults || isLoading.events || isLoading.profiles)
-    && (isManagedSearchSurface || !isResultsDismissed)
+    && !isResultsDismissed
   const showDiscoveryDropdown = showDesktopDiscovery && !emptyState && query.trim().length === 0 && hasFocusWithin && !isResultsDismissed
   const showAttachedDropdown = showDropdown || showDiscoveryDropdown
   const inputBaseClass = showAttachedDropdown ? 'bg-background' : 'bg-accent'
@@ -243,6 +243,18 @@ export default function HeaderSearch({
     }
   }, [blurFrameRef])
 
+  function handleSearchKeyDown(event: ReactKeyboardEvent<HTMLDivElement>) {
+    if (event.key !== 'Escape' || !showAttachedDropdown) {
+      return
+    }
+
+    event.preventDefault()
+    event.stopPropagation()
+    clearPendingBlurFrame()
+    setIsResultsDismissed(true)
+    hideResults()
+  }
+
   useSlashFocusShortcut(inputRef)
   useExternalFocusTrigger(focusTrigger, inputRef)
   useDismissSearchOnOutsidePointerDown({
@@ -264,6 +276,7 @@ export default function HeaderSearch({
         className="relative w-full"
         ref={searchRef}
         data-testid="header-search-container"
+        onKeyDown={handleSearchKeyDown}
         onFocusCapture={() => {
           clearPendingBlurFrame()
           setHasFocusWithin(true)

--- a/tests/unit/HeaderSearch.test.tsx
+++ b/tests/unit/HeaderSearch.test.tsx
@@ -132,4 +132,37 @@ describe('headerSearch', () => {
     expect(mocks.clearSearch).not.toHaveBeenCalled()
     expect(screen.queryByTestId('search-results')).not.toBeInTheDocument()
   })
+
+  it('keeps the attached dropdown open when escape is pressed during composition', () => {
+    mocks.useSearch.mockReturnValue({
+      activeTab: 'events',
+      clearSearch: mocks.clearSearch,
+      handleQueryChange: mocks.handleQueryChange,
+      hideResults: mocks.hideResults,
+      isLoading: {
+        events: false,
+        profiles: false,
+      },
+      query: 'brazil',
+      results: {
+        events: [],
+        profiles: [],
+      },
+      setActiveTab: mocks.setActiveTab,
+      showResults: true,
+      showSearchResults: mocks.showSearchResults,
+    })
+
+    render(<HeaderSearch />)
+
+    expect(screen.getByTestId('search-results')).toBeInTheDocument()
+
+    fireEvent.keyDown(screen.getByTestId('header-search-input'), {
+      key: 'Escape',
+      isComposing: true,
+    })
+
+    expect(mocks.hideResults).not.toHaveBeenCalled()
+    expect(screen.getByTestId('search-results')).toBeInTheDocument()
+  })
 })

--- a/tests/unit/HeaderSearch.test.tsx
+++ b/tests/unit/HeaderSearch.test.tsx
@@ -101,4 +101,35 @@ describe('headerSearch', () => {
     expect(mocks.clearSearch).not.toHaveBeenCalled()
     expect(mocks.push).not.toHaveBeenCalled()
   })
+
+  it('closes the attached dropdown when escape is pressed', () => {
+    mocks.useSearch.mockReturnValue({
+      activeTab: 'events',
+      clearSearch: mocks.clearSearch,
+      handleQueryChange: mocks.handleQueryChange,
+      hideResults: mocks.hideResults,
+      isLoading: {
+        events: false,
+        profiles: false,
+      },
+      query: 'brazil',
+      results: {
+        events: [],
+        profiles: [],
+      },
+      setActiveTab: mocks.setActiveTab,
+      showResults: true,
+      showSearchResults: mocks.showSearchResults,
+    })
+
+    render(<HeaderSearch />)
+
+    expect(screen.getByTestId('search-results')).toBeInTheDocument()
+
+    fireEvent.keyDown(screen.getByTestId('header-search-input'), { key: 'Escape' })
+
+    expect(mocks.hideResults).toHaveBeenCalledTimes(1)
+    expect(mocks.clearSearch).not.toHaveBeenCalled()
+    expect(screen.queryByTestId('search-results')).not.toBeInTheDocument()
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pressing Escape now closes the header search dropdown without clearing the query, and ignores Escape during IME composition. This matches expected keyboard behavior and prevents the menu from getting stuck open.

- **Bug Fixes**
  - Handle Escape to dismiss the attached dropdown; ignore during IME composition.
  - Require not dismissed before showing dropdown (removes managed-surface exception).
  - Add unit tests for Escape-to-close and IME composition behavior.

<sup>Written for commit 597b5ba636c46e93f44bd1da768e4c7163ecd03f. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/949?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

