### PR TITLE
build: pin next to v16.2.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,8 +17,8 @@
         "@fullcalendar/timegrid": "6.1.20",
         "@lifi/sdk": "3.16.3",
         "@next/third-parties": "16.2.5",
-        "@reown/appkit": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-adapter-wagmi": "1.8.20-wagmi-upgrade.0",
+        "@reown/appkit": "1.8.19",
+        "@reown/appkit-adapter-wagmi": "1.8.19",
         "@reown/appkit-siwe": "1.8.20-wagmi-upgrade.0",
         "@sentry/nextjs": "10.52.0",
         "@supabase/supabase-js": "2.105.3",
@@ -44,7 +44,7 @@
         "fumadocs-ui": "16.8.7",
         "input-otp": "1.4.2",
         "lucide-react": "1.14.0",
-        "next": "16.2.5",
+        "next": "16.2.6",
         "next-intl": "4.11.0",
         "next-themes": "0.4.6",
         "postgres": "3.4.9",
@@ -57,7 +57,7 @@
         "sonner": "2.0.7",
         "tailwind-merge": "3.5.0",
         "vaul": "1.1.2",
-        "viem": "2.48.8",
+        "viem": "2.48.11",
         "wagmi": "2.19.5",
         "zod": "4.4.3",
         "zustand": "5.0.13"
@@ -4724,9 +4724,9 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.5.tgz",
-      "integrity": "sha512-Lb9ElHD2klcyeVD25vW+siPFqz9QMzDUSgvFZNO+dZEKoMHex4viJhVuzBhrXKqb+UKnih7mVYbt50/7KLsSCA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.6.tgz",
+      "integrity": "sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
@@ -4740,9 +4740,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.5.tgz",
-      "integrity": "sha512-BW+8PGVmsruomXHsitD8JG6gny9lEdobctjBwvtPF8AKtxGDR7nR35FOl/oK9UAPXBOBm+vx0k8qtpeHOXQMGQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.6.tgz",
+      "integrity": "sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==",
       "cpu": [
         "arm64"
       ],
@@ -4756,9 +4756,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.5.tgz",
-      "integrity": "sha512-ZoCGnCl9LlQJWmqXrZAUlNxvuNmclvE+7zUif+nDydkkehl9FKxHJ+wxSQMj+C37BYFerKiEdX9s9o02ir975Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.6.tgz",
+      "integrity": "sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==",
       "cpu": [
         "x64"
       ],
@@ -4772,9 +4772,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.5.tgz",
-      "integrity": "sha512-AwcZzMChaWkOTZt3vu+2ZMIj8g4dYQY+B8VUVhlFSQ2JtvyZpefyYHTe00D6b6L7BysYw7vl3zsvs9jix8tl5Q==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.6.tgz",
+      "integrity": "sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==",
       "cpu": [
         "arm64"
       ],
@@ -4791,9 +4791,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.5.tgz",
-      "integrity": "sha512-QqMgqWbCBFsfiQ7BF3dUlW8HJy1LWhpcqbTpoHMWA9IV+TnWwDKozQJA5NdIAHjQ00yX2Q7AUkLr/XK4n77q8A==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.6.tgz",
+      "integrity": "sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==",
       "cpu": [
         "arm64"
       ],
@@ -4810,9 +4810,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.5.tgz",
-      "integrity": "sha512-3hzeiFGZtyATVx9pCeuzTshXmh50vHZitqaeZiyJZaUmjQyrfjsVUgS8apOj1vEJCIpKJM/55F45yPAV2kpjsA==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.6.tgz",
+      "integrity": "sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==",
       "cpu": [
         "x64"
       ],
@@ -4829,9 +4829,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.5.tgz",
-      "integrity": "sha512-0mzZV/mAt7Qj2tYNdTB6AqrS8dwng/AQLSYC5Z1YLpZdi2wxqKDPK7RY2RvjB1fXyJfOfdA3l/yTF5yLi+WfuQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.6.tgz",
+      "integrity": "sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==",
       "cpu": [
         "x64"
       ],
@@ -4848,9 +4848,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.5.tgz",
-      "integrity": "sha512-f/H4nZ2zJBvA8/+HpsB9mNonF9zfQoAU6D0WxJrfzhJDvJLfngVN85oqxUyrDVK99DIFfFYhLpGa5K+c5uotSw==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.6.tgz",
+      "integrity": "sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==",
       "cpu": [
         "arm64"
       ],
@@ -4864,9 +4864,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.5.tgz",
-      "integrity": "sha512-nuP7DHs4koAojsIxVPkihNgKiRUKtCU65j5X6DAbSy8VBrfT/o90bCLLHPf51JEdOZwZMFzM6e0NiGWfIWjVAg==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.6.tgz",
+      "integrity": "sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==",
       "cpu": [
         "x64"
       ],
