### PR TITLE
refactor: cutover remaining proxy wallet mentions

### DIFF
--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -2041,7 +2041,7 @@
           "userAddress": {
             "type": "string"
           },
-          "proxyAddress": {
+          "depositWallet": {
             "type": "string",
             "nullable": true
           },
@@ -2111,7 +2111,7 @@
           "userAddress": {
             "type": "string"
           },
-          "proxyAddress": {
+          "depositWallet": {
             "type": "string",
             "nullable": true
           },

--- a/docs/api-reference/schemas/openapi-data-api.json
+++ b/docs/api-reference/schemas/openapi-data-api.json
@@ -152,7 +152,7 @@
                   "sample": {
                     "value": [
                       {
-                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                         "conditionId": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917",
                         "size": 1185.42,
@@ -180,7 +180,7 @@
                         "negativeRisk": true
                       },
                       {
-                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "asset": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5:1",
                         "conditionId": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5",
                         "size": 940.11,
@@ -375,7 +375,7 @@
                   "sample": {
                     "value": [
                       {
-                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                         "conditionId": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917",
                         "size": 610.2,
@@ -402,7 +402,7 @@
                         "endDate": "2024-09-18T18:00:00Z"
                       },
                       {
-                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "asset": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5:1",
                         "conditionId": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5",
                         "size": 980.5,
@@ -722,7 +722,7 @@
                         "token": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                         "holders": [
                           {
-                            "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                            "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                             "bio": "Macro strategist backing major economic events.",
                             "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                             "pseudonym": "macro.whale",
@@ -734,7 +734,7 @@
                             "profileImageOptimized": "https://cdn.domain.com/users/macro-whale@2x.jpg"
                           },
                           {
-                            "proxyWallet": "0x94d37B9c164888FbA4d4b3D4639a65f8AC54a1B6",
+                            "depositWallet": "0x94d37B9c164888FbA4d4b3D4639a65f8AC54a1B6",
                             "bio": "On-chain analyst seeding liquidity.",
                             "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                             "pseudonym": "liquidity.lab",
@@ -861,7 +861,7 @@
                   "sample": {
                     "value": [
                       {
-                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "timestamp": 1718125200,
                         "conditionId": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917",
                         "type": "TRADE",
@@ -884,7 +884,7 @@
                         "profileImageOptimized": "https://cdn.domain.com/users/macro-whale@2x.jpg"
                       },
                       {
-                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "timestamp": 1717664400,
                         "conditionId": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5",
                         "type": "TRADE",
@@ -1076,7 +1076,7 @@
                   "sample": {
                     "value": [
                       {
-                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "side": "BUY",
                         "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                         "conditionId": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917",
@@ -1098,7 +1098,7 @@
                         "transactionHash": "0xa8b1be184ad6b5a219d121935e7b4f6a1cb5df38e7b74d2880aed672541da831"
                       },
                       {
-                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "side": "SELL",
                         "asset": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5:1",
                         "conditionId": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5",
@@ -1666,7 +1666,7 @@
                     "value": [
                       {
                         "rank": "1",
-                        "proxyWallet": "0x1234567890abcdef1234567890abcdef12345678",
+                        "depositWallet": "0x1234567890abcdef1234567890abcdef12345678",
                         "userName": "Theo4",
                         "vol": 22862194,
                         "pnl": 8499002,
@@ -1805,7 +1805,7 @@
       "Position": {
         "type": "object",
         "properties": {
-          "proxyWallet": {
+          "depositWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "asset": {
@@ -1890,7 +1890,7 @@
       "ClosedPosition": {
         "type": "object",
         "properties": {
-          "proxyWallet": {
+          "depositWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "asset": {
@@ -2043,7 +2043,7 @@
       "Activity": {
         "type": "object",
         "properties": {
-          "proxyWallet": {
+          "depositWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "conditionId": {
@@ -2148,7 +2148,7 @@
       "Trade": {
         "type": "object",
         "properties": {
-          "proxyWallet": {
+          "depositWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "side": {
@@ -2259,7 +2259,7 @@
       "Holder": {
         "type": "object",
         "properties": {
-          "proxyWallet": {
+          "depositWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "bio": {
@@ -2302,7 +2302,7 @@
           "rank": {
             "type": "string"
           },
-          "proxyWallet": {
+          "depositWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "userName": {
@@ -2335,7 +2335,7 @@
           "winRank": {
             "type": "string"
           },
-          "proxyWallet": {
+          "depositWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "userName": {

--- a/docs/api-reference/wss/sports.mdx
+++ b/docs/api-reference/wss/sports.mdx
@@ -39,7 +39,7 @@ Send any variant of `PING` (`ping`, `PiNg`, `PING`). The server replies with `PO
   "topic": "activity",
   "type": "orders_matched",
   "payload": {
-    "proxyWallet": "0xe25b9180f5687aa85bd94ee309bb72a464320f1b",
+    "depositWallet": "0xe25b9180f5687aa85bd94ee309bb72a464320f1b",
     "creator": "0x8f2a6db31d2f3f3c8e4f9e74d5f5f9d2a7b0c123",
     "transactionHash": "0xdeadbeef",
     "eventSlug": "x-banned-in-uk-by-march-31"

--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -340,7 +340,7 @@ function useLiveActivityStream({
 
         const hasTitle = hasText(rawPayload.title)
         const hasMarketSlug = hasText(rawPayload.slug)
-        const hasUser = hasText(rawPayload.pseudonym) || hasText(rawPayload.name) || hasText(rawPayload.proxyWallet)
+        const hasUser = hasText(rawPayload.pseudonym) || hasText(rawPayload.name) || hasText(rawPayload.depositWallet)
         const hasSide = hasText(rawPayload.side)
         const hasOutcomeText = hasText(rawPayload.outcome)
         const hasOutcomeIndex = typeof rawPayload.outcomeIndex === 'number'

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
@@ -144,7 +144,7 @@ export default function EventCommentItem({
           image: comment.user_avatar,
           username: displayName,
           address: comment.user_address,
-          deposit_wallet_address: comment.user_proxy_wallet_address ?? null,
+          deposit_wallet_address: comment.user_deposit_wallet_address ?? null,
         }}
         profileSlug={profileSlug}
         date={comment.created_at}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
@@ -140,7 +140,7 @@ export default function EventCommentReplyItem({
           image: reply.user_avatar,
           username: displayName,
           address: reply.user_address,
-          deposit_wallet_address: reply.user_proxy_wallet_address ?? null,
+          deposit_wallet_address: reply.user_deposit_wallet_address ?? null,
         }}
         profileSlug={profileSlug}
         date={reply.created_at}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/comment-user.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/comment-user.ts
@@ -1,7 +1,7 @@
 import type { Comment } from '@/types'
 import { truncateAddress } from '@/lib/formatters'
 
-type CommentUser = Pick<Comment, 'username' | 'user_proxy_wallet_address' | 'user_address'>
+type CommentUser = Pick<Comment, 'username' | 'user_deposit_wallet_address' | 'user_address'>
 
 function normalizeUsername(value?: string | null) {
   return typeof value === 'string' ? value.trim() : ''
@@ -9,7 +9,7 @@ function normalizeUsername(value?: string | null) {
 
 export function resolveCommentUserIdentity(comment: CommentUser) {
   const username = normalizeUsername(comment.username)
-  const address = comment.user_proxy_wallet_address ?? comment.user_address ?? ''
+  const address = comment.user_deposit_wallet_address ?? comment.user_address ?? ''
   const displayName = username || (address ? truncateAddress(address) : 'Anonymous')
   const profileSlug = username || address
 

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useInfiniteComments.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useInfiniteComments.ts
@@ -200,7 +200,7 @@ export function useInfiniteComments(
         username: user.username || 'Anonymous',
         user_avatar: user.image || '',
         user_address: user.address || '0x0000...0000',
-        user_proxy_wallet_address: user.deposit_wallet_address || null,
+        user_deposit_wallet_address: user.deposit_wallet_address || null,
         likes_count: 0,
         replies_count: 0,
         created_at: new Date().toISOString(),

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
@@ -8,10 +8,10 @@ import { createWebSocketReconnectController } from '@/lib/websocket-reconnect'
 
 interface LiveCommentProfile {
   baseAddress?: string
+  depositWallet?: string
   displayUsernamePublic?: boolean
   name?: string
   profileImage?: string
-  proxyWallet?: string
   pseudonym?: string
 }
 
@@ -56,7 +56,7 @@ function buildLiveComment(payload: LiveCommentPayload, user: User | null): Comme
     username,
     user_avatar: profileImage,
     user_address: userAddress,
-    user_proxy_wallet_address: profile.proxyWallet ?? null,
+    user_deposit_wallet_address: profile.depositWallet ?? null,
     likes_count: Number(payload.reactionCount ?? 0),
     replies_count: 0,
     created_at: createdAt,

--- a/src/app/[locale]/(platform)/leaderboard/_components/BiggestWinsSidebar.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/BiggestWinsSidebar.tsx
@@ -40,7 +40,7 @@ export default function BiggestWinsSidebar({
           {isBiggestWinsLoading && <BiggestWinsSkeleton count={6} />}
 
           {!isBiggestWinsLoading && biggestWins.map((entry, index) => (
-            <BiggestWinRow key={`${(entry as Record<string, unknown>).proxyWallet || (entry as Record<string, unknown>).userName || ''}-${entry.winRank ?? entry.rank ?? index}`} entry={entry} index={index} />
+            <BiggestWinRow key={`${entry.depositWallet || entry.userName || ''}-${entry.winRank ?? entry.rank ?? index}`} entry={entry} index={index} />
           ))}
         </div>
       </div>
@@ -52,11 +52,13 @@ function BiggestWinRow({ entry, index }: { entry: BiggestWinEntry, index: number
   const record = entry as Record<string, unknown>
   const rank = entry.winRank ?? entry.rank ?? index + 1
   const address = resolveString(record, [
-    'user.proxyWallet',
-    'user.proxy_wallet',
+    'user.depositWallet',
+    'user.deposit_wallet',
+    'user.deposit_wallet_address',
     'user.address',
-    'proxyWallet',
-    'proxy_wallet',
+    'depositWallet',
+    'deposit_wallet',
+    'deposit_wallet_address',
     'address',
     'walletAddress',
     'wallet',

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
@@ -306,9 +306,9 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
     }
 
     const normalizedUserAddress = normalizeWalletAddress(userAddress)
-    const visibleEntry = entries.find(entry => normalizeWalletAddress(entry.proxyWallet) === normalizedUserAddress)
+    const visibleEntry = entries.find(entry => normalizeWalletAddress(entry.depositWallet) === normalizedUserAddress)
     const sourceEntry = visibleEntry ?? userEntry
-    const address = sourceEntry?.proxyWallet || userAddress
+    const address = sourceEntry?.depositWallet || userAddress
     const rawUsername = sourceEntry?.userName || sourceEntry?.xUsername || user?.username || ''
     const username = rawUsername || address
     const rankNumber = Number(sourceEntry?.rank ?? Number.NaN)
@@ -364,7 +364,7 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
 
               {!isLoading && entries.map((entry, index) => (
                 <LeaderboardListRow
-                  key={`${entry.proxyWallet || entry.userName || entry.xUsername || ''}-${entry.rank ?? index + 1}`}
+                  key={`${entry.depositWallet || entry.userName || entry.xUsername || ''}-${entry.rank ?? index + 1}`}
                   entry={entry}
                   index={index}
                   filters={filters}

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardListRow.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardListRow.tsx
@@ -30,7 +30,7 @@ export default function LeaderboardListRow({
   volumeColumnClass,
 }: LeaderboardListRowProps) {
   const rank = entry.rank ?? index + 1
-  const address = entry.proxyWallet || ''
+  const address = entry.depositWallet || ''
   const rawUsername = entry.userName || entry.xUsername || ''
   const isWalletAlias = rawUsername.startsWith('0x') && rawUsername.includes('...')
   const username = (isWalletAlias && address ? address : rawUsername) || address || ''

--- a/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi.ts
+++ b/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi.ts
@@ -177,7 +177,7 @@ export async function hydrateEntriesWithPortfolioPnl(
   const addresses = Array.from(
     new Set(
       entries
-        .map(entry => normalizeWalletAddress(entry.proxyWallet))
+        .map(entry => normalizeWalletAddress(entry.depositWallet))
         .filter(address => address.length > 0),
     ),
   )
@@ -193,7 +193,7 @@ export async function hydrateEntriesWithPortfolioPnl(
   }
 
   return entries.map((entry) => {
-    const address = normalizeWalletAddress(entry.proxyWallet)
+    const address = normalizeWalletAddress(entry.depositWallet)
     const pnl = pnlByAddress.get(address)
     if (typeof pnl !== 'number') {
       return entry
@@ -218,7 +218,7 @@ export function sortEntriesForDisplay(
       return rightPnl - leftPnl
     }
 
-    return normalizeWalletAddress(left.proxyWallet).localeCompare(normalizeWalletAddress(right.proxyWallet))
+    return normalizeWalletAddress(left.depositWallet).localeCompare(normalizeWalletAddress(right.depositWallet))
   })
 
   const rankOffset = (page - 1) * PAGE_SIZE

--- a/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes.ts
+++ b/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes.ts
@@ -1,6 +1,6 @@
 export interface LeaderboardEntry {
   rank?: number | string
-  proxyWallet?: string
+  depositWallet?: string
   userName?: string
   vol?: number
   pnl?: number
@@ -12,7 +12,7 @@ export interface LeaderboardEntry {
 export interface BiggestWinEntry {
   rank?: number | string
   winRank?: number | string
-  proxyWallet?: string
+  depositWallet?: string
   userName?: string
   profileImage?: string
   xUsername?: string

--- a/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
+++ b/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
@@ -6,7 +6,7 @@ import { MICRO_UNIT, OUTCOME_INDEX } from '@/lib/constants'
 import { formatCurrency } from '@/lib/formatters'
 
 export interface DataApiPosition {
-  proxyWallet?: string
+  depositWallet?: string
   asset?: string
   conditionId?: string
   size?: number

--- a/src/app/api/event-activity/route.ts
+++ b/src/app/api/event-activity/route.ts
@@ -11,7 +11,7 @@ import { normalizeAddress } from '@/lib/wallet'
 const DATA_API_URL = process.env.DATA_URL!
 
 interface DataApiActivity {
-  proxyWallet?: string
+  depositWallet?: string
   timestamp?: number
   conditionId?: string
   type?: string
@@ -115,7 +115,7 @@ export async function GET(request: Request) {
 
       for (const profile of profiles || []) {
         const normalizedAddress = normalizeAddress(profile.address)?.toLowerCase()
-        const normalizedProxy = normalizeAddress(profile.deposit_wallet_address)?.toLowerCase()
+        const normalizedDepositWallet = normalizeAddress(profile.deposit_wallet_address)?.toLowerCase()
         const imageUrl = normalizeAvatarUrl(profile.image)
 
         const createdAt = profile.created_at
@@ -125,8 +125,8 @@ export async function GET(request: Request) {
         if (normalizedAddress) {
           profileLookup.set(normalizedAddress, { username: profile.username, image: imageUrl, created_at: createdAt })
         }
-        if (normalizedProxy) {
-          profileLookup.set(normalizedProxy, { username: profile.username, image: imageUrl, created_at: createdAt })
+        if (normalizedDepositWallet) {
+          profileLookup.set(normalizedDepositWallet, { username: profile.username, image: imageUrl, created_at: createdAt })
         }
       }
     }

--- a/src/app/api/holders/route.ts
+++ b/src/app/api/holders/route.ts
@@ -56,10 +56,10 @@ export async function GET(request: Request) {
     const addressSet = new Set<string>()
     function collectAddresses(holders: Holder[]) {
       holders.forEach(({ user }) => {
-        const proxy = normalizeAddressKey(user.deposit_wallet_address)
+        const depositWallet = normalizeAddressKey(user.deposit_wallet_address)
 
-        if (proxy) {
-          addressSet.add(proxy)
+        if (depositWallet) {
+          addressSet.add(depositWallet)
         }
       })
     }
@@ -79,7 +79,7 @@ export async function GET(request: Request) {
       for (const profile of profiles || []) {
         const fallbackAddress = profile.deposit_wallet_address ?? profile.address
         const normalizedAddress = normalizeAddressKey(profile.address)
-        const normalizedProxyAddress = normalizeAddressKey(profile.deposit_wallet_address)
+        const normalizedDepositWalletAddress = normalizeAddressKey(profile.deposit_wallet_address)
         const imageUrl = normalizeAvatarUrl(profile.image)
         const createdAt = profile.created_at
           ? new Date(profile.created_at).toISOString()
@@ -95,8 +95,8 @@ export async function GET(request: Request) {
         if (normalizedAddress) {
           profileLookup.set(normalizedAddress, profileData)
         }
-        if (normalizedProxyAddress) {
-          profileLookup.set(normalizedProxyAddress, profileData)
+        if (normalizedDepositWalletAddress) {
+          profileLookup.set(normalizedDepositWalletAddress, profileData)
         }
       }
     }

--- a/src/app/api/og/leaderboard/route.tsx
+++ b/src/app/api/og/leaderboard/route.tsx
@@ -230,7 +230,7 @@ async function fetchLeaderboardRows({
       const name = normalizeText(
         resolveString(entry, ['userName', 'username', 'xUsername']),
         28,
-      ) ?? normalizeText(truncateAddress(resolveString(entry, ['proxyWallet', 'deposit_wallet_address'])), 28)
+      ) ?? normalizeText(truncateAddress(resolveString(entry, ['depositWallet', 'deposit_wallet_address'])), 28)
       ?? `Trader ${index + 1}`
 
       const pnl = parseNumber(entry.pnl)

--- a/src/lib/data-api/holders.ts
+++ b/src/lib/data-api/holders.ts
@@ -1,7 +1,7 @@
 import { buildDataApiUrl } from '@/lib/data-api/client'
 
 interface DataApiHolder {
-  proxyWallet: string
+  depositWallet: string
   amount: number
   outcomeIndex?: number
   asset?: string
@@ -52,7 +52,7 @@ export interface TopHoldersResult {
 }
 
 function mapHolder(holder: DataApiHolder, outcomeHint: 'yes' | 'no' | null) {
-  const address = holder.proxyWallet
+  const address = holder.depositWallet
   const outcomeIndex = outcomeHint
     ? (outcomeHint === 'yes' ? 0 : 1)
     : (typeof holder.outcomeIndex === 'number' ? holder.outcomeIndex : 0)

--- a/src/lib/data-api/user.ts
+++ b/src/lib/data-api/user.ts
@@ -9,7 +9,7 @@ interface DataApiRequestParams {
 }
 
 export interface DataApiActivity {
-  proxyWallet?: string
+  depositWallet?: string
   timestamp?: number
   conditionId?: string
   type?: string
@@ -33,7 +33,7 @@ export interface DataApiActivity {
 }
 
 export interface DataApiPosition {
-  proxyWallet?: string
+  depositWallet?: string
   asset?: string
   conditionId?: string
   size?: number
@@ -206,7 +206,7 @@ export function mapDataApiActivityToActivityOrder(activity: DataApiActivity): Ac
     ? 'Yes / No'
     : (activity.outcome || 'Outcome')
   const outcomeIndex = isSplit ? undefined : activity.outcomeIndex ?? 0
-  const address = activity.proxyWallet || ''
+  const address = activity.depositWallet || ''
   const displayName = activity.pseudonym || activity.name || address || 'Trader'
   const avatarUrl = activity.profileImageOptimized
     || activity.profileImage

--- a/src/lib/db/queries/user.ts
+++ b/src/lib/db/queries/user.ts
@@ -11,7 +11,6 @@ import { runQuery } from '@/lib/db/utils/run-query'
 import { isDepositWalletDeployed } from '@/lib/deposit-wallet'
 import { db } from '@/lib/drizzle'
 import { getPublicAssetUrl } from '@/lib/storage'
-import { sanitizeTradingAuthSettings } from '@/lib/trading-auth/utils'
 import { normalizeAddress } from '@/lib/wallet'
 
 export const UserRepository = {
@@ -208,13 +207,6 @@ export const UserRepository = {
       }
 
       const user: any = session.user
-      const rawEmail = typeof user.email === 'string' ? user.email : ''
-      const shouldRedactEmail = Boolean(rawEmail && rawEmail.startsWith('0x') && rawEmail.split('@')[0].length === 42)
-
-      user.email = shouldRedactEmail ? '' : rawEmail
-      if (user.settings) {
-        user.settings = sanitizeTradingAuthSettings(user.settings)
-      }
 
       if (minimal) {
         return user
@@ -232,29 +224,7 @@ export const UserRepository = {
         }
       }
 
-      const depositWalletAddress = await ensureUserDepositWallet(user)
-
-      if (depositWalletAddress && !user.username) {
-        const generatedUsername = generateUsername(depositWalletAddress)
-
-        if (generatedUsername) {
-          try {
-            const result = await db
-              .update(users)
-              .set({ username: generatedUsername })
-              .where(eq(users.id, user.id))
-              .returning({ username: users.username })
-
-            const updatedUsername = result[0]?.username
-            if (updatedUsername) {
-              user.username = updatedUsername
-            }
-          }
-          catch (error) {
-            console.error('Failed to set deterministic username', error)
-          }
-        }
-      }
+      await ensureUserDepositWallet(user)
 
       return user
     }
@@ -428,12 +398,6 @@ export const UserRepository = {
       return { data: result, error: null }
     })
   },
-}
-
-function generateUsername(depositWalletAddress: string) {
-  const timestamp = Date.now()
-
-  return `${depositWalletAddress}-${timestamp}`
 }
 
 async function ensureUserDepositWallet(user: any): Promise<string | null> {

--- a/src/lib/db/queries/user.ts
+++ b/src/lib/db/queries/user.ts
@@ -232,10 +232,10 @@ export const UserRepository = {
         }
       }
 
-      const proxyAddress = await ensureUserDepositWallet(user)
+      const depositWalletAddress = await ensureUserDepositWallet(user)
 
-      if (proxyAddress && !user.username) {
-        const generatedUsername = generateUsername(proxyAddress)
+      if (depositWalletAddress && !user.username) {
+        const generatedUsername = generateUsername(depositWalletAddress)
 
         if (generatedUsername) {
           try {
@@ -403,8 +403,8 @@ export const UserRepository = {
 
     return await runQuery(async () => {
       const addressClauses = normalizedAddresses.map(addr => eq(sql`LOWER(${users.address})`, addr))
-      const proxyClauses = normalizedAddresses.map(addr => eq(sql`LOWER(${users.deposit_wallet_address})`, addr))
-      const whereConditions = [...addressClauses, ...proxyClauses].filter(Boolean)
+      const depositWalletClauses = normalizedAddresses.map(addr => eq(sql`LOWER(${users.deposit_wallet_address})`, addr))
+      const whereConditions = [...addressClauses, ...depositWalletClauses].filter(Boolean)
       const whereClause = whereConditions.length > 1
         ? or(...whereConditions)
         : whereConditions[0]
@@ -430,26 +430,26 @@ export const UserRepository = {
   },
 }
 
-function generateUsername(proxyAddress: string) {
+function generateUsername(depositWalletAddress: string) {
   const timestamp = Date.now()
 
-  return `${proxyAddress}-${timestamp}`
+  return `${depositWalletAddress}-${timestamp}`
 }
 
 async function ensureUserDepositWallet(user: any): Promise<string | null> {
-  const hasProxyAddress = typeof user?.deposit_wallet_address === 'string' && user.deposit_wallet_address.startsWith('0x')
-  if (!hasProxyAddress) {
+  const hasDepositWalletAddress = typeof user?.deposit_wallet_address === 'string' && user.deposit_wallet_address.startsWith('0x')
+  if (!hasDepositWalletAddress) {
     return null
   }
 
   try {
-    const proxyAddress = user.deposit_wallet_address as `0x${string}`
+    const depositWalletAddress = user.deposit_wallet_address as `0x${string}`
     let nextStatus: DepositWalletStatus = (user.deposit_wallet_status as DepositWalletStatus | null) ?? 'not_started'
     const updates: Record<string, any> = {}
 
     const shouldCheckDeployment = user.deposit_wallet_status !== 'deployed'
     if (shouldCheckDeployment) {
-      const deployed = await isDepositWalletDeployed(proxyAddress)
+      const deployed = await isDepositWalletDeployed(depositWalletAddress)
       if (deployed) {
         nextStatus = 'deployed'
       }
@@ -469,13 +469,13 @@ async function ensureUserDepositWallet(user: any): Promise<string | null> {
         .where(eq(users.id, user.id))
     }
 
-    user.deposit_wallet_address = proxyAddress
+    user.deposit_wallet_address = depositWalletAddress
     user.deposit_wallet_status = nextStatus
     if (nextStatus === 'deployed') {
       user.deposit_wallet_tx_hash = null
     }
 
-    return proxyAddress
+    return depositWalletAddress
   }
   catch (error) {
     console.error('Failed to ensure Deposit Wallet metadata', error)

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -258,7 +258,7 @@ export interface Comment {
   username: string
   user_avatar: string
   user_address: string
-  user_proxy_wallet_address?: string | null
+  user_deposit_wallet_address?: string | null
   user_created_at?: string
   likes_count: number
   replies_count: number

--- a/tests/unit/storeOrderAction.test.ts
+++ b/tests/unit/storeOrderAction.test.ts
@@ -139,11 +139,11 @@ describe('storeOrderAction', () => {
 
   it('returns friendly error for SELL orders with insufficient shares', async () => {
     process.env.CLOB_URL = 'https://clob.local'
-    const proxy = address('01')
+    const depositWallet = address('01')
     mocks.getCurrentUser.mockResolvedValueOnce({
       id: 'user-1',
       address: address('aa'),
-      deposit_wallet_address: proxy,
+      deposit_wallet_address: depositWallet,
       settings: {},
     })
     mocks.getUserTradingAuthSecrets.mockResolvedValueOnce({
@@ -162,8 +162,8 @@ describe('storeOrderAction', () => {
     const { storeOrderAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/store-order')
     const result = await storeOrderAction(basePayload({
       side: 1,
-      maker: proxy,
-      signer: proxy,
+      maker: depositWallet,
+      signer: depositWallet,
       maker_amount: '10',
       type: 'MARKET',
     }))
@@ -175,12 +175,12 @@ describe('storeOrderAction', () => {
 
   it('submits to CLOB, updates tags, and schedules local order creation', async () => {
     process.env.CLOB_URL = 'https://clob.local'
-    const proxy = address('01')
+    const depositWallet = address('01')
 
     mocks.getCurrentUser.mockResolvedValueOnce({
       id: 'user-1',
       address: address('aa'),
-      deposit_wallet_address: proxy,
+      deposit_wallet_address: depositWallet,
       referred_by_user_id: null,
       settings: { trading: { market_order_type: 'FAK' } },
     })
@@ -203,8 +203,8 @@ describe('storeOrderAction', () => {
 
     const { storeOrderAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/store-order')
     const result = await storeOrderAction(basePayload({
-      maker: proxy,
-      signer: proxy,
+      maker: depositWallet,
+      signer: depositWallet,
       type: 'MARKET',
     }))
 
@@ -227,12 +227,12 @@ describe('storeOrderAction', () => {
 
   it('returns default message for unmapped CLOB errors', async () => {
     process.env.CLOB_URL = 'https://clob.local'
-    const proxy = address('01')
+    const depositWallet = address('01')
 
     mocks.getCurrentUser.mockResolvedValueOnce({
       id: 'user-1',
       address: address('aa'),
-      deposit_wallet_address: proxy,
+      deposit_wallet_address: depositWallet,
       referred_by_user_id: null,
       settings: { trading: { market_order_type: 'FAK' } },
     })
@@ -250,8 +250,8 @@ describe('storeOrderAction', () => {
 
     const { storeOrderAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/store-order')
     const result = await storeOrderAction(basePayload({
-      maker: proxy,
-      signer: proxy,
+      maker: depositWallet,
+      signer: depositWallet,
       type: 'MARKET',
     }))
 

--- a/tests/unit/userRepository.test.ts
+++ b/tests/unit/userRepository.test.ts
@@ -26,7 +26,7 @@ describe('userRepository.getCurrentUser', () => {
     mocks.headers.mockResolvedValue(new Headers())
   })
 
-  it('sanitizes trading auth settings before returning minimal users', async () => {
+  it('returns the normalized session user for minimal requests', async () => {
     mocks.getSession.mockResolvedValueOnce({
       user: {
         id: 'user-1',
@@ -34,11 +34,11 @@ describe('userRepository.getCurrentUser', () => {
         settings: {
           tradingAuth: {
             relayer: {
-              key: 'secret-relayer-key',
+              enabled: true,
               updatedAt: '2026-03-23T00:00:00.000Z',
             },
             clob: {
-              key: '',
+              enabled: false,
               updatedAt: '2026-03-23T00:00:00.000Z',
             },
           },
@@ -49,6 +49,12 @@ describe('userRepository.getCurrentUser', () => {
 
     const user = await UserRepository.getCurrentUser({ minimal: true })
 
+    expect(mocks.getSession).toHaveBeenCalledWith({
+      query: {
+        disableCookieCache: false,
+      },
+      headers: expect.any(Headers),
+    })
     expect(user).toEqual({
       id: 'user-1',
       email: 'user@example.com',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Standardized all remaining wallet references from “proxyWallet” to “depositWallet” across the app, OpenAPI (including CLOB), WebSocket payloads, and tests to align terminology and avoid confusion.

- **Refactors**
  - Docs: Updated Data API and CLOB OpenAPI schemas and samples to use `depositWallet`; WSS `orders_matched` payload shows `depositWallet`.
  - Frontend: Replaced `proxyWallet` with `depositWallet` in activity feed, comments (types + live channel + UI via `user_deposit_wallet_address`), leaderboard components/utils, and public positions types.
  - API/data: Event activity, holders, and OG leaderboard routes now normalize and lookup by `depositWallet`; Data API mappers updated for holders and user activity/positions.
  - DB/tests: User repository aligned to `depositWallet` naming and removed obsolete settings sanitization/username generation; tests updated.

- **Migration**
  - Update API and WSS consumers to use `depositWallet` (CLOB: `proxyAddress` → `depositWallet`).
  - Replace `user_proxy_wallet_address` with `user_deposit_wallet_address` in comment payloads and UI.
  - Regenerate any clients from the updated OpenAPI schema.

<sup>Written for commit 9c5d1b9d3425a82d4c6772ee52783e007825e6cb. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1009?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

