### PR TITLE
fix: restore deposit wallet open orders

### DIFF
--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
@@ -24,6 +24,8 @@ interface PortfolioOpenOrdersListProps {
   userAddress: string
 }
 
+type OpenTradeRequirements = ReturnType<typeof useTradingOnboarding>['openTradeRequirements']
+
 function useOpenOrdersFilterState(userAddress: string) {
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebounce(searchQuery, 300)
@@ -80,7 +82,7 @@ function useCancelAllOpenOrders({
   orders: PortfolioUserOpenOrder[]
   queryClient: QueryClient
   openOrdersQueryKey: (string | undefined)[]
-  openTradeRequirements: ReturnType<typeof useTradingOnboarding>['openTradeRequirements']
+  openTradeRequirements: OpenTradeRequirements
 }) {
   const t = useExtracted()
   const [isCancellingAll, setIsCancellingAll] = useState(false)
@@ -182,6 +184,31 @@ function useInfiniteScrollSentinel({
   return { loadMoreRef }
 }
 
+function promptTradingAuthForOpenOrdersError({
+  error,
+  hasPromptedTradingAuthRef,
+  openTradeRequirements,
+  status,
+}: {
+  error: Error | null
+  hasPromptedTradingAuthRef: RefObject<boolean>
+  openTradeRequirements: OpenTradeRequirements
+  status: 'error' | 'pending' | 'success'
+}) {
+  if (status !== 'error') {
+    hasPromptedTradingAuthRef.current = false
+    return
+  }
+
+  const message = error instanceof Error ? error.message : ''
+  if (hasPromptedTradingAuthRef.current || !isTradingAuthRequiredError(message)) {
+    return
+  }
+
+  hasPromptedTradingAuthRef.current = true
+  openTradeRequirements({ forceTradingAuth: true })
+}
+
 export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOrdersListProps) {
   const user = useUser()
   const t = useExtracted()
@@ -213,19 +240,13 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
   const { orders, visibleOrders } = useVisibleOpenOrders({ data, searchQuery, sortBy })
   const hasPromptedTradingAuthRef = useRef(false)
 
-  useEffect(() => {
-    if (status !== 'error') {
-      hasPromptedTradingAuthRef.current = false
-      return
-    }
-
-    const message = error instanceof Error ? error.message : ''
-    if (hasPromptedTradingAuthRef.current || !isTradingAuthRequiredError(message)) {
-      return
-    }
-
-    hasPromptedTradingAuthRef.current = true
-    openTradeRequirements({ forceTradingAuth: true })
+  useEffect(function handleOpenOrdersTradingAuthError() {
+    promptTradingAuthForOpenOrdersError({
+      error,
+      hasPromptedTradingAuthRef,
+      openTradeRequirements,
+      status,
+    })
   }, [error, openTradeRequirements, status])
 
   const canCancelAll = Boolean(

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
@@ -199,6 +199,7 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
 
   const {
     status,
+    error,
     data,
     fetchNextPage,
     hasNextPage,
@@ -210,6 +211,22 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
   })
 
   const { orders, visibleOrders } = useVisibleOpenOrders({ data, searchQuery, sortBy })
+  const hasPromptedTradingAuthRef = useRef(false)
+
+  useEffect(() => {
+    if (status !== 'error') {
+      hasPromptedTradingAuthRef.current = false
+      return
+    }
+
+    const message = error instanceof Error ? error.message : ''
+    if (hasPromptedTradingAuthRef.current || !isTradingAuthRequiredError(message)) {
+      return
+    }
+
+    hasPromptedTradingAuthRef.current = true
+    openTradeRequirements({ forceTradingAuth: true })
+  }, [error, openTradeRequirements, status])
 
   const canCancelAll = Boolean(
     user?.deposit_wallet_address

--- a/src/app/api/events/[slug]/open-orders/route.ts
+++ b/src/app/api/events/[slug]/open-orders/route.ts
@@ -11,6 +11,7 @@ import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { EventRepository } from '@/lib/db/queries/event'
 import { UserRepository } from '@/lib/db/queries/user'
 import { buildClobHmacSignature } from '@/lib/hmac'
+import { TRADING_AUTH_REQUIRED_ERROR } from '@/lib/trading-auth/errors'
 import { getUserTradingAuthSecrets } from '@/lib/trading-auth/server'
 
 const CLOB_URL = process.env.CLOB_URL
@@ -59,7 +60,7 @@ export async function GET(
 
     const tradingAuth = await getUserTradingAuthSecrets(user.id)
     if (!tradingAuth?.clob) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ error: TRADING_AUTH_REQUIRED_ERROR }, { status: 401 })
     }
 
     const { searchParams } = new URL(request.url)
@@ -86,6 +87,7 @@ export async function GET(
 
     const { data: clobOrders, next_cursor } = await fetchClobOpenOrders({
       market: conditionId,
+      makerAddress: user.deposit_wallet_address ?? undefined,
       userAddress: user.address,
       auth: tradingAuth.clob,
       nextCursor,
@@ -146,11 +148,13 @@ function buildMarketLookups(markets: Array<{
 
 async function fetchClobOpenOrders({
   market,
+  makerAddress,
   auth,
   userAddress,
   nextCursor,
 }: {
   market?: string
+  makerAddress?: string
   auth: { key: string, secret: string, passphrase: string }
   userAddress: string
   nextCursor?: string
@@ -162,6 +166,9 @@ async function fetchClobOpenOrders({
   const searchParams = new URLSearchParams()
   if (market) {
     searchParams.set('market', market)
+  }
+  if (makerAddress) {
+    searchParams.set('maker_address', makerAddress)
   }
   if (nextCursor) {
     searchParams.set('next_cursor', nextCursor)

--- a/src/app/api/open-orders/route.ts
+++ b/src/app/api/open-orders/route.ts
@@ -15,6 +15,7 @@ import { runQuery } from '@/lib/db/utils/run-query'
 import { db } from '@/lib/drizzle'
 import { buildClobHmacSignature } from '@/lib/hmac'
 import { getPublicAssetUrl } from '@/lib/storage'
+import { TRADING_AUTH_REQUIRED_ERROR } from '@/lib/trading-auth/errors'
 import { getUserTradingAuthSecrets } from '@/lib/trading-auth/server'
 
 const CLOB_URL = process.env.CLOB_URL
@@ -51,7 +52,7 @@ export async function GET(request: Request) {
 
     const tradingAuth = await getUserTradingAuthSecrets(user.id)
     if (!tradingAuth?.clob) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ error: TRADING_AUTH_REQUIRED_ERROR }, { status: 401 })
     }
 
     const { searchParams } = new URL(request.url)
@@ -115,7 +116,7 @@ async function fetchClobOpenOrders({
 }): Promise<{ data: ClobOpenOrder[], next_cursor: string }> {
   const params = new URLSearchParams()
   if (makerAddress) {
-    params.set('maker', makerAddress)
+    params.set('maker_address', makerAddress)
   }
   if (id) {
     params.set('id', id)

--- a/src/lib/community-auth.ts
+++ b/src/lib/community-auth.ts
@@ -1,6 +1,8 @@
 const STORAGE_KEY = 'community_auth'
+const STORAGE_VERSION = 2
 
 interface StoredCommunityAuth {
+  version?: number
   token: string
   address: string
   expires_at: string
@@ -63,6 +65,10 @@ export function loadCommunityAuth(address?: string) {
   try {
     const parsed = JSON.parse(raw) as StoredCommunityAuth
     if (!parsed?.token || !parsed?.address || !parsed?.expires_at) {
+      return null
+    }
+    if (parsed.version !== STORAGE_VERSION) {
+      window.localStorage.removeItem(STORAGE_KEY)
       return null
     }
     if (address && parsed.address.toLowerCase() !== address.toLowerCase()) {
@@ -147,6 +153,7 @@ export async function ensureCommunityToken({
   const verifyPayload = await verifyResponse.json() as AuthVerifyResponse
 
   storeCommunityAuth({
+    version: STORAGE_VERSION,
     token: verifyPayload.token,
     address,
     expires_at: verifyPayload.expires_at,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore deposit wallet open orders by sending the correct `maker_address` to the CLOB API and enforcing trading auth, with a one-time UI prompt when auth is missing. Also resolves ESLint warnings in the portfolio open orders list.

- **Bug Fixes**
  - Use `maker_address` and pass the deposit wallet to CLOB in both open-orders endpoints; events API filters by `maker_address`.
  - Return 401 with `TRADING_AUTH_REQUIRED_ERROR` when trading auth is missing.
  - Portfolio open orders list detects this error and prompts once for trading auth.
  - Versioned community auth storage (`v2`); invalidate old entries.
  - Resolve ESLint warnings in `PortfolioOpenOrdersList`.

<sup>Written for commit 584dbe9ddc6f9b37e37b159a0be65b1fc85563f2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

