### PR TITLE
fix: prerender shell warnings on build

### DIFF
--- a/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
+++ b/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
@@ -18,8 +18,7 @@ import {
   UnplugIcon,
 } from 'lucide-react'
 import { useExtracted, useLocale } from 'next-intl'
-import dynamic from 'next/dynamic'
-import { useEffect, useState } from 'react'
+import { lazy, Suspense, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import SearchDiscoveryContent from '@/app/[locale]/(platform)/_components/SearchDiscoveryContent'
 import { MOBILE_BOTTOM_NAV_OFFSET } from '@/app/[locale]/(platform)/_lib/mobile-bottom-nav'
@@ -43,15 +42,8 @@ import { cn } from '@/lib/utils'
 import { usePortfolioValueVisibility } from '@/stores/usePortfolioValueVisibility'
 import { useUser } from '@/stores/useUser'
 
-const HeaderSearch = dynamic(
-  () => import('@/app/[locale]/(platform)/_components/HeaderSearch'),
-  { ssr: false },
-)
-
-const HowItWorks = dynamic(
-  () => import('@/app/[locale]/(platform)/_components/HowItWorks'),
-  { ssr: false },
-)
+const HeaderSearch = lazy(() => import('@/app/[locale]/(platform)/_components/HeaderSearch'))
+const HowItWorks = lazy(() => import('@/app/[locale]/(platform)/_components/HowItWorks'))
 
 const { useSession } = authClient
 
@@ -200,14 +192,18 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
     <>
       <div aria-hidden="true" className="lg:hidden" style={{ height: MOBILE_BOTTOM_NAV_OFFSET }} />
 
-      <div className="lg:hidden">
-        <HowItWorks
-          open={isHowItWorksOpen}
-          onOpenChange={setIsHowItWorksOpen}
-          hideTrigger
-          displayMode="mobile"
-        />
-      </div>
+      {isHowItWorksOpen && (
+        <div className="lg:hidden">
+          <Suspense fallback={null}>
+            <HowItWorks
+              open={isHowItWorksOpen}
+              onOpenChange={setIsHowItWorksOpen}
+              hideTrigger
+              displayMode="mobile"
+            />
+          </Suspense>
+        </div>
+      )}
 
       <Drawer
         open={isSearchOpen}
@@ -226,12 +222,16 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
             <DrawerTitle>{t('Search')}</DrawerTitle>
           </DrawerHeader>
           <div className="mt-4">
-            <HeaderSearch
-              onNavigate={handleSearchNavigate}
-              onPredictionResultsNavigate={handlePredictionResultsNavigate}
-              emptyState={<SearchDiscoveryContent onNavigate={handleSearchNavigate} />}
-              focusTrigger={searchFocusTrigger}
-            />
+            {isSearchOpen && (
+              <Suspense fallback={null}>
+                <HeaderSearch
+                  onNavigate={handleSearchNavigate}
+                  onPredictionResultsNavigate={handlePredictionResultsNavigate}
+                  emptyState={<SearchDiscoveryContent onNavigate={handleSearchNavigate} />}
+                  focusTrigger={searchFocusTrigger}
+                />
+              </Suspense>
+            )}
           </div>
         </DrawerContent>
       </Drawer>

--- a/src/providers/AppKitProvider.tsx
+++ b/src/providers/AppKitProvider.tsx
@@ -9,11 +9,11 @@ import { createAppKit, useAppKitTheme } from '@reown/appkit/react'
 import { generateRandomString } from 'better-auth/crypto'
 import { useExtracted } from 'next-intl'
 import { useTheme } from 'next-themes'
-import dynamic from 'next/dynamic'
-import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { lazy, Suspense, useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { toast } from 'sonner'
 import { WagmiProvider } from 'wagmi'
 import { AppKitContext, defaultAppKitValue } from '@/hooks/useAppKit'
+import { useHasHydrated } from '@/hooks/useHasHydrated'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import { defaultNetwork, networks, wagmiAdapter, wagmiConfig } from '@/lib/appkit'
 import { authClient } from '@/lib/auth-client'
@@ -27,10 +27,10 @@ let appKitInstance: AppKit | null = null
 const appKitStateListeners = new Set<() => void>()
 const APPKIT_INIT_RETRY_DELAY_MS = 3000
 
-const SignaturePrompt = dynamic(
-  () => import('@/components/SignaturePrompt').then(mod => mod.SignaturePrompt),
-  { ssr: false },
-)
+const SignaturePrompt = lazy(async () => {
+  const mod = await import('@/components/SignaturePrompt')
+  return { default: mod.SignaturePrompt }
+})
 
 function clearAppKitState() {
   if (!IS_BROWSER) {
@@ -308,6 +308,7 @@ function useAppKitContextValue({
 export default function AppKitProvider({ children }: { children: ReactNode }) {
   const t = useExtracted()
   const site = useSiteIdentity()
+  const hasHydrated = useHasHydrated()
   const currentUser = useUser()
   const resolvedTheme = useResolvedThemeMode()
   const appKitThemeMode: 'light' | 'dark' = resolvedTheme === 'dark' ? 'dark' : 'light'
@@ -328,7 +329,11 @@ export default function AppKitProvider({ children }: { children: ReactNode }) {
     <WagmiProvider config={wagmiConfig}>
       <AppKitContext value={appKitValue}>
         {children}
-        <SignaturePrompt />
+        {hasHydrated && (
+          <Suspense fallback={null}>
+            <SignaturePrompt />
+          </Suspense>
+        )}
         {canSyncTheme && <AppKitThemeSynchronizer themeMode={appKitThemeMode} />}
       </AppKitContext>
     </WagmiProvider>

--- a/src/providers/AppProviders.tsx
+++ b/src/providers/AppProviders.tsx
@@ -4,17 +4,18 @@ import type { ReactNode } from 'react'
 import { GoogleAnalytics } from '@next/third-parties/google'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ThemeProvider } from 'next-themes'
-import dynamic from 'next/dynamic'
+import { lazy, Suspense } from 'react'
 import { Toaster } from '@/components/ui/sonner'
+import { useHasHydrated } from '@/hooks/useHasHydrated'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import ProgressIndicatorProvider from '@/providers/ProgressIndicatorProvider'
 
 const SpeedInsights = process.env.IS_VERCEL === 'true'
-  ? dynamic(
-      () => import('@vercel/speed-insights/next').then(mod => mod.SpeedInsights),
-      { ssr: false },
-    )
-  : () => null
+  ? lazy(async () => {
+      const mod = await import('@vercel/speed-insights/next')
+      return { default: mod.SpeedInsights }
+    })
+  : null
 
 const queryClient = new QueryClient()
 
@@ -24,13 +25,19 @@ interface AppProvidersProps {
 
 export function AppProviders({ children }: AppProvidersProps) {
   const site = useSiteIdentity()
+  const hasHydrated = useHasHydrated()
   const gaId = site.googleAnalyticsId
+  const shouldRenderSpeedInsights = process.env.NODE_ENV === 'production' && hasHydrated
 
   const content = (
     <div className="min-h-screen bg-background">
       {children}
       <Toaster position="bottom-left" />
-      {process.env.NODE_ENV === 'production' && <SpeedInsights />}
+      {shouldRenderSpeedInsights && SpeedInsights && (
+        <Suspense fallback={null}>
+          <SpeedInsights />
+        </Suspense>
+      )}
       {process.env.NODE_ENV === 'production' && gaId && <GoogleAnalytics gaId={gaId} />}
     </div>
   )

--- a/src/providers/ProgressIndicatorProvider.tsx
+++ b/src/providers/ProgressIndicatorProvider.tsx
@@ -2,17 +2,23 @@
 
 import type { ReactNode } from 'react'
 import { ProgressProvider } from '@bprogress/next/app'
+import { useHasHydrated } from '@/hooks/useHasHydrated'
 
 function ProgressIndicatorProvider({ children }: { children: ReactNode }) {
+  const hasHydrated = useHasHydrated()
+
   return (
-    <ProgressProvider
-      height="2px"
-      color="var(--primary)"
-      options={{ showSpinner: false }}
-      shallowRouting
-    >
+    <>
       {children}
-    </ProgressProvider>
+      {hasHydrated && (
+        <ProgressProvider
+          height="2px"
+          color="var(--primary)"
+          options={{ showSpinner: false }}
+          shallowRouting
+        />
+      )}
+    </>
   )
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix prerender shell warnings by moving client-only components to React `lazy` + `Suspense` and deferring mounts until after hydration. This removes build-time noise and avoids SSR mismatch without changing UX.

- **Bug Fixes**
  - Replaced `next/dynamic` with React `lazy` + `Suspense` for `HeaderSearch`, `HowItWorks`, `SignaturePrompt`, and `@vercel/speed-insights/next`.
  - Gated rendering by state and hydration:
    - Only mount `HowItWorks` and `HeaderSearch` when open, wrapped in `Suspense`.
    - Added `useHasHydrated` to mount `SignaturePrompt`, `SpeedInsights`, and `ProgressProvider` only after hydration.
  - Updated `ProgressIndicatorProvider` to render `@bprogress/next/app` after hydration to prevent SSR mismatches.

<sup>Written for commit 686d5e3eeb5fe1d526734d30760a4304047eb738. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1005?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

