### PR TITLE
refactor: replace empty fragments with null and simplify AppProviders

### DIFF
--- a/src/app/[locale]/(platform)/_components/AffiliateQueryHandler.tsx
+++ b/src/app/[locale]/(platform)/_components/AffiliateQueryHandler.tsx
@@ -22,5 +22,5 @@ function useAffiliateQueryRedirect() {
 export default function AffiliateQueryHandler() {
   useAffiliateQueryRedirect()
 
-  return <></>
+  return null
 }

--- a/src/app/[locale]/(platform)/_components/SearchResults.tsx
+++ b/src/app/[locale]/(platform)/_components/SearchResults.tsx
@@ -64,7 +64,7 @@ export function SearchResults({
   }
 
   if (query.length < 2 && !isLoading.events && !isLoading.profiles) {
-    return <></>
+    return null
   }
 
   return (
@@ -340,7 +340,7 @@ function ProfileResults({ profiles, isLoading, query, onResultClick }: ProfileRe
   }
 
   if (profiles.length === 0) {
-    return <></>
+    return null
   }
 
   return (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyForm.tsx
@@ -57,7 +57,7 @@ export default function EventCommentReplyForm({
   }
 
   if (!user) {
-    return <></>
+    return null
   }
 
   const avatarUrl = user.image?.trim() ?? ''

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentsLoadMoreReplies.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentsLoadMoreReplies.tsx
@@ -21,7 +21,7 @@ export default function EventCommentsLoadMoreReplies({
   }
 
   if (comment.replies_count <= 3) {
-    return <></>
+    return null
   }
 
   if (error) {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
@@ -140,7 +140,7 @@ export default function EventMarketHistory({ market }: EventMarketHistoryProps) 
   }
 
   if (!userAddress) {
-    return <></>
+    return null
   }
 
   if (hasInitialError) {
@@ -186,7 +186,7 @@ export default function EventMarketHistory({ market }: EventMarketHistoryProps) 
   if (isLoadingInitial || activities.length === 0) {
     return (
       isSingleMarket
-        ? <></>
+        ? null
         : (
             <div className="text-sm text-muted-foreground">
               {t('No activity for this outcome.')}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
@@ -955,7 +955,7 @@ export default function EventMarketPositions({
   }, [resolvedConvertOptions.length])
 
   if (!userAddress) {
-    return <></>
+    return null
   }
 
   if (hasInitialError) {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -867,7 +867,7 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
   const shouldShowResolvedSection = !showResolvedInline && sortedResolvedDisplayRows.length > 0
 
   if (isSingleMarket) {
-    return <></>
+    return null
   }
 
   return (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelMarketInfo.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelMarketInfo.tsx
@@ -7,7 +7,7 @@ interface EventOrderPanelMarketInfoProps {
 
 export default function EventOrderPanelMarketInfo({ market }: EventOrderPanelMarketInfoProps) {
   if (!market) {
-    return <></>
+    return null
   }
 
   return (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelMobileMarketInfo.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelMobileMarketInfo.tsx
@@ -23,7 +23,7 @@ export default function EventOrderPanelMobileMarketInfo({
   const areValuesHidden = usePortfolioValueVisibility(state => state.isHidden)
 
   if (!market) {
-    return <></>
+    return null
   }
 
   return (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
@@ -294,7 +294,7 @@ export default function EventRules({ event, mode = 'accordion', showEndDate = fa
           </div>
         </div>
       )
-    : <></>
+    : null
 
   const content = (
     <div className={cn('space-y-2', { 'p-3': !isInline })}>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventSingleMarketOrderBook.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventSingleMarketOrderBook.tsx
@@ -96,7 +96,7 @@ export default function EventSingleMarketOrderBook({
   }
 
   if (market.outcomes.length < 2) {
-    return <></>
+    return null
   }
 
   return (

--- a/src/components/HeaderDropdownUserMenuAuth.tsx
+++ b/src/components/HeaderDropdownUserMenuAuth.tsx
@@ -169,7 +169,7 @@ export default function HeaderDropdownUserMenuAuth() {
   }
 
   if (!user) {
-    return <></>
+    return null
   }
 
   return (

--- a/src/components/UserInfoSection.tsx
+++ b/src/components/UserInfoSection.tsx
@@ -13,7 +13,7 @@ export default function UserInfoSection() {
   const { copied, copy } = useClipboard()
 
   if (!user) {
-    return <></>
+    return null
   }
 
   const proxyWalletAddress = user.proxy_wallet_address!

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -35,17 +35,13 @@ export function AppProviders({ children }: AppProvidersProps) {
     </div>
   )
 
-  const providersContent = (
-    <ThemeProvider attribute="class">
-      <QueryClientProvider client={queryClient}>
-        {content}
-      </QueryClientProvider>
-    </ThemeProvider>
-  )
-
   return (
     <ProgressIndicatorProvider>
-      {providersContent}
+      <ThemeProvider attribute="class">
+        <QueryClientProvider client={queryClient}>
+          {content}
+        </QueryClientProvider>
+      </ThemeProvider>
     </ProgressIndicatorProvider>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced empty fragments with null and simplified `AppProviders` composition to remove unnecessary React nodes and slightly reduce render work. No behavior changes.

- **Refactors**
  - Swapped `<>...</>` for `null` across several UI components to explicitly render nothing and avoid extra elements.
  - Inlined provider composition in `AppProviders` by removing the `providersContent` variable.

<sup>Written for commit 090a02ec8de8cbfad829f06e249a4c30d3b742f7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