@@ -7531,299 +7531,132 @@
       "license": "MIT"
     },
     "node_modules/@reown/appkit": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-OSqpcdMiJh74BcmE0dGzpELERRAbnSt46qbUyY+nD3AuDe+qjBq9clljUqCrw92EzjszranJp9GBrkgOkEbxxw==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit/-/appkit-1.8.19.tgz",
+      "integrity": "sha512-wB+xatkRbOy0AY1cZxxtcKzzPk3l3CTFulDbaISLVmZI6ZnQrOFuLnYc285zGsC6DB4d6bmwYUh89zcMLa4PvQ==",
       "hasInstallScript": true,
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-controllers": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-pay": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-polyfills": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-scaffold-ui": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-ui": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-utils": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-wallet": "1.8.20-wagmi-upgrade.0",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-pay": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-scaffold-ui": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
         "@walletconnect/universal-provider": "2.23.7",
         "bs58": "6.0.0",
         "semver": "7.7.2",
         "valtio": "2.1.7",
-        "viem": "^2.45.0"
+        "viem": ">=2.45.0"
       },
       "optionalDependencies": {
         "@lit/react": "1.0.8"
       }
     },
     "node_modules/@reown/appkit-adapter-wagmi": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-1pIUitrSGDSuDj4DqD3jKc17azh/2J4BbPn88tuchU4xDfUbctp4Fjoi22vD7K/8It+60A2ag/VUFaYH3CQssA==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-adapter-wagmi/-/appkit-adapter-wagmi-1.8.19.tgz",
+      "integrity": "sha512-KY2sbIXJDLlUVBAKdHBQ8KT8aQY67rWwW9aIz4XthRIt8WCjZQBEf4JGy/kd0LwRS78XSSpZcxDxEBarMPLpaA==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-common": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-controllers": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-polyfills": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-scaffold-ui": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-utils": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-wallet": "1.8.20-wagmi-upgrade.0",
+        "@reown/appkit": "1.8.19",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-scaffold-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
         "@walletconnect/universal-provider": "2.23.7",
         "valtio": "2.1.7"
       },
       "optionalDependencies": {
-        "@wagmi/connectors": "^5.9.9"
+        "@wagmi/connectors": ">=5.9.9"
       },
       "peerDependencies": {
-        "@wagmi/core": "^2.21.2",
-        "viem": "^2.45.0",
-        "wagmi": "^2.19.5"
+        "@wagmi/core": ">=2.21.2",
+        "viem": ">=2.45.0",
+        "wagmi": ">=2.19.5"
       }
     },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@base-org/account": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/@base-org/account/-/account-1.1.1.tgz",
-      "integrity": "sha512-IfVJPrDPhHfqXRDb89472hXkpvJuQQR7FDI9isLPHEqSYt/45whIoBxSPgZ0ssTt379VhQo4+87PWI1DoLSfAQ==",
-      "license": "Apache-2.0",
-      "optional": true,
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-common": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
+      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@noble/hashes": "1.4.0",
-        "clsx": "1.2.1",
-        "eventemitter3": "5.0.1",
-        "idb-keyval": "6.2.1",
-        "ox": "0.6.9",
-        "preact": "10.24.2",
-        "viem": "^2.31.7",
-        "zustand": "5.0.3"
+        "big.js": "6.2.2",
+        "dayjs": "1.11.13",
+        "viem": ">=2.45.0"
       }
     },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@gemini-wallet/core": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@gemini-wallet/core/-/core-0.2.0.tgz",
-      "integrity": "sha512-vv9aozWnKrrPWQ3vIFcWk7yta4hQW1Ie0fsNNPeXnjAxkbXr2hqMagEptLuMxpEP2W3mnRu05VDNKzcvAuuZDw==",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-controllers": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
+      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@metamask/rpc-errors": "7.0.2",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "viem": ">=2.0.0"
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
       }
     },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@noble/curves": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.9.1.tgz",
-      "integrity": "sha512-k11yZxZg+t+gWvBbIswW0yoJlu8cHOC7dhunwOzoWH/mXGBiYyR4YY6hAEK/3EUs4UpB8la1RfdRpeGsFHkWsA==",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-polyfills": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
+      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@noble/hashes": "1.8.0"
-      },
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
+        "buffer": "6.0.3"
       }
     },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@noble/curves/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@noble/hashes": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
