### PR TITLE
fix: disable "use connected" wallet for withdrawal with social wallets

### DIFF
--- a/src/app/[locale]/(platform)/_components/wallet-modal/WalletSendForm.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/WalletSendForm.tsx
@@ -2,6 +2,7 @@
 
 import type { ChangeEventHandler, FormEventHandler } from 'react'
 import type { PendingWithdrawalItem } from '@/app/[locale]/(platform)/_components/wallet-modal/utils'
+import { useAppKitAccount } from '@reown/appkit/react'
 import {
   ArrowLeftIcon,
   ChevronRightIcon,
@@ -58,6 +59,7 @@ function WalletSendForm({
   const [receiveChain, setReceiveChain] = useState<string>('Polygon')
   const [isBreakdownOpen, setIsBreakdownOpen] = useState(false)
   const inputValue = formatDisplayAmount(sendAmount)
+  const appKitAccount = useAppKitAccount()
   const isSubmitDisabled = (
     isSending
     || !trimmedRecipient
@@ -144,7 +146,7 @@ function WalletSendForm({
                 variant="default"
                 size="sm"
                 onClick={onUseConnectedWallet}
-                disabled={!connectedWalletAddress}
+                disabled={!connectedWalletAddress || !!appKitAccount.embeddedWalletInfo?.authProvider}
                 className="absolute inset-y-2 right-2 text-xs"
               >
                 <WalletIcon className="size-3.5 shrink-0" />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable the "Use connected wallet" button in the withdrawal form when the connected account is a social/embedded wallet. We now detect social wallets via `useAppKitAccount` from `@reown/appkit/react` and prevent using them as the source, avoiding unsupported flows.

<sup>Written for commit 0b18b1d32c447954a264af20f5a6816ea5b088aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

