### PR TITLE
fix: recover manual claim batches

### DIFF
--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingContext.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingContext.tsx
@@ -7,6 +7,7 @@ export interface TradingOnboardingContextValue {
   startWithdrawFlow: () => void
   ensureTradingReady: () => boolean
   openTradeRequirements: (options?: { forceTradingAuth?: boolean }) => void
+  promptAutoRedeem: () => boolean
   hasDepositWallet: boolean
   openWalletModal: () => void
 }

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -1066,6 +1066,54 @@ function TradingOnboardingProviderContent({
     })
   }, [openNextRequirement])
 
+  const promptAutoRedeem = useCallback(() => {
+    if (!user) {
+      void openAppKit()
+      return false
+    }
+    if (status.hasAutoRedeemApproval) {
+      return false
+    }
+    if (!status.tradingReady) {
+      openNextRequirement({ allowTradingAuthPrompt: true })
+      return false
+    }
+    if (!user.deposit_wallet_address) {
+      return false
+    }
+
+    void ensureAutoRedeemStatusFromChain(user.deposit_wallet_address as `0x${string}`)
+      .then((hasAutoRedeemOnChain) => {
+        if (hasAutoRedeemOnChain) {
+          return
+        }
+
+        setDismissedModal(null)
+        setAutoRedeemStep('idle')
+        setAutoRedeemError(null)
+        setShouldContinueTradingAuthPrompt(false)
+        setShouldShowFundAfterTradingReady(false)
+        setActiveModal('auto-redeem')
+      })
+      .catch((error) => {
+        console.warn('Failed to verify auto-redeem approval before prompting.', error)
+        setDismissedModal(null)
+        setAutoRedeemStep('idle')
+        setAutoRedeemError(null)
+        setShouldContinueTradingAuthPrompt(false)
+        setShouldShowFundAfterTradingReady(false)
+        setActiveModal('auto-redeem')
+      })
+    return true
+  }, [
+    ensureAutoRedeemStatusFromChain,
+    openAppKit,
+    openNextRequirement,
+    status.hasAutoRedeemApproval,
+    status.tradingReady,
+    user,
+  ])
+
   const openWalletModal = useCallback(() => {
     if (!user) {
       void openAppKit()
@@ -1119,12 +1167,14 @@ function TradingOnboardingProviderContent({
     startWithdrawFlow,
     ensureTradingReady,
     openTradeRequirements,
+    promptAutoRedeem,
     hasDepositWallet: status.hasDeployedDepositWallet,
     openWalletModal,
   }), [
     ensureTradingReady,
     openTradeRequirements,
     openWalletModal,
+    promptAutoRedeem,
     startDepositFlow,
     startWithdrawFlow,
     status.hasDeployedDepositWallet,

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -859,7 +859,7 @@ export default function EventOrderPanelForm({
     outcomeTokenId ? [outcomeTokenId] : [],
     { enabled: shouldLoadOrderBookSummary },
   )
-  const { ensureTradingReady, openTradeRequirements, startDepositFlow } = useTradingOnboarding()
+  const { ensureTradingReady, openTradeRequirements, promptAutoRedeem, startDepositFlow } = useTradingOnboarding()
   const hasDeployedDepositWallet = Boolean(user?.deposit_wallet_address && user?.deposit_wallet_status === 'deployed')
   const depositWalletAddress = hasDeployedDepositWallet ? normalizeAddress(user?.deposit_wallet_address) : null
   const userAddress = normalizeAddress(user?.address)
@@ -1589,6 +1589,7 @@ export default function EventOrderPanelForm({
       toast.success(t('Claim submitted'), {
         description: t('We sent your claim transaction.'),
       })
+      promptAutoRedeem()
       setClaimedConditionIdsByEvent((current) => {
         const currentEventClaims = current[event.id] ?? {}
         if (currentEventClaims[conditionId]) {

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
@@ -30,7 +30,7 @@ import { buildPublicProfilePath } from '@/lib/platform-routing'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import { triggerConfetti } from '@/lib/utils'
 import { normalizeAddress } from '@/lib/wallet'
-import { signAndSubmitDepositWalletCalls } from '@/lib/wallet/client'
+import { signAndSubmitDepositWalletCallItemsWithSplitFallback } from '@/lib/wallet/client'
 import {
   buildNegRiskRedeemPositionCall,
   buildRedeemPositionCall,
@@ -168,7 +168,7 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
   const t = useExtracted()
   const { summary, markets } = data
   const { isSubmitting, setIsSubmitting, hiddenClaimSignature, setHiddenClaimSignature } = useMarketsWonClaimState()
-  const { ensureTradingReady, openTradeRequirements } = useTradingOnboarding()
+  const { ensureTradingReady, openTradeRequirements, promptAutoRedeem } = useTradingOnboarding()
   const { signTypedDataAsync } = useSignTypedData()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
   const queryClient = useQueryClient()
@@ -226,23 +226,21 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
     setIsSubmitting(true)
 
     try {
-      const calls = claimTargets.map(market =>
-        market.isNegRisk
-          ? buildNegRiskRedeemPositionCall({
-              conditionId: market.conditionId as `0x${string}`,
-              yesAmount: market.yesShares ?? 0,
-              noAmount: market.noShares ?? 0,
-              contract: normalizeAddress(market.negRiskAdapterAddress) as `0x${string}`,
-            })
-          : buildRedeemPositionCall({
-              conditionId: market.conditionId as `0x${string}`,
-              indexSets: market.indexSets,
-            }),
-      )
-
-      const response = await runWithSignaturePrompt(() => signAndSubmitDepositWalletCalls({
+      const response = await runWithSignaturePrompt(() => signAndSubmitDepositWalletCallItemsWithSplitFallback({
         user,
-        calls,
+        items: claimTargets,
+        getCall: market =>
+          market.isNegRisk
+            ? buildNegRiskRedeemPositionCall({
+                conditionId: market.conditionId as `0x${string}`,
+                yesAmount: market.yesShares ?? 0,
+                noAmount: market.noShares ?? 0,
+                contract: normalizeAddress(market.negRiskAdapterAddress) as `0x${string}`,
+              })
+            : buildRedeemPositionCall({
+                conditionId: market.conditionId as `0x${string}`,
+                indexSets: market.indexSets,
+              }),
         metadata: 'redeem_positions',
         signTypedDataAsync,
       }))
@@ -264,10 +262,17 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
           : t('We sent your claim transaction.'),
       })
 
-      const claimedConditionIds = claimTargets.map(market => market.conditionId)
+      if (response.partialFailure) {
+        toast.error(t('We could not submit your claim. Please try again.'))
+      }
 
-      setHiddenClaimSignature(claimableSignature)
+      const claimedConditionIds = response.successfulItems.map(market => market.conditionId)
+
+      if (response.failedItems.length === 0) {
+        setHiddenClaimSignature(claimableSignature)
+      }
       setIsDialogOpen(false)
+      promptAutoRedeem()
 
       updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
         queryClient,

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
@@ -116,7 +116,35 @@ function useMarketsWonDialogState() {
 function useMarketsWonClaimState() {
   const [isSubmitting, setIsSubmitting] = useState(false)
   const [hiddenClaimSignature, setHiddenClaimSignature] = useState<string | null>(null)
-  return { isSubmitting, setIsSubmitting, hiddenClaimSignature, setHiddenClaimSignature }
+  const [locallyClaimedConditionIds, setLocallyClaimedConditionIds] = useState<Set<string>>(() => new Set())
+
+  const markLocallyClaimedConditionIds = useCallback((conditionIds: string[]) => {
+    if (conditionIds.length === 0) {
+      return
+    }
+
+    setLocallyClaimedConditionIds((current) => {
+      const next = new Set(current)
+      let changed = false
+      for (const conditionId of conditionIds) {
+        if (!next.has(conditionId)) {
+          next.add(conditionId)
+          changed = true
+        }
+      }
+
+      return changed ? next : current
+    })
+  }, [])
+
+  return {
+    isSubmitting,
+    setIsSubmitting,
+    hiddenClaimSignature,
+    setHiddenClaimSignature,
+    locallyClaimedConditionIds,
+    markLocallyClaimedConditionIds,
+  }
 }
 
 function useMarketsWonShareOnX({
@@ -169,8 +197,15 @@ function useMarketsWonShareOnX({
 
 export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarketsWonCardClientProps) {
   const t = useExtracted()
-  const { summary, markets } = data
-  const { isSubmitting, setIsSubmitting, hiddenClaimSignature, setHiddenClaimSignature } = useMarketsWonClaimState()
+  const { markets } = data
+  const {
+    isSubmitting,
+    setIsSubmitting,
+    hiddenClaimSignature,
+    setHiddenClaimSignature,
+    locallyClaimedConditionIds,
+    markLocallyClaimedConditionIds,
+  } = useMarketsWonClaimState()
   const { ensureTradingReady, openTradeRequirements, promptAutoRedeem } = useTradingOnboarding()
   const { signTypedDataAsync } = useSignTypedData()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
@@ -180,11 +215,19 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
   const site = useSiteIdentity()
 
   const siteName = site.name
-  const { previewMarkets, previewExtraCount, claimableSignature, hasClaimableMarkets } = useMarketsWonClaimSignature(markets)
+  const visibleMarkets = useMemo(
+    () => markets.filter(market => !locallyClaimedConditionIds.has(market.conditionId)),
+    [locallyClaimedConditionIds, markets],
+  )
+  const visibleTotalProceeds = useMemo(
+    () => visibleMarkets.reduce((total, market) => total + market.proceeds, 0),
+    [visibleMarkets],
+  )
+  const { previewMarkets, previewExtraCount, claimableSignature, hasClaimableMarkets } = useMarketsWonClaimSignature(visibleMarkets)
   const { isDialogOpen, setIsDialogOpen, handleDialogOpenChange } = useMarketsWonDialogState()
   const { isSharingOnX, handleShareOnX } = useMarketsWonShareOnX({
     siteName,
-    totalProceeds: summary.totalProceeds,
+    totalProceeds: visibleTotalProceeds,
     userUsername: user?.username,
     userDepositWalletAddress: user?.deposit_wallet_address,
   })
@@ -193,6 +236,8 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
     if (claimedConditionIds.length === 0) {
       return
     }
+
+    markLocallyClaimedConditionIds(claimedConditionIds)
 
     updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
       queryClient,
@@ -229,7 +274,7 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
       return
     }
 
-    if (!markets.length) {
+    if (!visibleMarkets.length) {
       toast.info(t('No claimable markets available right now.'))
       return
     }
@@ -243,7 +288,7 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
       return
     }
 
-    const claimTargets = markets.filter(market => market.indexSets.length > 0)
+    const claimTargets = visibleMarkets.filter(market => market.indexSets.length > 0)
     if (claimTargets.length === 0) {
       toast.info(t('No claimable markets available right now.'))
       return
@@ -331,6 +376,8 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
               ? t('We sent a claim for your winning markets.')
               : t('We sent your claim transaction.'),
           })
+          toast.error(t('We could not submit your claim. Please try again.'))
+          return
         }
       }
 
@@ -346,7 +393,7 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
     && hiddenClaimSignature === claimableSignature
     && claimableSignature.length > 0
 
-  if (shouldHideClaimCard || markets.length === 0) {
+  if (shouldHideClaimCard || visibleMarkets.length === 0) {
     return null
   }
 
@@ -425,7 +472,7 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
               >
                 <span>{t('You won')}</span>
                 <span className="text-lg leading-none font-semibold text-foreground tabular-nums sm:text-2xl">
-                  {formatCurrency(summary.totalProceeds)}
+                  {formatCurrency(visibleTotalProceeds)}
                 </span>
               </p>
             </div>
@@ -469,7 +516,7 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
           <p className="inline-flex items-center gap-2 text-foreground dark:text-white">
             <span className="text-xl font-semibold">{t('You won')}</span>
             <span className="text-3xl leading-none font-semibold tabular-nums">
-              {formatCurrency(summary.totalProceeds)}
+              {formatCurrency(visibleTotalProceeds)}
             </span>
           </p>
           <p className="text-sm text-muted-foreground">
@@ -478,7 +525,7 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
         </div>
 
         <div className="max-h-[min(40vh,12rem)] space-y-2 overflow-y-auto pr-1 text-left">
-          {markets.map((market) => {
+          {visibleMarkets.map((market) => {
             const href = market.eventSlug ? (`/event/${market.eventSlug}` as Route) : null
             const itemClassName = [
               'flex w-full items-center gap-3 rounded-md p-3 transition-colors',
@@ -559,7 +606,7 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
           <Button className="h-10 flex-1" onClick={handleClaimAll} disabled={isSubmitting || !hasClaimableMarkets}>
             {isSubmitting
               ? t('Submitting...')
-              : `${t('Claim')} ${formatCurrency(summary.totalProceeds)}`}
+              : `${t('Claim')} ${formatCurrency(visibleTotalProceeds)}`}
           </Button>
         </div>
       </DialogContent>

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
@@ -30,7 +30,10 @@ import { buildPublicProfilePath } from '@/lib/platform-routing'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import { triggerConfetti } from '@/lib/utils'
 import { normalizeAddress } from '@/lib/wallet'
-import { signAndSubmitDepositWalletCallItemsWithSplitFallback } from '@/lib/wallet/client'
+import {
+  DepositWalletCallItemsSplitFallbackError,
+  signAndSubmitDepositWalletCallItemsWithSplitFallback,
+} from '@/lib/wallet/client'
 import {
   buildNegRiskRedeemPositionCall,
   buildRedeemPositionCall,
@@ -186,6 +189,41 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
     userDepositWalletAddress: user?.deposit_wallet_address,
   })
 
+  function syncClaimedMarkets(claimedConditionIds: string[]) {
+    if (claimedConditionIds.length === 0) {
+      return
+    }
+
+    updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
+      queryClient,
+      ['user-positions'],
+      currentQueryKey => currentQueryKey[2] === 'active',
+      current => current
+        ? {
+            ...current,
+            pages: current.pages.map(page => removeClaimedPublicPositions(page, claimedConditionIds) ?? page),
+          }
+        : current,
+    )
+
+    setTimeout(() => {
+      void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
+      void queryClient.invalidateQueries({ queryKey: ['user-market-positions'] })
+      void queryClient.invalidateQueries({ queryKey: ['user-conditional-shares'] })
+      void queryClient.invalidateQueries({ queryKey: [DEPOSIT_WALLET_BALANCE_QUERY_KEY] })
+      void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
+    }, 4_000)
+    setTimeout(() => {
+      void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
+      void queryClient.invalidateQueries({ queryKey: ['user-market-positions'] })
+      void queryClient.invalidateQueries({ queryKey: ['user-conditional-shares'] })
+      void queryClient.invalidateQueries({ queryKey: [DEPOSIT_WALLET_BALANCE_QUERY_KEY] })
+      void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
+    }, 12_000)
+
+    router.refresh()
+  }
+
   async function handleClaimAll() {
     if (isSubmitting) {
       return
@@ -262,48 +300,40 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
           : t('We sent your claim transaction.'),
       })
 
-      if (response.partialFailure) {
-        toast.error(t('We could not submit your claim. Please try again.'))
-      }
-
       const claimedConditionIds = response.successfulItems.map(market => market.conditionId)
+      syncClaimedMarkets(claimedConditionIds)
 
       if (response.failedItems.length === 0) {
         setHiddenClaimSignature(claimableSignature)
       }
+
+      if (response.partialFailure) {
+        toast.error(t('We could not submit your claim. Please try again.'))
+
+        const failureError = response.failure?.error
+        if (failureError && isTradingAuthRequiredError(failureError)) {
+          setIsDialogOpen(false)
+          openTradeRequirements({ forceTradingAuth: true })
+        }
+        return
+      }
+
       setIsDialogOpen(false)
       promptAutoRedeem()
-
-      updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
-        queryClient,
-        ['user-positions'],
-        currentQueryKey => currentQueryKey[2] === 'active',
-        current => current
-          ? {
-              ...current,
-              pages: current.pages.map(page => removeClaimedPublicPositions(page, claimedConditionIds) ?? page),
-            }
-          : current,
-      )
-
-      setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
-        void queryClient.invalidateQueries({ queryKey: ['user-market-positions'] })
-        void queryClient.invalidateQueries({ queryKey: ['user-conditional-shares'] })
-        void queryClient.invalidateQueries({ queryKey: [DEPOSIT_WALLET_BALANCE_QUERY_KEY] })
-        void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
-      }, 4_000)
-      setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
-        void queryClient.invalidateQueries({ queryKey: ['user-market-positions'] })
-        void queryClient.invalidateQueries({ queryKey: ['user-conditional-shares'] })
-        void queryClient.invalidateQueries({ queryKey: [DEPOSIT_WALLET_BALANCE_QUERY_KEY] })
-        void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
-      }, 12_000)
-
-      router.refresh()
     }
     catch (error) {
+      if (error instanceof DepositWalletCallItemsSplitFallbackError) {
+        const claimedConditionIds = (error.successfulItems as PortfolioClaimMarket[]).map(market => market.conditionId)
+        syncClaimedMarkets(claimedConditionIds)
+        if (claimedConditionIds.length > 0) {
+          toast.success(t('Claim submitted'), {
+            description: claimedConditionIds.length > 1
+              ? t('We sent a claim for your winning markets.')
+              : t('We sent your claim transaction.'),
+          })
+        }
+      }
+
       console.error('Failed to submit claim.', error)
       toast.error(t('We could not submit your claim. Please try again.'))
     }

--- a/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
@@ -434,6 +434,15 @@ function useRedeemClaimSubmission({
         )
         syncClaimedConditionIds(claimedConditionIds)
         onPartialClaimSuccess(Array.from(claimedConditionIds))
+        if (claimedConditionIds.size > 0) {
+          toast.success('Claim submitted', {
+            description: claimedConditionIds.size > 1
+              ? 'We sent claims for your selected markets.'
+              : 'We sent your claim transaction.',
+          })
+          toast.error('We could not submit your claim. Please try again.')
+          return
+        }
       }
       console.error('Failed to submit claim.', error)
       toast.error('We could not submit your claim. Please try again.')

--- a/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
@@ -19,7 +19,10 @@ import { isCurrentNegRiskAdapterAddress } from '@/lib/neg-risk-adapter'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import { cn } from '@/lib/utils'
 import { normalizeAddress } from '@/lib/wallet'
-import { signAndSubmitDepositWalletCallItemsWithSplitFallback } from '@/lib/wallet/client'
+import {
+  DepositWalletCallItemsSplitFallbackError,
+  signAndSubmitDepositWalletCallItemsWithSplitFallback,
+} from '@/lib/wallet/client'
 import {
   buildNegRiskRedeemPositionCall,
   buildRedeemPositionCall,
@@ -163,11 +166,9 @@ function useRedeemSelectionState({
     defaultSelectedConditionId,
     defaultSelectedSectionKey,
     open ? 'open' : 'closed',
-    normalizedGroups.map(group => group.conditionId).join(','),
   ].join('|'), [
     defaultSelectedConditionId,
     defaultSelectedSectionKey,
-    normalizedGroups,
     open,
   ])
 
@@ -308,6 +309,37 @@ function useRedeemClaimSubmission({
   const { ensureTradingReady, openTradeRequirements, promptAutoRedeem } = useTradingOnboarding()
   const [isSubmitting, setIsSubmitting] = useState(false)
 
+  function syncClaimedConditionIds(claimedConditionIds: Set<string>) {
+    if (claimedConditionIds.size === 0) {
+      return
+    }
+
+    queryClient.setQueriesData({ queryKey: ['order-panel-user-positions'] }, current =>
+      markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
+    queryClient.setQueriesData({ queryKey: ['user-market-positions'] }, current =>
+      markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
+    queryClient.setQueriesData({ queryKey: ['event-user-positions'] }, current =>
+      markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
+    queryClient.setQueriesData({ queryKey: ['user-event-positions'] }, current =>
+      markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
+    queryClient.setQueriesData({ queryKey: ['sports-card-user-positions'] }, current =>
+      markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
+    queryClient.setQueriesData({ queryKey: ['sports-event-user-positions'] }, current =>
+      markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
+
+    void queryClient.invalidateQueries({ queryKey: ['order-panel-user-positions'] })
+    void queryClient.invalidateQueries({ queryKey: ['user-market-positions'] })
+    void queryClient.invalidateQueries({ queryKey: ['event-user-positions'] })
+    void queryClient.invalidateQueries({ queryKey: ['user-event-positions'] })
+    void queryClient.invalidateQueries({ queryKey: ['sports-card-user-positions'] })
+    void queryClient.invalidateQueries({ queryKey: ['sports-event-user-positions'] })
+    void queryClient.invalidateQueries({ queryKey: ['user-conditional-shares'] })
+    void queryClient.invalidateQueries({ queryKey: [DEPOSIT_WALLET_BALANCE_QUERY_KEY] })
+    void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
+
+    onClaimSuccess?.(Array.from(claimedConditionIds))
+  }
+
   async function submitClaim() {
     if (isSubmitting) {
       return
@@ -379,31 +411,15 @@ function useRedeemClaimSubmission({
       }
 
       const claimedConditionIds = new Set(response.successfulItems.map(group => group.conditionId))
-      queryClient.setQueriesData({ queryKey: ['order-panel-user-positions'] }, current =>
-        markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
-      queryClient.setQueriesData({ queryKey: ['user-market-positions'] }, current =>
-        markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
-      queryClient.setQueriesData({ queryKey: ['event-user-positions'] }, current =>
-        markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
-      queryClient.setQueriesData({ queryKey: ['user-event-positions'] }, current =>
-        markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
-      queryClient.setQueriesData({ queryKey: ['sports-card-user-positions'] }, current =>
-        markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
-      queryClient.setQueriesData({ queryKey: ['sports-event-user-positions'] }, current =>
-        markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
-
-      void queryClient.invalidateQueries({ queryKey: ['order-panel-user-positions'] })
-      void queryClient.invalidateQueries({ queryKey: ['user-market-positions'] })
-      void queryClient.invalidateQueries({ queryKey: ['event-user-positions'] })
-      void queryClient.invalidateQueries({ queryKey: ['user-event-positions'] })
-      void queryClient.invalidateQueries({ queryKey: ['sports-card-user-positions'] })
-      void queryClient.invalidateQueries({ queryKey: ['sports-event-user-positions'] })
-      void queryClient.invalidateQueries({ queryKey: ['user-conditional-shares'] })
-      void queryClient.invalidateQueries({ queryKey: [DEPOSIT_WALLET_BALANCE_QUERY_KEY] })
-      void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
-
-      onClaimSuccess?.(Array.from(claimedConditionIds))
+      syncClaimedConditionIds(claimedConditionIds)
       if (response.partialFailure) {
+        const failureError = response.failure?.error
+        if (failureError && isTradingAuthRequiredError(failureError)) {
+          onOpenChange(false)
+          openTradeRequirements({ forceTradingAuth: true })
+          return
+        }
+
         onPartialClaimSuccess(Array.from(claimedConditionIds))
         return
       }
@@ -412,6 +428,13 @@ function useRedeemClaimSubmission({
       promptAutoRedeem()
     }
     catch (error) {
+      if (error instanceof DepositWalletCallItemsSplitFallbackError) {
+        const claimedConditionIds = new Set(
+          (error.successfulItems as SportsRedeemModalGroup[]).map(group => group.conditionId),
+        )
+        syncClaimedConditionIds(claimedConditionIds)
+        onPartialClaimSuccess(Array.from(claimedConditionIds))
+      }
       console.error('Failed to submit claim.', error)
       toast.error('We could not submit your claim. Please try again.')
     }

--- a/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
@@ -19,7 +19,7 @@ import { isCurrentNegRiskAdapterAddress } from '@/lib/neg-risk-adapter'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import { cn } from '@/lib/utils'
 import { normalizeAddress } from '@/lib/wallet'
-import { signAndSubmitDepositWalletCalls } from '@/lib/wallet/client'
+import { signAndSubmitDepositWalletCallItemsWithSplitFallback } from '@/lib/wallet/client'
 import {
   buildNegRiskRedeemPositionCall,
   buildRedeemPositionCall,
@@ -252,6 +252,31 @@ function useRedeemSelectionState({
     })
   }
 
+  function removeConditionSelection(conditionIds: string[]) {
+    if (conditionIds.length === 0) {
+      return
+    }
+
+    const claimedSet = new Set(conditionIds)
+    setSelectionState((current) => {
+      const baseSelected = current.key === selectionStateKey
+        ? current.selectedConditionIds
+        : initialSelectedConditionIds
+      const baseExpanded = current.key === selectionStateKey
+        ? current.expandedConditionIds
+        : {}
+      const nextSelected = Object.fromEntries(
+        Object.entries(baseSelected).filter(([conditionId]) => !claimedSet.has(conditionId)),
+      ) as Record<string, true>
+
+      return {
+        key: selectionStateKey,
+        selectedConditionIds: nextSelected,
+        expandedConditionIds: baseExpanded,
+      }
+    })
+  }
+
   return {
     normalizedSections,
     normalizedGroups,
@@ -261,15 +286,18 @@ function useRedeemSelectionState({
     selectedAmount,
     toggleConditionSelection,
     toggleConditionExpansion,
+    removeConditionSelection,
   }
 }
 
 function useRedeemClaimSubmission({
   selectedGroups,
+  onPartialClaimSuccess,
   onClaimSuccess,
   onOpenChange,
 }: {
   selectedGroups: SportsRedeemModalGroup[]
+  onPartialClaimSuccess: (conditionIds: string[]) => void
   onClaimSuccess?: (conditionIds: string[]) => void
   onOpenChange: (open: boolean) => void
 }) {
@@ -277,7 +305,7 @@ function useRedeemClaimSubmission({
   const queryClient = useQueryClient()
   const { signTypedDataAsync } = useSignTypedData()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
-  const { ensureTradingReady, openTradeRequirements } = useTradingOnboarding()
+  const { ensureTradingReady, openTradeRequirements, promptAutoRedeem } = useTradingOnboarding()
   const [isSubmitting, setIsSubmitting] = useState(false)
 
   async function submitClaim() {
@@ -313,23 +341,21 @@ function useRedeemClaimSubmission({
     setIsSubmitting(true)
 
     try {
-      const calls = selectedGroups.map(group =>
-        group.isNegRisk
-          ? buildNegRiskRedeemPositionCall({
-              conditionId: group.conditionId as `0x${string}`,
-              yesAmount: group.yesShares ?? 0,
-              noAmount: group.noShares ?? 0,
-              contract: normalizeAddress(group.negRiskAdapterAddress) as `0x${string}`,
-            })
-          : buildRedeemPositionCall({
-              conditionId: group.conditionId as `0x${string}`,
-              indexSets: group.indexSets,
-            }),
-      )
-
-      const response = await runWithSignaturePrompt(() => signAndSubmitDepositWalletCalls({
+      const response = await runWithSignaturePrompt(() => signAndSubmitDepositWalletCallItemsWithSplitFallback({
         user,
-        calls,
+        items: selectedGroups,
+        getCall: group =>
+          group.isNegRisk
+            ? buildNegRiskRedeemPositionCall({
+                conditionId: group.conditionId as `0x${string}`,
+                yesAmount: group.yesShares ?? 0,
+                noAmount: group.noShares ?? 0,
+                contract: normalizeAddress(group.negRiskAdapterAddress) as `0x${string}`,
+              })
+            : buildRedeemPositionCall({
+                conditionId: group.conditionId as `0x${string}`,
+                indexSets: group.indexSets,
+              }),
         metadata: 'redeem_positions',
         signTypedDataAsync,
       }))
@@ -344,12 +370,15 @@ function useRedeemClaimSubmission({
       }
 
       toast.success('Claim submitted', {
-        description: selectedGroups.length > 1
+        description: response.successfulItems.length > 1
           ? 'We sent claims for your selected markets.'
           : 'We sent your claim transaction.',
       })
+      if (response.partialFailure) {
+        toast.error('We could not submit your claim. Please try again.')
+      }
 
-      const claimedConditionIds = new Set(selectedGroups.map(group => group.conditionId))
+      const claimedConditionIds = new Set(response.successfulItems.map(group => group.conditionId))
       queryClient.setQueriesData({ queryKey: ['order-panel-user-positions'] }, current =>
         markConditionsAsClaimedInPositions(current as any[] | undefined, claimedConditionIds))
       queryClient.setQueriesData({ queryKey: ['user-market-positions'] }, current =>
@@ -374,7 +403,13 @@ function useRedeemClaimSubmission({
       void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
 
       onClaimSuccess?.(Array.from(claimedConditionIds))
+      if (response.partialFailure) {
+        onPartialClaimSuccess(Array.from(claimedConditionIds))
+        return
+      }
+
       onOpenChange(false)
+      promptAutoRedeem()
     }
     catch (error) {
       console.error('Failed to submit claim.', error)
@@ -407,6 +442,7 @@ export default function SportsRedeemModal({
     selectedAmount,
     toggleConditionSelection,
     toggleConditionExpansion,
+    removeConditionSelection,
   } = useRedeemSelectionState({
     sections,
     defaultSelectedConditionId,
@@ -415,6 +451,7 @@ export default function SportsRedeemModal({
   })
   const { isSubmitting, submitClaim } = useRedeemClaimSubmission({
     selectedGroups,
+    onPartialClaimSuccess: removeConditionSelection,
     onClaimSuccess,
     onOpenChange,
   })

--- a/src/lib/wallet/client.ts
+++ b/src/lib/wallet/client.ts
@@ -37,6 +37,21 @@ export interface SignAndSubmitDepositWalletCallItemsResult<T> extends SignAndSub
   successfulItems: T[]
   failedItems: T[]
   partialFailure: boolean
+  failure?: SignAndSubmitDepositWalletCallsResult
+}
+
+export class DepositWalletCallItemsSplitFallbackError<T> extends Error {
+  readonly successfulItems: T[]
+  readonly failedItems: T[]
+  readonly originalError: unknown
+
+  constructor(error: unknown, successfulItems: T[], failedItems: T[]) {
+    super(error instanceof Error && error.message ? error.message : DEFAULT_ERROR_MESSAGE)
+    this.name = 'DepositWalletCallItemsSplitFallbackError'
+    this.successfulItems = successfulItems
+    this.failedItems = failedItems
+    this.originalError = error
+  }
 }
 
 export async function signAndSubmitDepositWalletCalls({
@@ -109,12 +124,19 @@ function shouldSplitDepositWalletCallFailure(result: SignAndSubmitDepositWalletC
     || normalized.includes('transaction failed')
 }
 
-function walletCallExceptionToResult(error: unknown): SignAndSubmitDepositWalletCallsResult {
-  if (error instanceof Error && error.message) {
-    return { error: error.message }
+function getPreferredFailure(
+  current: SignAndSubmitDepositWalletCallsResult | null,
+  next: SignAndSubmitDepositWalletCallsResult,
+) {
+  if (!current) {
+    return next
   }
 
-  return { error: DEFAULT_ERROR_MESSAGE }
+  if (next.error && isTradingAuthRequiredError(next.error) && !isTradingAuthRequiredError(current.error)) {
+    return next
+  }
+
+  return current
 }
 
 export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
@@ -146,7 +168,13 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
       })
     }
     catch (error) {
-      result = walletCallExceptionToResult(error)
+      if (successfulItems.length > 0) {
+        throw new DepositWalletCallItemsSplitFallbackError(error, successfulItems, [
+          ...failedItems,
+          ...chunk,
+        ])
+      }
+      throw error
     }
 
     if (!result.error) {
@@ -155,7 +183,7 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
       return
     }
 
-    firstFailure ??= result
+    firstFailure = getPreferredFailure(firstFailure, result)
     if (chunk.length <= 1 || !shouldSplitDepositWalletCallFailure(result)) {
       failedItems.push(...chunk)
       return
@@ -174,6 +202,7 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
       successfulItems,
       failedItems: failedItems.length ? failedItems : items,
       partialFailure: false,
+      failure: firstFailure ?? undefined,
     }
   }
 
@@ -183,5 +212,6 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
     successfulItems,
     failedItems,
     partialFailure: failedItems.length > 0,
+    failure: firstFailure ?? undefined,
   }
 }

--- a/src/lib/wallet/client.ts
+++ b/src/lib/wallet/client.ts
@@ -9,6 +9,7 @@ import {
 } from '@/app/[locale]/(platform)/_actions/approve-tokens'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { DEFAULT_CHAIN_ID } from '@/lib/network'
+import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import {
   buildWalletTransactionRequestPayload,
   getDepositWalletBatchTypedData,
@@ -30,6 +31,12 @@ export interface SignAndSubmitDepositWalletCallsResult {
     updatedAt: string
     version: string
   }
+}
+
+export interface SignAndSubmitDepositWalletCallItemsResult<T> extends SignAndSubmitDepositWalletCallsResult {
+  successfulItems: T[]
+  failedItems: T[]
+  partialFailure: boolean
 }
 
 export async function signAndSubmitDepositWalletCalls({
@@ -90,4 +97,91 @@ export async function signAndSubmitDepositWalletCalls({
   }
 
   return await attempt()
+}
+
+function shouldSplitDepositWalletCallFailure(result: SignAndSubmitDepositWalletCallsResult) {
+  if (!result.error || result.code || isTradingAuthRequiredError(result.error)) {
+    return false
+  }
+
+  const normalized = result.error.toLowerCase()
+  return normalized.includes('revert')
+    || normalized.includes('transaction failed')
+}
+
+function walletCallExceptionToResult(error: unknown): SignAndSubmitDepositWalletCallsResult {
+  if (error instanceof Error && error.message) {
+    return { error: error.message }
+  }
+
+  return { error: DEFAULT_ERROR_MESSAGE }
+}
+
+export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
+  user,
+  items,
+  getCall,
+  metadata,
+  signTypedDataAsync,
+}: {
+  user: Pick<User, 'address' | 'deposit_wallet_address'>
+  items: T[]
+  getCall: (item: T) => WalletCall
+  metadata?: string
+  signTypedDataAsync: SignTypedDataFn
+}): Promise<SignAndSubmitDepositWalletCallItemsResult<T>> {
+  const successfulItems: T[] = []
+  const failedItems: T[] = []
+  let lastSuccess: SignAndSubmitDepositWalletCallsResult | null = null
+  let firstFailure: SignAndSubmitDepositWalletCallsResult | null = null
+
+  async function submitChunk(chunk: T[]): Promise<void> {
+    let result: SignAndSubmitDepositWalletCallsResult
+    try {
+      result = await signAndSubmitDepositWalletCalls({
+        user,
+        calls: chunk.map(getCall),
+        metadata,
+        signTypedDataAsync,
+      })
+    }
+    catch (error) {
+      result = walletCallExceptionToResult(error)
+    }
+
+    if (!result.error) {
+      successfulItems.push(...chunk)
+      lastSuccess = result
+      return
+    }
+
+    firstFailure ??= result
+    if (chunk.length <= 1 || !shouldSplitDepositWalletCallFailure(result)) {
+      failedItems.push(...chunk)
+      return
+    }
+
+    const midpoint = Math.ceil(chunk.length / 2)
+    await submitChunk(chunk.slice(0, midpoint))
+    await submitChunk(chunk.slice(midpoint))
+  }
+
+  await submitChunk(items)
+
+  if (successfulItems.length === 0) {
+    return {
+      ...(firstFailure ?? { error: DEFAULT_ERROR_MESSAGE }),
+      successfulItems,
+      failedItems: failedItems.length ? failedItems : items,
+      partialFailure: false,
+    }
+  }
+
+  return {
+    ...(lastSuccess ?? { error: null }),
+    error: null,
+    successfulItems,
+    failedItems,
+    partialFailure: failedItems.length > 0,
+  }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Recover manual claim batches by splitting failing transactions so successful items still redeem, and prompt Auto Redeem after claims. Also prevent duplicate claim retries by hiding already-claimed items in Portfolio and Sports.

- **New Features**
  - Added `promptAutoRedeem` in trading onboarding. After a claim in Events/Portfolio/Sports, checks on-chain approval and opens the Auto Redeem modal when logged in, trading-ready, and not approved.

- **Bug Fixes**
  - Added `signAndSubmitDepositWalletCallItemsWithSplitFallback` and `DepositWalletCallItemsSplitFallbackError` to recursively split failing claim batches and preserve per-item outcomes (`successfulItems`, `failedItems`, `partialFailure`).
  - Updated Portfolio and Sports claim flows to use the splitter, sync only successful condition IDs to UI/state, keep dialogs open on partial failures, remove/hide claimed selections to avoid duplicate retries, surface trading auth when required, and trigger Auto Redeem only after full success.

<sup>Written for commit ae99ef733291ddbd64c07379f19457abfcf3a969. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1015?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

