### PR TITLE
infra: railway target

### DIFF
--- a/infra/railway/railway.json
+++ b/infra/railway/railway.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "build": {
+    "builder": "DOCKERFILE",
+    "dockerfilePath": "infra/docker/Dockerfile"
+  },
+  "deploy": {
+    "preDeployCommand": ["npm run db:push"]
+  }
+}

--- a/infra/terraform/environments/production/railway/main.tf
+++ b/infra/terraform/environments/production/railway/main.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.0"
+    }
+  }
+}
+
+module "target_railway" {
+  source = "../../../modules/target-railway"
+
+  repo_root           = local.resolved_repo_root
+  railway_project_id  = var.railway_project_id
+  railway_environment = var.railway_environment
+  railway_service     = var.railway_service
+  deploy_path         = var.deploy_path
+  path_as_root        = var.path_as_root
+}
+
+output "deployment_target" {
+  value       = module.target_railway.target
+  description = "Deployment target"
+}
+
+output "railway_project_id" {
+  value       = module.target_railway.railway_project_id
+  description = "Railway project ID used for deployment"
+}
+
+output "railway_environment" {
+  value       = module.target_railway.railway_environment
+  description = "Railway environment used for deployment"
+}
+
+output "railway_service" {
+  value       = module.target_railway.railway_service
+  description = "Railway service used for deployment"
+}
+
+output "deploy_path" {
+  value       = module.target_railway.deploy_path
+  description = "Repository path deployed with Railway"
+}

--- a/infra/terraform/environments/production/railway/terraform.tfvars.example
+++ b/infra/terraform/environments/production/railway/terraform.tfvars.example
@@ -1,0 +1,6 @@
+# Requires Railway CLI auth (for example via RAILWAY_TOKEN or `railway login`).
+railway_project_id  = "replace-with-railway-project-id"
+railway_environment = "production"
+railway_service     = "web"
+deploy_path         = "."
+path_as_root        = false

--- a/infra/terraform/environments/production/railway/variables.tf
+++ b/infra/terraform/environments/production/railway/variables.tf
@@ -1,0 +1,39 @@
+variable "repo_root" {
+  type        = string
+  description = "Absolute path to repository root"
+  default     = ""
+}
+
+variable "railway_project_id" {
+  type        = string
+  description = "Railway project ID (optional when the CLI is already linked to a project)"
+  default     = ""
+}
+
+variable "railway_environment" {
+  type        = string
+  description = "Railway environment name or ID (required when railway_project_id is provided)"
+  default     = ""
+}
+
+variable "railway_service" {
+  type        = string
+  description = "Railway service name or ID"
+  default     = ""
+}
+
+variable "deploy_path" {
+  type        = string
+  description = "Path to deploy relative to repo root"
+  default     = "."
+}
+
+variable "path_as_root" {
+  type        = bool
+  description = "Whether Railway should treat deploy_path as the archive root"
+  default     = false
+}
+
+locals {
+  resolved_repo_root = var.repo_root != "" ? var.repo_root : abspath("${path.root}/../../../../..")
+}

