### PR TITLE
refactor: unify timeout abort signal usage

### DIFF
--- a/src/app/[locale]/admin/events/calendar/_components/admin-create-event-form-utils.ts
+++ b/src/app/[locale]/admin/events/calendar/_components/admin-create-event-form-utils.ts
@@ -303,26 +303,27 @@ export async function fetchAdminApi(pathname: string, init?: RequestInit) {
   return fetch(`/${maybeLocale}/admin/api${normalizedPath}`, init)
 }
 
+function isAbortException(error: unknown) {
+  return error instanceof DOMException && (error.name === 'AbortError' || error.name === 'TimeoutError')
+}
+
 export async function fetchAdminApiWithTimeout(pathname: string, timeoutMs: number, init?: RequestInit) {
-  const controller = new AbortController()
-  const timeoutId = window.setTimeout(() => {
-    controller.abort()
-  }, timeoutMs)
+  const timeoutSignal = AbortSignal.timeout(timeoutMs)
+  const requestSignal = init?.signal
+    ? AbortSignal.any([init.signal, timeoutSignal])
+    : timeoutSignal
 
   try {
     return await fetchAdminApi(pathname, {
       ...init,
-      signal: controller.signal,
+      signal: requestSignal,
     })
   }
   catch (error) {
-    if (error instanceof DOMException && error.name === 'AbortError') {
+    if (requestSignal.reason === timeoutSignal.reason && isAbortException(error)) {
       throw new Error('Request timed out. Try again in a few moments.')
     }
     throw error
-  }
-  finally {
-    window.clearTimeout(timeoutId)
   }
 }
 

--- a/src/lib/operator-domain-register.ts
+++ b/src/lib/operator-domain-register.ts
@@ -47,9 +47,6 @@ export async function reportOperatorDomainSnapshot() {
     return
   }
 
-  const controller = new AbortController()
-  const timeout = setTimeout(() => controller.abort(), REQUEST_TIMEOUT_MS)
-
   try {
     const response = await fetch(endpoint, {
       method: 'POST',
@@ -60,7 +57,7 @@ export async function reportOperatorDomainSnapshot() {
         url: siteUrl,
       }),
       cache: 'no-store',
-      signal: controller.signal,
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
     })
 
     if (!response.ok) {
@@ -75,8 +72,5 @@ export async function reportOperatorDomainSnapshot() {
       '[operator-domain-register] Failed to report domain snapshot.',
       error instanceof Error ? error.message : error,
     )
-  }
-  finally {
-    clearTimeout(timeout)
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unifies fetch timeout handling by switching to `AbortSignal.timeout(...)` and composing with `AbortSignal.any(...)`, removing manual timers and improving timeout error messages.

- **Refactors**
  - Replaced `AbortController` + `setTimeout` with `AbortSignal.timeout(...)`.
  - Combined request and timeout signals in `fetchAdminApiWithTimeout` using `AbortSignal.any(...)`.
  - Added `isAbortException` and stricter timeout detection to show the timeout message only on real timeouts.
  - Simplified operator domain reporting to use a timeout signal and removed manual cleanup.

<sup>Written for commit 641a545949bdffa8b629305cc5d9b7131c49be75. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1007?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

