### PR TITLE
fix: mount trading onboarding provider at platform root

### DIFF
--- a/src/app/[locale]/(platform)/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/page.tsx
@@ -8,7 +8,6 @@ import {
   generateDynamicHomeCategoryStaticParams,
 } from '@/app/[locale]/(platform)/_lib/dynamic-home-category-page'
 import { buildPublicProfileMetadata, PublicProfilePageContent } from '@/app/[locale]/(platform)/_lib/public-profile-page'
-import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { isPlatformReservedRootSlug, normalizePublicProfileSlug } from '@/lib/platform-routing'
 import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
@@ -54,13 +53,11 @@ async function renderPlatformSlugPage({
   const profileSlug = normalizePublicProfileSlug(slug)
   if (profileSlug.type !== 'invalid') {
     return (
-      <TradingOnboardingProvider>
-        <main className="container py-8">
-          <div className="mx-auto grid max-w-6xl gap-12">
-            <PublicProfilePageContent slug={slug} />
-          </div>
-        </main>
-      </TradingOnboardingProvider>
+      <main className="container py-8">
+        <div className="mx-auto grid max-w-6xl gap-12">
+          <PublicProfilePageContent slug={slug} />
+        </div>
+      </main>
     )
   }
 

--- a/src/app/[locale]/(platform)/_components/HeaderDepositFlow.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderDepositFlow.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useRef } from 'react'
 import { useTradingOnboarding } from '@/app/[locale]/(platform)/_providers/TradingOnboardingContext'
-import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 
 function useStartDepositFlowOnRequest(requestId: number) {
   const { startDepositFlow } = useTradingOnboarding()
@@ -33,9 +32,5 @@ interface HeaderDepositFlowProps {
 }
 
 export default function HeaderDepositFlow({ requestId }: HeaderDepositFlowProps) {
-  return (
-    <TradingOnboardingProvider>
-      <HeaderDepositFlowInner requestId={requestId} />
-    </TradingOnboardingProvider>
-  )
+  return <HeaderDepositFlowInner requestId={requestId} />
 }

--- a/src/app/[locale]/(platform)/esports/layout.tsx
+++ b/src/app/[locale]/(platform)/esports/layout.tsx
@@ -1,5 +1,4 @@
 import { notFound } from 'next/navigation'
-import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import SportsLayoutShell from '@/app/[locale]/(platform)/sports/_components/SportsLayoutShell'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
@@ -10,17 +9,15 @@ export default async function EsportsLayout({ children }: LayoutProps<'/[locale]
   }
 
   return (
-    <TradingOnboardingProvider>
-      <SportsLayoutShell
-        vertical="esports"
-        sportsCountsBySlug={layoutData.countsBySlug}
-        sportsMenuEntries={layoutData.menuEntries}
-        canonicalSlugByAliasKey={layoutData.canonicalSlugByAliasKey}
-        h1TitleBySlug={layoutData.h1TitleBySlug}
-        sectionsBySlug={layoutData.sectionsBySlug}
-      >
-        {children}
-      </SportsLayoutShell>
-    </TradingOnboardingProvider>
+    <SportsLayoutShell
+      vertical="esports"
+      sportsCountsBySlug={layoutData.countsBySlug}
+      sportsMenuEntries={layoutData.menuEntries}
+      canonicalSlugByAliasKey={layoutData.canonicalSlugByAliasKey}
+      h1TitleBySlug={layoutData.h1TitleBySlug}
+      sectionsBySlug={layoutData.sectionsBySlug}
+    >
+      {children}
+    </SportsLayoutShell>
   )
 }

--- a/src/app/[locale]/(platform)/event/[slug]/layout.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/layout.tsx
@@ -1,5 +1,4 @@
 import { setRequestLocale } from 'next-intl/server'
-import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
@@ -11,10 +10,8 @@ export default async function EventLayout({ params, children }: LayoutProps<'/[l
   setRequestLocale(locale)
 
   return (
-    <TradingOnboardingProvider>
-      <main className="container grid min-h-screen gap-8 pb-12 lg:grid-cols-[minmax(0,3fr)_21.25rem]">
-        {children}
-      </main>
-    </TradingOnboardingProvider>
+    <main className="container grid min-h-screen gap-8 pb-12 lg:grid-cols-[minmax(0,3fr)_21.25rem]">
+      {children}
+    </main>
   )
 }

--- a/src/app/[locale]/(platform)/layout.tsx
+++ b/src/app/[locale]/(platform)/layout.tsx
@@ -7,6 +7,7 @@ import NavigationTabs from '@/app/[locale]/(platform)/_components/NavigationTabs
 import PlatformViewerState from '@/app/[locale]/(platform)/_components/PlatformViewerState'
 import { FilterProvider } from '@/app/[locale]/(platform)/_providers/FilterProvider'
 import PlatformNavigationProvider from '@/app/[locale]/(platform)/_providers/PlatformNavigationProvider'
+import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { loadPlatformMainTags } from '@/lib/platform-main-tags'
 import { buildChildParentMap, buildPlatformNavigationTags } from '@/lib/platform-navigation'
 import AppKitProvider from '@/providers/AppKitProvider'
@@ -27,16 +28,18 @@ export default async function PlatformLayout({ params, children }: LayoutProps<'
 
   return (
     <AppKitProvider>
-      <PlatformViewerState />
-      <FilterProvider>
-        <PlatformNavigationProvider tags={tags} childParentMap={childParentMap}>
-          <Header />
-          <NavigationTabs />
-          {children}
-          <MobileBottomNav />
-          <AffiliateQueryHandler />
-        </PlatformNavigationProvider>
-      </FilterProvider>
+      <TradingOnboardingProvider>
+        <PlatformViewerState />
+        <FilterProvider>
+          <PlatformNavigationProvider tags={tags} childParentMap={childParentMap}>
+            <Header />
+            <NavigationTabs />
+            {children}
+            <MobileBottomNav />
+            <AffiliateQueryHandler />
+          </PlatformNavigationProvider>
+        </FilterProvider>
+      </TradingOnboardingProvider>
     </AppKitProvider>
   )
 }

--- a/src/app/[locale]/(platform)/portfolio/layout.tsx
+++ b/src/app/[locale]/(platform)/portfolio/layout.tsx
@@ -1,17 +1,14 @@
 import { setRequestLocale } from 'next-intl/server'
-import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 
 export default async function PortfolioLayout({ params, children }: LayoutProps<'/[locale]/portfolio'>) {
   const { locale } = await params
   setRequestLocale(locale)
 
   return (
-    <TradingOnboardingProvider>
-      <main className="container py-8">
-        <div className="mx-auto grid max-w-5xl gap-6">
-          {children}
-        </div>
-      </main>
-    </TradingOnboardingProvider>
+    <main className="container py-8">
+      <div className="mx-auto grid max-w-5xl gap-6">
+        {children}
+      </div>
+    </main>
   )
 }

--- a/src/app/[locale]/(platform)/profile/[slug]/layout.tsx
+++ b/src/app/[locale]/(platform)/profile/[slug]/layout.tsx
@@ -1,17 +1,14 @@
 import { setRequestLocale } from 'next-intl/server'
-import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 
 export default async function PublicProfileLayout({ params, children }: LayoutProps<'/[locale]/profile/[slug]'>) {
   const { locale } = await params
   setRequestLocale(locale)
 
   return (
-    <TradingOnboardingProvider>
-      <main className="container py-8">
-        <div className="mx-auto grid max-w-6xl gap-12">
-          {children}
-        </div>
-      </main>
-    </TradingOnboardingProvider>
+    <main className="container py-8">
+      <div className="mx-auto grid max-w-6xl gap-12">
+        {children}
+      </div>
+    </main>
   )
 }

--- a/src/app/[locale]/(platform)/settings/affiliate/page.tsx
+++ b/src/app/[locale]/(platform)/settings/affiliate/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
-import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import SettingsAffiliateContent from '@/app/[locale]/(platform)/settings/_components/SettingsAffiliateContent'
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/i18n/locales'
 import { getAffiliateFeeSettings } from '@/lib/affiliate-fee-settings'
@@ -116,15 +115,13 @@ export default async function AffiliateSettingsPage({ params }: PageProps<'/[loc
       </div>
 
       <div className="mx-auto w-full max-w-5xl lg:mx-0">
-        <TradingOnboardingProvider>
-          <SettingsAffiliateContent
-            affiliateData={affiliateData}
-            mainCategories={(mainTags ?? []).map(tag => ({
-              slug: tag.slug,
-              name: tag.name,
-            }))}
-          />
-        </TradingOnboardingProvider>
+        <SettingsAffiliateContent
+          affiliateData={affiliateData}
+          mainCategories={(mainTags ?? []).map(tag => ({
+            slug: tag.slug,
+            name: tag.name,
+          }))}
+        />
       </div>
     </section>
   )

--- a/src/app/[locale]/(platform)/sports/layout.tsx
+++ b/src/app/[locale]/(platform)/sports/layout.tsx
@@ -1,5 +1,4 @@
 import { notFound } from 'next/navigation'
-import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import SportsLayoutShell from '@/app/[locale]/(platform)/sports/_components/SportsLayoutShell'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
@@ -10,17 +9,15 @@ export default async function SportsLayout({ children }: LayoutProps<'/[locale]/
   }
 
   return (
-    <TradingOnboardingProvider>
-      <SportsLayoutShell
-        vertical="sports"
-        sportsCountsBySlug={layoutData.countsBySlug}
-        sportsMenuEntries={layoutData.menuEntries}
-        canonicalSlugByAliasKey={layoutData.canonicalSlugByAliasKey}
-        h1TitleBySlug={layoutData.h1TitleBySlug}
-        sectionsBySlug={layoutData.sectionsBySlug}
-      >
-        {children}
-      </SportsLayoutShell>
-    </TradingOnboardingProvider>
+    <SportsLayoutShell
+      vertical="sports"
+      sportsCountsBySlug={layoutData.countsBySlug}
+      sportsMenuEntries={layoutData.menuEntries}
+      canonicalSlugByAliasKey={layoutData.canonicalSlugByAliasKey}
+      h1TitleBySlug={layoutData.h1TitleBySlug}
+      sectionsBySlug={layoutData.sectionsBySlug}
+    >
+      {children}
+    </SportsLayoutShell>
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Mounted `TradingOnboardingProvider` at the platform root to make onboarding and deposit flows available across all platform pages. Removed redundant local providers to fix missing/duplicated context and simplify layouts.

- **Bug Fixes**
  - Provide a single `TradingOnboardingProvider` in `/(platform)/layout.tsx`; `useTradingOnboarding` now works consistently across all platform routes.
  - Removed local wrappers in esports, sports, event, portfolio, profile, affiliate settings, `[slug]` page, and `HeaderDepositFlow` to avoid nested contexts.

<sup>Written for commit 51182354e7971a85dbcff2dc0ce9fba302418336. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

