### PR TITLE
fix: mobile bottom nav hydration error

### DIFF
--- a/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
+++ b/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
@@ -31,6 +31,7 @@ import { Drawer, DrawerClose, DrawerContent, DrawerHeader, DrawerTitle } from '@
 import { Skeleton } from '@/components/ui/skeleton'
 import { useAppKit } from '@/hooks/useAppKit'
 import { useBalance } from '@/hooks/useBalance'
+import { useHasHydrated } from '@/hooks/useHasHydrated'
 import { usePortfolioValue } from '@/hooks/usePortfolioValue'
 import { usePwaInstall } from '@/hooks/usePwaInstall'
 import { LOCALE_LABELS, LOOP_LABELS, normalizeEnabledLocales, SUPPORTED_LOCALES } from '@/i18n/locales'
@@ -88,6 +89,7 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
   const { open } = useAppKit()
   const { data: session } = useSession()
   const user = useUser()
+  const hasHydrated = useHasHydrated()
   const { canShowInstallUi, isIos, isPrompting, requestInstall } = usePwaInstall()
   const {
     isSearchOpen,
@@ -100,7 +102,7 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
     setIsHowItWorksOpen,
   } = useMobileBottomNavState()
 
-  const isAuthenticated = Boolean(session?.user) || Boolean(user)
+  const isAuthenticated = hasHydrated && (Boolean(session?.user) || Boolean(user))
 
   function focusMobileSearchInput() {
     const input = document.querySelector<HTMLInputElement>(

--- a/tests/unit/MobileBottomNav.test.tsx
+++ b/tests/unit/MobileBottomNav.test.tsx
@@ -1,0 +1,127 @@
+import { render, screen } from '@testing-library/react'
+import MobileBottomNav from '@/app/[locale]/(platform)/_components/MobileBottomNav'
+
+const mocks = vi.hoisted(() => ({
+  useHasHydrated: vi.fn(),
+  useSession: vi.fn(),
+  useUser: vi.fn(),
+}))
+
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => function MockDynamicComponent() {
+    return <div data-testid="mobile-bottom-nav-dynamic" />
+  },
+}))
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (value: string) => value,
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/app/[locale]/(platform)/_components/SearchDiscoveryContent', () => ({
+  default: () => <div data-testid="search-discovery" />,
+}))
+
+vi.mock('@/components/AppLink', () => ({
+  default: function MockAppLink({ children, href, ...props }: any) {
+    return <a href={href} {...props}>{children}</a>
+  },
+}))
+
+vi.mock('@/components/PwaInstallIosInstructions', () => ({
+  default: () => <div data-testid="pwa-ios-instructions" />,
+}))
+
+vi.mock('@/components/ThemeSelector', () => ({
+  default: () => <div data-testid="theme-selector" />,
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: function MockButton({ children, ...props }: any) {
+    return <button {...props}>{children}</button>
+  },
+}))
+
+vi.mock('@/components/ui/drawer', () => ({
+  Drawer: ({ children }: any) => <div>{children}</div>,
+  DrawerClose: ({ children }: any) => <>{children}</>,
+  DrawerContent: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  DrawerHeader: ({ children, ...props }: any) => <div {...props}>{children}</div>,
+  DrawerTitle: ({ children }: any) => <div>{children}</div>,
+}))
+
+vi.mock('@/components/ui/skeleton', () => ({
+  Skeleton: (props: any) => <span {...props} />,
+}))
+
+vi.mock('@/hooks/useAppKit', () => ({
+  useAppKit: () => ({ open: vi.fn() }),
+}))
+
+vi.mock('@/hooks/useBalance', () => ({
+  useBalance: () => ({ balance: { raw: 0 }, isLoadingBalance: false }),
+}))
+
+vi.mock('@/hooks/useHasHydrated', () => ({
+  useHasHydrated: () => mocks.useHasHydrated(),
+}))
+
+vi.mock('@/hooks/usePortfolioValue', () => ({
+  usePortfolioValue: () => ({ isLoading: false, value: 0 }),
+}))
+
+vi.mock('@/hooks/usePwaInstall', () => ({
+  usePwaInstall: () => ({
+    canShowInstallUi: false,
+    isIos: false,
+    isPrompting: false,
+    requestInstall: vi.fn(),
+  }),
+}))
+
+vi.mock('@/i18n/navigation', () => ({
+  usePathname: () => '/crypto',
+  useRouter: () => ({ push: vi.fn() }),
+}))
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    useSession: () => mocks.useSession(),
+  },
+}))
+
+vi.mock('@/stores/usePortfolioValueVisibility', () => ({
+  usePortfolioValueVisibility: (selector: (state: { isHidden: boolean }) => unknown) => selector({ isHidden: false }),
+}))
+
+vi.mock('@/stores/useUser', () => ({
+  useUser: () => mocks.useUser(),
+}))
+
+describe('mobileBottomNav', () => {
+  beforeEach(() => {
+    mocks.useHasHydrated.mockReset()
+    mocks.useSession.mockReset()
+    mocks.useUser.mockReset()
+    mocks.useHasHydrated.mockReturnValue(false)
+    mocks.useSession.mockReturnValue({ data: { user: { id: 'user-1' } } })
+    mocks.useUser.mockReturnValue({ id: 'user-1' })
+  })
+
+  it('keeps the hydration render on the guest fourth-tab shape', () => {
+    render(<MobileBottomNav />)
+
+    expect(screen.getByRole('button', { name: 'More' })).toBeInTheDocument()
+    expect(screen.queryByRole('link', { name: 'Portfolio' })).not.toBeInTheDocument()
+  })
+
+  it('shows the portfolio tab after hydration for authenticated users', () => {
+    mocks.useHasHydrated.mockReturnValue(true)
+
+    render(<MobileBottomNav />)
+
+    expect(screen.getByRole('link', { name: 'Portfolio' })).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'More' })).not.toBeInTheDocument()
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes a hydration mismatch in the mobile bottom nav. The Portfolio tab now shows only after client hydration for authenticated users, avoiding SSR/CSR warnings.

- **Bug Fixes**
  - Gate `isAuthenticated` with `useHasHydrated()` to keep the guest “More” tab during SSR and switch to “Portfolio” after hydration.
  - Added unit tests to cover pre- and post-hydration states.

<sup>Written for commit 63b33bd6275062b8dd6e847b1af8924c672bd5c6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