-      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@wagmi/connectors": {
-      "version": "5.11.2",
-      "resolved": "https://registry.npmjs.org/@wagmi/connectors/-/connectors-5.11.2.tgz",
-      "integrity": "sha512-OkiElOI8xXGPDZE5UdG6NgDT3laSkEh9llX1DDapUnfnKecK3Tr/HUf5YzgwDhEoox8mdxp+8ZCjtnTKz56SdA==",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-utils": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
+      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@base-org/account": "1.1.1",
-        "@coinbase/wallet-sdk": "4.3.6",
-        "@gemini-wallet/core": "0.2.0",
-        "@metamask/sdk": "0.33.1",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@wallet-standard/wallet": "1.1.0",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@base-org/account": "2.4.0",
         "@safe-global/safe-apps-provider": "0.18.6",
-        "@safe-global/safe-apps-sdk": "9.1.0",
-        "@walletconnect/ethereum-provider": "2.21.1",
-        "cbw-sdk": "npm:@coinbase/wallet-sdk@3.9.3",
-        "porto": "0.2.19"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/wevm"
+        "@safe-global/safe-apps-sdk": "9.1.0"
       },
       "peerDependencies": {
-        "@wagmi/core": "2.21.2",
-        "typescript": ">=5.0.4",
-        "viem": "2.x"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "valtio": "2.1.7"
       }
     },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/clsx": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
-      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/eventemitter3": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.1.tgz",
-      "integrity": "sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==",
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/porto": {
-      "version": "0.2.19",
-      "resolved": "https://registry.npmjs.org/porto/-/porto-0.2.19.tgz",
-      "integrity": "sha512-q1vEJgdtlEOf6byWgD31GHiMwpfLuxFSfx9f7Sw4RGdvpQs2ANBGfnzzardADZegr87ZXsebSp+3vaaznEUzPQ==",
-      "license": "MIT",
-      "optional": true,
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-wallet": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
+      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "hono": "^4.9.6",
-        "idb-keyval": "^6.2.1",
-        "mipd": "^0.0.7",
-        "ox": "^0.9.6",
-        "zod": "^4.1.5",
-        "zustand": "^5.0.1"
-      },
-      "bin": {
-        "porto": "_dist/cli/bin/index.js"
-      },
-      "peerDependencies": {
-        "@tanstack/react-query": ">=5.59.0",
-        "@wagmi/core": ">=2.16.3",
-        "react": ">=18",
-        "typescript": ">=5.4.0",
-        "viem": ">=2.37.0",
-        "wagmi": ">=2.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@tanstack/react-query": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "typescript": {
-          "optional": true
-        },
-        "wagmi": {
-          "optional": true
-        }
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@walletconnect/logger": "3.0.2",
+        "zod": "3.22.4"
       }
     },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/porto/node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+    "node_modules/@reown/appkit-adapter-wagmi/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
       "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
       "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/porto/node_modules/ox": {
-      "version": "0.9.17",
-      "resolved": "https://registry.npmjs.org/ox/-/ox-0.9.17.tgz",
-      "integrity": "sha512-rKAnhzhRU3Xh3hiko+i1ZxywZ55eWQzeS/Q4HRKLx2PqfHOolisZHErSsJVipGlmQKHW5qwOED/GighEw9dbLg==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/wevm"
-        }
-      ],
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@adraffy/ens-normalize": "^1.11.0",
-        "@noble/ciphers": "^1.3.0",
-        "@noble/curves": "1.9.1",
-        "@noble/hashes": "^1.8.0",
-        "@scure/bip32": "^1.7.0",
-        "@scure/bip39": "^1.6.0",
-        "abitype": "^1.0.9",
-        "eventemitter3": "5.0.1"
-      },
-      "peerDependencies": {
-        "typescript": ">=5.4.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/preact": {
-      "version": "10.24.2",
-      "resolved": "https://registry.npmjs.org/preact/-/preact-10.24.2.tgz",
-      "integrity": "sha512-1cSoF0aCC8uaARATfrlz4VCBqE8LwZwRfLgkxJOQwAlQt6ayTmi0D9OF7nXid1POI5SZidFuG9CnlXbDfLqY/Q==",
-      "license": "MIT",
-      "optional": true,
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/preact"
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/zustand": {
-      "version": "5.0.3",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.3.tgz",
-      "integrity": "sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12.20.0"
-      },
-      "peerDependencies": {
-        "@types/react": ">=18.0.0",
-        "immer": ">=9.0.6",
-        "react": ">=18.0.0",
-        "use-sync-external-store": ">=1.2.0"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        },
-        "immer": {
-          "optional": true
-        },
-        "react": {
-          "optional": true
-        },
-        "use-sync-external-store": {
-          "optional": true
-        }
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@reown/appkit-common": {
@@ -7851,17 +7684,110 @@
       }
     },
     "node_modules/@reown/appkit-pay": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-bRZiBxZYaI8Yq1xKtqi2SqpNXs+FReCZ5cvu1bAINekyQk7scICgLk9cspfD+fOVXDtzbis42lSV43oXA+kODg==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-pay/-/appkit-pay-1.8.19.tgz",
