### PR TITLE
fix: match deposit modal balance

### DIFF
--- a/src/app/[locale]/(platform)/_components/WalletFlow.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletFlow.tsx
@@ -321,10 +321,6 @@ export function WalletFlow({
   const hasDeployedDepositWallet = useHasDeployedDepositWallet(user)
   const depositWalletAddress = user?.deposit_wallet_address ?? null
   const {
-    formattedUsdBalance: formattedDepositWalletUsdBalance,
-    isLoadingUsdBalance: isLoadingDepositWalletUsdBalance,
-  } = useLiFiWalletUsdBalance(depositWalletAddress, { enabled: depositOpen && Boolean(depositWalletAddress) })
-  const {
     formattedUsdBalance: formattedConnectedWalletUsdBalance,
     isLoadingUsdBalance: isLoadingConnectedWalletUsdBalance,
   } = useLiFiWalletUsdBalance(user?.address, { enabled: depositOpen })
@@ -373,8 +369,8 @@ export function WalletFlow({
         view={depositView}
         onViewChange={setDepositView}
         onBuy={handleBuy}
-        depositWalletBalance={formattedDepositWalletUsdBalance}
-        isDepositWalletBalanceLoading={isLoadingDepositWalletUsdBalance}
+        depositWalletBalance={balance.text}
+        isDepositWalletBalanceLoading={isLoadingBalance}
         walletBalance={formattedConnectedWalletUsdBalance}
         isBalanceLoading={isLoadingConnectedWalletUsdBalance}
       />

--- a/src/app/[locale]/(platform)/_components/WalletFlow.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletFlow.tsx
@@ -317,9 +317,9 @@ export function WalletFlow({
     handleWithdrawModalChange,
   } = useWithdrawFormState(onWithdrawOpenChange)
   const { pendingWithdrawals: visiblePendingWithdrawals, setPendingWithdrawals } = usePendingWithdrawals()
-  const { balance, isLoadingBalance } = useBalance()
   const hasDeployedDepositWallet = useHasDeployedDepositWallet(user)
   const depositWalletAddress = user?.deposit_wallet_address ?? null
+  const { balance, isLoadingBalance } = useBalance({ depositWalletAddress })
   const {
     formattedUsdBalance: formattedConnectedWalletUsdBalance,
     isLoadingUsdBalance: isLoadingConnectedWalletUsdBalance,

--- a/src/hooks/useBalance.ts
+++ b/src/hooks/useBalance.ts
@@ -30,6 +30,7 @@ const INITIAL_STATE: Balance = {
 
 interface UseBalanceOptions {
   enabled?: boolean
+  depositWalletAddress?: string | null
 }
 
 function createBrowserPublicClient(): PublicClient {
@@ -47,8 +48,12 @@ export function useBalance(options: UseBalanceOptions = {}) {
   }
   const client = clientRef.current
 
-  const depositWalletAddress: Address | null = user?.deposit_wallet_address
-    ? normalizeAddress(user.deposit_wallet_address) as Address | null
+  const sourceDepositWalletAddress = Object.hasOwn(options, 'depositWalletAddress')
+    ? options.depositWalletAddress
+    : user?.deposit_wallet_address
+
+  const depositWalletAddress: Address | null = sourceDepositWalletAddress
+    ? normalizeAddress(sourceDepositWalletAddress) as Address | null
     : null
 
   const contract = useMemo(() => {

--- a/tests/unit/useBalance.test.tsx
+++ b/tests/unit/useBalance.test.tsx
@@ -96,6 +96,75 @@ describe('useBalance', () => {
     expect(result.current.balance.text).toBe('123.45')
   })
 
+  it('uses an explicit Deposit Wallet address instead of the global user state', async () => {
+    const balanceOf = vi.fn().mockResolvedValue(75_000_000n)
+    mocks.getContract.mockReturnValue({
+      read: {
+        balanceOf,
+      },
+    })
+
+    useUser.setState({
+      id: 'user-override',
+      address: '0x00000000000000000000000000000000000000cc',
+      email: 'user@example.com',
+      twoFactorEnabled: null,
+      username: 'override-user',
+      image: '',
+      settings: {},
+      is_admin: false,
+      deposit_wallet_address: '0x00000000000000000000000000000000000000aa',
+      deposit_wallet_status: 'deployed',
+    })
+
+    const { result } = renderHook(() => useBalance({
+      depositWalletAddress: '0x00000000000000000000000000000000000000dd',
+    }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoadingBalance).toBe(false)
+    })
+
+    expect(balanceOf).toHaveBeenCalledWith(['0x00000000000000000000000000000000000000dd'])
+    expect(result.current.balance.raw).toBe(75)
+    expect(result.current.balance.text).toBe('75.00')
+  })
+
+  it('does not fall back to the global user state when the explicit Deposit Wallet address is null', async () => {
+    mocks.getContract.mockReturnValue({
+      read: {
+        balanceOf: vi.fn(),
+      },
+    })
+
+    useUser.setState({
+      id: 'user-null-override',
+      address: '0x00000000000000000000000000000000000000ee',
+      email: 'user@example.com',
+      twoFactorEnabled: null,
+      username: 'null-override-user',
+      image: '',
+      settings: {},
+      is_admin: false,
+      deposit_wallet_address: '0x00000000000000000000000000000000000000aa',
+      deposit_wallet_status: 'deployed',
+    })
+
+    const { result } = renderHook(() => useBalance({ depositWalletAddress: null }), {
+      wrapper: createWrapper(),
+    })
+
+    await waitFor(() => {
+      expect(result.current.isLoadingBalance).toBe(false)
+    })
+
+    expect(mocks.getContract).not.toHaveBeenCalled()
+    expect(result.current.balance.raw).toBe(0)
+    expect(result.current.balance.text).toBe('0.00')
+  })
+
   it('stops loading when there is no Deposit Wallet to query yet', async () => {
     mocks.getContract.mockReturnValue({
       read: {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the deposit modal header to match the wallet balance by sourcing it from `useBalance`. The hook now supports an explicit `depositWalletAddress` for the modal, with tests for override and null behavior.

- **Bug Fixes**
  - Pass `depositWalletAddress` to `useBalance` in the modal; remove `useLiFiWalletUsdBalance`.
  - Update `useBalance` to use the explicit address when provided and not fall back when `null`.

<sup>Written for commit 62cafbbb955af77730702b399f28a0b73bf5db11. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1013?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

