### PR TITLE
fix: avoid viem client init during prerender in client hooks

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances.ts
@@ -1,6 +1,7 @@
+import type { PublicClient } from 'viem'
 import type { Event } from '@/types'
 import { useQuery } from '@tanstack/react-query'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { createPublicClient, erc1155Abi, http } from 'viem'
 import { MICRO_UNIT, OUTCOME_INDEX } from '@/lib/constants'
 import { CONDITIONAL_TOKENS_CONTRACT } from '@/lib/contracts'
@@ -18,6 +19,13 @@ interface UseUserShareBalancesOptions {
   ownerAddress?: `0x${string}` | null
 }
 
+function createBrowserPublicClient(): PublicClient {
+  return createPublicClient({
+    chain: defaultViemNetwork,
+    transport: http(defaultViemRpcUrl),
+  })
+}
+
 function normalizeSharesFromBalance(balance: bigint): number {
   if (balance <= 0n) {
     return 0
@@ -28,16 +36,11 @@ function normalizeSharesFromBalance(balance: bigint): number {
 }
 
 export function useUserShareBalances({ event, ownerAddress }: UseUserShareBalancesOptions) {
-  const rpcUrl = useMemo(() => defaultViemRpcUrl, [])
-
-  const client = useMemo(
-    () =>
-      createPublicClient({
-        chain: defaultViemNetwork,
-        transport: http(rpcUrl),
-      }),
-    [rpcUrl],
-  )
+  const clientRef = useRef<PublicClient | null>(null)
+  if (clientRef.current === null && typeof window !== 'undefined') {
+    clientRef.current = createBrowserPublicClient()
+  }
+  const client = clientRef.current
 
   const outcomeDescriptors = useMemo(() => {
     if (!event?.markets?.length) {
@@ -57,13 +60,13 @@ export function useUserShareBalances({ event, ownerAddress }: UseUserShareBalanc
 
   const query = useQuery({
     queryKey: ['user-conditional-shares', ownerAddress, event?.slug, descriptorKey],
-    enabled: Boolean(ownerAddress && outcomeDescriptors.length),
+    enabled: Boolean(client && ownerAddress && outcomeDescriptors.length),
     staleTime: 10_000,
     gcTime: 5 * 60 * 1000,
     refetchInterval: 10_000,
     refetchIntervalInBackground: true,
     queryFn: async (): Promise<SharesByCondition> => {
-      if (!ownerAddress || !outcomeDescriptors.length) {
+      if (!client || !ownerAddress || !outcomeDescriptors.length) {
         return {}
       }
 

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -1,6 +1,6 @@
 import type { Address, PublicClient } from 'viem'
 import { useQuery } from '@tanstack/react-query'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { createPublicClient, getContract, http } from 'viem'
 import { COLLATERAL_TOKEN_ADDRESS } from '@/lib/contracts'
 import { defaultViemNetwork, defaultViemRpcUrl } from '@/lib/viem-network'
@@ -32,24 +32,27 @@ interface UseBalanceOptions {
   enabled?: boolean
 }
 
-const RPC_URL = defaultViemRpcUrl
+function createBrowserPublicClient(): PublicClient {
+  return createPublicClient({
+    chain: defaultViemNetwork,
+    transport: http(defaultViemRpcUrl),
+  })
+}
 
 export function useBalance(options: UseBalanceOptions = {}) {
   const user = useUser()
-
-  const client = useMemo<PublicClient>(() => {
-    return createPublicClient({
-      chain: defaultViemNetwork,
-      transport: http(RPC_URL),
-    })
-  }, [])
+  const clientRef = useRef<PublicClient | null>(null)
+  if (clientRef.current === null && typeof window !== 'undefined') {
+    clientRef.current = createBrowserPublicClient()
+  }
+  const client = clientRef.current
 
   const proxyWalletAddress: Address | null = user?.proxy_wallet_address
     ? normalizeAddress(user.proxy_wallet_address) as Address | null
     : null
 
   const contract = useMemo(() => {
-    if (!proxyWalletAddress) {
+    if (!client || !proxyWalletAddress) {
       return null
     }
 
@@ -76,7 +79,7 @@ export function useBalance(options: UseBalanceOptions = {}) {
     refetchInterval: 10_000,
     refetchIntervalInBackground: true,
     queryFn: async (): Promise<Balance> => {
-      if (!proxyWalletAddress || !contract) {
+      if (!client || !proxyWalletAddress || !contract) {
         return INITIAL_STATE
       }
 

--- a/src/hooks/usePendingUsdcDeposit.ts
+++ b/src/hooks/usePendingUsdcDeposit.ts
@@ -1,7 +1,7 @@
-import type { Address } from 'viem'
+import type { Address, PublicClient } from 'viem'
 import { useAppKitAccount } from '@reown/appkit/react'
 import { useQuery } from '@tanstack/react-query'
-import { useMemo } from 'react'
+import { useMemo, useRef } from 'react'
 import { createPublicClient, formatUnits, getContract, http } from 'viem'
 import { NATIVE_USDC_TOKEN_ADDRESS } from '@/lib/contracts'
 import { IS_TEST_MODE } from '@/lib/network'
@@ -35,30 +35,36 @@ interface UsePendingUsdcDepositOptions {
   enabled?: boolean
 }
 
+function createBrowserPublicClient(): PublicClient {
+  return createPublicClient({
+    chain: defaultViemNetwork,
+    transport: http(defaultViemRpcUrl),
+  })
+}
+
 export function usePendingUsdcDeposit(options: UsePendingUsdcDepositOptions = {}) {
   const { isConnected } = useAppKitAccount()
   const user = useUser()
-
-  const rpcUrl = useMemo(() => defaultViemRpcUrl, [])
-
-  const client = useMemo(
-    () =>
-      createPublicClient({
-        chain: defaultViemNetwork,
-        transport: http(rpcUrl),
-      }),
-    [rpcUrl],
-  )
+  const clientRef = useRef<PublicClient | null>(null)
+  if (clientRef.current === null && typeof window !== 'undefined') {
+    clientRef.current = createBrowserPublicClient()
+  }
+  const client = clientRef.current
 
   const tokenAddress = NATIVE_USDC_TOKEN_ADDRESS
 
   const contract = useMemo(
-    () =>
-      getContract({
+    () => {
+      if (!client) {
+        return null
+      }
+
+      return getContract({
         address: tokenAddress as Address,
         abi: ERC20_ABI,
         client,
-      }),
+      })
+    },
     [client, tokenAddress],
   )
 
@@ -68,7 +74,7 @@ export function usePendingUsdcDeposit(options: UsePendingUsdcDepositOptions = {}
 
   const isOptionsEnabled = (options.enabled ?? true) && !IS_TEST_MODE
   const isAwaitingConnection = Boolean(user && isOptionsEnabled && !isConnected)
-  const isQueryEnabled = Boolean(isConnected && proxyWalletAddress && isOptionsEnabled)
+  const isQueryEnabled = Boolean(client && isConnected && proxyWalletAddress && isOptionsEnabled)
 
   const {
     data,
@@ -83,7 +89,7 @@ export function usePendingUsdcDeposit(options: UsePendingUsdcDepositOptions = {}
     refetchInterval: 60_000,
     refetchIntervalInBackground: true,
     queryFn: async (): Promise<Balance> => {
-      if (!proxyWalletAddress) {
+      if (!client || !proxyWalletAddress || !contract) {
         return INITIAL_STATE
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Avoid initializing `viem` public client during Next.js prerender in client hooks. This prevents SSR-time network setup and flaky queries by only creating the client in the browser.

- **Bug Fixes**
  - Create `PublicClient` in-browser using `useRef` with a `window` guard.
  - Gate contract setup and queries on client availability.
  - Updated hooks: `useUserShareBalances`, `useBalance`, `usePendingUsdcDeposit`.

<sup>Written for commit b1eb2f3c55fd9307128a3116521304d2a66d9847. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