+      "integrity": "sha512-HO/tQT0TbTQO3eONxNNPJAOZAOzUiHvjM0Mty1rFFeRBH68auiqQxQi2YFNMs014gNkRN+cb84VYau7+MCC0fQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-controllers": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-ui": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-utils": "1.8.20-wagmi-upgrade.0",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
         "lit": "3.3.0",
         "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-common": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
+      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "big.js": "6.2.2",
+        "dayjs": "1.11.13",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-controllers": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
+      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-polyfills": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
+      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "buffer": "6.0.3"
+      }
+    },
+    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-ui": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
+      "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@phosphor-icons/webcomponents": "2.1.5",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "lit": "3.3.0",
+        "qrcode": "1.5.3"
+      }
+    },
+    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-utils": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
+      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@wallet-standard/wallet": "1.1.0",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@base-org/account": "2.4.0",
+        "@safe-global/safe-apps-provider": "0.18.6",
+        "@safe-global/safe-apps-sdk": "9.1.0"
+      },
+      "peerDependencies": {
+        "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-wallet": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
+      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@walletconnect/logger": "3.0.2",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@reown/appkit-pay/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@reown/appkit-polyfills": {
@@ -7874,18 +7800,111 @@
       }
     },
     "node_modules/@reown/appkit-scaffold-ui": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-wvPASizx+71hscR7ogcRLITg3WSZYNyjM+mw6eKId0F3e41liqCxU6jwVgQ/2Iwx/FhdYsmZEqlrfgy+FlyMDg==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-scaffold-ui/-/appkit-scaffold-ui-1.8.19.tgz",
+      "integrity": "sha512-Ak767x0VzeDIXb0wbzkl19kx6udw7vkb1EU0SAweG3iKc9BunW87Rfcd48/YimzMZycJaYmlbtfmqQQDYs6Few==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-controllers": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-pay": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-ui": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-utils": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-wallet": "1.8.20-wagmi-upgrade.0",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-pay": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
         "lit": "3.3.0"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-common": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
