### PR TITLE
refactor: use constants for sitemap entries

### DIFF
--- a/src/app/sitemaps/sitemap.ts
+++ b/src/app/sitemaps/sitemap.ts
@@ -4,7 +4,17 @@ import { loadEnabledLocales } from '@/i18n/locale-settings'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
 import { withLocalePrefix } from '@/lib/locale-path'
 import siteUrlUtils from '@/lib/site-url'
-import { DOCS_SITEMAP_ID, formatDateForSitemap, getDynamicSitemapEntriesById, getSitemapIds } from '@/lib/sitemap'
+import {
+  ACTIVE_EVENTS_SITEMAP_PREFIX,
+  BASE_SITEMAP_ID,
+  CATEGORIES_SITEMAP_ID,
+  CLOSED_EVENTS_SITEMAP_PREFIX,
+  DOCS_SITEMAP_ID,
+  formatDateForSitemap,
+  getDynamicSitemapEntriesById,
+  getSitemapIds,
+  PREDICTIONS_SITEMAP_PREFIX,
+} from '@/lib/sitemap'
 
 const { resolveSiteUrl } = siteUrlUtils
 
@@ -42,7 +52,7 @@ async function buildSitemapEntries(
   lastModified: string,
   enabledLocales: SupportedLocale[],
 ): Promise<MetadataRoute.Sitemap> {
-  if (sitemapId === 'base') {
+  if (sitemapId === BASE_SITEMAP_ID) {
     return buildPathEntries(BASE_PATHS, siteUrl, lastModified, enabledLocales)
   }
 
@@ -51,22 +61,22 @@ async function buildSitemapEntries(
     return buildDynamicEntries(dynamicEntries, siteUrl, enabledLocales)
   }
 
-  if (sitemapId === 'categories') {
+  if (sitemapId === CATEGORIES_SITEMAP_ID) {
     const dynamicEntries = await getDynamicSitemapEntriesById(sitemapId)
     return buildDynamicEntries(dynamicEntries, siteUrl, enabledLocales)
   }
 
-  if (sitemapId.startsWith('predictions-')) {
+  if (sitemapId.startsWith(PREDICTIONS_SITEMAP_PREFIX)) {
     const dynamicEntries = await getDynamicSitemapEntriesById(sitemapId)
     return buildDynamicEntries(dynamicEntries, siteUrl, enabledLocales)
   }
 
-  if (sitemapId.startsWith('events-active-')) {
+  if (sitemapId.startsWith(ACTIVE_EVENTS_SITEMAP_PREFIX)) {
     const dynamicEntries = await getDynamicSitemapEntriesById(sitemapId)
     return buildDynamicEntries(dynamicEntries, siteUrl, enabledLocales)
   }
 
-  if (sitemapId.startsWith('events-closed-')) {
+  if (sitemapId.startsWith(CLOSED_EVENTS_SITEMAP_PREFIX)) {
     const dynamicEntries = await getDynamicSitemapEntriesById(sitemapId)
     return buildDynamicEntries(dynamicEntries, siteUrl, enabledLocales)
   }

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -14,17 +14,14 @@ import { source } from '@/lib/source'
 import { isSportsAuxiliaryEventSlug } from '@/lib/sports-event-slugs'
 import { resolveCanonicalSportsSportSlug } from '@/lib/sports-slug-mapping'
 
-const STATIC_SITEMAP_IDS = [
-  'base',
-] as const
-
-const CATEGORIES_SITEMAP_ID = 'categories'
+export const BASE_SITEMAP_ID = 'base'
+export const CATEGORIES_SITEMAP_ID = 'categories'
 export const DOCS_SITEMAP_ID = 'docs'
-const PREDICTIONS_SITEMAP_PREFIX = 'predictions-'
+export const PREDICTIONS_SITEMAP_PREFIX = 'predictions-'
 const PREDICTIONS_SITEMAP_PATTERN = /^predictions-(\d{3})$/
-const ACTIVE_EVENTS_SITEMAP_PREFIX = 'events-active-'
+export const ACTIVE_EVENTS_SITEMAP_PREFIX = 'events-active-'
 const ACTIVE_EVENTS_SITEMAP_PATTERN = /^events-active-(\d{3})$/
-const CLOSED_EVENTS_SITEMAP_PREFIX = 'events-closed-'
+export const CLOSED_EVENTS_SITEMAP_PREFIX = 'events-closed-'
 const CLOSED_EVENTS_SITEMAP_PATTERN = /^events-closed-(\d{4}-\d{2})(?:-(\d{3}))?$/
 const SITEMAP_URL_LIMIT = 50_000
 
@@ -111,7 +108,10 @@ export async function getSitemapIndexEntries(): Promise<SitemapIndexEntry[]> {
   const predictionEntries = await getPredictionSitemapEntries()
   const chunkSize = await resolveLocalizedSitemapChunkSize()
   const entries: SitemapIndexEntry[] = [
-    ...STATIC_SITEMAP_IDS.map(id => ({ id, lastmod: fallbackDate })),
+    {
+      id: BASE_SITEMAP_ID,
+      lastmod: fallbackDate,
+    },
     {
       id: DOCS_SITEMAP_ID,
       lastmod: getLatestLastModified(docsEntries, fallbackDate),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored sitemap generation to use shared constants for IDs and prefixes, replacing string literals. Centralizes config and reduces typos with no behavior changes.

- **Refactors**
  - Exported `BASE_SITEMAP_ID`, `CATEGORIES_SITEMAP_ID`, `DOCS_SITEMAP_ID`, `PREDICTIONS_SITEMAP_PREFIX`, `ACTIVE_EVENTS_SITEMAP_PREFIX`, `CLOSED_EVENTS_SITEMAP_PREFIX` in `src/lib/sitemap.ts`.
  - Switched comparisons in `src/app/sitemaps/sitemap.ts` to use these constants instead of hardcoded strings.
  - Removed `STATIC_SITEMAP_IDS`; base index entry now uses `BASE_SITEMAP_ID` in `getSitemapIndexEntries()`.

<sup>Written for commit 67c9e2b400c80a00e9a847738d174a4f21fe2459. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

