### PR TITLE
refactor: dismissible onboarding dialogs

### DIFF
--- a/src/app/[locale]/(platform)/_actions/deposit-wallet.ts
+++ b/src/app/[locale]/(platform)/_actions/deposit-wallet.ts
@@ -499,7 +499,6 @@ export async function updateOnboardingEmailAction(input: {
   try {
     const { error } = await UserRepository.updateUserProfileById(user.id, {
       email: parsed.data.email,
-      username: user.username,
     })
     if (error) {
       return { error, data: null }

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -442,6 +442,7 @@ function EnableTradingDialog({
   const t = useExtracted()
   const site = useSiteIdentity()
   const isLoading = step === 'enabling' || step === 'deploying'
+  const dismissible = Boolean(error)
 
   return (
     <OnboardingDialogShell
@@ -449,6 +450,7 @@ function EnableTradingDialog({
       onOpenChange={onOpenChange}
       title={t('Enable Trading')}
       description={t('Let\'s set up your wallet to trade on {siteName}.', { siteName: site.name })}
+      dismissible={dismissible}
       icon={(
         <div className="mx-auto flex size-20 items-center justify-center rounded-2xl bg-primary/10 text-primary">
           <WalletIcon className="size-10" />
@@ -497,10 +499,31 @@ function EnableTradingStatusDialog({
 }) {
   const t = useExtracted()
   const isSigning = step === 'enabling'
+  const dismissible = Boolean(error)
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!dismissible && !nextOpen) {
+      return
+    }
+    onOpenChange(nextOpen)
+  }
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-sm border bg-background p-6">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-w-sm border bg-background p-6"
+        showCloseButton={dismissible}
+        onEscapeKeyDown={(event) => {
+          if (!dismissible) {
+            event.preventDefault()
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (!dismissible) {
+            event.preventDefault()
+          }
+        }}
+      >
         <DialogHeader className="space-y-2 text-center">
           <DialogTitle className="text-center text-xl font-bold text-foreground">
             {t('Enable Trading')}
@@ -617,6 +640,7 @@ function ApproveTokensDialog({
 }) {
   const t = useExtracted()
   const isLoading = step === 'signing'
+  const dismissible = Boolean(error)
 
   return (
     <OnboardingDialogShell
@@ -624,6 +648,7 @@ function ApproveTokensDialog({
       onOpenChange={onOpenChange}
       title={t('Approve Tokens')}
       description={t('Approve token spending for trading')}
+      dismissible={dismissible}
       icon={(
         <div className="mx-auto flex size-20 items-center justify-center rounded-2xl bg-primary/10 text-primary">
           <WalletIcon className="size-10" />

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -26,8 +26,16 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerHeader,
+  DrawerTitle,
+} from '@/components/ui/drawer'
 import { Input } from '@/components/ui/input'
 import { InputError } from '@/components/ui/input-error'
+import { useIsMobile } from '@/hooks/useIsMobile'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 
 type OnboardingModal = 'username' | 'email' | 'enable' | 'enable-status' | 'approve' | 'auto-redeem' | null
@@ -89,11 +97,36 @@ function OnboardingDialogShell({
   children: ReactNode
   dismissible?: boolean
 }) {
+  const isMobile = useIsMobile()
+
   function handleOpenChange(nextOpen: boolean) {
     if (!dismissible && !nextOpen) {
       return
     }
     onOpenChange(nextOpen)
+  }
+
+  if (isMobile) {
+    return (
+      <Drawer
+        open={open}
+        onOpenChange={handleOpenChange}
+        dismissible={dismissible}
+      >
+        <DrawerContent className="max-h-[90vh] w-full bg-background px-4 pt-4 pb-6">
+          <DrawerHeader className="space-y-3 text-center">
+            {icon}
+            <DrawerTitle className="text-center text-2xl font-bold text-foreground">
+              {title}
+            </DrawerTitle>
+            <DrawerDescription className="text-center text-base text-muted-foreground">
+              {description}
+            </DrawerDescription>
+          </DrawerHeader>
+          {children}
+        </DrawerContent>
+      </Drawer>
+    )
   }
 
   return (
@@ -500,12 +533,65 @@ function EnableTradingStatusDialog({
   const t = useExtracted()
   const isSigning = step === 'enabling'
   const dismissible = Boolean(error)
+  const isMobile = useIsMobile()
 
   function handleOpenChange(nextOpen: boolean) {
     if (!dismissible && !nextOpen) {
       return
     }
     onOpenChange(nextOpen)
+  }
+
+  const timeline = (
+    <div className="mt-5 space-y-0">
+      <TimelineStep
+        title={t('Deploy Wallet')}
+        description={t('Deploy a smart contract wallet to enable trading')}
+        complete={hasDeployedDepositWallet}
+        trailing={hasDeployedDepositWallet ? t('Done') : null}
+      />
+      <TimelineStep
+        title={t('Enable Trading')}
+        description={t('Sign a message to generate your API keys')}
+        complete={hasTradingAuth}
+        trailing={hasTradingAuth ? t('Done') : null}
+        action={!hasTradingAuth && hasDeployedDepositWallet
+          ? {
+              label: t('Sign'),
+              loading: isSigning,
+              onClick: onEnableTradingAuth,
+            }
+          : undefined}
+        error={!hasTradingAuth ? error : null}
+      />
+      <TimelineStep
+        title={t('Approve Tokens')}
+        description={t('Approve token spending for trading')}
+        complete={hasTokenApprovals}
+        trailing={hasTokenApprovals ? t('Done') : null}
+        isLast
+      />
+    </div>
+  )
+
+  if (isMobile) {
+    return (
+      <Drawer
+        open={open}
+        onOpenChange={handleOpenChange}
+        dismissible={dismissible}
+      >
+        <DrawerContent className="max-h-[90vh] w-full bg-background px-4 pt-4 pb-6">
+          <DrawerHeader className="space-y-2 text-center">
+            <DrawerTitle className="text-center text-xl font-bold text-foreground">
+              {t('Enable Trading')}
+            </DrawerTitle>
+          </DrawerHeader>
+
+          {timeline}
+        </DrawerContent>
+      </Drawer>
+    )
   }
 
   return (
@@ -530,35 +616,7 @@ function EnableTradingStatusDialog({
           </DialogTitle>
         </DialogHeader>
 
-        <div className="mt-5 space-y-0">
-          <TimelineStep
-            title={t('Deploy Wallet')}
-            description={t('Deploy a smart contract wallet to enable trading')}
-            complete={hasDeployedDepositWallet}
-            trailing={hasDeployedDepositWallet ? t('Done') : null}
-          />
-          <TimelineStep
-            title={t('Enable Trading')}
-            description={t('Sign a message to generate your API keys')}
-            complete={hasTradingAuth}
-            trailing={hasTradingAuth ? t('Done') : null}
-            action={!hasTradingAuth && hasDeployedDepositWallet
-              ? {
-                  label: t('Sign'),
-                  loading: isSigning,
-                  onClick: onEnableTradingAuth,
-                }
-              : undefined}
-            error={!hasTradingAuth ? error : null}
-          />
-          <TimelineStep
-            title={t('Approve Tokens')}
-            description={t('Approve token spending for trading')}
-            complete={hasTokenApprovals}
-            trailing={hasTokenApprovals ? t('Done') : null}
-            isLast
-          />
-        </div>
+        {timeline}
       </DialogContent>
     </Dialog>
   )

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -385,6 +385,7 @@ function EmailDialog({
       onOpenChange={onOpenChange}
       title={t('What\'s your email?')}
       description={t('Add your email to receive market and trading notifications.')}
+      dismissible={false}
       icon={(
         <div className="mx-auto flex size-16 items-center justify-center rounded-2xl bg-primary/10 text-primary">
           <MailIcon className="size-8" />

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -79,6 +79,7 @@ function OnboardingDialogShell({
   title,
   description,
   children,
+  dismissible = true,
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
@@ -86,10 +87,31 @@ function OnboardingDialogShell({
   title: string
   description: string
   children: ReactNode
+  dismissible?: boolean
 }) {
+  function handleOpenChange(nextOpen: boolean) {
+    if (!dismissible && !nextOpen) {
+      return
+    }
+    onOpenChange(nextOpen)
+  }
+
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-md border bg-background p-8">
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="max-w-md border bg-background p-8"
+        showCloseButton={dismissible}
+        onEscapeKeyDown={(event) => {
+          if (!dismissible) {
+            event.preventDefault()
+          }
+        }}
+        onInteractOutside={(event) => {
+          if (!dismissible) {
+            event.preventDefault()
+          }
+        }}
+      >
         <DialogHeader className="space-y-3 text-center">
           {icon}
           <DialogTitle className="text-center text-2xl font-bold text-foreground">
@@ -234,6 +256,7 @@ function UsernameDialog({
       onOpenChange={onOpenChange}
       title={t('Choose a username')}
       description={t('You can update this later.')}
+      dismissible={false}
     >
       <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
         <div className="relative">

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -88,14 +88,24 @@ function OnboardingDialogShell({
   description,
   children,
   dismissible = true,
+  dialogContentClassName = 'max-w-md border bg-background p-8',
+  drawerContentClassName = 'max-h-[90vh] w-full bg-background px-4 pt-4 pb-6',
+  headerClassName = 'space-y-3 text-center',
+  titleClassName = 'text-center text-2xl font-bold text-foreground',
+  descriptionClassName = 'text-center text-base text-muted-foreground',
 }: {
   open: boolean
   onOpenChange: (open: boolean) => void
   icon?: ReactNode
   title: string
-  description: string
+  description?: string | null
   children: ReactNode
   dismissible?: boolean
+  dialogContentClassName?: string
+  drawerContentClassName?: string
+  headerClassName?: string
+  titleClassName?: string
+  descriptionClassName?: string
 }) {
   const isMobile = useIsMobile()
 
@@ -113,15 +123,17 @@ function OnboardingDialogShell({
         onOpenChange={handleOpenChange}
         dismissible={dismissible}
       >
-        <DrawerContent className="max-h-[90vh] w-full bg-background px-4 pt-4 pb-6">
-          <DrawerHeader className="space-y-3 text-center">
+        <DrawerContent className={drawerContentClassName}>
+          <DrawerHeader className={headerClassName}>
             {icon}
-            <DrawerTitle className="text-center text-2xl font-bold text-foreground">
+            <DrawerTitle className={titleClassName}>
               {title}
             </DrawerTitle>
-            <DrawerDescription className="text-center text-base text-muted-foreground">
-              {description}
-            </DrawerDescription>
+            {description && (
+              <DrawerDescription className={descriptionClassName}>
+                {description}
+              </DrawerDescription>
+            )}
           </DrawerHeader>
           {children}
         </DrawerContent>
@@ -132,7 +144,7 @@ function OnboardingDialogShell({
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="max-w-md border bg-background p-8"
+        className={dialogContentClassName}
         showCloseButton={dismissible}
         onEscapeKeyDown={(event) => {
           if (!dismissible) {
@@ -145,14 +157,16 @@ function OnboardingDialogShell({
           }
         }}
       >
-        <DialogHeader className="space-y-3 text-center">
+        <DialogHeader className={headerClassName}>
           {icon}
-          <DialogTitle className="text-center text-2xl font-bold text-foreground">
+          <DialogTitle className={titleClassName}>
             {title}
           </DialogTitle>
-          <DialogDescription className="text-center text-base text-muted-foreground">
-            {description}
-          </DialogDescription>
+          {description && (
+            <DialogDescription className={descriptionClassName}>
+              {description}
+            </DialogDescription>
+          )}
         </DialogHeader>
         {children}
       </DialogContent>
@@ -533,14 +547,6 @@ function EnableTradingStatusDialog({
   const t = useExtracted()
   const isSigning = step === 'enabling'
   const dismissible = Boolean(error)
-  const isMobile = useIsMobile()
-
-  function handleOpenChange(nextOpen: boolean) {
-    if (!dismissible && !nextOpen) {
-      return
-    }
-    onOpenChange(nextOpen)
-  }
 
   const timeline = (
     <div className="mt-5 space-y-0">
@@ -574,51 +580,19 @@ function EnableTradingStatusDialog({
     </div>
   )
 
-  if (isMobile) {
-    return (
-      <Drawer
-        open={open}
-        onOpenChange={handleOpenChange}
-        dismissible={dismissible}
-      >
-        <DrawerContent className="max-h-[90vh] w-full bg-background px-4 pt-4 pb-6">
-          <DrawerHeader className="space-y-2 text-center">
-            <DrawerTitle className="text-center text-xl font-bold text-foreground">
-              {t('Enable Trading')}
-            </DrawerTitle>
-          </DrawerHeader>
-
-          {timeline}
-        </DrawerContent>
-      </Drawer>
-    )
-  }
-
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent
-        className="max-w-sm border bg-background p-6"
-        showCloseButton={dismissible}
-        onEscapeKeyDown={(event) => {
-          if (!dismissible) {
-            event.preventDefault()
-          }
-        }}
-        onInteractOutside={(event) => {
-          if (!dismissible) {
-            event.preventDefault()
-          }
-        }}
-      >
-        <DialogHeader className="space-y-2 text-center">
-          <DialogTitle className="text-center text-xl font-bold text-foreground">
-            {t('Enable Trading')}
-          </DialogTitle>
-        </DialogHeader>
-
-        {timeline}
-      </DialogContent>
-    </Dialog>
+    <OnboardingDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t('Enable Trading')}
+      description={null}
+      dismissible={dismissible}
+      dialogContentClassName="max-w-sm border bg-background p-6"
+      headerClassName="space-y-2 text-center"
+      titleClassName="text-center text-xl font-bold text-foreground"
+    >
+      {timeline}
+    </OnboardingDialogShell>
   )
 }
 

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -50,6 +50,7 @@ import {
   TRADING_AUTH_TYPES,
 } from '@/lib/trading-auth/client'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
+import { hasUsableUserEmail } from '@/lib/user-email'
 import { defaultViemNetwork, defaultViemRpcUrl } from '@/lib/viem-network'
 import { signAndSubmitDepositWalletCalls } from '@/lib/wallet/client'
 import {
@@ -85,10 +86,6 @@ export function TradingOnboardingProvider({ children }: { children: ReactNode })
 interface TradingOnboardingProviderContentProps {
   children: ReactNode
   user: User | null
-}
-
-function hasUsableEmail(email?: string | null) {
-  return Boolean(email && /^[^\s@]+@[^\s@][^\s.@]*\.[^\s@]+$/.test(email))
 }
 
 function useSessionRefresher() {
@@ -139,7 +136,7 @@ function useOnboardingStatus(user: User | null, requiresTradingAuthRefresh: bool
     const needsUsername = Boolean(user && !hasUsername)
     const needsEmail = Boolean(
       user
-      && !hasUsableEmail(user.email)
+      && !hasUsableUserEmail(user.email)
       && !onboardingSettings.emailSkippedAt
       && !onboardingSettings.emailCompletedAt,
     )
@@ -437,6 +434,11 @@ function TradingOnboardingProviderContent({
       setActiveModal('username')
       return
     }
+    if (modal === 'email' && status.needsEmail) {
+      setDismissedModal(null)
+      setActiveModal('email')
+      return
+    }
     if (modal === 'auto-redeem') {
       setDismissedModal(modal)
       setActiveModal(null)
@@ -448,7 +450,7 @@ function TradingOnboardingProviderContent({
     setDismissedModal(modal)
     setActiveModal(null)
     setShouldContinueTradingAuthPrompt(false)
-  }, [openFundModalIfBalanceEmpty, status.needsUsername])
+  }, [openFundModalIfBalanceEmpty, status.needsEmail, status.needsUsername])
 
   const handleUsernameSubmit = useCallback(async (username: string, termsAccepted: boolean) => {
     if (isUsernameSubmitting) {
@@ -1207,7 +1209,7 @@ function TradingOnboardingProviderContent({
         usernameError={usernameError}
         isUsernameSubmitting={isUsernameSubmitting}
         onUsernameSubmit={handleUsernameSubmit}
-        emailDefaultValue={hasUsableEmail(user?.email) ? user?.email ?? '' : ''}
+        emailDefaultValue={hasUsableUserEmail(user?.email) ? user?.email ?? '' : ''}
         emailError={emailError}
         isEmailSubmitting={isEmailSubmitting}
         onEmailSubmit={handleEmailSubmit}

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -432,6 +432,11 @@ function TradingOnboardingProviderContent({
       setActiveModal(modal)
       return
     }
+    if (modal === 'username' && status.needsUsername) {
+      setDismissedModal(null)
+      setActiveModal('username')
+      return
+    }
     if (modal === 'auto-redeem') {
       setDismissedModal(modal)
       setActiveModal(null)
@@ -443,7 +448,7 @@ function TradingOnboardingProviderContent({
     setDismissedModal(modal)
     setActiveModal(null)
     setShouldContinueTradingAuthPrompt(false)
-  }, [openFundModalIfBalanceEmpty])
+  }, [openFundModalIfBalanceEmpty, status.needsUsername])
 
   const handleUsernameSubmit = useCallback(async (username: string, termsAccepted: boolean) => {
     if (isUsernameSubmitting) {

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -439,6 +439,16 @@ function TradingOnboardingProviderContent({
       setActiveModal('email')
       return
     }
+    if ((modal === 'enable' || modal === 'enable-status') && !enableTradingError) {
+      setDismissedModal(null)
+      setActiveModal(modal)
+      return
+    }
+    if (modal === 'approve' && !tokenApprovalError) {
+      setDismissedModal(null)
+      setActiveModal('approve')
+      return
+    }
     if (modal === 'auto-redeem') {
       setDismissedModal(modal)
       setActiveModal(null)
@@ -450,7 +460,13 @@ function TradingOnboardingProviderContent({
     setDismissedModal(modal)
     setActiveModal(null)
     setShouldContinueTradingAuthPrompt(false)
-  }, [openFundModalIfBalanceEmpty, status.needsEmail, status.needsUsername])
+  }, [
+    enableTradingError,
+    openFundModalIfBalanceEmpty,
+    status.needsEmail,
+    status.needsUsername,
+    tokenApprovalError,
+  ])
 
   const handleUsernameSubmit = useCallback(async (username: string, termsAccepted: boolean) => {
     if (isUsernameSubmitting) {

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -88,6 +88,40 @@ interface TradingOnboardingProviderContentProps {
   user: User | null
 }
 
+function isGeneratedDepositWalletUsername(username?: string | null, depositWalletAddress?: string | null) {
+  const trimmedUsername = username?.trim()
+  const trimmedDepositWalletAddress = depositWalletAddress?.trim()
+  if (!trimmedUsername || !trimmedDepositWalletAddress) {
+    return false
+  }
+
+  const prefix = `${trimmedDepositWalletAddress.toLowerCase()}-`
+  const normalizedUsername = trimmedUsername.toLowerCase()
+  if (!normalizedUsername.startsWith(prefix)) {
+    return false
+  }
+
+  return /^\d+$/.test(normalizedUsername.slice(prefix.length))
+}
+
+function hasUserProvidedUsername(user: User) {
+  const username = user.username?.trim()
+  return Boolean(
+    username
+    && !isGeneratedDepositWalletUsername(username, user.deposit_wallet_address),
+  )
+}
+
+function getUsernameDefaultValue(user: User | null) {
+  if (!user?.username) {
+    return ''
+  }
+  if (isGeneratedDepositWalletUsername(user.username, user.deposit_wallet_address)) {
+    return ''
+  }
+  return user.username
+}
+
 function useSessionRefresher() {
   return useCallback(async () => {
     try {
@@ -132,7 +166,7 @@ function useOnboardingStatus(user: User | null, requiresTradingAuthRefresh: bool
   return useMemo(() => {
     const onboardingSettings = user?.settings?.onboarding ?? {}
     const tradingAuthSettings = user?.settings?.tradingAuth ?? null
-    const hasUsername = Boolean(user?.username?.trim())
+    const hasUsername = Boolean(user && hasUserProvidedUsername(user))
     const needsUsername = Boolean(user && !hasUsername)
     const needsEmail = Boolean(
       user
@@ -1221,7 +1255,7 @@ function TradingOnboardingProviderContent({
       <TradingOnboardingDialogs
         activeModal={activeModal}
         onModalOpenChange={handleModalOpenChange}
-        usernameDefaultValue={user?.username ?? ''}
+        usernameDefaultValue={getUsernameDefaultValue(user)}
         usernameError={usernameError}
         isUsernameSubmitting={isUsernameSubmitting}
         onUsernameSubmit={handleUsernameSubmit}

--- a/src/app/api/sync/volume/route.ts
+++ b/src/app/api/sync/volume/route.ts
@@ -20,7 +20,7 @@ import { db } from '@/lib/drizzle'
 
 export const maxDuration = 300
 
-const CLOB_URL = (process.env.CLOB_URL ?? 'https://clob.kuest.com').replace(/\/+$/, '')
+const CLOB_URL = process.env.CLOB_URL!
 const SYNC_RUNNING_STALE_MS = 15 * 60 * 1000
 const VOLUME_SYNC_SERVICE = 'volume_sync'
 const VOLUME_SYNC_SUBGRAPH = 'volume'

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -27,8 +27,9 @@ export async function GET(request: Request) {
     }
 
     const profiles: PublicProfile[] = (data || []).map((user) => {
+      const publicAddress = getUserPublicAddress(user as unknown as User) || ''
       return {
-        address: getUserPublicAddress(user as unknown as User) || '',
+        address: publicAddress,
         deposit_wallet_address: user.deposit_wallet_address ?? null,
         username: user.username!,
         image: user.image ? getPublicAssetUrl(user.image) : '',

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -17,6 +17,7 @@ import { getPublicAssetUrl } from '@/lib/storage'
 import { DEFAULT_THEME_SITE_NAME } from '@/lib/theme-site-identity'
 import { ensureUserTradingAuthSecretFingerprint } from '@/lib/trading-auth/server'
 import { sanitizeTradingAuthSettings } from '@/lib/trading-auth/utils'
+import { isWalletPlaceholderEmail } from '@/lib/user-email'
 import * as schema from './db/schema'
 
 const TWO_FACTOR_COOKIE_NAME = 'two_factor'
@@ -209,6 +210,7 @@ export const auth = betterAuth({
   plugins: [
     customSession(async ({ user, session }) => {
       const userId = String((user as any).id ?? '')
+      const email = isWalletPlaceholderEmail(user.email) ? '' : user.email
       const rawSettings = (user as any).settings as Record<string, any> | undefined
       const hydratedSettings = rawSettings && userId
         ? await ensureUserTradingAuthSecretFingerprint(userId, rawSettings)
@@ -220,6 +222,7 @@ export const auth = betterAuth({
       return {
         user: {
           ...user,
+          email,
           settings,
           image: user.image ? getPublicAssetUrl(user.image) : '',
           is_admin: isAdminWallet(user.name),

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -210,7 +210,7 @@ export const auth = betterAuth({
   plugins: [
     customSession(async ({ user, session }) => {
       const userId = String((user as any).id ?? '')
-      const email = isWalletPlaceholderEmail(user.email) ? '' : user.email
+      const email = isWalletPlaceholderEmail(user.email, [SIWE_EMAIL_DOMAIN]) ? '' : user.email
       const rawSettings = (user as any).settings as Record<string, any> | undefined
       const hydratedSettings = rawSettings && userId
         ? await ensureUserTradingAuthSecretFingerprint(userId, rawSettings)

--- a/src/lib/db/queries/affiliate.ts
+++ b/src/lib/db/queries/affiliate.ts
@@ -81,6 +81,10 @@ function convertAffiliateStats(rawData: any): AffiliateStats {
   }
 }
 
+function getDisplayUsername(username: string | null, address: string) {
+  return username?.trim() || address
+}
+
 function convertAffiliateOverview(rawData: any[]): AffiliateOverview[] {
   return rawData.map(item => ({
     affiliate_user_id: item.affiliate_user_id,
@@ -174,7 +178,7 @@ export const AffiliateRepository = {
           ? {
               id: result[0].id,
               affiliate_code: result[0].affiliate_code,
-              username: result[0].username!,
+              username: getDisplayUsername(result[0].username, result[0].address),
               address: result[0].address,
               image: result[0].image,
             }
@@ -309,7 +313,7 @@ export const AffiliateRepository = {
 
       const data = result.map(user => ({
         id: user.id,
-        username: user.username!,
+        username: getDisplayUsername(user.username, user.address),
         address: user.address,
         deposit_wallet_address: user.deposit_wallet_address,
         image: user.image,
@@ -343,7 +347,7 @@ export const AffiliateRepository = {
         user_id: row.user_id,
         created_at: row.created_at,
         users: {
-          username: row.username!,
+          username: getDisplayUsername(row.username, row.address),
           address: row.address,
           deposit_wallet_address: row.deposit_wallet_address,
           image: row.image,

--- a/src/lib/db/queries/user.ts
+++ b/src/lib/db/queries/user.ts
@@ -11,7 +11,6 @@ import { runQuery } from '@/lib/db/utils/run-query'
 import { isDepositWalletDeployed } from '@/lib/deposit-wallet'
 import { db } from '@/lib/drizzle'
 import { getPublicAssetUrl } from '@/lib/storage'
-import { sanitizeTradingAuthSettings } from '@/lib/trading-auth/utils'
 import { normalizeAddress } from '@/lib/wallet'
 
 export const UserRepository = {
@@ -208,13 +207,6 @@ export const UserRepository = {
       }
 
       const user: any = session.user
-      const rawEmail = typeof user.email === 'string' ? user.email : ''
-      const shouldRedactEmail = Boolean(rawEmail && rawEmail.startsWith('0x') && rawEmail.split('@')[0].length === 42)
-
-      user.email = shouldRedactEmail ? '' : rawEmail
-      if (user.settings) {
-        user.settings = sanitizeTradingAuthSettings(user.settings)
-      }
 
       if (minimal) {
         return user

--- a/src/lib/db/queries/user.ts
+++ b/src/lib/db/queries/user.ts
@@ -224,29 +224,7 @@ export const UserRepository = {
         }
       }
 
-      const proxyAddress = await ensureUserDepositWallet(user)
-
-      if (proxyAddress && !user.username) {
-        const generatedUsername = generateUsername(proxyAddress)
-
-        if (generatedUsername) {
-          try {
-            const result = await db
-              .update(users)
-              .set({ username: generatedUsername })
-              .where(eq(users.id, user.id))
-              .returning({ username: users.username })
-
-            const updatedUsername = result[0]?.username
-            if (updatedUsername) {
-              user.username = updatedUsername
-            }
-          }
-          catch (error) {
-            console.error('Failed to set deterministic username', error)
-          }
-        }
-      }
+      await ensureUserDepositWallet(user)
 
       return user
     }
@@ -420,12 +398,6 @@ export const UserRepository = {
       return { data: result, error: null }
     })
   },
-}
-
-function generateUsername(proxyAddress: string) {
-  const timestamp = Date.now()
-
-  return `${proxyAddress}-${timestamp}`
 }
 
 async function ensureUserDepositWallet(user: any): Promise<string | null> {

--- a/src/lib/user-email.ts
+++ b/src/lib/user-email.ts
@@ -1,0 +1,17 @@
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@][^\s.@]*\.[^\s@]+$/
+const WALLET_ADDRESS_PATTERN = /^0x[a-f0-9]{40}$/i
+
+export function isWalletPlaceholderEmail(email?: string | null) {
+  const rawEmail = email?.trim() ?? ''
+  if (!rawEmail) {
+    return false
+  }
+
+  const localPart = rawEmail.split('@')[0]
+  return WALLET_ADDRESS_PATTERN.test(localPart)
+}
+
+export function hasUsableUserEmail(email?: string | null) {
+  const rawEmail = email?.trim() ?? ''
+  return Boolean(rawEmail && EMAIL_PATTERN.test(rawEmail) && !isWalletPlaceholderEmail(rawEmail))
+}

--- a/src/lib/user-email.ts
+++ b/src/lib/user-email.ts
@@ -1,17 +1,24 @@
 import { z } from 'zod'
-import siteUrlUtils from '@/lib/site-url'
 
 const WALLET_ADDRESS_PATTERN = /^0x[a-f0-9]{40}$/i
+const HAS_PROTOCOL_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i
+const LOCAL_HOST_PATTERN = /^(?:localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0)(?::\d+)?(?:\/|$)/i
 const EmailSchema = z.email({ pattern: z.regexes.html5Email })
-const { resolveSiteUrl } = siteUrlUtils
 
 function normalizeEmailDomain(domain?: string | null) {
   return domain?.trim().toLowerCase() ?? ''
 }
 
 function getConfiguredPlaceholderEmailDomains() {
+  const rawSiteUrl = process.env.SITE_URL?.trim() || process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim()
+  if (!rawSiteUrl) {
+    return []
+  }
+
   try {
-    const siteUrl = resolveSiteUrl(process.env)
+    const siteUrl = HAS_PROTOCOL_PATTERN.test(rawSiteUrl)
+      ? rawSiteUrl
+      : `${LOCAL_HOST_PATTERN.test(rawSiteUrl) ? 'http' : 'https'}://${rawSiteUrl}`
     return [new URL(siteUrl).hostname]
   }
   catch {

--- a/src/lib/user-email.ts
+++ b/src/lib/user-email.ts
@@ -1,17 +1,36 @@
-const EMAIL_PATTERN = /^[^\s@]+@[^\s@][^\s.@]*\.[^\s@]+$/
-const WALLET_ADDRESS_PATTERN = /^0x[a-f0-9]{40}$/i
+import { z } from 'zod'
 
-export function isWalletPlaceholderEmail(email?: string | null) {
+const WALLET_ADDRESS_PATTERN = /^0x[a-f0-9]{40}$/i
+const EmailSchema = z.email({ pattern: z.regexes.html5Email })
+
+function normalizeEmailDomain(domain?: string | null) {
+  return domain?.trim().toLowerCase() ?? ''
+}
+
+function getBrowserPlaceholderEmailDomains() {
+  if (typeof window === 'undefined') {
+    return []
+  }
+  return [window.location.hostname]
+}
+
+export function isWalletPlaceholderEmail(email?: string | null, placeholderDomains?: readonly string[]) {
   const rawEmail = email?.trim() ?? ''
   if (!rawEmail) {
     return false
   }
 
-  const localPart = rawEmail.split('@')[0]
-  return WALLET_ADDRESS_PATTERN.test(localPart)
+  const [localPart, domain, ...extraParts] = rawEmail.split('@')
+  if (!localPart || !domain || extraParts.length > 0 || !WALLET_ADDRESS_PATTERN.test(localPart)) {
+    return false
+  }
+
+  const normalizedDomain = normalizeEmailDomain(domain)
+  const domains = placeholderDomains ?? getBrowserPlaceholderEmailDomains()
+  return domains.some(candidate => normalizeEmailDomain(candidate) === normalizedDomain)
 }
 
-export function hasUsableUserEmail(email?: string | null) {
+export function hasUsableUserEmail(email?: string | null, placeholderDomains?: readonly string[]) {
   const rawEmail = email?.trim() ?? ''
-  return Boolean(rawEmail && EMAIL_PATTERN.test(rawEmail) && !isWalletPlaceholderEmail(rawEmail))
+  return Boolean(rawEmail && EmailSchema.safeParse(rawEmail).success && !isWalletPlaceholderEmail(rawEmail, placeholderDomains))
 }

--- a/src/lib/user-email.ts
+++ b/src/lib/user-email.ts
@@ -1,17 +1,22 @@
 import { z } from 'zod'
+import siteUrlUtils from '@/lib/site-url'
 
 const WALLET_ADDRESS_PATTERN = /^0x[a-f0-9]{40}$/i
 const EmailSchema = z.email({ pattern: z.regexes.html5Email })
+const { resolveSiteUrl } = siteUrlUtils
 
 function normalizeEmailDomain(domain?: string | null) {
   return domain?.trim().toLowerCase() ?? ''
 }
 
-function getBrowserPlaceholderEmailDomains() {
-  if (typeof window === 'undefined') {
+function getConfiguredPlaceholderEmailDomains() {
+  try {
+    const siteUrl = resolveSiteUrl(process.env)
+    return [new URL(siteUrl).hostname]
+  }
+  catch {
     return []
   }
-  return [window.location.hostname]
 }
 
 export function isWalletPlaceholderEmail(email?: string | null, placeholderDomains?: readonly string[]) {
@@ -26,7 +31,7 @@ export function isWalletPlaceholderEmail(email?: string | null, placeholderDomai
   }
 
   const normalizedDomain = normalizeEmailDomain(domain)
-  const domains = placeholderDomains ?? getBrowserPlaceholderEmailDomains()
+  const domains = placeholderDomains ?? getConfiguredPlaceholderEmailDomains()
   return domains.some(candidate => normalizeEmailDomain(candidate) === normalizedDomain)
 }
 

--- a/tests/unit/TradingOnboardingDialogs.test.tsx
+++ b/tests/unit/TradingOnboardingDialogs.test.tsx
@@ -1,0 +1,118 @@
+import type { ComponentProps } from 'react'
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import TradingOnboardingDialogs from '@/app/[locale]/(platform)/_components/TradingOnboardingDialogs'
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (message: string) => message,
+}))
+
+vi.mock('@/app/[locale]/(platform)/_actions/deposit-wallet', () => ({
+  checkUsernameAvailabilityAction: vi.fn(),
+}))
+
+vi.mock('@/app/[locale]/(platform)/_components/TradingDialogs', () => ({
+  FundAccountDialog: ({ open }: { open: boolean }) => open ? <div data-testid="fund-account-dialog" /> : null,
+}))
+
+vi.mock('@/app/[locale]/(platform)/_components/WalletFlow', () => ({
+  WalletFlow: () => null,
+}))
+
+vi.mock('@/components/AppLink', () => ({
+  default: function MockAppLink({ children, href, ...props }: any) {
+    return <a href={href} {...props}>{children}</a>
+  },
+}))
+
+vi.mock('@/hooks/useSiteIdentity', () => ({
+  useSiteIdentity: () => ({ name: 'Kuest' }),
+}))
+
+type TradingOnboardingDialogsProps = ComponentProps<typeof TradingOnboardingDialogs>
+
+function createProps(
+  overrides: Partial<TradingOnboardingDialogsProps> = {},
+): TradingOnboardingDialogsProps {
+  return {
+    activeModal: null,
+    onModalOpenChange: vi.fn(),
+    usernameDefaultValue: '',
+    usernameError: null,
+    isUsernameSubmitting: false,
+    onUsernameSubmit: vi.fn(),
+    emailDefaultValue: '',
+    emailError: null,
+    isEmailSubmitting: false,
+    onEmailSubmit: vi.fn(),
+    onEmailSkip: vi.fn(),
+    enableTradingStep: 'idle',
+    enableTradingError: null,
+    onCreateDepositWallet: vi.fn(),
+    onEnableTradingAuth: vi.fn(),
+    hasDeployedDepositWallet: false,
+    hasTradingAuth: false,
+    hasTokenApprovals: false,
+    approvalsStep: 'idle',
+    tokenApprovalError: null,
+    onApproveTokens: vi.fn(),
+    autoRedeemStep: 'idle',
+    autoRedeemError: null,
+    onApproveAutoRedeem: vi.fn(),
+    fundModalOpen: false,
+    onFundOpenChange: vi.fn(),
+    onFundDeposit: vi.fn(),
+    depositModalOpen: false,
+    onDepositOpenChange: vi.fn(),
+    withdrawModalOpen: false,
+    onWithdrawOpenChange: vi.fn(),
+    user: null,
+    meldUrl: null,
+    ...overrides,
+  }
+}
+
+describe('tradingOnboardingDialogs', () => {
+  it('does not let the username step close from dialog dismissal controls', async () => {
+    const user = userEvent.setup()
+    const onModalOpenChange = vi.fn()
+
+    render(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'username',
+          onModalOpenChange,
+        })}
+      />,
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(onModalOpenChange).not.toHaveBeenCalled()
+  })
+
+  it('keeps other onboarding dialogs dismissible', async () => {
+    const user = userEvent.setup()
+    const onModalOpenChange = vi.fn()
+
+    render(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'email',
+          onModalOpenChange,
+        })}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(onModalOpenChange).toHaveBeenCalledWith('email', false)
+    })
+  })
+})

--- a/tests/unit/TradingOnboardingDialogs.test.tsx
+++ b/tests/unit/TradingOnboardingDialogs.test.tsx
@@ -121,11 +121,11 @@ describe('tradingOnboardingDialogs', () => {
     expect(onEmailSkip).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps later onboarding dialogs dismissible', async () => {
+  it('keeps enable trading non-dismissible until an error appears', async () => {
     const user = userEvent.setup()
     const onModalOpenChange = vi.fn()
 
-    render(
+    const view = render(
       <TradingOnboardingDialogs
         {...createProps({
           activeModal: 'enable',
@@ -134,12 +134,109 @@ describe('tradingOnboardingDialogs', () => {
       />,
     )
 
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(onModalOpenChange).not.toHaveBeenCalled()
+
+    view.rerender(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'enable',
+          enableTradingError: 'Relayer is unavailable.',
+          onModalOpenChange,
+        })}
+      />,
+    )
+
     expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
 
+    onModalOpenChange.mockClear()
     await user.keyboard('{Escape}')
 
     await waitFor(() => {
       expect(onModalOpenChange).toHaveBeenCalledWith('enable', false)
+    })
+  })
+
+  it('keeps enable trading status non-dismissible until an error appears', async () => {
+    const user = userEvent.setup()
+    const onModalOpenChange = vi.fn()
+
+    const view = render(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'enable-status',
+          hasDeployedDepositWallet: true,
+          onModalOpenChange,
+        })}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(onModalOpenChange).not.toHaveBeenCalled()
+
+    view.rerender(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'enable-status',
+          enableTradingError: 'Relayer is unavailable.',
+          hasDeployedDepositWallet: true,
+          onModalOpenChange,
+        })}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+
+    onModalOpenChange.mockClear()
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(onModalOpenChange).toHaveBeenCalledWith('enable-status', false)
+    })
+  })
+
+  it('keeps approve tokens non-dismissible until an error appears', async () => {
+    const user = userEvent.setup()
+    const onModalOpenChange = vi.fn()
+
+    const view = render(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'approve',
+          onModalOpenChange,
+        })}
+      />,
+    )
+
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(onModalOpenChange).not.toHaveBeenCalled()
+
+    view.rerender(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'approve',
+          onModalOpenChange,
+          tokenApprovalError: 'Relayer is unavailable.',
+        })}
+      />,
+    )
+
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument()
+
+    onModalOpenChange.mockClear()
+    await user.keyboard('{Escape}')
+
+    await waitFor(() => {
+      expect(onModalOpenChange).toHaveBeenCalledWith('approve', false)
     })
   })
 })

--- a/tests/unit/TradingOnboardingDialogs.test.tsx
+++ b/tests/unit/TradingOnboardingDialogs.test.tsx
@@ -3,6 +3,10 @@ import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import TradingOnboardingDialogs from '@/app/[locale]/(platform)/_components/TradingOnboardingDialogs'
 
+const mocks = vi.hoisted(() => ({
+  useIsMobile: vi.fn(() => false),
+}))
+
 vi.mock('next-intl', () => ({
   useExtracted: () => (message: string) => message,
 }))
@@ -27,6 +31,10 @@ vi.mock('@/components/AppLink', () => ({
 
 vi.mock('@/hooks/useSiteIdentity', () => ({
   useSiteIdentity: () => ({ name: 'Kuest' }),
+}))
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: mocks.useIsMobile,
 }))
 
 type TradingOnboardingDialogsProps = ComponentProps<typeof TradingOnboardingDialogs>
@@ -73,6 +81,11 @@ function createProps(
 }
 
 describe('tradingOnboardingDialogs', () => {
+  beforeEach(() => {
+    mocks.useIsMobile.mockReset()
+    mocks.useIsMobile.mockReturnValue(false)
+  })
+
   it('does not let the username step close from dialog dismissal controls', async () => {
     const user = userEvent.setup()
     const onModalOpenChange = vi.fn()
@@ -238,5 +251,21 @@ describe('tradingOnboardingDialogs', () => {
     await waitFor(() => {
       expect(onModalOpenChange).toHaveBeenCalledWith('approve', false)
     })
+  })
+
+  it('renders onboarding surfaces as drawers on mobile', () => {
+    mocks.useIsMobile.mockReturnValue(true)
+
+    render(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'enable',
+          enableTradingError: 'Relayer is unavailable.',
+        })}
+      />,
+    )
+
+    expect(document.querySelector('[data-slot="drawer-content"]')).toBeInTheDocument()
+    expect(document.querySelector('[data-slot="dialog-content"]')).not.toBeInTheDocument()
   })
 })

--- a/tests/unit/TradingOnboardingDialogs.test.tsx
+++ b/tests/unit/TradingOnboardingDialogs.test.tsx
@@ -94,14 +94,41 @@ describe('tradingOnboardingDialogs', () => {
     expect(onModalOpenChange).not.toHaveBeenCalled()
   })
 
-  it('keeps other onboarding dialogs dismissible', async () => {
+  it('only lets the explicit email skip button skip the email step', async () => {
+    const user = userEvent.setup()
+    const onModalOpenChange = vi.fn()
+    const onEmailSkip = vi.fn()
+
+    render(
+      <TradingOnboardingDialogs
+        {...createProps({
+          activeModal: 'email',
+          onModalOpenChange,
+          onEmailSkip,
+        })}
+      />,
+    )
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Close' })).not.toBeInTheDocument()
+
+    await user.keyboard('{Escape}')
+
+    expect(onModalOpenChange).not.toHaveBeenCalled()
+
+    await user.click(screen.getByRole('button', { name: 'Do this later' }))
+
+    expect(onEmailSkip).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps later onboarding dialogs dismissible', async () => {
     const user = userEvent.setup()
     const onModalOpenChange = vi.fn()
 
     render(
       <TradingOnboardingDialogs
         {...createProps({
-          activeModal: 'email',
+          activeModal: 'enable',
           onModalOpenChange,
         })}
       />,
@@ -112,7 +139,7 @@ describe('tradingOnboardingDialogs', () => {
     await user.keyboard('{Escape}')
 
     await waitFor(() => {
-      expect(onModalOpenChange).toHaveBeenCalledWith('email', false)
+      expect(onModalOpenChange).toHaveBeenCalledWith('enable', false)
     })
   })
 })

--- a/tests/unit/TradingOnboardingProvider.test.tsx
+++ b/tests/unit/TradingOnboardingProvider.test.tsx
@@ -1,0 +1,139 @@
+import type { User } from '@/types'
+import { render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
+import { useUser } from '@/stores/useUser'
+
+const mocks = vi.hoisted(() => ({
+  dialogProps: null as any,
+  getSession: vi.fn().mockResolvedValue({ data: { user: null } }),
+  openAppKit: vi.fn(),
+  usePathname: vi.fn(() => '/'),
+}))
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (message: string) => message,
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: mocks.usePathname,
+}))
+
+vi.mock('wagmi', () => ({
+  useSignMessage: () => ({
+    signMessageAsync: vi.fn(),
+  }),
+  useSignTypedData: () => ({
+    signTypedDataAsync: vi.fn(),
+  }),
+}))
+
+vi.mock('@/app/[locale]/(platform)/_actions/approve-tokens', () => ({
+  markApprovalStateWithoutTransactionAction: vi.fn(),
+}))
+
+vi.mock('@/app/[locale]/(platform)/_actions/deposit-wallet', () => ({
+  checkUsernameAvailabilityAction: vi.fn(),
+  createDepositWalletAction: vi.fn(),
+  enableTradingAuthAction: vi.fn(),
+  markAutoRedeemApprovalCompletedAction: vi.fn(),
+  updateOnboardingEmailAction: vi.fn(),
+  updateOnboardingUsernameAction: vi.fn(),
+}))
+
+vi.mock('@/app/[locale]/(platform)/_components/TradingOnboardingDialogs', () => ({
+  __esModule: true,
+  default: function MockTradingOnboardingDialogs(props: any) {
+    mocks.dialogProps = props
+    return <div data-testid="active-modal">{props.activeModal ?? ''}</div>
+  },
+}))
+
+vi.mock('@/hooks/useAffiliateOrderMetadata', () => ({
+  useAffiliateOrderMetadata: () => ({
+    affiliateAddress: null,
+    affiliateSharePercent: null,
+    referrerAddress: null,
+  }),
+}))
+
+vi.mock('@/hooks/useAppKit', () => ({
+  useAppKit: () => ({
+    open: mocks.openAppKit,
+  }),
+}))
+
+vi.mock('@/hooks/useDepositWalletPolling', () => ({
+  useDepositWalletPolling: vi.fn(),
+}))
+
+vi.mock('@/hooks/useSignaturePromptRunner', () => ({
+  useSignaturePromptRunner: () => ({
+    runWithSignaturePrompt: (callback: () => Promise<string>) => callback(),
+  }),
+}))
+
+vi.mock('@/lib/auth-client', () => ({
+  authClient: {
+    getSession: mocks.getSession,
+  },
+}))
+
+function createUser(overrides: Partial<User> = {}): User {
+  return {
+    id: 'user-1',
+    address: '0x00000000000000000000000000000000000000bb',
+    email: '',
+    twoFactorEnabled: false,
+    username: '',
+    image: '',
+    settings: {},
+    is_admin: false,
+    deposit_wallet_address: null,
+    deposit_wallet_status: 'not_started',
+    ...overrides,
+  }
+}
+
+describe('TradingOnboardingProvider', () => {
+  beforeEach(() => {
+    useUser.setState(null)
+    mocks.dialogProps = null
+    mocks.getSession.mockClear()
+    mocks.openAppKit.mockClear()
+    mocks.usePathname.mockReturnValue('/')
+  })
+
+  afterEach(() => {
+    useUser.setState(null)
+  })
+
+  it('shows username before email when the current username is generated from the deposit wallet', async () => {
+    const depositWalletAddress = '0xbc040c5a56d757986475005f8cde8e41fe3e2486'
+    const generatedUsername = `${depositWalletAddress}-1770000000000`
+
+    useUser.setState(createUser({
+      deposit_wallet_address: depositWalletAddress,
+      deposit_wallet_status: 'deployed',
+      email: '',
+      settings: {
+        onboarding: {
+          termsAcceptedAt: '2026-05-18T18:32:43.349Z',
+          usernameCompletedAt: '2026-05-18T18:32:43.349Z',
+        },
+      },
+      username: generatedUsername,
+    }))
+
+    render(
+      <TradingOnboardingProvider>
+        <div />
+      </TradingOnboardingProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-modal')).toHaveTextContent('username')
+    })
+    expect(mocks.dialogProps.usernameDefaultValue).toBe('')
+  })
+})

--- a/tests/unit/userEmail.test.ts
+++ b/tests/unit/userEmail.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { hasUsableUserEmail, isWalletPlaceholderEmail } from '@/lib/user-email'
+
+describe('userEmail', () => {
+  it('treats Better Auth SIWE placeholder emails as unusable', () => {
+    const email = '0xbc040c5a56d757986475005f8cde8e41fe3e2486@demo.kuest.com'
+
+    expect(isWalletPlaceholderEmail(email)).toBe(true)
+    expect(hasUsableUserEmail(email)).toBe(false)
+  })
+
+  it('accepts normal email addresses', () => {
+    expect(isWalletPlaceholderEmail('trader@example.com')).toBe(false)
+    expect(hasUsableUserEmail('trader@example.com')).toBe(true)
+  })
+
+  it('rejects missing and malformed emails', () => {
+    expect(hasUsableUserEmail(null)).toBe(false)
+    expect(hasUsableUserEmail('not-an-email')).toBe(false)
+  })
+})

--- a/tests/unit/userEmail.test.ts
+++ b/tests/unit/userEmail.test.ts
@@ -5,8 +5,29 @@ describe('userEmail', () => {
   it('treats Better Auth SIWE placeholder emails as unusable', () => {
     const email = '0xbc040c5a56d757986475005f8cde8e41fe3e2486@demo.kuest.com'
 
-    expect(isWalletPlaceholderEmail(email)).toBe(true)
-    expect(hasUsableUserEmail(email)).toBe(false)
+    expect(isWalletPlaceholderEmail(email, ['demo.kuest.com'])).toBe(true)
+    expect(hasUsableUserEmail(email, ['demo.kuest.com'])).toBe(false)
+  })
+
+  it('does not hard-code placeholder domains', () => {
+    const email = '0xbc040c5a56d757986475005f8cde8e41fe3e2486@demo.kuest.com'
+
+    expect(isWalletPlaceholderEmail(email)).toBe(false)
+    expect(hasUsableUserEmail(email)).toBe(true)
+  })
+
+  it('does not treat wallet-shaped emails on normal domains as placeholders', () => {
+    const email = '0xbc040c5a56d757986475005f8cde8e41fe3e2486@gmail.com'
+
+    expect(isWalletPlaceholderEmail(email)).toBe(false)
+    expect(hasUsableUserEmail(email)).toBe(true)
+  })
+
+  it('matches placeholders against the configured SIWE email domain', () => {
+    const email = '0xbc040c5a56d757986475005f8cde8e41fe3e2486@example.com'
+
+    expect(isWalletPlaceholderEmail(email)).toBe(false)
+    expect(isWalletPlaceholderEmail(email, ['example.com'])).toBe(true)
   })
 
   it('accepts normal email addresses', () => {
@@ -17,5 +38,7 @@ describe('userEmail', () => {
   it('rejects missing and malformed emails', () => {
     expect(hasUsableUserEmail(null)).toBe(false)
     expect(hasUsableUserEmail('not-an-email')).toBe(false)
+    expect(hasUsableUserEmail('trader@example..com')).toBe(false)
+    expect(hasUsableUserEmail('trader@example_.com')).toBe(false)
   })
 })

--- a/tests/unit/userEmail.test.ts
+++ b/tests/unit/userEmail.test.ts
@@ -1,7 +1,17 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { hasUsableUserEmail, isWalletPlaceholderEmail } from '@/lib/user-email'
 
+const ORIGINAL_SITE_URL = process.env.SITE_URL
+
 describe('userEmail', () => {
+  afterEach(() => {
+    if (ORIGINAL_SITE_URL === undefined) {
+      delete process.env.SITE_URL
+      return
+    }
+    process.env.SITE_URL = ORIGINAL_SITE_URL
+  })
+
   it('treats Better Auth SIWE placeholder emails as unusable', () => {
     const email = '0xbc040c5a56d757986475005f8cde8e41fe3e2486@demo.kuest.com'
 
@@ -10,10 +20,19 @@ describe('userEmail', () => {
   })
 
   it('does not hard-code placeholder domains', () => {
+    delete process.env.SITE_URL
     const email = '0xbc040c5a56d757986475005f8cde8e41fe3e2486@demo.kuest.com'
 
     expect(isWalletPlaceholderEmail(email)).toBe(false)
     expect(hasUsableUserEmail(email)).toBe(true)
+  })
+
+  it('matches placeholders against the configured site url hostname by default', () => {
+    process.env.SITE_URL = 'tenant.example'
+    const email = '0xbc040c5a56d757986475005f8cde8e41fe3e2486@tenant.example'
+
+    expect(isWalletPlaceholderEmail(email)).toBe(true)
+    expect(hasUsableUserEmail(email)).toBe(false)
   })
 
   it('does not treat wallet-shaped emails on normal domains as placeholders', () => {

--- a/tests/unit/userRepository.test.ts
+++ b/tests/unit/userRepository.test.ts
@@ -26,7 +26,7 @@ describe('userRepository.getCurrentUser', () => {
     mocks.headers.mockResolvedValue(new Headers())
   })
 
-  it('sanitizes trading auth settings before returning minimal users', async () => {
+  it('returns the normalized session user for minimal requests', async () => {
     mocks.getSession.mockResolvedValueOnce({
       user: {
         id: 'user-1',
@@ -34,11 +34,11 @@ describe('userRepository.getCurrentUser', () => {
         settings: {
           tradingAuth: {
             relayer: {
-              key: 'secret-relayer-key',
+              enabled: true,
               updatedAt: '2026-03-23T00:00:00.000Z',
             },
             clob: {
-              key: '',
+              enabled: false,
               updatedAt: '2026-03-23T00:00:00.000Z',
             },
           },
@@ -49,6 +49,12 @@ describe('userRepository.getCurrentUser', () => {
 
     const user = await UserRepository.getCurrentUser({ minimal: true })
 
+    expect(mocks.getSession).toHaveBeenCalledWith({
+      query: {
+        disableCookieCache: false,
+      },
+      headers: expect.any(Headers),
+    })
     expect(user).toEqual({
       id: 'user-1',
       email: 'user@example.com',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refactored trading onboarding to control dismissal, require a real username, and render dialogs as drawers on mobile. Tightened email validation and stripped wallet-placeholder emails from session using the configured `SITE_URL` or SIWE domain.

- **New Features**
  - On mobile, onboarding dialogs render as a `Drawer`.

- **Refactors**
  - Username and Email steps are non-dismissible; email can only be skipped via “Do this later”.
  - Enable Trading and Approve Tokens are non-dismissible until an error appears; then close is allowed.
  - Removed auto-generated usernames based on deposit wallets; treat these as placeholders and don’t prefill.
  - Email handling: stricter validation with `hasUsableUserEmail`; detect wallet-shaped placeholder emails using `SITE_URL` (and SIWE domain) via `isWalletPlaceholderEmail`; strip these from the session.
  - Affiliate queries fall back to address when username is missing.
  - Added unit tests for dialogs, provider flow, and email utils.

<sup>Written for commit 5f5795e3351c12c45cd5e78107133d7850f8b635. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1020?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