+      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "big.js": "6.2.2",
+        "dayjs": "1.11.13",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-controllers": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
+      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-polyfills": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
+      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "buffer": "6.0.3"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-ui": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
+      "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@phosphor-icons/webcomponents": "2.1.5",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "lit": "3.3.0",
+        "qrcode": "1.5.3"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-utils": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
+      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@wallet-standard/wallet": "1.1.0",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@base-org/account": "2.4.0",
+        "@safe-global/safe-apps-provider": "0.18.6",
+        "@safe-global/safe-apps-sdk": "9.1.0"
+      },
+      "peerDependencies": {
+        "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-wallet": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
+      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@walletconnect/logger": "3.0.2",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@reown/appkit-scaffold-ui/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@reown/appkit-siwe": {
@@ -8105,6 +8124,99 @@
       }
     },
     "node_modules/@reown/appkit-wallet/node_modules/zod": {
+      "version": "3.22.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
+      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@reown/appkit-common": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
+      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "big.js": "6.2.2",
+        "dayjs": "1.11.13",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@reown/appkit-controllers": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
+      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@reown/appkit-polyfills": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
+      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "buffer": "6.0.3"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@reown/appkit-ui": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
+      "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@phosphor-icons/webcomponents": "2.1.5",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "lit": "3.3.0",
+        "qrcode": "1.5.3"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@reown/appkit-utils": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
+      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
+        "@wallet-standard/wallet": "1.1.0",
+        "@walletconnect/logger": "3.0.2",
+        "@walletconnect/universal-provider": "2.23.7",
+        "valtio": "2.1.7",
+        "viem": ">=2.45.0"
+      },
+      "optionalDependencies": {
+        "@base-org/account": "2.4.0",
+        "@safe-global/safe-apps-provider": "0.18.6",
+        "@safe-global/safe-apps-sdk": "9.1.0"
+      },
+      "peerDependencies": {
+        "valtio": "2.1.7"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/@reown/appkit-wallet": {
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
+      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
+      "license": "SEE LICENSE IN LICENSE.md",
+      "dependencies": {
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-polyfills": "1.8.19",
+        "@walletconnect/logger": "3.0.2",
+        "zod": "3.22.4"
+      }
+    },
+    "node_modules/@reown/appkit/node_modules/zod": {
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
@@ -22859,12 +22971,12 @@
       "peer": true
     },
     "node_modules/next": {
-      "version": "16.2.5",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.5.tgz",
-      "integrity": "sha512-TkVTm9F2WEulkgGljm4wPwNgvCCWCVw6StUHsZb8WZpHFRjepoUWg3d7L4IMg7IyjcJ4Co9eVhpro8e8O+KarQ==",
+      "version": "16.2.6",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.6.tgz",
+      "integrity": "sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.5",
+        "@next/env": "16.2.6",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -22878,14 +22990,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.5",
-        "@next/swc-darwin-x64": "16.2.5",
-        "@next/swc-linux-arm64-gnu": "16.2.5",
-        "@next/swc-linux-arm64-musl": "16.2.5",
-        "@next/swc-linux-x64-gnu": "16.2.5",
-        "@next/swc-linux-x64-musl": "16.2.5",
-        "@next/swc-win32-arm64-msvc": "16.2.5",
-        "@next/swc-win32-x64-msvc": "16.2.5",
+        "@next/swc-darwin-arm64": "16.2.6",
+        "@next/swc-darwin-x64": "16.2.6",
+        "@next/swc-linux-arm64-gnu": "16.2.6",
+        "@next/swc-linux-arm64-musl": "16.2.6",
+        "@next/swc-linux-x64-gnu": "16.2.6",
+        "@next/swc-linux-x64-musl": "16.2.6",
+        "@next/swc-win32-arm64-msvc": "16.2.6",
+        "@next/swc-win32-x64-msvc": "16.2.6",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -22996,34 +23108,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-addon-api": {
@@ -23861,7 +23945,6 @@
       "version": "8.5.14",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
       "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
-      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -26848,9 +26931,9 @@
       }
     },
     "node_modules/viem": {
-      "version": "2.48.8",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.8.tgz",
-      "integrity": "sha512-Xj3Nrt66SKtn06kczU91ELn9Difr84ZM5A62BTlaisT5lpgt058i2mBkfMZCXHGb1ocOLjzC2ztPhD0Lvky7uQ==",
+      "version": "2.48.11",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.48.11.tgz",
+      "integrity": "sha512-+WZ5E0dBS6GtKb+1wEk5DeYRRRW42+pFnXCo67Ydodf42sBwO+hu3wnQy66lc4MKmHz+llPVdbyehYr9oTE2iw==",
       "funding": [
         {
           "type": "github",

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@next/third-parties": "16.2.5",
         "@reown/appkit": "1.8.19",
         "@reown/appkit-adapter-wagmi": "1.8.19",
-        "@reown/appkit-siwe": "1.8.20-wagmi-upgrade.0",
+        "@reown/appkit-siwe": "1.8.19",
         "@sentry/nextjs": "10.52.0",
         "@supabase/supabase-js": "2.105.3",
         "@tanstack/react-query": "5.100.9",
@@ -7580,7 +7580,7 @@
         "wagmi": ">=2.19.5"
       }
     },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-common": {
+    "node_modules/@reown/appkit-common": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
       "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
@@ -7591,7 +7591,7 @@
         "viem": ">=2.45.0"
       }
     },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-controllers": {
+    "node_modules/@reown/appkit-controllers": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
       "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
@@ -7602,85 +7602,6 @@
         "@walletconnect/universal-provider": "2.23.7",
         "valtio": "2.1.7",
         "viem": ">=2.45.0"
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-polyfills": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
-      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "buffer": "6.0.3"
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-utils": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
-      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-controllers": "1.8.19",
-        "@reown/appkit-polyfills": "1.8.19",
-        "@reown/appkit-wallet": "1.8.19",
-        "@wallet-standard/wallet": "1.1.0",
-        "@walletconnect/logger": "3.0.2",
-        "@walletconnect/universal-provider": "2.23.7",
-        "valtio": "2.1.7",
-        "viem": ">=2.45.0"
-      },
-      "optionalDependencies": {
-        "@base-org/account": "2.4.0",
-        "@safe-global/safe-apps-provider": "0.18.6",
-        "@safe-global/safe-apps-sdk": "9.1.0"
-      },
-      "peerDependencies": {
-        "valtio": "2.1.7"
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/@reown/appkit-wallet": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
-      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-polyfills": "1.8.19",
-        "@walletconnect/logger": "3.0.2",
-        "zod": "3.22.4"
-      }
-    },
-    "node_modules/@reown/appkit-adapter-wagmi/node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@reown/appkit-common": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-1BoML1amL23cmDfcYumMno0bKl6UZ5Et5bc3wb7JLOGwNpHqLsGf7lqEQ2uv+dOYnQZdv1Xk7nDZIiY9XQ07jw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "big.js": "6.2.2",
-        "dayjs": "1.11.13",
-        "viem": "^2.45.0"
-      }
-    },
-    "node_modules/@reown/appkit-controllers": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-S/velXGe2FwsGURcic/RY613cbwGqaRuJsDhal+iXBZCPW/CbRXQYFRAXl4dQ1VA/iE6Bfb4Ty7zPeWp3nBwZQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-wallet": "1.8.20-wagmi-upgrade.0",
-        "@walletconnect/universal-provider": "2.23.7",
-        "valtio": "2.1.7",
-        "viem": "^2.45.0"
       }
     },
     "node_modules/@reown/appkit-pay": {
@@ -7697,103 +7618,10 @@
         "valtio": "2.1.7"
       }
     },
