### PR TITLE
fix: refresh homepage live events and bookmark cache

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventsGrid.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventsGrid.tsx
@@ -41,6 +41,10 @@ const HOME_LIVE_PRICE_OBSERVER_ROOT_MARGIN = '200px 0px'
 const HOME_LIVE_OVERRIDE_SETTLE_DELAY_MS = 2_000
 const HOME_FEED_REFRESH_INTERVAL_MS = 60_000
 
+function hasFiniteTimestamp(value: number | null | undefined) {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
 function resolveCardMarkets(event: Event) {
   const activeMarkets = isHomeEventResolvedLike(event)
     ? event.markets
@@ -425,11 +429,18 @@ export default function EventsGrid({
     && !filters.hideEarnings
   const initialSnapshotEvents = isRouteInitialState ? initialEvents : EMPTY_EVENTS
   const PAGE_SIZE = HOME_EVENTS_PAGE_SIZE
+  const shouldAutoRefreshEvents = filters.status === 'active'
+  const resolvedCurrentTimestamp = currentTimestamp ?? initialCurrentTimestamp
+  const hasResolvedCurrentTimestamp = hasFiniteTimestamp(resolvedCurrentTimestamp)
+  const hasInitialCurrentTimestamp = hasFiniteTimestamp(initialCurrentTimestamp)
+  const homeFeedClockState = shouldAutoRefreshEvents
+    ? (hasResolvedCurrentTimestamp ? 'clock-ready' : 'clock-pending')
+    : 'clock-static'
   const shouldUseInitialData = isRouteInitialState
     && initialEvents.length > 0
     && queryUserScope === 'guest'
-  const shouldAutoRefreshEvents = filters.status === 'active'
-  const resolvedCurrentTimestamp = currentTimestamp ?? initialCurrentTimestamp
+    && (!shouldAutoRefreshEvents || !hasResolvedCurrentTimestamp || hasInitialCurrentTimestamp)
+  const shouldEnableEventsQuery = !shouldAutoRefreshEvents || hasResolvedCurrentTimestamp
   const loadMoreStateKey = [
     filters.tag,
     filters.mainTag,
@@ -457,6 +468,7 @@ export default function EventsGrid({
     filters.hideEarnings,
     locale,
     queryUserScope,
+    homeFeedClockState,
   ]
 
   const {
@@ -479,6 +491,7 @@ export default function EventsGrid({
     getNextPageParam: (lastPage, allPages) => lastPage.length === PAGE_SIZE ? allPages.length * PAGE_SIZE : undefined,
     initialPageParam: 0,
     initialData: shouldUseInitialData ? { pages: [initialEvents], pageParams: [0] } : undefined,
+    enabled: shouldEnableEventsQuery,
     refetchOnMount: false,
     refetchOnWindowFocus: false,
     staleTime: 'static',

--- a/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
@@ -5,12 +5,14 @@ import { listHomeEventsPage } from '@/lib/home-events-page'
 
 interface HomeContentProps {
   locale: string
+  currentTimestamp?: number | null
   initialTag?: string
   initialMainTag?: string
 }
 
 export default async function HomeContent({
   locale,
+  currentTimestamp = null,
   initialTag,
   initialMainTag,
 }: HomeContentProps) {
@@ -22,17 +24,21 @@ export default async function HomeContent({
   let initialEvents: Event[] = []
 
   try {
-    const { data: events, error, currentTimestamp } = await listHomeEventsPage({
+    const {
+      data: events,
+      error,
+      currentTimestamp: resolvedCurrentTimestamp,
+    } = await listHomeEventsPage({
       tag: initialTagSlug,
       mainTag: initialMainTagSlug,
       search: '',
       userId: '',
       bookmarked: false,
       locale: resolvedLocale,
-      currentTimestamp: null,
+      currentTimestamp,
     })
 
-    initialCurrentTimestamp = currentTimestamp ?? null
+    initialCurrentTimestamp = resolvedCurrentTimestamp ?? null
 
     if (!error) {
       initialEvents = events ?? []

--- a/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
+++ b/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
@@ -1,7 +1,7 @@
 export const HOME_INITIAL_EVENTS_CACHE_LIFE = {
-  stale: 900,
-  revalidate: 900,
-  expire: 1800,
+  stale: 60,
+  revalidate: 60,
+  expire: 900,
 } as const
 
 const HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS = 60_000

--- a/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
+++ b/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
@@ -1,0 +1,11 @@
+export const HOME_INITIAL_EVENTS_CACHE_LIFE = {
+  stale: 900,
+  revalidate: 900,
+  expire: 1800,
+} as const
+
+const HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS = 60_000
+
+export function getHomeInitialCurrentTimestamp() {
+  return Math.floor(Date.now() / HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS) * HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS
+}

--- a/src/app/[locale]/(platform)/(home)/new/page.tsx
+++ b/src/app/[locale]/(platform)/(home)/new/page.tsx
@@ -2,7 +2,12 @@
 
 import type { Metadata } from 'next'
 import { setRequestLocale } from 'next-intl/server'
+import { cacheLife } from 'next/cache'
 import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
+import {
+  getHomeInitialCurrentTimestamp,
+  HOME_INITIAL_EVENTS_CACHE_LIFE,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
 import { getNewPageSeoTitle } from '@/lib/platform-routing'
 
 const MAIN_TAG_SLUG = 'new' as const
@@ -12,8 +17,11 @@ export const metadata: Metadata = {
 }
 
 export default async function NewPage({ params }: PageProps<'/[locale]/new'>) {
+  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
+
   const { locale } = await params
   setRequestLocale(locale)
+  const currentTimestamp = getHomeInitialCurrentTimestamp()
 
-  return <HomeContent locale={locale} initialTag={MAIN_TAG_SLUG} />
+  return <HomeContent locale={locale} currentTimestamp={currentTimestamp} initialTag={MAIN_TAG_SLUG} />
 }

--- a/src/app/[locale]/(platform)/(home)/page.tsx
+++ b/src/app/[locale]/(platform)/(home)/page.tsx
@@ -2,12 +2,10 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { cacheLife } from 'next/cache'
 import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
-
-const HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS = 60_000
-
-function getHomeInitialCurrentTimestamp() {
-  return Math.floor(Date.now() / HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS) * HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS
-}
+import {
+  getHomeInitialCurrentTimestamp,
+  HOME_INITIAL_EVENTS_CACHE_LIFE,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
 
 async function CachedHomePageContent({
   locale,
@@ -15,7 +13,7 @@ async function CachedHomePageContent({
   locale: SupportedLocale
 }) {
   'use cache'
-  cacheLife({ stale: 900, revalidate: 900, expire: 1800 })
+  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
 
   const currentTimestamp = getHomeInitialCurrentTimestamp()
   return <HomeContent locale={locale} currentTimestamp={currentTimestamp} />

--- a/src/app/[locale]/(platform)/(home)/page.tsx
+++ b/src/app/[locale]/(platform)/(home)/page.tsx
@@ -1,11 +1,24 @@
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
+import { cacheLife } from 'next/cache'
 import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
 
-async function CachedHomePageContent({ locale }: { locale: SupportedLocale }) {
-  'use cache'
+const HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS = 60_000
 
-  return <HomeContent locale={locale} />
+function getHomeInitialCurrentTimestamp() {
+  return Math.floor(Date.now() / HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS) * HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS
+}
+
+async function CachedHomePageContent({
+  locale,
+}: {
+  locale: SupportedLocale
+}) {
+  'use cache'
+  cacheLife({ stale: 900, revalidate: 900, expire: 1800 })
+
+  const currentTimestamp = getHomeInitialCurrentTimestamp()
+  return <HomeContent locale={locale} currentTimestamp={currentTimestamp} />
 }
 
 export default async function HomePage({ params }: PageProps<'/[locale]'>) {

--- a/src/app/[locale]/(platform)/_actions/bookmark.ts
+++ b/src/app/[locale]/(platform)/_actions/bookmark.ts
@@ -1,5 +1,7 @@
 'use server'
 
+import { updateTag } from 'next/cache'
+import { cacheTags } from '@/lib/cache-tags'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { BookmarkRepository } from '@/lib/db/queries/bookmark'
 import { UserRepository } from '@/lib/db/queries/user'
@@ -29,6 +31,8 @@ export async function toggleBookmarkAction(eventId: string) {
     if (result.error) {
       return result
     }
+
+    updateTag(cacheTags.events(user.id))
 
     return {
       data: {

--- a/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
+++ b/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
@@ -31,6 +31,7 @@ import { Drawer, DrawerClose, DrawerContent, DrawerHeader, DrawerTitle } from '@
 import { Skeleton } from '@/components/ui/skeleton'
 import { useAppKit } from '@/hooks/useAppKit'
 import { useBalance } from '@/hooks/useBalance'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { usePortfolioValue } from '@/hooks/usePortfolioValue'
 import { usePwaInstall } from '@/hooks/usePwaInstall'
 import { LOCALE_LABELS, LOOP_LABELS, normalizeEnabledLocales, SUPPORTED_LOCALES } from '@/i18n/locales'
@@ -85,6 +86,7 @@ function useMobileBottomNavState() {
 function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
   const t = useExtracted()
   const router = useRouter()
+  const isMobile = useIsMobile()
   const { open } = useAppKit()
   const { data: session } = useSession()
   const user = useUser()
@@ -192,6 +194,10 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
     window.setTimeout(() => {
       setIsHowItWorksOpen(true)
     }, 120)
+  }
+
+  if (!isMobile) {
+    return null
   }
 
   return (

--- a/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
+++ b/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
@@ -31,7 +31,6 @@ import { Drawer, DrawerClose, DrawerContent, DrawerHeader, DrawerTitle } from '@
 import { Skeleton } from '@/components/ui/skeleton'
 import { useAppKit } from '@/hooks/useAppKit'
 import { useBalance } from '@/hooks/useBalance'
-import { useIsMobile } from '@/hooks/useIsMobile'
 import { usePortfolioValue } from '@/hooks/usePortfolioValue'
 import { usePwaInstall } from '@/hooks/usePwaInstall'
 import { LOCALE_LABELS, LOOP_LABELS, normalizeEnabledLocales, SUPPORTED_LOCALES } from '@/i18n/locales'
@@ -86,7 +85,6 @@ function useMobileBottomNavState() {
 function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
   const t = useExtracted()
   const router = useRouter()
-  const isMobile = useIsMobile()
   const { open } = useAppKit()
   const { data: session } = useSession()
   const user = useUser()
@@ -194,10 +192,6 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
     window.setTimeout(() => {
       setIsHowItWorksOpen(true)
     }, 120)
-  }
-
-  if (!isMobile) {
-    return null
   }
 
   return (

--- a/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
@@ -1,7 +1,12 @@
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
+import { cacheLife } from 'next/cache'
 import { notFound } from 'next/navigation'
 import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
+import {
+  getHomeInitialCurrentTimestamp,
+  HOME_INITIAL_EVENTS_CACHE_LIFE,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
 import {
   buildLocalizedPagePath,
   buildPredictionResultsOgImageUrl,
@@ -20,6 +25,29 @@ const { resolveSiteUrl } = siteUrlUtils
 async function getMainTags(locale: SupportedLocale) {
   const { data: mainTags } = await loadPlatformMainTags(locale)
   return mainTags ?? []
+}
+
+async function CachedDynamicHomeContent({
+  initialMainTag,
+  initialTag,
+  locale,
+}: {
+  initialMainTag?: string
+  initialTag: string
+  locale: SupportedLocale
+}) {
+  'use cache'
+  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
+
+  const currentTimestamp = getHomeInitialCurrentTimestamp()
+  return (
+    <HomeContent
+      locale={locale}
+      currentTimestamp={currentTimestamp}
+      initialTag={initialTag}
+      initialMainTag={initialMainTag}
+    />
+  )
 }
 
 export async function generateDynamicHomeCategoryStaticParams() {
@@ -128,7 +156,7 @@ export async function DynamicHomeCategoryPageContent({
     notFound()
   }
 
-  return <HomeContent locale={locale} initialTag={category.slug} />
+  return <CachedDynamicHomeContent locale={locale} initialTag={category.slug} />
 }
 
 export async function DynamicHomeSubcategoryPageContent({
@@ -155,7 +183,7 @@ export async function DynamicHomeSubcategoryPageContent({
   }
 
   return (
-    <HomeContent
+    <CachedDynamicHomeContent
       locale={locale}
       initialTag={resolvedSubcategory.subcategory.slug}
       initialMainTag={resolvedSubcategory.category.slug}

--- a/tests/unit/EventBookmark.test.tsx
+++ b/tests/unit/EventBookmark.test.tsx
@@ -195,7 +195,7 @@ describe('eventBookmark', () => {
 
   it('only rewrites the acting user event caches', async () => {
     const cachedQueries = [
-      [['events', 'trending', 'trending', '', false, 'all', 'active', false, false, false, 'en', 'user-1'], { pages: [[{ id: 'event-1', is_bookmarked: false }]], pageParams: [0] }],
+      [['events', 'trending', 'trending', '', false, 'all', 'active', false, false, false, 'en', 'user-1', 'clock-ready'], { pages: [[{ id: 'event-1', is_bookmarked: false }]], pageParams: [0] }],
       [['events', 'trending', 'trending', '', false, 'all', 'active', false, false, false, 'en', 'guest'], { pages: [[{ id: 'event-1', is_bookmarked: false }]], pageParams: [0] }],
       [['events', '', true, 'all', 'active', false, false, false, 'en', 'user-2', null, null], { pages: [[{ id: 'event-1', is_bookmarked: false }]], pageParams: [0] }],
     ] as const

--- a/tests/unit/EventsGrid.test.tsx
+++ b/tests/unit/EventsGrid.test.tsx
@@ -245,7 +245,7 @@ describe('eventsGrid', () => {
     expect(mocks.refetch).not.toHaveBeenCalled()
   })
 
-  it('keeps interval refresh active when the client timestamp hydrates from null', async () => {
+  it('starts a fresh active feed query when the client timestamp hydrates from null', async () => {
     const filters = {
       tag: 'trending',
       mainTag: 'trending',
@@ -264,18 +264,26 @@ describe('eventsGrid', () => {
     const { rerender } = render(
       <EventsGrid
         filters={filters}
-        initialEvents={[]}
+        initialEvents={[{ id: 'server-seeded-event' } as any]}
         initialCurrentTimestamp={null}
         routeMainTag="trending"
         routeTag="trending"
       />,
     )
 
+    const pendingClockOptions = mocks.useInfiniteQuery.mock.calls.at(-1)?.[0]
+    expect(pendingClockOptions.queryKey).toContain('clock-pending')
+    expect(pendingClockOptions.enabled).toBe(false)
+    expect(pendingClockOptions.initialData).toEqual({
+      pages: [[{ id: 'server-seeded-event' }]],
+      pageParams: [0],
+    })
+
     await act(async () => {
       rerender(
         <EventsGrid
           filters={filters}
-          initialEvents={[]}
+          initialEvents={[{ id: 'server-seeded-event' } as any]}
           initialCurrentTimestamp={null}
           routeMainTag="trending"
           routeTag="trending"
@@ -283,7 +291,11 @@ describe('eventsGrid', () => {
       )
     })
 
+    const readyClockOptions = mocks.useInfiniteQuery.mock.calls.at(-1)?.[0]
     expect(mocks.refetch).not.toHaveBeenCalled()
-    expect(mocks.useInfiniteQuery.mock.calls.at(-1)?.[0].refetchInterval).toBe(60_000)
+    expect(readyClockOptions.queryKey).toContain('clock-ready')
+    expect(readyClockOptions.enabled).toBe(true)
+    expect(readyClockOptions.initialData).toBeUndefined()
+    expect(readyClockOptions.refetchInterval).toBe(60_000)
   })
 })

--- a/tests/unit/bookmarkAction.test.ts
+++ b/tests/unit/bookmarkAction.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  isBookmarked: vi.fn(),
+  toggleBookmark: vi.fn(),
+  updateTag: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+  updateTag: (...args: any[]) => mocks.updateTag(...args),
+}))
+
+vi.mock('@/lib/db/queries/bookmark', () => ({
+  BookmarkRepository: {
+    isBookmarked: (...args: any[]) => mocks.isBookmarked(...args),
+    toggleBookmark: (...args: any[]) => mocks.toggleBookmark(...args),
+  },
+}))
+
+vi.mock('@/lib/db/queries/user', () => ({
+  UserRepository: {
+    getCurrentUser: (...args: any[]) => mocks.getCurrentUser(...args),
+  },
+}))
+
+describe('bookmark actions', () => {
+  beforeEach(() => {
+    mocks.getCurrentUser.mockReset()
+    mocks.isBookmarked.mockReset()
+    mocks.toggleBookmark.mockReset()
+    mocks.updateTag.mockReset()
+  })
+
+  it('expires the acting user event-list cache after a bookmark toggle', async () => {
+    mocks.getCurrentUser.mockResolvedValueOnce({ id: 'user-1' })
+    mocks.toggleBookmark.mockResolvedValueOnce({ data: true, error: null })
+
+    const { toggleBookmarkAction } = await import('@/app/[locale]/(platform)/_actions/bookmark')
+    const result = await toggleBookmarkAction('event-1')
+
+    expect(result).toEqual({
+      data: {
+        isBookmarked: true,
+        userId: 'user-1',
+      },
+      error: null,
+    })
+    expect(mocks.updateTag).toHaveBeenCalledWith('events:user-1')
+  })
+
+  it('does not expire event-list cache when the toggle fails', async () => {
+    mocks.getCurrentUser.mockResolvedValueOnce({ id: 'user-1' })
+    mocks.toggleBookmark.mockResolvedValueOnce({ data: null, error: 'Failed' })
+
+    const { toggleBookmarkAction } = await import('@/app/[locale]/(platform)/_actions/bookmark')
+    await toggleBookmarkAction('event-1')
+
+    expect(mocks.updateTag).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/dynamicHomeCategoryPage.test.tsx
+++ b/tests/unit/dynamicHomeCategoryPage.test.tsx
@@ -1,0 +1,84 @@
+import { isValidElement } from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  findDynamicHomeCategoryBySlug: vi.fn(),
+  findDynamicHomeSubcategoryBySlug: vi.fn(),
+  loadPlatformMainTags: vi.fn(),
+  notFound: vi.fn(),
+}))
+
+vi.mock('next/navigation', () => ({
+  notFound: () => mocks.notFound(),
+}))
+
+vi.mock('next/cache', () => ({
+  cacheLife: vi.fn(),
+}))
+
+vi.mock('@/app/[locale]/(platform)/(home)/_components/HomeContent', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/platform-main-tags', () => ({
+  loadPlatformMainTags: (...args: any[]) => mocks.loadPlatformMainTags(...args),
+}))
+
+vi.mock('@/lib/platform-routing', () => ({
+  findDynamicHomeCategoryBySlug: (...args: any[]) => mocks.findDynamicHomeCategoryBySlug(...args),
+  findDynamicHomeSubcategoryBySlug: (...args: any[]) => mocks.findDynamicHomeSubcategoryBySlug(...args),
+  getMainTagSeoTitle: (value: string) => value,
+}))
+
+describe('dynamicHomeCategoryPage', () => {
+  beforeEach(() => {
+    mocks.findDynamicHomeCategoryBySlug.mockReset()
+    mocks.findDynamicHomeSubcategoryBySlug.mockReset()
+    mocks.loadPlatformMainTags.mockReset()
+    mocks.notFound.mockReset()
+    mocks.loadPlatformMainTags.mockResolvedValue({ data: [] })
+    mocks.notFound.mockImplementation(() => {
+      throw new Error('not found')
+    })
+  })
+
+  it('routes category pages through cached timestamped home content', async () => {
+    mocks.findDynamicHomeCategoryBySlug.mockReturnValueOnce({
+      slug: 'crypto',
+      name: 'Crypto',
+    })
+
+    const { DynamicHomeCategoryPageContent } = await import('@/app/[locale]/(platform)/_lib/dynamic-home-category-page')
+    const result = await DynamicHomeCategoryPageContent({
+      locale: 'en',
+      slug: 'crypto',
+    })
+
+    expect(isValidElement(result)).toBe(true)
+    expect((result as any).props).toEqual(expect.objectContaining({
+      initialTag: 'crypto',
+      locale: 'en',
+    }))
+  })
+
+  it('routes subcategory pages through cached timestamped home content', async () => {
+    mocks.findDynamicHomeSubcategoryBySlug.mockReturnValueOnce({
+      category: { slug: 'crypto', name: 'Crypto' },
+      subcategory: { slug: 'crypto-prices', name: 'Crypto Prices' },
+    })
+
+    const { DynamicHomeSubcategoryPageContent } = await import('@/app/[locale]/(platform)/_lib/dynamic-home-category-page')
+    const result = await DynamicHomeSubcategoryPageContent({
+      locale: 'en',
+      slug: 'crypto',
+      subcategory: 'crypto-prices',
+    })
+
+    expect(isValidElement(result)).toBe(true)
+    expect((result as any).props).toEqual(expect.objectContaining({
+      initialMainTag: 'crypto',
+      initialTag: 'crypto-prices',
+      locale: 'en',
+    }))
+  })
+})

--- a/tests/unit/homeContent.test.ts
+++ b/tests/unit/homeContent.test.ts
@@ -34,4 +34,19 @@ describe('homeContent', () => {
       currentTimestamp: null,
     }))
   })
+
+  it('uses the provided current timestamp for initial home events', async () => {
+    const currentTimestamp = Date.parse('2026-05-11T12:34:00.000Z')
+    mocks.listHomeEventsPage.mockResolvedValueOnce({ data: [], error: null, currentTimestamp })
+
+    const HomeContent = (await import('@/app/[locale]/(platform)/(home)/_components/HomeContent')).default
+    await HomeContent({
+      locale: 'en',
+      currentTimestamp,
+    })
+
+    expect(mocks.listHomeEventsPage).toHaveBeenCalledWith(expect.objectContaining({
+      currentTimestamp,
+    }))
+  })
 })

--- a/tests/unit/homeInitialEventsCache.test.ts
+++ b/tests/unit/homeInitialEventsCache.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getHomeInitialCurrentTimestamp,
+  HOME_INITIAL_EVENTS_CACHE_LIFE,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+
+describe('homeInitialEventsCache', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('uses a one-minute revalidation window for cached initial home events', () => {
+    expect(HOME_INITIAL_EVENTS_CACHE_LIFE).toEqual({
+      stale: 60,
+      revalidate: 60,
+      expire: 900,
+    })
+  })
+
+  it('normalizes the seed timestamp to the current minute', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-11T12:34:56.789Z'))
+
+    expect(getHomeInitialCurrentTimestamp()).toBe(Date.parse('2026-05-11T12:34:00.000Z'))
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes live event auto-refresh across Home/New/category pages using a server-seeded, minute-bucketed clock, and makes bookmark toggles expire only the acting user’s caches so badges update immediately. Also rolls back the mobile bottom nav render.

- **Bug Fixes**
  - Home feed: Home/New/category/subcategory pages seed a minute-bucketed timestamp and set `cacheLife`; the client keeps SSR events while the clock is pending, then starts a fresh enabled query with `clock-*` in the key and a 60s refetch interval.
  - Bookmarks: after a successful toggle, call `updateTag` from `next/cache` with `events:<userId>` to expire only the acting user’s event-list caches.

- **Refactors**
  - Rolled back mobile bottom nav rendering to previous behavior.

<sup>Written for commit 6c3cee0ae4ae66cd839b33dbb6e6a591a05e528c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

