### PR TITLE
fix: homepage current series event

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -227,7 +227,6 @@ export const auth = betterAuth({
         session,
       }
     }),
-    nextCookies(),
     siwe({
       schema: {
         walletAddress: {
@@ -283,6 +282,7 @@ export const auth = betterAuth({
         },
       },
     }),
+    nextCookies(),
   ],
   user: {
     modelName: 'users',

--- a/src/lib/home-events.ts
+++ b/src/lib/home-events.ts
@@ -94,11 +94,7 @@ function isPreferredSeriesEvent<T extends HomeVisibleEventCandidate>(candidate: 
   const candidateOverdueUnresolved = isOverdueUnresolved(candidate, nowMs)
   const currentOverdueUnresolved = isOverdueUnresolved(current, nowMs)
 
-  if (candidateOverdueUnresolved || currentOverdueUnresolved) {
-    if (candidateOverdueUnresolved !== currentOverdueUnresolved) {
-      return candidateOverdueUnresolved
-    }
-
+  if (candidateOverdueUnresolved && currentOverdueUnresolved) {
     if (candidateEnd !== currentEnd) {
       return candidateEnd > currentEnd
     }
@@ -120,6 +116,10 @@ function isPreferredSeriesEvent<T extends HomeVisibleEventCandidate>(candidate: 
 
   if (candidateHasFutureEnd !== currentHasFutureEnd) {
     return candidateHasFutureEnd
+  }
+
+  if (candidateOverdueUnresolved !== currentOverdueUnresolved) {
+    return candidateOverdueUnresolved
   }
 
   if (candidateResolved !== currentResolved) {

--- a/tests/unit/homeEvents.test.ts
+++ b/tests/unit/homeEvents.test.ts
@@ -125,4 +125,45 @@ describe('home-events', () => {
       },
     )).toEqual([soonerActiveEvent, resolvedEvent])
   })
+
+  it('prefers the current active series event over an overdue unresolved entry', () => {
+    const overdueEvent = {
+      id: 'overdue-event',
+      slug: 'meta-up-or-down-on-may-11-2026',
+      series_slug: 'meta-daily-up-down',
+      status: 'active' as const,
+      end_date: '2026-05-11T20:00:00.000Z',
+      created_at: '2026-05-08T12:00:00.000Z',
+      updated_at: '2026-05-10T12:00:00.000Z',
+      markets: [{ is_resolved: false }],
+    }
+    const currentEvent = {
+      id: 'current-event',
+      slug: 'meta-up-or-down-on-may-12-2026',
+      series_slug: 'meta-daily-up-down',
+      status: 'active' as const,
+      end_date: '2026-05-12T20:00:00.000Z',
+      created_at: '2026-05-11T12:00:00.000Z',
+      updated_at: '2026-05-11T12:00:00.000Z',
+      markets: [{ is_resolved: false }],
+    }
+    const futureEvent = {
+      id: 'future-event',
+      slug: 'meta-up-or-down-on-may-13-2026',
+      series_slug: 'meta-daily-up-down',
+      status: 'active' as const,
+      end_date: '2026-05-13T20:00:00.000Z',
+      created_at: '2026-05-12T12:00:00.000Z',
+      updated_at: '2026-05-12T12:00:00.000Z',
+      markets: [{ is_resolved: false }],
+    }
+
+    expect(filterHomeEvents(
+      [overdueEvent, futureEvent, currentEvent],
+      {
+        currentTimestamp: Date.parse('2026-05-12T17:30:00.000Z'),
+        status: 'active',
+      },
+    )).toEqual([currentEvent])
+  })
 })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "tests"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,6 @@
     ".next/dev/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules",
-    "tests"
+    "node_modules"
   ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes homepage event selection to always show the current active series event instead of an overdue unresolved one. Also moves `nextCookies` to the end of `better-auth` plugins so cookies are read in the right order.

- **Bug Fixes**
  - Prefer the current active series event over overdue unresolved entries.
  - Move `nextCookies` to the end of `better-auth` plugins to fix cookie read order.
  - Add a unit test covering this selection case.

- **Refactors**
  - Roll back `tsconfig.json` to previous settings.

<sup>Written for commit e9719f0aeef8ed0cdaeab484f4545488b11087f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