-    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-common": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
-      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "big.js": "6.2.2",
-        "dayjs": "1.11.13",
-        "viem": ">=2.45.0"
-      }
-    },
-    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-controllers": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
-      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-wallet": "1.8.19",
-        "@walletconnect/universal-provider": "2.23.7",
-        "valtio": "2.1.7",
-        "viem": ">=2.45.0"
-      }
-    },
-    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-polyfills": {
+    "node_modules/@reown/appkit-polyfills": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
       "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "buffer": "6.0.3"
-      }
-    },
-    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-ui": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
-      "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@phosphor-icons/webcomponents": "2.1.5",
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-controllers": "1.8.19",
-        "@reown/appkit-wallet": "1.8.19",
-        "lit": "3.3.0",
-        "qrcode": "1.5.3"
-      }
-    },
-    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-utils": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
-      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-controllers": "1.8.19",
-        "@reown/appkit-polyfills": "1.8.19",
-        "@reown/appkit-wallet": "1.8.19",
-        "@wallet-standard/wallet": "1.1.0",
-        "@walletconnect/logger": "3.0.2",
-        "@walletconnect/universal-provider": "2.23.7",
-        "valtio": "2.1.7",
-        "viem": ">=2.45.0"
-      },
-      "optionalDependencies": {
-        "@base-org/account": "2.4.0",
-        "@safe-global/safe-apps-provider": "0.18.6",
-        "@safe-global/safe-apps-sdk": "9.1.0"
-      },
-      "peerDependencies": {
-        "valtio": "2.1.7"
-      }
-    },
-    "node_modules/@reown/appkit-pay/node_modules/@reown/appkit-wallet": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
-      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-polyfills": "1.8.19",
-        "@walletconnect/logger": "3.0.2",
-        "zod": "3.22.4"
-      }
-    },
-    "node_modules/@reown/appkit-pay/node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@reown/appkit-polyfills": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-ijuNHGdpFoANz+q8uuT66kZTJVhJ9ycW4oce0VSO5xLRtYbUl7IowqMo4KHVmYLwVSTiJI5tVk1VXWMTXYVv4g==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "buffer": "6.0.3"
@@ -7814,110 +7642,17 @@
         "lit": "3.3.0"
       }
     },
-    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-common": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
-      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "big.js": "6.2.2",
-        "dayjs": "1.11.13",
-        "viem": ">=2.45.0"
-      }
-    },
-    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-controllers": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
-      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-wallet": "1.8.19",
-        "@walletconnect/universal-provider": "2.23.7",
-        "valtio": "2.1.7",
-        "viem": ">=2.45.0"
-      }
-    },
-    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-polyfills": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
-      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "buffer": "6.0.3"
-      }
-    },
-    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-ui": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
-      "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@phosphor-icons/webcomponents": "2.1.5",
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-controllers": "1.8.19",
-        "@reown/appkit-wallet": "1.8.19",
-        "lit": "3.3.0",
-        "qrcode": "1.5.3"
-      }
-    },
-    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-utils": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
-      "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-controllers": "1.8.19",
-        "@reown/appkit-polyfills": "1.8.19",
-        "@reown/appkit-wallet": "1.8.19",
-        "@wallet-standard/wallet": "1.1.0",
-        "@walletconnect/logger": "3.0.2",
-        "@walletconnect/universal-provider": "2.23.7",
-        "valtio": "2.1.7",
-        "viem": ">=2.45.0"
-      },
-      "optionalDependencies": {
-        "@base-org/account": "2.4.0",
-        "@safe-global/safe-apps-provider": "0.18.6",
-        "@safe-global/safe-apps-sdk": "9.1.0"
-      },
-      "peerDependencies": {
-        "valtio": "2.1.7"
-      }
-    },
-    "node_modules/@reown/appkit-scaffold-ui/node_modules/@reown/appkit-wallet": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
-      "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-polyfills": "1.8.19",
-        "@walletconnect/logger": "3.0.2",
-        "zod": "3.22.4"
-      }
-    },
-    "node_modules/@reown/appkit-scaffold-ui/node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
     "node_modules/@reown/appkit-siwe": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-siwe/-/appkit-siwe-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-OlD0ML31pMCfFzCmBZy2H985D9xX0oIFbb4B5oCnXzHVU+EUmtLfnoH1IimTqTxboJPf35K6uD//INmCyylyFA==",
