### PR TITLE
docs: expand playground result

### DIFF
--- a/src/app/[locale]/docs/[[...slug]]/layout.tsx
+++ b/src/app/[locale]/docs/[[...slug]]/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next'
 import type { ReactNode } from 'react'
 import { DocsLayout } from 'fumadocs-ui/layouts/docs'
-import { BookOpenIcon, CodeIcon, HomeIcon } from 'lucide-react'
+import { BookOpenIcon, HomeIcon, SquareTerminalIcon } from 'lucide-react'
 import { setRequestLocale } from 'next-intl/server'
 import SiteLogoIcon from '@/components/SiteLogoIcon'
 import { source } from '@/lib/source'
@@ -64,7 +64,7 @@ export default async function Layout({ params, children }: DocsSlugLayoutProps) 
             title: 'API Reference',
             description: 'For Developers',
             url: '/docs/api-reference',
-            icon: <CodeIcon className="size-4" />,
+            icon: <SquareTerminalIcon className="size-4" />,
           },
         ],
       }}

--- a/src/app/[locale]/docs/_components/APIPage.client.tsx
+++ b/src/app/[locale]/docs/_components/APIPage.client.tsx
@@ -1,5 +1,12 @@
 'use client'
 
 import { defineClientConfig } from 'fumadocs-openapi/ui/client'
+import { OpenAPIPlaygroundResult } from '@/app/[locale]/docs/_components/OpenAPIPlaygroundResult'
 
-export default defineClientConfig({})
+export default defineClientConfig({
+  playground: {
+    components: {
+      ResultDisplay: OpenAPIPlaygroundResult,
+    },
+  },
+})

--- a/src/app/[locale]/docs/_components/GammaAPIPage.client.tsx
+++ b/src/app/[locale]/docs/_components/GammaAPIPage.client.tsx
@@ -3,6 +3,7 @@
 import { Custom } from 'fumadocs-openapi/playground/client'
 import { defineClientConfig } from 'fumadocs-openapi/ui/client'
 import { useEffect } from 'react'
+import { OpenAPIPlaygroundResult } from '@/app/[locale]/docs/_components/OpenAPIPlaygroundResult'
 import { Input } from '@/components/ui/input'
 
 function resolveCreatorHostname(siteUrl: string | undefined): string {
@@ -153,6 +154,9 @@ function GammaParameterField({ fieldName, param }: { fieldName: (string | number
 
 export default defineClientConfig({
   playground: {
+    components: {
+      ResultDisplay: OpenAPIPlaygroundResult,
+    },
     renderParameterField(fieldName, param) {
       return <GammaParameterField fieldName={fieldName} param={param} />
     },

--- a/src/app/[locale]/docs/_components/OpenAPIPlaygroundResult.tsx
+++ b/src/app/[locale]/docs/_components/OpenAPIPlaygroundResult.tsx
@@ -1,0 +1,34 @@
+'use client'
+
+import type { ResultDisplayProps } from 'fumadocs-openapi/playground/client'
+import { DefaultResultDisplay } from 'fumadocs-openapi/playground/client'
+import { useMemo } from 'react'
+import { prettifyJsonResponseBody } from '@/lib/openapi-playground-result'
+
+export function OpenAPIPlaygroundResult(props: ResultDisplayProps) {
+  const data = useMemo(() => {
+    if (props.data.type !== 'response') {
+      return props.data
+    }
+
+    const body = prettifyJsonResponseBody(
+      props.data.headers.get('Content-Type'),
+      props.data.body,
+    )
+
+    if (!body) {
+      return props.data
+    }
+
+    const headers = new Headers(props.data.headers)
+    headers.delete('content-length')
+
+    return {
+      ...props.data,
+      headers,
+      body,
+    }
+  }, [props.data])
+
+  return <DefaultResultDisplay {...props} data={data} />
+}

--- a/src/app/[locale]/docs/docs.css
+++ b/src/app/[locale]/docs/docs.css
@@ -3,3 +3,12 @@
 @import 'fumadocs-ui/css/preset.css';
 @import 'fumadocs-openapi/css/preset.css';
 @import 'tailwindcss/utilities.css' source(none);
+
+#nd-sidebar div:has(> [data-theme-toggle]:only-child)  {
+  width: fit-content;
+  align-self: center;
+}
+
+#nd-sidebar div:has(> [data-theme-toggle]:only-child) > [data-theme-toggle] {
+  margin-inline-start: 0;
+}

--- a/src/lib/openapi-playground-result.ts
+++ b/src/lib/openapi-playground-result.ts
@@ -1,0 +1,25 @@
+function isJsonContentType(contentType: string | null): boolean {
+  const mimeType = contentType?.split(';', 1)[0]?.trim().toLowerCase()
+  return mimeType === 'application/json' || Boolean(mimeType?.endsWith('+json'))
+}
+
+export function prettifyJsonResponseBody(
+  contentType: string | null,
+  body: ArrayBuffer,
+): ArrayBuffer | null {
+  if (!isJsonContentType(contentType) || body.byteLength === 0) {
+    return null
+  }
+
+  const decoder = new TextDecoder('utf-8')
+  const bodyText = decoder.decode(body)
+
+  try {
+    const formattedBody = JSON.stringify(JSON.parse(bodyText), null, 2)
+    const bytes = new TextEncoder().encode(formattedBody)
+    return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+  }
+  catch {
+    return null
+  }
+}

--- a/tests/unit/openapiPlaygroundResult.test.ts
+++ b/tests/unit/openapiPlaygroundResult.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { prettifyJsonResponseBody } from '@/lib/openapi-playground-result'
+
+const encoder = new TextEncoder()
+const decoder = new TextDecoder()
+
+function encodeBody(value: string): ArrayBuffer {
+  const bytes = encoder.encode(value)
+  return bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength)
+}
+
+function decodeBody(body: ArrayBuffer): string {
+  return decoder.decode(body)
+}
+
+describe('openapi playground result formatting', () => {
+  it('expands compact JSON responses', () => {
+    const body = prettifyJsonResponseBody(
+      'application/json; charset=utf-8',
+      encodeBody('{"ok":true,"items":[1,2]}'),
+    )
+
+    expect(body).not.toBeNull()
+    expect(decodeBody(body!)).toBe(`{
+  "ok": true,
+  "items": [
+    1,
+    2
+  ]
+}`)
+  })
+
+  it('supports json suffix media types', () => {
+    const body = prettifyJsonResponseBody(
+      'application/problem+json',
+      encodeBody('{"title":"Invalid request"}'),
+    )
+
+    expect(body).not.toBeNull()
+    expect(decodeBody(body!)).toBe(`{
+  "title": "Invalid request"
+}`)
+  })
+
+  it('leaves non-json and invalid json bodies unchanged', () => {
+    expect(prettifyJsonResponseBody('text/plain', encodeBody('{"ok":true}'))).toBeNull()
+    expect(prettifyJsonResponseBody('application/json', encodeBody('not json'))).toBeNull()
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prettifies JSON responses in the OpenAPI playground for easier reading, and updates docs UI (centered theme toggle and a new API Reference icon). The playground now auto-detects JSON content types and shows expanded, formatted bodies.

- **New Features**
  - Added `OpenAPIPlaygroundResult` as the custom `ResultDisplay` in both playground configs from `fumadocs-openapi`.
  - Formats `application/json` and `*+json` responses with indentation; leaves non‑JSON or invalid JSON unchanged.
  - Removes `content-length` after formatting to avoid mismatches, and adds `prettifyJsonResponseBody` with unit tests.

<sup>Written for commit 410c29acd0ae079e8eb3ff4ed20413edd02b369b. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1029?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

