### PR TITLE
fix: reduce volume sync batch size

### DIFF
--- a/src/app/api/sync/volume/helpers.ts
+++ b/src/app/api/sync/volume/helpers.ts
@@ -1,4 +1,4 @@
-export const VOLUME_BATCH_SIZE = 100
+export const VOLUME_BATCH_SIZE = 25
 export const VOLUME_REQUEST_TIMEOUT_MS = 10_000
 export const DEFAULT_VOLUME_SYNC_LIMIT = 150
 export const MAX_VOLUME_SYNC_LIMIT = 500


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reduced volume sync batch size from 100 to 25 to decrease peak load and avoid request timeouts during volume sync. Improves reliability for large syncs without changing existing limits or timeouts.

<sup>Written for commit 754d8dcf1aa2a089c97ad1c74f10737eb2c58daf. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1032?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