+      "version": "1.8.19",
+      "resolved": "https://registry.npmjs.org/@reown/appkit-siwe/-/appkit-siwe-1.8.19.tgz",
+      "integrity": "sha512-LXBh9UmcxpqFq6dlfhd8+kvQc9tmm+omiRahQz2H+wtnUA/n5MMupi122iMxSJ1OvYq1q2Iia2wDL8zTFcgydQ==",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
-        "@reown/appkit-common": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-controllers": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-ui": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-utils": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-wallet": "1.8.20-wagmi-upgrade.0",
+        "@reown/appkit-common": "1.8.19",
+        "@reown/appkit-controllers": "1.8.19",
+        "@reown/appkit-ui": "1.8.19",
+        "@reown/appkit-utils": "1.8.19",
+        "@reown/appkit-wallet": "1.8.19",
         "@walletconnect/types": "2.23.7",
         "@walletconnect/utils": "2.23.7",
         "lit": "3.1.0",
@@ -8072,100 +7807,6 @@
       }
     },
     "node_modules/@reown/appkit-ui": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-jzTExPjBcUYVNLXS4g6qdS40Dz1xLgZOxpn1BfszEcI01ZKyNFFgNvw9GzOKspkfQGVBpiDpU2Yw1WaU8FIyaw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@phosphor-icons/webcomponents": "2.1.5",
-        "@reown/appkit-common": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-controllers": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-wallet": "1.8.20-wagmi-upgrade.0",
-        "lit": "3.3.0",
-        "qrcode": "1.5.3"
-      }
-    },
-    "node_modules/@reown/appkit-utils": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-uMkaeGpXBaG9OwiSSz6Sw4by6yJrHJ4RM5DXWGqJDOy4U1pO8+steBf/8wMKeXZYcnOFVL9dn9hxGrOVWwr+pA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-controllers": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-polyfills": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-wallet": "1.8.20-wagmi-upgrade.0",
-        "@wallet-standard/wallet": "1.1.0",
-        "@walletconnect/logger": "3.0.2",
-        "@walletconnect/universal-provider": "2.23.7",
-        "valtio": "2.1.7",
-        "viem": "^2.45.0"
-      },
-      "optionalDependencies": {
-        "@base-org/account": "2.4.0",
-        "@coinbase/wallet-sdk": "4.3.6",
-        "@safe-global/safe-apps-provider": "0.18.6",
-        "@safe-global/safe-apps-sdk": "9.1.0"
-      },
-      "peerDependencies": {
-        "valtio": "2.1.7"
-      }
-    },
-    "node_modules/@reown/appkit-wallet": {
-      "version": "1.8.20-wagmi-upgrade.0",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.20-wagmi-upgrade.0.tgz",
-      "integrity": "sha512-1yQHQPPF5lHl5NrhV6wyD3Tj7mrzZzS482MHd9EvMxrl1DasC7f48Ia8WRlfb2M6fTBnsixVEyg2KxUUicK0JA==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.20-wagmi-upgrade.0",
-        "@reown/appkit-polyfills": "1.8.20-wagmi-upgrade.0",
-        "@walletconnect/logger": "3.0.2",
-        "zod": "3.22.4"
-      }
-    },
-    "node_modules/@reown/appkit-wallet/node_modules/zod": {
-      "version": "3.22.4",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
-      "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@reown/appkit-common": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-common/-/appkit-common-1.8.19.tgz",
-      "integrity": "sha512-z5wDrYjUGY7YbM4b14NHVo54WKZ5++PQtGkcsXhiOP39yAVijubBQD8BfHs/Pu2fSFqnqLIFoCVvIEfNWWccRw==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "big.js": "6.2.2",
-        "dayjs": "1.11.13",
-        "viem": ">=2.45.0"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@reown/appkit-controllers": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-controllers/-/appkit-controllers-1.8.19.tgz",
-      "integrity": "sha512-JFNT8CfAVit9FJXh596Ye4U8A/oIapW+Y0KQqjB59DXyTCDZbxZDB32rULBQrSkZ6PufTEa239Dil4kABCQKtg==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "@reown/appkit-common": "1.8.19",
-        "@reown/appkit-wallet": "1.8.19",
-        "@walletconnect/universal-provider": "2.23.7",
-        "valtio": "2.1.7",
-        "viem": ">=2.45.0"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@reown/appkit-polyfills": {
-      "version": "1.8.19",
-      "resolved": "https://registry.npmjs.org/@reown/appkit-polyfills/-/appkit-polyfills-1.8.19.tgz",
-      "integrity": "sha512-PSoetRSuZg7f2YFPzdfs4BayQl51zcGqYr7frwOe6td0XEsspLrrVFn/zk5QFbFHZVsMdfRZ+TTunt84ozRdnQ==",
-      "license": "SEE LICENSE IN LICENSE.md",
-      "dependencies": {
-        "buffer": "6.0.3"
-      }
-    },
-    "node_modules/@reown/appkit/node_modules/@reown/appkit-ui": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-ui/-/appkit-ui-1.8.19.tgz",
       "integrity": "sha512-fCAwW8yyyC3JcgKLBPvCtYuDGC4H8anO7u4LTaAXGEzdcU5H+IrCgNFSPNK7NuTSmgXm1TnoYxPxRFKNiNwFdA==",
