### PR TITLE
refactor: reduce ISR revalidation frequency

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
+++ b/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
@@ -1,10 +1,10 @@
 export const HOME_INITIAL_EVENTS_CACHE_LIFE = {
-  stale: 60,
-  revalidate: 60,
-  expire: 900,
+  stale: 900,
+  revalidate: 900,
+  expire: 31_536_000,
 } as const
 
-const HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS = 60_000
+const HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS = 900_000
 
 export function getHomeInitialCurrentTimestamp() {
   return Math.floor(Date.now() / HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS) * HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS

--- a/src/app/api/og/event/route.tsx
+++ b/src/app/api/og/event/route.tsx
@@ -122,7 +122,7 @@ async function fetchImageDataUrl(url: string) {
         Accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
       },
       next: {
-        revalidate: 300,
+        revalidate: 900,
       },
       signal: AbortSignal.timeout(SOCIAL_IMAGE_FETCH_TIMEOUT_MS),
     })
@@ -362,7 +362,7 @@ async function fetchMarketPriceHistory(tokenId: string, createdAt: string, resol
   try {
     const response = await fetch(url.toString(), {
       next: {
-        revalidate: 300,
+        revalidate: 900,
       },
       signal: AbortSignal.timeout(SOCIAL_HISTORY_FETCH_TIMEOUT_MS),
     })

--- a/src/app/api/og/leaderboard/route.tsx
+++ b/src/app/api/og/leaderboard/route.tsx
@@ -212,7 +212,7 @@ async function fetchLeaderboardRows({
   try {
     const response = await fetch(`${LEADERBOARD_API_URL}/leaderboard?${params.toString()}`, {
       next: {
-        revalidate: 60,
+        revalidate: 900,
       },
     })
 

--- a/src/app/api/og/profile/route.tsx
+++ b/src/app/api/og/profile/route.tsx
@@ -270,7 +270,7 @@ async function fetchProfilePositions(userAddress: string, siteUrl: string): Prom
   try {
     const response = await fetch(`${DATA_API_URL}/positions?${params.toString()}`, {
       next: {
-        revalidate: 60,
+        revalidate: 900,
       },
     })
 

--- a/src/lib/clob-fees.ts
+++ b/src/lib/clob-fees.ts
@@ -68,7 +68,7 @@ export async function fetchKuestFeeSettings(): Promise<KuestFeeSettings | null> 
         Accept: 'application/json',
       },
       next: {
-        revalidate: 300,
+        revalidate: 900,
       },
       signal: AbortSignal.timeout(8_000),
     })

--- a/src/lib/db/queries/sports-menu.ts
+++ b/src/lib/db/queries/sports-menu.ts
@@ -215,7 +215,7 @@ const getCachedActiveSportsCountRows = unstable_cache(
   },
   ['sports-menu-active-count-rows-v4'],
   {
-    revalidate: 300,
+    revalidate: 900,
     tags: [cacheTags.sportsMenu],
   },
 )

--- a/tests/unit/homeInitialEventsCache.test.ts
+++ b/tests/unit/homeInitialEventsCache.test.ts
@@ -9,18 +9,18 @@ describe('homeInitialEventsCache', () => {
     vi.useRealTimers()
   })
 
-  it('uses a one-minute revalidation window for cached initial home events', () => {
+  it('uses a fifteen-minute revalidation window for cached initial home events', () => {
     expect(HOME_INITIAL_EVENTS_CACHE_LIFE).toEqual({
-      stale: 60,
-      revalidate: 60,
-      expire: 900,
+      stale: 900,
+      revalidate: 900,
+      expire: 31_536_000,
     })
   })
 
-  it('normalizes the seed timestamp to the current minute', () => {
+  it('normalizes the seed timestamp to the current fifteen-minute window', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-11T12:34:56.789Z'))
 
-    expect(getHomeInitialCurrentTimestamp()).toBe(Date.parse('2026-05-11T12:34:00.000Z'))
+    expect(getHomeInitialCurrentTimestamp()).toBe(Date.parse('2026-05-11T12:30:00.000Z'))
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Raised ISR revalidation to 15 minutes across key endpoints and caches to reduce write pressure and API load. Expanded the home initial events cache window and timestamp bucket to cut cache churn.

- **Refactors**
  - Standardized next.revalidate to 900s for OG event images, market price history, leaderboard, profile positions, and `fetchKuestFeeSettings`.
  - Set sports menu `unstable_cache` revalidate to 900s.
  - Home initial events cache: stale/revalidate 900s, expire 31,536,000s (1 year), timestamp bucket 900,000ms (15 minutes).
  - Updated unit tests to match new timings.

<sup>Written for commit 37d9c951fd377069b5666c5c26eb0a0d449ebb6e. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1033?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