--- a/infra/terraform/modules/target-railway/main.tf
+++ b/infra/terraform/modules/target-railway/main.tf
@@ -17,6 +17,7 @@ locals {
 
 resource "null_resource" "deploy" {
   triggers = {
+    repo_root          = var.repo_root
     railway_project_id  = var.railway_project_id
     railway_environment = var.railway_environment
     railway_service     = var.railway_service

--- a/infra/terraform/modules/target-railway/main.tf
+++ b/infra/terraform/modules/target-railway/main.tf
@@ -1,0 +1,39 @@
+terraform {
+  required_providers {
+    null = {
+      source  = "hashicorp/null"
+      version = ">= 3.2.0"
+    }
+  }
+}
+
+locals {
+  project_arg      = var.railway_project_id != "" ? "--project ${var.railway_project_id}" : ""
+  environment_arg  = var.railway_environment != "" ? "--environment ${var.railway_environment}" : ""
+  service_arg      = var.railway_service != "" ? "--service ${var.railway_service}" : ""
+  path_as_root_arg = var.path_as_root ? "--path-as-root" : ""
+  deploy_path_arg  = trimspace(var.deploy_path) != "" ? trimspace(var.deploy_path) : "."
+}
+
+resource "null_resource" "deploy" {
+  triggers = {
+    railway_project_id  = var.railway_project_id
+    railway_environment = var.railway_environment
+    railway_service     = var.railway_service
+    deploy_path         = local.deploy_path_arg
+    path_as_root        = tostring(var.path_as_root)
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.railway_project_id == "" || var.railway_environment != ""
+      error_message = "railway_environment must be set when railway_project_id is provided."
+    }
+  }
+
+  provisioner "local-exec" {
+    working_dir = var.repo_root
+    command     = "railway up --ci ${local.project_arg} ${local.environment_arg} ${local.service_arg} ${local.path_as_root_arg} \"${local.deploy_path_arg}\""
+    interpreter = ["/bin/bash", "-lc"]
+  }
+}

--- a/infra/terraform/modules/target-railway/outputs.tf
+++ b/infra/terraform/modules/target-railway/outputs.tf
@@ -1,0 +1,24 @@
+output "target" {
+  value       = "railway"
+  description = "Deployment target type"
+}
+
+output "railway_project_id" {
+  value       = var.railway_project_id
+  description = "Railway project ID"
+}
+
+output "railway_environment" {
+  value       = var.railway_environment
+  description = "Railway environment name or ID"
+}
+
+output "railway_service" {
+  value       = var.railway_service
+  description = "Railway service name or ID"
+}
+
+output "deploy_path" {
+  value       = trimspace(var.deploy_path) != "" ? trimspace(var.deploy_path) : "."
+  description = "Path deployed by the Railway CLI"
+}

--- a/infra/terraform/modules/target-railway/variables.tf
+++ b/infra/terraform/modules/target-railway/variables.tf
@@ -1,0 +1,34 @@
+variable "repo_root" {
+  type        = string
+  description = "Absolute path to repository root"
+}
+
+variable "railway_project_id" {
+  type        = string
+  description = "Railway project ID (optional when the CLI is already linked to a project)"
+  default     = ""
+}
+
+variable "railway_environment" {
+  type        = string
+  description = "Railway environment name or ID (required when railway_project_id is provided)"
+  default     = ""
+}
+
+variable "railway_service" {
+  type        = string
+  description = "Railway service name or ID"
+  default     = ""
+}
+
+variable "deploy_path" {
+  type        = string
+  description = "Path to deploy relative to repo_root"
+  default     = "."
+}
+
+variable "path_as_root" {
+  type        = bool
+  description = "Whether Railway should treat deploy_path as the archive root"
+  default     = false
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a Terraform-based Railway deployment target that runs `railway up` with configurable project, environment, service, and deploy path. Also adds `railway.json` to build via the repo Dockerfile and run `npm run db:push` before deploy.

- **New Features**
  - New Terraform module `infra/terraform/modules/target-railway` that shells `railway up` with optional args, a precondition check, and change triggers (now includes `repo_root`) to ensure redeploys when the repo root changes.
  - Production wiring under `infra/terraform/environments/production/railway` with outputs and `terraform.tfvars.example`.
  - `infra/railway/railway.json` to use the Dockerfile at `infra/docker/Dockerfile` and run a pre-deploy command.

- **Migration**
  - Authenticate the `railway` CLI (`RAILWAY_TOKEN` or `railway login`).
  - Copy and fill `terraform.tfvars.example` in `environments/production/railway`.
  - Run Terraform in that directory to deploy.
  - Set `path_as_root` when deploying a subfolder as the archive root.

<sup>Written for commit 8ef4f71d0dc37f5a7a64a08d3a15c99b732c06da. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

