### PR TITLE
chore: hide useless tag from menu

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRelated.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRelated.tsx
@@ -233,6 +233,10 @@ export default function EventRelated({ event }: EventRelatedProps) {
           continue
         }
 
+        if (tag.slug === 'rewards-automation-50-4-5-50') {
+          continue
+        }
+
         const label = tag.name?.trim() || tag.slug
         uniqueTags.set(tag.slug, label)
       }

--- a/src/lib/db/queries/tag.ts
+++ b/src/lib/db/queries/tag.ts
@@ -10,10 +10,14 @@ import { resolveCategorySidebarData } from '@/lib/category-sidebar-config'
 import { event_tags, events, tag_translations, tags, v_main_tag_subcategories } from '@/lib/db/schema/events/tables'
 import { runQuery } from '@/lib/db/utils/run-query'
 import { db } from '@/lib/drizzle'
-import { buildPublicEventListVisibilityCondition, HIDE_FROM_NEW_TAG_SLUG } from '@/lib/event-visibility'
+import {
+  buildPublicEventListVisibilityCondition,
+  HIDE_FROM_NEW_TAG_SLUG,
+  REWARDS_AUTOMATION_TAG_SLUG,
+} from '@/lib/event-visibility'
 import { filterHomeEvents } from '@/lib/home-events'
 
-const EXCLUDED_SUB_SLUGS = new Set([HIDE_FROM_NEW_TAG_SLUG])
+const EXCLUDED_SUB_SLUGS = new Set([HIDE_FROM_NEW_TAG_SLUG, REWARDS_AUTOMATION_TAG_SLUG])
 
 interface ListTagsParams {
   limit?: number

--- a/src/lib/event-visibility.ts
+++ b/src/lib/event-visibility.ts
@@ -4,6 +4,7 @@ import { event_tags, tags } from '@/lib/db/schema/events/tables'
 import { db } from '@/lib/drizzle'
 
 export const HIDE_FROM_NEW_TAG_SLUG = 'hide-from-new'
+export const REWARDS_AUTOMATION_TAG_SLUG = 'rewards-automation-50-4-5-50'
 const HIDE_FROM_NEW_TAG_NAME = 'Hide From New'
 
 let cachedHideFromNewTagId: number | null = null


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hide the internal rewards automation tag (`rewards-automation-50-4-5-50`) from tag menus and the Related section on event pages to keep the UI clean and avoid confusion.

<sup>Written for commit 36b348d93a98d4131a59fba74f1a905d31615342. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1011?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

