### PR TITLE
fix: unblock username submit and enforce required onboarding modals

### DIFF
--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -128,8 +128,9 @@ function UsernameDialog({
   const canSubmit = (
     !isSubmitting
     && termsAccepted
+    && trimmedUsername.length > 0
     && !localFormatError
-    && availabilityState === 'available'
+    && availabilityState !== 'taken'
   )
 
   /* eslint-disable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react/set-state-in-effect -- Debounced username availability is derived from input and an async data-api response. */

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -47,6 +47,7 @@ import { mergeSessionUserState, useUser } from '@/stores/useUser'
 type OnboardingModal = 'username' | 'email' | 'enable' | 'enable-status' | 'approve' | 'auto-redeem' | null
 type EnableTradingStep = 'idle' | 'enabling' | 'deploying' | 'completed'
 type ApprovalsStep = 'idle' | 'signing' | 'completed'
+const REQUIRED_TRADING_MODALS = new Set<Exclude<OnboardingModal, null>>(['enable', 'enable-status', 'approve'])
 
 export function TradingOnboardingProvider({ children }: { children: ReactNode }) {
   const user = useUser()
@@ -224,7 +225,10 @@ function TradingOnboardingProviderContent({
     if (!user || activeModal || fundModalOpen || depositModalOpen || withdrawModalOpen) {
       return
     }
-    if (!nextModal || dismissedModal === nextModal) {
+    if (!nextModal) {
+      return
+    }
+    if (dismissedModal === nextModal && !REQUIRED_TRADING_MODALS.has(nextModal)) {
       return
     }
     setActiveModal(nextModal)
@@ -288,7 +292,9 @@ function TradingOnboardingProviderContent({
       setFundModalOpen(true)
       return
     }
-    setDismissedModal(modal)
+    if (!REQUIRED_TRADING_MODALS.has(modal)) {
+      setDismissedModal(modal)
+    }
     setActiveModal(null)
   }, [])
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unblocked username submission and enforced required trading onboarding modals so users can complete setup without getting stuck. Username can now be submitted when not taken; required modals re-open until finished.

- **Bug Fixes**
  - Username dialog: allow submit when terms are accepted, username is non-empty, and availability is not 'taken' (no longer blocks on pending checks).
  - Onboarding: mark 'enable', 'enable-status', and 'approve' as required; they can’t be dismissed and will re-open until completed.

<sup>Written for commit f88364399e3b04e2314ff1a4ac13b87a9c81f87f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

