### PR TITLE
fix: volume sync

### DIFF
--- a/src/app/api/sync/volume/route.ts
+++ b/src/app/api/sync/volume/route.ts
@@ -62,6 +62,13 @@ export async function GET(request: Request) {
     }
 
     const stats = await syncMarketVolumes(request)
+    const syncFailed = hasFatalVolumeSyncErrors(stats.errors)
+    if (syncFailed) {
+      const errorMessage = summarizeVolumeSyncErrors(stats.errors)
+      await updateSyncStatus('error', errorMessage, stats.updated, stats.nextCursor)
+      return NextResponse.json({ success: false, ...stats }, { status: 502 })
+    }
+
     await updateSyncStatus('completed', null, stats.updated, stats.nextCursor)
     return NextResponse.json({ success: true, ...stats })
   }
@@ -208,6 +215,21 @@ function normalizeCursorParam(value: string | null): string | null {
 
   const trimmed = value.trim()
   return trimmed || null
+}
+
+function hasFatalVolumeSyncErrors(errors: VolumeSyncStats['errors']): boolean {
+  return errors.some(error =>
+    error.context.startsWith('batch:')
+    || error.context.startsWith('update:')
+    || error.context.startsWith('volume:'),
+  )
+}
+
+function summarizeVolumeSyncErrors(errors: VolumeSyncStats['errors']): string {
+  return errors
+    .slice(0, 5)
+    .map(error => `${error.context}:${error.error}`)
+    .join('; ')
 }
 
 async function buildVolumeWorklist(limit: number, cursor: string | null): Promise<{
@@ -410,6 +432,7 @@ async function updateMarketVolume(conditionId: string, totalVolume: string, volu
     .set({
       volume: totalVolume,
       volume_24h: volume24h,
+      updated_at: new Date(),
     })
     .where(eq(markets.condition_id, conditionId))
 }

--- a/src/app/api/sync/volume/route.ts
+++ b/src/app/api/sync/volume/route.ts
@@ -65,7 +65,7 @@ export async function GET(request: Request) {
     const syncFailed = hasFatalVolumeSyncErrors(stats.errors)
     if (syncFailed) {
       const errorMessage = summarizeVolumeSyncErrors(stats.errors)
-      await updateSyncStatus('error', errorMessage, stats.updated, stats.nextCursor)
+      await updateSyncStatus('error', errorMessage, stats.updated)
       return NextResponse.json({ success: false, ...stats }, { status: 502 })
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make volume sync fail fast on fatal errors, preserve the cursor, and record a clear error status (502). Also timestamp market updates with `updated_at`.

- **Bug Fixes**
  - Detect fatal sync errors (`batch:`, `update:`, `volume:`) and stop the run.
  - Record error state and current cursor with a summary of the first 5 errors; return `{ success: false, ...stats }` with 502.
  - Mark successful runs as `completed`; add `updated_at` when updating market volumes.

<sup>Written for commit 6856d249b025cb0cf4bc610e804e18f73340b7e5. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1028?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

