### PR TITLE
fix: restore external proxy wallet payload handling

### DIFF
--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -2041,7 +2041,7 @@
           "userAddress": {
             "type": "string"
           },
-          "depositWallet": {
+          "proxyAddress": {
             "type": "string",
             "nullable": true
           },
@@ -2111,7 +2111,7 @@
           "userAddress": {
             "type": "string"
           },
-          "depositWallet": {
+          "proxyAddress": {
             "type": "string",
             "nullable": true
           },

--- a/docs/api-reference/schemas/openapi-data-api.json
+++ b/docs/api-reference/schemas/openapi-data-api.json
@@ -152,7 +152,7 @@
                   "sample": {
                     "value": [
                       {
-                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                         "conditionId": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917",
                         "size": 1185.42,
@@ -180,7 +180,7 @@
                         "negativeRisk": true
                       },
                       {
-                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "asset": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5:1",
                         "conditionId": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5",
                         "size": 940.11,
@@ -375,7 +375,7 @@
                   "sample": {
                     "value": [
                       {
-                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                         "conditionId": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917",
                         "size": 610.2,
@@ -402,7 +402,7 @@
                         "endDate": "2024-09-18T18:00:00Z"
                       },
                       {
-                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "asset": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5:1",
                         "conditionId": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5",
                         "size": 980.5,
@@ -722,7 +722,7 @@
                         "token": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                         "holders": [
                           {
-                            "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                            "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                             "bio": "Macro strategist backing major economic events.",
                             "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                             "pseudonym": "macro.whale",
@@ -734,7 +734,7 @@
                             "profileImageOptimized": "https://cdn.domain.com/users/macro-whale@2x.jpg"
                           },
                           {
-                            "depositWallet": "0x94d37B9c164888FbA4d4b3D4639a65f8AC54a1B6",
+                            "proxyWallet": "0x94d37B9c164888FbA4d4b3D4639a65f8AC54a1B6",
                             "bio": "On-chain analyst seeding liquidity.",
                             "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                             "pseudonym": "liquidity.lab",
@@ -861,7 +861,7 @@
                   "sample": {
                     "value": [
                       {
-                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "timestamp": 1718125200,
                         "conditionId": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917",
                         "type": "TRADE",
@@ -884,7 +884,7 @@
                         "profileImageOptimized": "https://cdn.domain.com/users/macro-whale@2x.jpg"
                       },
                       {
-                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "timestamp": 1717664400,
                         "conditionId": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5",
                         "type": "TRADE",
@@ -1076,7 +1076,7 @@
                   "sample": {
                     "value": [
                       {
-                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "side": "BUY",
                         "asset": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917:0",
                         "conditionId": "0xdd22472e552920b8438158ea7238bfadfa4f736aa4cee91a6b86c39ead110917",
@@ -1098,7 +1098,7 @@
                         "transactionHash": "0xa8b1be184ad6b5a219d121935e7b4f6a1cb5df38e7b74d2880aed672541da831"
                       },
                       {
-                        "depositWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
+                        "proxyWallet": "0x56687bF447db6fFa42FfE2204a05edAa20f55839",
                         "side": "SELL",
                         "asset": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5:1",
                         "conditionId": "0x8eee3789813eead2d47db3bdf6a1c5021f564ef18e2aefc8b80b9dcd5d6f8ac5",
@@ -1666,7 +1666,7 @@
                     "value": [
                       {
                         "rank": "1",
-                        "depositWallet": "0x1234567890abcdef1234567890abcdef12345678",
+                        "proxyWallet": "0x1234567890abcdef1234567890abcdef12345678",
                         "userName": "Theo4",
                         "vol": 22862194,
                         "pnl": 8499002,
@@ -1805,7 +1805,7 @@
       "Position": {
         "type": "object",
         "properties": {
-          "depositWallet": {
+          "proxyWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "asset": {
@@ -1890,7 +1890,7 @@
       "ClosedPosition": {
         "type": "object",
         "properties": {
-          "depositWallet": {
+          "proxyWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "asset": {
@@ -2043,7 +2043,7 @@
       "Activity": {
         "type": "object",
         "properties": {
-          "depositWallet": {
+          "proxyWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "conditionId": {
@@ -2148,7 +2148,7 @@
       "Trade": {
         "type": "object",
         "properties": {
-          "depositWallet": {
+          "proxyWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "side": {
@@ -2259,7 +2259,7 @@
       "Holder": {
         "type": "object",
         "properties": {
-          "depositWallet": {
+          "proxyWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "bio": {
@@ -2302,7 +2302,7 @@
           "rank": {
             "type": "string"
           },
-          "depositWallet": {
+          "proxyWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "userName": {
@@ -2335,7 +2335,7 @@
           "winRank": {
             "type": "string"
           },
-          "depositWallet": {
+          "proxyWallet": {
             "$ref": "#/components/schemas/Address"
           },
           "userName": {

--- a/docs/api-reference/wss/sports.mdx
+++ b/docs/api-reference/wss/sports.mdx
@@ -39,7 +39,7 @@ Send any variant of `PING` (`ping`, `PiNg`, `PING`). The server replies with `PO
   "topic": "activity",
   "type": "orders_matched",
   "payload": {
-    "depositWallet": "0xe25b9180f5687aa85bd94ee309bb72a464320f1b",
+    "proxyWallet": "0xe25b9180f5687aa85bd94ee309bb72a464320f1b",
     "creator": "0x8f2a6db31d2f3f3c8e4f9e74d5f5f9d2a7b0c123",
     "transactionHash": "0xdeadbeef",
     "eventSlug": "x-banned-in-uk-by-march-31"

--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -340,7 +340,7 @@ function useLiveActivityStream({
 
         const hasTitle = hasText(rawPayload.title)
         const hasMarketSlug = hasText(rawPayload.slug)
-        const hasUser = hasText(rawPayload.pseudonym) || hasText(rawPayload.name) || hasText(rawPayload.depositWallet)
+        const hasUser = hasText(rawPayload.pseudonym) || hasText(rawPayload.name) || hasText(rawPayload.proxyWallet)
         const hasSide = hasText(rawPayload.side)
         const hasOutcomeText = hasText(rawPayload.outcome)
         const hasOutcomeIndex = typeof rawPayload.outcomeIndex === 'number'

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventActivity.tsx
@@ -6,6 +6,7 @@ import { useInfiniteQuery, useQueryClient } from '@tanstack/react-query'
 import { ExternalLinkIcon, Loader2Icon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { resolveEventActivityOutcomeColorClass } from '@/app/[locale]/(platform)/event/[slug]/_components/event-activity-utils'
 import {
   useMarketChannelSubscription,
 } from '@/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider'
@@ -410,11 +411,7 @@ export default function EventActivity({ event }: EventActivityProps) {
               const priceLabel = formatSharePriceLabel(Number(activity.price))
               const valueLabel = formatTotalValue(activity.total_value)
               const amountLabel = fromMicro(activity.amount)
-              const outcomeColorClass = isSportsEvent
-                ? 'text-primary'
-                : (activity.outcome.text || '').toLowerCase() === 'yes'
-                    ? 'text-yes'
-                    : 'text-no'
+              const outcomeColorClass = resolveEventActivityOutcomeColorClass(activity, isSportsEvent)
               const rawUsername = activity.user.username
                 || activity.user.address
                 || 'trader'

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
@@ -144,7 +144,7 @@ export default function EventCommentItem({
           image: comment.user_avatar,
           username: displayName,
           address: comment.user_address,
-          deposit_wallet_address: comment.user_deposit_wallet_address ?? null,
+          deposit_wallet_address: comment.user_proxy_wallet_address ?? null,
         }}
         profileSlug={profileSlug}
         date={comment.created_at}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
@@ -140,7 +140,7 @@ export default function EventCommentReplyItem({
           image: reply.user_avatar,
           username: displayName,
           address: reply.user_address,
-          deposit_wallet_address: reply.user_deposit_wallet_address ?? null,
+          deposit_wallet_address: reply.user_proxy_wallet_address ?? null,
         }}
         profileSlug={profileSlug}
         date={reply.created_at}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/comment-user.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/comment-user.ts
@@ -1,7 +1,7 @@
 import type { Comment } from '@/types'
 import { truncateAddress } from '@/lib/formatters'
 
-type CommentUser = Pick<Comment, 'username' | 'user_deposit_wallet_address' | 'user_address'>
+type CommentUser = Pick<Comment, 'username' | 'user_proxy_wallet_address' | 'user_address'>
 
 function normalizeUsername(value?: string | null) {
   return typeof value === 'string' ? value.trim() : ''
@@ -9,7 +9,7 @@ function normalizeUsername(value?: string | null) {
 
 export function resolveCommentUserIdentity(comment: CommentUser) {
   const username = normalizeUsername(comment.username)
-  const address = comment.user_deposit_wallet_address ?? comment.user_address ?? ''
+  const address = comment.user_proxy_wallet_address ?? comment.user_address ?? ''
   const displayName = username || (address ? truncateAddress(address) : 'Anonymous')
   const profileSlug = username || address
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/event-activity-utils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/event-activity-utils.ts
@@ -1,0 +1,34 @@
+import type { ActivityOrder } from '@/types'
+import { OUTCOME_INDEX } from '@/lib/constants'
+
+export function resolveEventActivityOutcomeColorClass(
+  activity: Pick<ActivityOrder, 'outcome'>,
+  isSportsEvent: boolean,
+) {
+  if (isSportsEvent) {
+    return 'text-primary'
+  }
+
+  const outcomeTokens = new Set(
+    (activity.outcome.text || '')
+      .trim()
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  )
+  const isNegativeOutcomeText = outcomeTokens.has('no')
+    || outcomeTokens.has('down')
+    || outcomeTokens.has('false')
+  const isPositiveOutcomeText = outcomeTokens.has('yes')
+    || outcomeTokens.has('up')
+    || outcomeTokens.has('true')
+
+  if (isNegativeOutcomeText && !isPositiveOutcomeText) {
+    return 'text-no'
+  }
+  if (isPositiveOutcomeText && !isNegativeOutcomeText) {
+    return 'text-yes'
+  }
+
+  return activity.outcome.index === OUTCOME_INDEX.NO ? 'text-no' : 'text-yes'
+}

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useInfiniteComments.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useInfiniteComments.ts
@@ -200,7 +200,7 @@ export function useInfiniteComments(
         username: user.username || 'Anonymous',
         user_avatar: user.image || '',
         user_address: user.address || '0x0000...0000',
-        user_deposit_wallet_address: user.deposit_wallet_address || null,
+        user_proxy_wallet_address: user.deposit_wallet_address || null,
         likes_count: 0,
         replies_count: 0,
         created_at: new Date().toISOString(),

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
@@ -8,10 +8,10 @@ import { createWebSocketReconnectController } from '@/lib/websocket-reconnect'
 
 interface LiveCommentProfile {
   baseAddress?: string
-  depositWallet?: string
   displayUsernamePublic?: boolean
   name?: string
   profileImage?: string
+  proxyWallet?: string
   pseudonym?: string
 }
 
@@ -56,7 +56,7 @@ function buildLiveComment(payload: LiveCommentPayload, user: User | null): Comme
     username,
     user_avatar: profileImage,
     user_address: userAddress,
-    user_deposit_wallet_address: profile.depositWallet ?? null,
+    user_proxy_wallet_address: profile.proxyWallet ?? null,
     likes_count: Number(payload.reactionCount ?? 0),
     replies_count: 0,
     created_at: createdAt,

--- a/src/app/[locale]/(platform)/leaderboard/_components/BiggestWinsSidebar.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/BiggestWinsSidebar.tsx
@@ -4,7 +4,11 @@ import type { Route } from 'next'
 import type { BiggestWinEntry } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes'
 import { MoveRightIcon } from 'lucide-react'
 import { BiggestWinsSkeleton } from '@/app/[locale]/(platform)/leaderboard/_components/LeaderboardSkeletons'
-import { resolveNumber, resolveString } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi'
+import {
+  resolveLeaderboardProxyWallet,
+  resolveNumber,
+  resolveString,
+} from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi'
 import { formatValueOrDash } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardFormatters'
 import AppLink from '@/components/AppLink'
 import ProfileLink from '@/components/ProfileLink'
@@ -39,9 +43,19 @@ export default function BiggestWinsSidebar({
         <div className="w-full px-5">
           {isBiggestWinsLoading && <BiggestWinsSkeleton count={6} />}
 
-          {!isBiggestWinsLoading && biggestWins.map((entry, index) => (
-            <BiggestWinRow key={`${entry.proxyWallet || entry.userName || ''}-${entry.winRank ?? entry.rank ?? index}`} entry={entry} index={index} />
-          ))}
+          {!isBiggestWinsLoading && biggestWins.map((entry, index) => {
+            const rowKey = [
+              resolveLeaderboardProxyWallet(entry) || entry.userName || '',
+              entry.winRank ?? entry.rank ?? index,
+            ].join('-')
+            return (
+              <BiggestWinRow
+                key={rowKey}
+                entry={entry}
+                index={index}
+              />
+            )
+          })}
         </div>
       </div>
     </aside>
@@ -51,16 +65,7 @@ export default function BiggestWinsSidebar({
 function BiggestWinRow({ entry, index }: { entry: BiggestWinEntry, index: number }) {
   const record = entry as Record<string, unknown>
   const rank = entry.winRank ?? entry.rank ?? index + 1
-  const address = resolveString(record, [
-    'user.proxyWallet',
-    'user.proxy_wallet',
-    'user.address',
-    'proxyWallet',
-    'proxy_wallet',
-    'address',
-    'walletAddress',
-    'wallet',
-  ])
+  const address = resolveLeaderboardProxyWallet(entry)
   const rawUsername = resolveString(record, [
     'user.userName',
     'user.username',

--- a/src/app/[locale]/(platform)/leaderboard/_components/BiggestWinsSidebar.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/BiggestWinsSidebar.tsx
@@ -40,7 +40,7 @@ export default function BiggestWinsSidebar({
           {isBiggestWinsLoading && <BiggestWinsSkeleton count={6} />}
 
           {!isBiggestWinsLoading && biggestWins.map((entry, index) => (
-            <BiggestWinRow key={`${entry.depositWallet || entry.userName || ''}-${entry.winRank ?? entry.rank ?? index}`} entry={entry} index={index} />
+            <BiggestWinRow key={`${entry.proxyWallet || entry.userName || ''}-${entry.winRank ?? entry.rank ?? index}`} entry={entry} index={index} />
           ))}
         </div>
       </div>
@@ -52,13 +52,11 @@ function BiggestWinRow({ entry, index }: { entry: BiggestWinEntry, index: number
   const record = entry as Record<string, unknown>
   const rank = entry.winRank ?? entry.rank ?? index + 1
   const address = resolveString(record, [
-    'user.depositWallet',
-    'user.deposit_wallet',
-    'user.deposit_wallet_address',
+    'user.proxyWallet',
+    'user.proxy_wallet',
     'user.address',
-    'depositWallet',
-    'deposit_wallet',
-    'deposit_wallet_address',
+    'proxyWallet',
+    'proxy_wallet',
     'address',
     'walletAddress',
     'wallet',

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
@@ -22,6 +22,7 @@ import {
   normalizeLeaderboardResponse,
   normalizeWalletAddress,
   PAGE_SIZE,
+  resolveLeaderboardProxyWallet,
   sortEntriesForDisplay,
 } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi'
 import {
@@ -306,9 +307,11 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
     }
 
     const normalizedUserAddress = normalizeWalletAddress(userAddress)
-    const visibleEntry = entries.find(entry => normalizeWalletAddress(entry.proxyWallet) === normalizedUserAddress)
+    const visibleEntry = entries.find((entry) => {
+      return normalizeWalletAddress(resolveLeaderboardProxyWallet(entry)) === normalizedUserAddress
+    })
     const sourceEntry = visibleEntry ?? userEntry
-    const address = sourceEntry?.proxyWallet || userAddress
+    const address = resolveLeaderboardProxyWallet(sourceEntry) || userAddress
     const rawUsername = sourceEntry?.userName || sourceEntry?.xUsername || user?.username || ''
     const username = rawUsername || address
     const rankNumber = Number(sourceEntry?.rank ?? Number.NaN)
@@ -362,17 +365,23 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
             <div className={listContainerClassName}>
               {isLoading && <LeaderboardListSkeleton count={10} rowClassName={rowClassName} />}
 
-              {!isLoading && entries.map((entry, index) => (
-                <LeaderboardListRow
-                  key={`${entry.proxyWallet || entry.userName || entry.xUsername || ''}-${entry.rank ?? index + 1}`}
-                  entry={entry}
-                  index={index}
-                  filters={filters}
-                  rowClassName={rowClassName}
-                  profitColumnClass={profitColumnClass}
-                  volumeColumnClass={volumeColumnClass}
-                />
-              ))}
+              {!isLoading && entries.map((entry, index) => {
+                const rowKey = [
+                  resolveLeaderboardProxyWallet(entry) || entry.userName || entry.xUsername || '',
+                  entry.rank ?? index + 1,
+                ].join('-')
+                return (
+                  <LeaderboardListRow
+                    key={rowKey}
+                    entry={entry}
+                    index={index}
+                    filters={filters}
+                    rowClassName={rowClassName}
+                    profitColumnClass={profitColumnClass}
+                    volumeColumnClass={volumeColumnClass}
+                  />
+                )
+              })}
             </div>
             {pinnedEntry && (
               <PinnedUserRow

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
@@ -306,9 +306,9 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
     }
 
     const normalizedUserAddress = normalizeWalletAddress(userAddress)
-    const visibleEntry = entries.find(entry => normalizeWalletAddress(entry.depositWallet) === normalizedUserAddress)
+    const visibleEntry = entries.find(entry => normalizeWalletAddress(entry.proxyWallet) === normalizedUserAddress)
     const sourceEntry = visibleEntry ?? userEntry
-    const address = sourceEntry?.depositWallet || userAddress
+    const address = sourceEntry?.proxyWallet || userAddress
     const rawUsername = sourceEntry?.userName || sourceEntry?.xUsername || user?.username || ''
     const username = rawUsername || address
     const rankNumber = Number(sourceEntry?.rank ?? Number.NaN)
@@ -364,7 +364,7 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
 
               {!isLoading && entries.map((entry, index) => (
                 <LeaderboardListRow
-                  key={`${entry.depositWallet || entry.userName || entry.xUsername || ''}-${entry.rank ?? index + 1}`}
+                  key={`${entry.proxyWallet || entry.userName || entry.xUsername || ''}-${entry.rank ?? index + 1}`}
                   entry={entry}
                   index={index}
                   filters={filters}

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardListRow.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardListRow.tsx
@@ -3,6 +3,7 @@
 import type { LeaderboardFilters } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardFilters'
 import type { LeaderboardEntry } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes'
 import Image from 'next/image'
+import { resolveLeaderboardProxyWallet } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi'
 import {
   formatSignedCurrency,
   formatVolumeCurrency,
@@ -30,7 +31,7 @@ export default function LeaderboardListRow({
   volumeColumnClass,
 }: LeaderboardListRowProps) {
   const rank = entry.rank ?? index + 1
-  const address = entry.proxyWallet || ''
+  const address = resolveLeaderboardProxyWallet(entry)
   const rawUsername = entry.userName || entry.xUsername || ''
   const isWalletAlias = rawUsername.startsWith('0x') && rawUsername.includes('...')
   const username = (isWalletAlias && address ? address : rawUsername) || address || ''

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardListRow.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardListRow.tsx
@@ -30,7 +30,7 @@ export default function LeaderboardListRow({
   volumeColumnClass,
 }: LeaderboardListRowProps) {
   const rank = entry.rank ?? index + 1
-  const address = entry.depositWallet || ''
+  const address = entry.proxyWallet || ''
   const rawUsername = entry.userName || entry.xUsername || ''
   const isWalletAlias = rawUsername.startsWith('0x') && rawUsername.includes('...')
   const username = (isWalletAlias && address ? address : rawUsername) || address || ''

--- a/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi.ts
+++ b/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi.ts
@@ -177,7 +177,7 @@ export async function hydrateEntriesWithPortfolioPnl(
   const addresses = Array.from(
     new Set(
       entries
-        .map(entry => normalizeWalletAddress(entry.depositWallet))
+        .map(entry => normalizeWalletAddress(entry.proxyWallet))
         .filter(address => address.length > 0),
     ),
   )
@@ -193,7 +193,7 @@ export async function hydrateEntriesWithPortfolioPnl(
   }
 
   return entries.map((entry) => {
-    const address = normalizeWalletAddress(entry.depositWallet)
+    const address = normalizeWalletAddress(entry.proxyWallet)
     const pnl = pnlByAddress.get(address)
     if (typeof pnl !== 'number') {
       return entry
@@ -218,7 +218,7 @@ export function sortEntriesForDisplay(
       return rightPnl - leftPnl
     }
 
-    return normalizeWalletAddress(left.depositWallet).localeCompare(normalizeWalletAddress(right.depositWallet))
+    return normalizeWalletAddress(left.proxyWallet).localeCompare(normalizeWalletAddress(right.proxyWallet))
   })
 
   const rankOffset = (page - 1) * PAGE_SIZE

--- a/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi.ts
+++ b/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi.ts
@@ -96,6 +96,31 @@ export function normalizeWalletAddress(value?: string) {
   return (value ?? '').trim().toLowerCase()
 }
 
+export function resolveLeaderboardProxyWallet(entry: object | null | undefined) {
+  if (!entry || typeof entry !== 'object') {
+    return ''
+  }
+
+  return resolveString(entry as Record<string, unknown>, [
+    'proxyWallet',
+    'proxy_wallet',
+    'proxyAddress',
+    'proxy_address',
+    'proxyWalletAddress',
+    'proxy_wallet_address',
+    'user.proxyWallet',
+    'user.proxy_wallet',
+    'user.proxyAddress',
+    'user.proxy_address',
+    'user.proxyWalletAddress',
+    'user.proxy_wallet_address',
+    'user.address',
+    'address',
+    'walletAddress',
+    'wallet',
+  ])
+}
+
 export function buildFiltersKey(filters: LeaderboardFilters) {
   return `${filters.category}:${filters.period}:${filters.order}`
 }
@@ -177,7 +202,7 @@ export async function hydrateEntriesWithPortfolioPnl(
   const addresses = Array.from(
     new Set(
       entries
-        .map(entry => normalizeWalletAddress(entry.proxyWallet))
+        .map(entry => normalizeWalletAddress(resolveLeaderboardProxyWallet(entry)))
         .filter(address => address.length > 0),
     ),
   )
@@ -193,7 +218,7 @@ export async function hydrateEntriesWithPortfolioPnl(
   }
 
   return entries.map((entry) => {
-    const address = normalizeWalletAddress(entry.proxyWallet)
+    const address = normalizeWalletAddress(resolveLeaderboardProxyWallet(entry))
     const pnl = pnlByAddress.get(address)
     if (typeof pnl !== 'number') {
       return entry
@@ -218,7 +243,8 @@ export function sortEntriesForDisplay(
       return rightPnl - leftPnl
     }
 
-    return normalizeWalletAddress(left.proxyWallet).localeCompare(normalizeWalletAddress(right.proxyWallet))
+    return normalizeWalletAddress(resolveLeaderboardProxyWallet(left))
+      .localeCompare(normalizeWalletAddress(resolveLeaderboardProxyWallet(right)))
   })
 
   const rankOffset = (page - 1) * PAGE_SIZE

--- a/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes.ts
+++ b/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes.ts
@@ -1,11 +1,14 @@
-export interface LeaderboardEntry {
-  rank?: number | string
+interface LeaderboardWalletAliases {
   proxyWallet?: string
   proxy_wallet?: string
   proxyAddress?: string
   proxy_address?: string
   proxyWalletAddress?: string
   proxy_wallet_address?: string
+}
+
+export interface LeaderboardEntry extends LeaderboardWalletAliases {
+  rank?: number | string
   userName?: string
   vol?: number
   pnl?: number
@@ -14,15 +17,9 @@ export interface LeaderboardEntry {
   verifiedBadge?: boolean
 }
 
-export interface BiggestWinEntry {
+export interface BiggestWinEntry extends LeaderboardWalletAliases {
   rank?: number | string
   winRank?: number | string
-  proxyWallet?: string
-  proxy_wallet?: string
-  proxyAddress?: string
-  proxy_address?: string
-  proxyWalletAddress?: string
-  proxy_wallet_address?: string
   userName?: string
   profileImage?: string
   xUsername?: string

--- a/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes.ts
+++ b/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes.ts
@@ -1,6 +1,6 @@
 export interface LeaderboardEntry {
   rank?: number | string
-  depositWallet?: string
+  proxyWallet?: string
   userName?: string
   vol?: number
   pnl?: number
@@ -12,7 +12,7 @@ export interface LeaderboardEntry {
 export interface BiggestWinEntry {
   rank?: number | string
   winRank?: number | string
-  depositWallet?: string
+  proxyWallet?: string
   userName?: string
   profileImage?: string
   xUsername?: string

--- a/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes.ts
+++ b/src/app/[locale]/(platform)/leaderboard/_utils/leaderboardTypes.ts
@@ -1,6 +1,11 @@
 export interface LeaderboardEntry {
   rank?: number | string
   proxyWallet?: string
+  proxy_wallet?: string
+  proxyAddress?: string
+  proxy_address?: string
+  proxyWalletAddress?: string
+  proxy_wallet_address?: string
   userName?: string
   vol?: number
   pnl?: number
@@ -13,6 +18,11 @@ export interface BiggestWinEntry {
   rank?: number | string
   winRank?: number | string
   proxyWallet?: string
+  proxy_wallet?: string
+  proxyAddress?: string
+  proxy_address?: string
+  proxyWalletAddress?: string
+  proxy_wallet_address?: string
   userName?: string
   profileImage?: string
   xUsername?: string

--- a/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
+++ b/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
@@ -6,7 +6,7 @@ import { MICRO_UNIT, OUTCOME_INDEX } from '@/lib/constants'
 import { formatCurrency } from '@/lib/formatters'
 
 export interface DataApiPosition {
-  depositWallet?: string
+  proxyWallet?: string
   asset?: string
   conditionId?: string
   size?: number

--- a/src/app/api/event-activity/route.ts
+++ b/src/app/api/event-activity/route.ts
@@ -11,7 +11,7 @@ import { normalizeAddress } from '@/lib/wallet'
 const DATA_API_URL = process.env.DATA_URL!
 
 interface DataApiActivity {
-  depositWallet?: string
+  proxyWallet?: string
   timestamp?: number
   conditionId?: string
   type?: string

--- a/src/app/api/og/leaderboard/route.tsx
+++ b/src/app/api/og/leaderboard/route.tsx
@@ -230,7 +230,7 @@ async function fetchLeaderboardRows({
       const name = normalizeText(
         resolveString(entry, ['userName', 'username', 'xUsername']),
         28,
-      ) ?? normalizeText(truncateAddress(resolveString(entry, ['depositWallet', 'deposit_wallet_address'])), 28)
+      ) ?? normalizeText(truncateAddress(resolveString(entry, ['proxyWallet', 'proxy_wallet'])), 28)
       ?? `Trader ${index + 1}`
 
       const pnl = parseNumber(entry.pnl)

--- a/src/lib/data-api/holders.ts
+++ b/src/lib/data-api/holders.ts
@@ -1,7 +1,7 @@
 import { buildDataApiUrl } from '@/lib/data-api/client'
 
 interface DataApiHolder {
-  depositWallet: string
+  proxyWallet: string
   amount: number
   outcomeIndex?: number
   asset?: string
@@ -52,7 +52,7 @@ export interface TopHoldersResult {
 }
 
 function mapHolder(holder: DataApiHolder, outcomeHint: 'yes' | 'no' | null) {
-  const address = holder.depositWallet
+  const address = holder.proxyWallet
   const outcomeIndex = outcomeHint
     ? (outcomeHint === 'yes' ? 0 : 1)
     : (typeof holder.outcomeIndex === 'number' ? holder.outcomeIndex : 0)

--- a/src/lib/data-api/user.ts
+++ b/src/lib/data-api/user.ts
@@ -9,7 +9,7 @@ interface DataApiRequestParams {
 }
 
 export interface DataApiActivity {
-  depositWallet?: string
+  proxyWallet?: string
   timestamp?: number
   conditionId?: string
   type?: string
@@ -33,7 +33,7 @@ export interface DataApiActivity {
 }
 
 export interface DataApiPosition {
-  depositWallet?: string
+  proxyWallet?: string
   asset?: string
   conditionId?: string
   size?: number
@@ -206,7 +206,7 @@ export function mapDataApiActivityToActivityOrder(activity: DataApiActivity): Ac
     ? 'Yes / No'
     : (activity.outcome || 'Outcome')
   const outcomeIndex = isSplit ? undefined : activity.outcomeIndex ?? 0
-  const address = activity.depositWallet || ''
+  const address = activity.proxyWallet || ''
   const displayName = activity.pseudonym || activity.name || address || 'Trader'
   const avatarUrl = activity.profileImageOptimized
     || activity.profileImage

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -258,7 +258,7 @@ export interface Comment {
   username: string
   user_avatar: string
   user_address: string
-  user_deposit_wallet_address?: string | null
+  user_proxy_wallet_address?: string | null
   user_created_at?: string
   likes_count: number
   replies_count: number

--- a/tests/unit/dataApiUser.test.ts
+++ b/tests/unit/dataApiUser.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { mapDataApiActivityToActivityOrder } from '@/lib/data-api/user'
+
+describe('mapDataApiActivityToActivityOrder', () => {
+  it('uses proxyWallet as the activity user address for DATA_URL responses', () => {
+    const proxyWallet = '0xa6a0413f8fa248df51a49bfc759ff190d24fe25b'
+
+    const activity = mapDataApiActivityToActivityOrder({
+      proxyWallet,
+      side: 'SELL',
+      conditionId: '0x8d0af56260655c6c6d61949c76196114766112ebce7d32ea6acc43b779732c13',
+      size: 19.66,
+      price: 0.3,
+      timestamp: 1779198845,
+      transactionHash: '0xbdedb891c9e999602f9cb3416592fffbee8d0ec8eb4962906e3f92bdea4125d7',
+      usdcSize: 5.898,
+      title: 'Dogecoin Up or Down on May 19?',
+      slug: 'dogecoin-up-or-down-on-may-19-2026',
+      eventSlug: 'dogecoin-up-or-down-on-may-19-2026',
+      outcome: 'Down',
+      outcomeIndex: 1,
+    })
+
+    expect(activity.user.id).toBe(proxyWallet)
+    expect(activity.user.address).toBe(proxyWallet)
+    expect(activity.user.username).toBe(proxyWallet)
+    expect(activity.side).toBe('sell')
+  })
+
+  it('prefers the external profile pseudonym over proxyWallet for display name', () => {
+    const activity = mapDataApiActivityToActivityOrder({
+      proxyWallet: '0xa6a0413f8fa248df51a49bfc759ff190d24fe25b',
+      pseudonym: 'doge.trader',
+      conditionId: '0x8d0af56260655c6c6d61949c76196114766112ebce7d32ea6acc43b779732c13',
+      size: 1,
+      price: 0.5,
+      timestamp: 1779198845,
+    })
+
+    expect(activity.user.username).toBe('doge.trader')
+  })
+})

--- a/tests/unit/eventActivityUtils.test.ts
+++ b/tests/unit/eventActivityUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+import { OUTCOME_INDEX } from '@/lib/constants'
+import { resolveEventActivityOutcomeColorClass } from '@/app/[locale]/(platform)/event/[slug]/_components/event-activity-utils'
+
+function createActivityOutcome(index: number, text: string) {
+  return {
+    outcome: {
+      index,
+      text,
+    },
+  }
+}
+
+describe('resolveEventActivityOutcomeColorClass', () => {
+  it('colors the first binary outcome green even when the label is not Yes', () => {
+    expect(resolveEventActivityOutcomeColorClass(
+      createActivityOutcome(OUTCOME_INDEX.YES, 'Up'),
+      false,
+    )).toBe('text-yes')
+  })
+
+  it('colors the second binary outcome red', () => {
+    expect(resolveEventActivityOutcomeColorClass(
+      createActivityOutcome(OUTCOME_INDEX.NO, 'Down'),
+      false,
+    )).toBe('text-no')
+  })
+
+  it('keeps sports activity neutral', () => {
+    expect(resolveEventActivityOutcomeColorClass(
+      createActivityOutcome(OUTCOME_INDEX.YES, 'Home'),
+      true,
+    )).toBe('text-primary')
+  })
+})

--- a/tests/unit/leaderboardApi.test.ts
+++ b/tests/unit/leaderboardApi.test.ts
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 import { DEFAULT_FILTERS } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardFilters'
 
 type LeaderboardApiModule = typeof import('@/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi')
@@ -8,6 +8,10 @@ let helpers: LeaderboardApiModule
 beforeAll(async () => {
   process.env.DATA_URL = 'https://data-api.test'
   helpers = await import('@/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi')
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
 })
 
 describe('leaderboard API helpers', () => {
@@ -41,5 +45,38 @@ describe('leaderboard API helpers', () => {
       '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
       '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
     ])
+  })
+
+  it('resolves snake_case proxy wallet fields when hydrating timeframe pnl', async () => {
+    const proxyWallet = '0x2222222222222222222222222222222222222222'
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(new Response(
+      JSON.stringify({ values: { [proxyWallet]: 123 } }),
+      { status: 200, headers: { 'content-type': 'application/json' } },
+    ))
+
+    const [entry] = await helpers.hydrateEntriesWithPortfolioPnl([
+      {
+        proxy_wallet: proxyWallet,
+        pnl: 0,
+      },
+    ], DEFAULT_FILTERS, new AbortController().signal)
+
+    expect(fetchMock).toHaveBeenCalledOnce()
+    const requestInit = fetchMock.mock.calls[0]?.[1] as RequestInit
+    expect(JSON.parse(String(requestInit.body))).toEqual({
+      period: DEFAULT_FILTERS.period,
+      addresses: [proxyWallet],
+    })
+    expect(entry.pnl).toBe(123)
+  })
+
+  it('resolves proxy_wallet_address aliases for biggest-wins rows', () => {
+    const proxyWallet = '0x3333333333333333333333333333333333333333'
+
+    expect(helpers.resolveLeaderboardProxyWallet({
+      user: {
+        proxy_wallet_address: proxyWallet,
+      },
+    })).toBe(proxyWallet)
   })
 })

--- a/tests/unit/leaderboardApi.test.ts
+++ b/tests/unit/leaderboardApi.test.ts
@@ -1,0 +1,45 @@
+import { beforeAll, describe, expect, it } from 'vitest'
+import { DEFAULT_FILTERS } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardFilters'
+
+type LeaderboardApiModule = typeof import('@/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi')
+
+let helpers: LeaderboardApiModule
+
+beforeAll(async () => {
+  process.env.DATA_URL = 'https://data-api.test'
+  helpers = await import('@/app/[locale]/(platform)/leaderboard/_utils/leaderboardApi')
+})
+
+describe('leaderboard API helpers', () => {
+  it('keeps proxyWallet entries from DATA_URL leaderboard responses', () => {
+    const [entry] = helpers.normalizeLeaderboardResponse({
+      data: [
+        {
+          proxyWallet: '0x2222222222222222222222222222222222222222',
+          userName: 'leader',
+          pnl: 10,
+        },
+      ],
+    })
+
+    expect(entry.proxyWallet).toBe('0x2222222222222222222222222222222222222222')
+  })
+
+  it('uses proxyWallet as the stable tie breaker when sorting profit rows', () => {
+    const sorted = helpers.sortEntriesForDisplay([
+      {
+        proxyWallet: '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        pnl: 10,
+      },
+      {
+        proxyWallet: '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        pnl: 10,
+      },
+    ], DEFAULT_FILTERS, 1)
+
+    expect(sorted.map(entry => entry.proxyWallet)).toEqual([
+      '0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+    ])
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores external proxy wallet payload handling and fixes event activity outcome colors. Replaces `depositWallet` with `proxyWallet`/`proxyAddress` across APIs, UI, and docs, and hardens leaderboard address detection to fix identity display and sorting/hydration edge cases.

- **Bug Fixes**
  - Switched Data API models/mappers and UI to `proxyWallet` for activity, comments, holders, profile positions, and live streams; comments now use `user_proxy_wallet_address`.
  - Leaderboard now uses a unified proxy wallet resolver (supports `proxyWallet`, `proxyAddress`, snake_case, and nested `user.*`) with shared alias types to key rows, match users, hydrate timeframe PnL, apply a stable tie-break on address, and render OG images.
  - Corrected event activity outcome colors: sports remain neutral; yes/up/true map to green and no/down/false map to red, with outcome index fallback.
  - Updated docs: OpenAPI `data-api` schemas to `proxyWallet`, `clob` schemas to `proxyAddress`, and WSS examples to `proxyWallet`. Added unit tests for activity mapping, event activity colors, and leaderboard helpers covering proxy wallet preservation, alias resolution, PnL hydration, and stable sorting.

<sup>Written for commit 5369d394e61862116608556c138e6182e65b7ec3. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1027?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