@@ -8179,7 +7820,7 @@
         "qrcode": "1.5.3"
       }
     },
-    "node_modules/@reown/appkit/node_modules/@reown/appkit-utils": {
+    "node_modules/@reown/appkit-utils": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-utils/-/appkit-utils-1.8.19.tgz",
       "integrity": "sha512-VQPgUMTFqoh4UD3EDZSw9wyMkyZsmIVmu8CdQ2FUxIuqYW4fLd0VIpkDeO64MMhSv8b0X8Vd6m4+eGcqSwlUAg==",
@@ -8204,7 +7845,7 @@
         "valtio": "2.1.7"
       }
     },
-    "node_modules/@reown/appkit/node_modules/@reown/appkit-wallet": {
+    "node_modules/@reown/appkit-wallet": {
       "version": "1.8.19",
       "resolved": "https://registry.npmjs.org/@reown/appkit-wallet/-/appkit-wallet-1.8.19.tgz",
       "integrity": "sha512-NVdIKceUhkXYtsG32925ctmVn0QJFNyDlr+mWheMLCEZ/IUPn+6aA53vTVaSUquhyeFxUXtrCOh3ln6v1tup5w==",
@@ -8216,7 +7857,7 @@
         "zod": "3.22.4"
       }
     },
-    "node_modules/@reown/appkit/node_modules/zod": {
+    "node_modules/@reown/appkit-wallet/node_modules/zod": {
       "version": "3.22.4",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.4.tgz",
       "integrity": "sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==",

--- a/package.json
+++ b/package.json
@@ -33,8 +33,8 @@
     "@fullcalendar/timegrid": "6.1.20",
     "@lifi/sdk": "3.16.3",
     "@next/third-parties": "16.2.5",
-    "@reown/appkit": "1.8.20-wagmi-upgrade.0",
-    "@reown/appkit-adapter-wagmi": "1.8.20-wagmi-upgrade.0",
+    "@reown/appkit": "1.8.19",
+    "@reown/appkit-adapter-wagmi": "1.8.19",
     "@reown/appkit-siwe": "1.8.20-wagmi-upgrade.0",
     "@sentry/nextjs": "10.52.0",
     "@supabase/supabase-js": "2.105.3",
@@ -60,7 +60,7 @@
     "fumadocs-ui": "16.8.7",
     "input-otp": "1.4.2",
     "lucide-react": "1.14.0",
-    "next": "16.2.5",
+    "next": "16.2.6",
     "next-intl": "4.11.0",
     "next-themes": "0.4.6",
     "postgres": "3.4.9",
@@ -73,7 +73,7 @@
     "sonner": "2.0.7",
     "tailwind-merge": "3.5.0",
     "vaul": "1.1.2",
-    "viem": "2.48.8",
+    "viem": "2.48.11",
     "wagmi": "2.19.5",
     "zod": "4.4.3",
     "zustand": "5.0.13"
@@ -108,7 +108,8 @@
     "vitest": "^4.1.5"
   },
   "overrides": {
-    "axios": "1.16.0"
+    "axios": "1.16.0",
+    "postcss": "^8.5.14"
   },
   "lint-staged": {
     "*": "eslint --fix"

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@next/third-parties": "16.2.5",
     "@reown/appkit": "1.8.19",
     "@reown/appkit-adapter-wagmi": "1.8.19",
-    "@reown/appkit-siwe": "1.8.20-wagmi-upgrade.0",
+    "@reown/appkit-siwe": "1.8.19",
     "@sentry/nextjs": "10.52.0",
     "@supabase/supabase-js": "2.105.3",
     "@tanstack/react-query": "5.100.9",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Pin Next.js to 16.2.6 to pick up the latest patch and keep builds stable. Also aligns AppKit deps and enforces a single `postcss` version.

- **Dependencies**
  - Set `next` to `16.2.6` (updates `@next/env` and `@next/swc-*`).
  - Bumped `viem` to `2.48.11`.
  - Pinned `@reown/appkit`, `@reown/appkit-adapter-wagmi`, and `@reown/appkit-siwe` to `1.8.19`.
  - Added `overrides.postcss` to `^8.5.14` for consistent PostCSS.

<sup>Written for commit ae5af4f7ef34af501324f9eff3b0de990b1db4ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

