### PR TITLE
fix: normalize multiline classNames for hydration

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/CategorySidebar.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/CategorySidebar.tsx
@@ -318,11 +318,11 @@ export default function CategorySidebar({
   return (
     <nav
       aria-label={`${categoryTitle} subcategories`}
-      className={`
+      className={cn(`
         hidden h-[calc(100vh-9rem)] w-47.5 shrink-0 flex-col overflow-y-auto py-5 [scrollbar-width:none]
         lg:sticky lg:top-32 lg:flex lg:py-0
         [&::-webkit-scrollbar]:hidden
-      `}
+      `)}
     >
       {items.map((item) => {
         if (item.type === 'divider') {

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
@@ -139,11 +139,11 @@ export default function EventCardMarketsList({
                 ? (
                     resolvedOutcome
                       ? (
-                          <span className={`
+                          <span className={cn(`
                             inline-flex items-center gap-2 rounded-md px-2.5 py-1 text-sm font-semibold text-foreground
                             transition-colors
                             group-hover:bg-card
-                          `}
+                          `)}
                           >
                             <span className={cn(`flex size-4 items-center justify-center rounded-full ${isYesOutcome
                               ? `bg-yes`
@@ -157,11 +157,11 @@ export default function EventCardMarketsList({
                           </span>
                         )
                       : (
-                          <span className={`
+                          <span className={cn(`
                             inline-flex items-center rounded-md px-2.5 py-1 text-sm font-semibold text-muted-foreground
                             transition-colors
                             group-hover:bg-card
-                          `}
+                          `)}
                           >
                             Resolved
                           </span>

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
@@ -45,12 +45,12 @@ export default function EventCardSingleMarketActions({
       <div className="mt-auto mb-0">
         {resolvedOutcome
           ? (
-              <div className={`
+              <div className={cn(`
                 flex h-12 w-full cursor-default items-center justify-center gap-2 rounded-md border px-3 text-sm
                 font-semibold text-foreground transition-colors
                 dark:border-none dark:bg-secondary
                 dark:group-hover:bg-card
-              `}
+              `)}
               >
                 <span className={cn(`flex size-4 items-center justify-center rounded-full ${isYesOutcome
                   ? 'bg-yes'
@@ -64,11 +64,11 @@ export default function EventCardSingleMarketActions({
               </div>
             )
           : (
-              <div className={`
+              <div className={cn(`
                 flex h-10 w-full cursor-default items-center justify-center rounded-md px-3 text-sm font-semibold
                 text-muted-foreground transition-colors
                 dark:group-hover:bg-card
-              `}
+              `)}
               >
                 Resolved
               </div>

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
@@ -199,12 +199,12 @@ export default function EventCardSportsMoneyline({
 
   return (
     <Card
-      className={`
+      className={cn(`
         group relative flex h-45 cursor-pointer flex-col overflow-hidden rounded-xl shadow-md shadow-black/4
         transition-all
         hover:-translate-y-0.5 hover:shadow-black/8
         dark:hover:bg-secondary
-      `}
+      `)}
     >
       <CardContent
         className={cn(`
@@ -275,12 +275,12 @@ export default function EventCardSportsMoneyline({
           <div className={cn(isResolvedEvent ? 'mt-auto mb-3' : 'mt-auto mb-2')}>
             {isResolvedEvent && resolvedWinner
               ? (
-                  <div className={`
+                  <div className={cn(`
                     flex h-12 w-full cursor-default items-center justify-center gap-2 rounded-md border px-3 text-sm
                     font-semibold text-foreground transition-colors
                     dark:border-none dark:bg-secondary
                     dark:group-hover:bg-card
-                  `}
+                  `)}
                   >
                     <span className="flex size-4 shrink-0 items-center justify-center rounded-full bg-yes">
                       <CheckIcon className="size-3 text-background" strokeWidth={2.5} />

--- a/src/app/[locale]/(platform)/(home)/_components/FilterToolbarSearchInput.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/FilterToolbarSearchInput.tsx
@@ -5,6 +5,7 @@ import { SearchIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useCallback, useRef } from 'react'
 import { Input } from '@/components/ui/input'
+import { cn } from '@/lib/utils'
 
 interface FilterToolbarSearchInputProps {
   search: string
@@ -98,11 +99,11 @@ function FilterToolbarSearchInputField({
         placeholder={searchPlaceholder}
         defaultValue={search}
         onChange={handleInputChange}
-        className={`
+        className={cn(`
           border-transparent bg-accent pl-10 shadow-none transition-colors
           hover:bg-secondary
           focus-visible:border-border focus-visible:bg-background focus-visible:ring-0 focus-visible:ring-offset-0
-        `}
+        `)}
       />
     </div>
   )

--- a/src/app/[locale]/(platform)/_components/Header.tsx
+++ b/src/app/[locale]/(platform)/_components/Header.tsx
@@ -2,15 +2,16 @@ import HeaderMenu from '@/app/[locale]/(platform)/_components/HeaderMenu'
 import HeaderSearch from '@/app/[locale]/(platform)/_components/HeaderSearch'
 import HowItWorksDeferred from '@/app/[locale]/(platform)/_components/HowItWorksDeferred'
 import HeaderLogo from '@/components/HeaderLogo'
+import { cn } from '@/lib/utils'
 
 export default async function Header() {
   return (
     <header className="sticky top-0 z-30 bg-background">
       <div
-        className={`
+        className={cn(`
           relative z-50 container mx-auto flex min-h-15 w-full items-center justify-between gap-4 py-3 pb-1
           md:min-h-17 md:pb-2
-        `}
+        `)}
       >
         <HeaderLogo />
         <div className="hidden w-full items-center gap-2 lg:flex">

--- a/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
@@ -136,10 +136,10 @@ export default function HeaderNotifications() {
           <BellIcon className="size-[1.35rem]" />
           {unreadCount > 0 && (
             <span
-              className={`
+              className={cn(`
                 absolute top-0.5 right-1.5 flex size-3 items-center justify-center rounded-full bg-primary text-xs
                 font-medium text-destructive-foreground
-              `}
+              `)}
             />
           )}
         </Button>
@@ -197,9 +197,9 @@ export default function HeaderNotifications() {
                   ? (
                       <div
                         aria-hidden="true"
-                        className={`
+                        className={cn(`
                           flex size-10.5 items-center justify-center rounded-md bg-muted text-muted-foreground
-                        `}
+                        `)}
                       >
                         <MergeIcon className="size-4 rotate-90" />
                       </div>

--- a/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderSearch.tsx
@@ -363,11 +363,11 @@ export default function HeaderSearch({
           ? (
               <button
                 type="button"
-                className={`
+                className={cn(`
                   absolute top-1/2 right-3 inline-flex -translate-y-1/2 items-center justify-center rounded-sm p-1
                   text-muted-foreground transition-colors
                   hover:text-foreground
-                `}
+                `)}
                 onClick={() => {
                   clearSearch()
                   setIsResultsDismissed(false)
@@ -379,10 +379,10 @@ export default function HeaderSearch({
               </button>
             )
           : (
-              <span className={`
+              <span className={cn(`
                 absolute top-1/2 right-3 hidden -translate-y-1/2 font-mono text-xs text-muted-foreground
                 lg:inline-flex
-              `}
+              `)}
               >
                 /
               </span>
@@ -400,9 +400,9 @@ export default function HeaderSearch({
         )}
         {showDiscoveryDropdown && (
           <div
-            className={`
+            className={cn(`
               absolute inset-x-0 top-full z-50 mt-0 rounded-lg rounded-t-none border border-t-0 bg-background shadow-lg
-            `}
+            `)}
           >
             <SearchDiscoveryContent variant="desktop" onNavigate={handleNavigate} />
           </div>

--- a/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
+++ b/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
@@ -213,10 +213,10 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
       >
         <DrawerContent
           data-mobile-search-drawer="true"
-          className="
+          className={cn(`
             h-[90dvh] max-h-dvh overflow-y-auto rounded-none border-x-0 border-b-0 border-border/70 bg-background px-4
             pt-2 pb-6
-          "
+          `)}
         >
           <DrawerHeader className="sr-only p-0">
             <DrawerTitle>{t('Search')}</DrawerTitle>
@@ -245,10 +245,10 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
                   <>
                     <button
                       type="button"
-                      className={`
+                      className={cn(`
                         flex w-full items-center gap-3 px-4 py-3 text-left text-sm font-semibold
                         disabled:pointer-events-none disabled:opacity-50
-                      `}
+                      `)}
                       onClick={() => {
                         void handleInstallAction()
                       }}
@@ -356,11 +356,11 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
 
       <nav className="fixed inset-x-0 bottom-0 z-40 lg:hidden" aria-label="Primary navigation">
         <div
-          className={`
+          className={cn(`
             border-t border-border/70 bg-background/95 pb-[calc(env(safe-area-inset-bottom)+0.25rem)]
             shadow-[0_-20px_48px_-36px_rgba(15,23,42,0.55)] backdrop-blur-sm
             supports-backdrop-filter:bg-background/90
-          `}
+          `)}
         >
           <div className="grid h-16.5 grid-cols-4">
             <MobileNavLink href="/" label={t('Home')} active={pathname === '/'} icon={HouseIcon} />

--- a/src/app/[locale]/(platform)/_components/NavigationMoreMenu.tsx
+++ b/src/app/[locale]/(platform)/_components/NavigationMoreMenu.tsx
@@ -77,11 +77,11 @@ export default function NavigationMoreMenu() {
       >
         <DropdownMenuItem
           asChild
-          className={`
+          className={cn(`
             group flex w-full items-center gap-2 px-2.5 py-1.5 text-sm font-medium text-muted-foreground
             transition-colors
             hover:text-foreground
-          `}
+          `)}
         >
           <AppLink intentPrefetch href="/activity">
             <ActivityIcon className="size-4 text-muted-foreground transition-colors group-hover:text-foreground" />
@@ -90,11 +90,11 @@ export default function NavigationMoreMenu() {
         </DropdownMenuItem>
         <DropdownMenuItem
           asChild
-          className={`
+          className={cn(`
             group flex w-full items-center gap-2 px-2.5 py-1.5 text-sm font-medium text-muted-foreground
             transition-colors
             hover:text-foreground
-          `}
+          `)}
         >
           <AppLink intentPrefetch href="/leaderboard">
             <TrophyIcon className="size-4 text-muted-foreground transition-colors group-hover:text-foreground" />

--- a/src/app/[locale]/(platform)/_components/PositionShareDialog.tsx
+++ b/src/app/[locale]/(platform)/_components/PositionShareDialog.tsx
@@ -274,9 +274,9 @@ function PositionShareDialogContent({
           />
         )}
         {!isShareReady && (
-          <div className={`
+          <div className={cn(`
             absolute inset-0 flex flex-col items-center justify-center gap-2 text-sm text-muted-foreground
-          `}
+          `)}
           >
             {shareCardStatus === 'error'
               ? (

--- a/src/app/[locale]/(platform)/_components/ProfileOverviewCard.tsx
+++ b/src/app/[locale]/(platform)/_components/ProfileOverviewCard.tsx
@@ -177,10 +177,10 @@ export default function ProfileOverviewCard({
                       <div className="flex items-start justify-between gap-3 sm:gap-4">
                         <div className="flex min-w-0 flex-1 items-start gap-3">
                           <div
-                            className={`
+                            className={cn(`
                               relative flex size-12 shrink-0 items-center justify-center overflow-hidden rounded-full
                               border bg-muted/40
-                            `}
+                            `)}
                             style={avatarFallbackStyle}
                           >
                             {!showPlaceholder && avatarUrl
@@ -226,11 +226,11 @@ export default function ProfileOverviewCard({
                           <Button
                             variant="ghost"
                             size="icon"
-                            className={`
+                            className={cn(`
                               size-9 rounded-full border bg-background/60 text-muted-foreground shadow-sm
                               transition-colors
                               hover:bg-background
-                            `}
+                            `)}
                             onClick={() => profile.portfolioAddress && copy(profile.portfolioAddress)}
                             aria-label={t('Copy portfolio address')}
                           >

--- a/src/app/[locale]/(platform)/_components/SearchResults.tsx
+++ b/src/app/[locale]/(platform)/_components/SearchResults.tsx
@@ -44,9 +44,9 @@ export function SearchResults({
 
   if ((isLoading.events && isLoading.profiles) && events.length === 0 && profiles.length === 0) {
     return (
-      <div className={`
+      <div className={cn(`
         absolute inset-x-0 top-full z-50 mt-0 w-full rounded-lg rounded-t-none border border-t-0 bg-background shadow-lg
-      `}
+      `)}
       >
         {showTabs && (
           <SearchTabs
@@ -70,9 +70,9 @@ export function SearchResults({
   return (
     <div
       data-testid="search-results"
-      className={`
+      className={cn(`
         absolute inset-x-0 top-full z-50 mt-0 rounded-lg rounded-t-none border border-t-0 bg-background shadow-lg
-      `}
+      `)}
     >
       {showTabs && (
         <SearchTabs
@@ -282,11 +282,11 @@ function EventResults({
               <button
                 type="button"
                 onClick={() => navigateToHref(allResultsHref)}
-                className={`
+                className={cn(`
                   flex w-full items-center justify-between gap-2 rounded-b-lg border-t p-3 text-left text-sm font-medium
                   text-primary transition-colors
                   hover:bg-accent hover:text-primary
-                `}
+                `)}
               >
                 <span>{t('See all results')}</span>
                 <ArrowRightIcon className="size-4" />
@@ -297,11 +297,11 @@ function EventResults({
                 intentPrefetch
                 href={allResultsHref}
                 onClick={onResultClick}
-                className={`
+                className={cn(`
                   flex items-center justify-between gap-2 rounded-b-lg border-t p-3 text-sm font-medium text-primary
                   transition-colors
                   hover:bg-accent hover:text-primary
-                `}
+                `)}
               >
                 <span>{t('See all results')}</span>
                 <ArrowRightIcon className="size-4" />

--- a/src/app/[locale]/(platform)/_components/SellPositionModal.tsx
+++ b/src/app/[locale]/(platform)/_components/SellPositionModal.tsx
@@ -165,9 +165,9 @@ export default function SellPositionModal({
               />
             )
           : (
-              <div className={`
+              <div className={cn(`
                 flex size-16 items-center justify-center rounded-md bg-muted text-sm font-semibold text-muted-foreground
-              `}
+              `)}
               >
                 {outcomeLabel.slice(0, 1)}
               </div>
@@ -223,9 +223,9 @@ export default function SellPositionModal({
               )
             })}
             <span
-              className={`
+              className={cn(`
                 absolute top-1/2 block size-5 -translate-1/2 rounded-full border-2 border-primary bg-primary shadow-sm
-              `}
+              `)}
               style={{ left: `${sellPercent}%` }}
             />
             <input

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -37,6 +37,7 @@ import { Input } from '@/components/ui/input'
 import { InputError } from '@/components/ui/input-error'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
+import { cn } from '@/lib/utils'
 
 type OnboardingModal = 'username' | 'email' | 'enable' | 'enable-status' | 'approve' | 'auto-redeem' | null
 type EnableTradingStep = 'idle' | 'enabling' | 'deploying' | 'completed'
@@ -307,9 +308,9 @@ function UsernameDialog({
     >
       <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
         <div className="relative">
-          <AtSignIcon className="
+          <AtSignIcon className={cn(`
             pointer-events-none absolute top-1/2 left-4 size-5 -translate-y-1/2 text-muted-foreground
-          "
+          `)}
           />
           <Input
             value={username}
@@ -620,12 +621,12 @@ function TimelineStep({
   return (
     <div className="grid grid-cols-[1.5rem_1fr_auto] gap-x-3">
       <div className="flex flex-col items-center">
-        <div className={`
+        <div className={cn(`
           flex size-6 shrink-0 items-center justify-center rounded-full border text-xs
           ${complete
       ? 'border-primary bg-primary text-primary-foreground'
       : `border-muted-foreground/30 bg-muted text-muted-foreground`}
-        `}
+        `)}
         >
           {complete ? <CheckIcon className="size-3.5" /> : null}
         </div>

--- a/src/app/[locale]/(platform)/_components/WalletModal.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletModal.tsx
@@ -17,6 +17,7 @@ import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } f
 import { useLiFiQuote } from '@/hooks/useLiFiQuote'
 import { useLiFiWalletTokens } from '@/hooks/useLiFiWalletTokens'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
+import { cn } from '@/lib/utils'
 
 export type { WalletDepositModalProps, WalletWithdrawModalProps }
 
@@ -173,14 +174,14 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
                 ? (
                     <button
                       type="button"
-                      className={`
+                      className={cn(`
                         rounded-md p-2 opacity-70 ring-offset-background transition
                         hover:bg-muted hover:opacity-100
                         focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden
                         disabled:pointer-events-none
                         [&_svg]:pointer-events-none [&_svg]:shrink-0
                         [&_svg:not([class*='size-'])]:size-4
-                      `}
+                      `)}
                       onClick={() => onViewChange('fund')}
                     >
                       <ChevronLeftIcon />
@@ -234,14 +235,14 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
               ? (
                   <button
                     type="button"
-                    className={`
+                    className={cn(`
                       rounded-md p-2 opacity-70 ring-offset-background transition
                       hover:bg-muted hover:opacity-100
                       focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden
                       disabled:pointer-events-none
                       [&_svg]:pointer-events-none [&_svg]:shrink-0
                       [&_svg:not([class*='size-'])]:size-4
-                    `}
+                    `)}
                     onClick={() => onViewChange('fund')}
                   >
                     <ChevronLeftIcon />

--- a/src/app/[locale]/(platform)/_components/wallet-modal/CountdownBadge.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/CountdownBadge.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useEffect, useRef, useState } from 'react'
+import { cn } from '@/lib/utils'
 
 interface CountdownBadgeContentProps {
   seconds: number
@@ -84,10 +85,10 @@ function CountdownBadgeContent({
             className="text-primary"
           />
         </svg>
-        <div className={`
+        <div className={cn(`
           absolute inset-0.75 flex items-center justify-center rounded-full bg-background text-[9px] font-semibold
           text-foreground ring-1 ring-border/60
-        `}
+        `)}
         >
           {remaining}
         </div>

--- a/src/app/[locale]/(platform)/_components/wallet-modal/WalletAddressCard.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/WalletAddressCard.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { CheckIcon, CopyIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
 function WalletAddressCard({
   walletAddress,
@@ -24,11 +25,11 @@ function WalletAddressCard({
           onCopy()
         }
       }}
-      className={`
+      className={cn(`
         cursor-pointer rounded-md border p-1.5 text-sm transition
         hover:bg-muted/40
         focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2
-      `}
+      `)}
     >
       <div className="flex items-center justify-between gap-3">
         <div className="space-y-1">

--- a/src/app/[locale]/(platform)/_components/wallet-modal/WalletAmountStep.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/WalletAmountStep.tsx
@@ -91,11 +91,11 @@ function WalletAmountStep({
             handleBlur(event.target.value)
           }}
           placeholder={placeholderText}
-          className={`
+          className={cn(`
             min-h-[1.2em] bg-transparent pb-1 text-center leading-tight font-semibold text-foreground outline-none
             placeholder:leading-tight
             ${amountSizeClass}
-          `}
+          `)}
           style={{ width: `${Math.max(inputValue.length, minChWidth)}ch`, maxWidth: '70vw' }}
         />
         {selectedTokenSymbol && (

--- a/src/app/[locale]/(platform)/_components/wallet-modal/WalletFundMenu.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/WalletFundMenu.tsx
@@ -13,6 +13,7 @@ import { MELD_PAYMENT_METHODS, TEST_MODE_DISCORD_URL, TRANSFER_PAYMENT_METHODS }
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { IS_TEST_MODE } from '@/lib/network'
+import { cn } from '@/lib/utils'
 
 function WalletFundMenu({
   onBuy,
@@ -50,11 +51,11 @@ function WalletFundMenu({
           href={TEST_MODE_DISCORD_URL}
           target="_blank"
           rel="noreferrer"
-          className={`
+          className={cn(`
             group flex w-full items-center justify-between gap-4 rounded-lg border border-border px-4 py-2 text-left
             transition
             hover:bg-muted/50
-          `}
+          `)}
         >
           <div className="flex items-center gap-3">
             <div className="flex size-12 items-center justify-center text-foreground">
@@ -79,10 +80,10 @@ function WalletFundMenu({
               </div>
             </div>
           </div>
-          <span className="
+          <span className={cn(`
             inline-flex items-center gap-1 text-xs text-muted-foreground transition-colors
             group-hover:text-foreground
-          "
+          `)}
           >
             <span>Open Discord</span>
             <ExternalLinkIcon className="size-3.5" />
@@ -92,11 +93,11 @@ function WalletFundMenu({
 
       <button
         type="button"
-        className={`
+        className={cn(`
           group flex w-full items-center justify-between gap-4 rounded-lg border border-border px-4 py-2 text-left
           transition
           ${IS_TEST_MODE ? 'cursor-not-allowed opacity-50' : 'hover:bg-muted/50'}
-        `}
+        `)}
         onClick={() => {
           if (IS_TEST_MODE) {
             return
@@ -118,9 +119,9 @@ function WalletFundMenu({
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <span className={`
+                      <span className={cn(`
                         ml-2 inline-flex size-4 items-center justify-center rounded-full text-muted-foreground
-                      `}
+                      `)}
                       >
                         <InfoIcon className="size-3" />
                       </span>
@@ -156,12 +157,12 @@ function WalletFundMenu({
 
       <button
         type="button"
-        className={`
+        className={cn(`
           group flex w-full items-center justify-between gap-4 rounded-lg border border-border px-4 py-2 text-left
           transition
           hover:bg-muted/50
           disabled:cursor-not-allowed disabled:opacity-50
-        `}
+        `)}
         onClick={() => {
           if (!meldUrl) {
             return
@@ -203,12 +204,12 @@ function WalletFundMenu({
 
       <button
         type="button"
-        className={`
+        className={cn(`
           group flex w-full items-center justify-between gap-4 rounded-lg border border-border px-4 py-2 text-left
           transition
           hover:bg-muted/50
           disabled:cursor-not-allowed disabled:opacity-50
-        `}
+        `)}
         onClick={onReceive}
         disabled={disabledReceive}
       >

--- a/src/app/[locale]/(platform)/_components/wallet-modal/WalletSendForm.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/WalletSendForm.tsx
@@ -166,11 +166,11 @@ function WalletSendForm({
               onChange={event => handleAmountChange(event.target.value)}
               onBlur={event => handleAmountBlur(event.target.value)}
               placeholder="0.00"
-              className={`
+              className={cn(`
                 h-12 [appearance:textfield] pr-36 text-sm
                 [&::-webkit-inner-spin-button]:appearance-none
                 [&::-webkit-outer-spin-button]:appearance-none
-              `}
+              `)}
               required
             />
             <div className="absolute inset-y-2 right-2 flex items-center gap-2">

--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -738,10 +738,10 @@ export default function ActivityFeed() {
                       intentPrefetch
                       href={eventHref}
                       onClick={event => event.stopPropagation()}
-                      className={`
+                      className={cn(`
                         block max-w-[64ch] truncate text-sm text-muted-foreground underline-offset-2
                         hover:underline
-                      `}
+                      `)}
                       title={activity.market.title}
                     >
                       {activity.market.title}
@@ -790,10 +790,10 @@ export default function ActivityFeed() {
                   </div>
                 </div>
 
-                <div className={`
+                <div className={cn(`
                   flex w-full shrink-0 items-center justify-end gap-1.5 text-xs text-muted-foreground
                   sm:w-auto
-                `}
+                `)}
                 >
                   {txUrl
                     ? (

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartControls.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartControls.tsx
@@ -121,11 +121,11 @@ export default function EventChartControls({
             <button
               type="button"
               className={
-                `
+                cn(`
                   flex items-center justify-center rounded-md px-2 py-1 text-xs font-semibold text-muted-foreground
                   transition-colors
                   hover:text-foreground
-                `
+                `)
               }
               aria-label={t('Show outcomes on chart')}
             >
@@ -235,11 +235,11 @@ export default function EventChartControls({
             <button
               type="button"
               className={
-                `
+                cn(`
                   flex items-center justify-center rounded-md px-2 py-1 text-xs font-semibold text-muted-foreground
                   transition-colors
                   hover:text-foreground
-                `
+                `)
               }
               onClick={onShuffle}
               aria-label={t('Switch to {outcome}', { outcome: normalizeOutcomeLabel(oppositeOutcomeLabel) })}
@@ -257,11 +257,11 @@ export default function EventChartControls({
         <DropdownMenuTrigger asChild>
           <button
             type="button"
-            className={`
+            className={cn(`
               flex items-center justify-center rounded-md px-2 py-1 text-xs font-semibold text-muted-foreground
               transition-colors
               hover:text-foreground
-            `}
+            `)}
             aria-label={t('Chart settings')}
           >
             <SettingsIcon className="size-4" />
@@ -307,10 +307,10 @@ export default function EventChartControls({
                   <label
                     key={item.key}
                     htmlFor={settingId}
-                    className={`
+                    className={cn(`
                       flex items-center justify-between gap-4 text-foreground transition-colors
                       hover:text-foreground/80
-                    `}
+                    `)}
                   >
                     <span>{item.label}</span>
                     <Switch

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
@@ -403,12 +403,12 @@ function EventChartEmbedDialogEditor({
               <div className="space-y-3">
                 <Label className="text-xs font-semibold tracking-wide text-muted-foreground">{t('MARKET')}</Label>
                 <Select value={selectedMarketId} onValueChange={handleMarketChange}>
-                  <SelectTrigger className={`
+                  <SelectTrigger className={cn(`
                     w-full bg-transparent text-sm
                     hover:bg-transparent
                     dark:bg-transparent
                     dark:hover:bg-transparent
-                  `}
+                  `)}
                   >
                     <SelectValue />
                   </SelectTrigger>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartLegend.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartLegend.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import type { SeriesConfig } from '@/types/PredictionChartTypes'
+import { cn } from '@/lib/utils'
 
 interface EventChartLegendProps {
   entries: Array<SeriesConfig & { value: number | null }>
@@ -26,15 +27,15 @@ export default function EventChartLegend({ entries }: EventChartLegendProps) {
               style={{ backgroundColor: entry.color }}
             />
             <span
-              className="
+              className={cn(`
                 inline-flex min-w-0 flex-wrap items-center gap-x-1.5 gap-y-0.5 text-xs font-medium text-muted-foreground
-              "
+              `)}
             >
               <span className="min-w-0 wrap-break-word">{entry.name}</span>
-              <span className={`
+              <span className={cn(`
                 inline-flex min-w-8 shrink-0 items-baseline justify-end text-sm font-semibold whitespace-nowrap
                 text-foreground tabular-nums
-              `}
+              `)}
               >
                 {resolvedValue.toFixed(0)}
                 <span className="ml-0.5 text-sm text-foreground">%</span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartTradeFlow.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartTradeFlow.tsx
@@ -14,9 +14,9 @@ export default function EventChartTradeFlow({ items }: EventChartTradeFlowProps)
   }
 
   return (
-    <div className={`
+    <div className={cn(`
       pointer-events-none absolute bottom-6 left-4 flex flex-col gap-1 text-sm font-semibold tabular-nums
-    `}
+    `)}
     >
       {items.map(item => (
         <span

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentForm.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useAppKit } from '@/hooks/useAppKit'
+import { cn } from '@/lib/utils'
 
 interface EventCommentFormProps {
   user: User | null
@@ -71,11 +72,11 @@ export default function EventCommentForm({
       >
         <Input
           name="content"
-          className={`
+          className={cn(`
             h-11 pr-16
             focus:border-primary focus:ring-primary/20
             focus-visible:border-primary focus-visible:ring-primary/20
-          `}
+          `)}
           placeholder={t('Add a comment')}
           required
           value={content}
@@ -86,10 +87,10 @@ export default function EventCommentForm({
           type="submit"
           size="sm"
           variant="ghost"
-          className={`
+          className={cn(`
             absolute top-1/2 right-2 -translate-y-1/2 bg-transparent text-xs font-medium text-primary
             hover:bg-accent/70 hover:text-primary
-          `}
+          `)}
           disabled={isCreatingComment || !content.trim()}
         >
           {isCreatingComment ? t('Posting...') : user ? t('Post') : t('Connect to Post')}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
@@ -8,6 +8,7 @@ import { CommentPositionsIndicator } from '@/app/[locale]/(platform)/event/[slug
 import ProfileLink from '@/components/ProfileLink'
 import { DropdownMenu, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { useAppKit } from '@/hooks/useAppKit'
+import { cn } from '@/lib/utils'
 import EventCommentLikeForm from './EventCommentLikeForm'
 import EventCommentMenu from './EventCommentMenu'
 import EventCommentReplyForm from './EventCommentReplyForm'
@@ -172,10 +173,10 @@ export default function EventCommentItem({
               />
               <button
                 type="button"
-                className={`
+                className={cn(`
                   rounded-sm px-1.5 py-0.5 text-sm text-muted-foreground transition-colors
                   hover:bg-accent hover:text-foreground
-                `}
+                `)}
                 onClick={handleReplyClick}
               >
                 {t('Reply')}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentLikeForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentLikeForm.tsx
@@ -42,10 +42,10 @@ export default function EventCommentLikeForm({
       disabled={isSubmitting}
       aria-pressed={comment.user_has_liked}
       title={comment.user_has_liked ? 'Remove like' : 'Like'}
-      className={`
+      className={cn(`
         flex size-auto items-center gap-1 rounded-sm px-1.5 py-0.5 text-sm text-muted-foreground
         hover:bg-accent hover:text-foreground
-      `}
+      `)}
     >
       <HeartIcon className={cn({
         'fill-current text-destructive': comment.user_has_liked,

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyForm.tsx
@@ -7,6 +7,7 @@ import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { getAvatarPlaceholderStyle, shouldUseAvatarPlaceholder } from '@/lib/avatar'
+import { cn } from '@/lib/utils'
 
 interface EventCommentReplyFormProps {
   user: User | null
@@ -92,12 +93,12 @@ export default function EventCommentReplyForm({
             ref={inputRef}
             value={content}
             onChange={e => setContent(e.target.value)}
-            className={`
+            className={cn(`
               h-11 pr-16 text-sm
               placeholder:text-muted-foreground/70
               focus:border-primary focus:ring-primary/20
               focus-visible:border-primary focus-visible:ring-primary/20
-            `}
+            `)}
             placeholder={placeholder}
             required
           />

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
@@ -10,6 +10,7 @@ import ProfileLink from '@/components/ProfileLink'
 import { DropdownMenu, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
 import { useAppKit } from '@/hooks/useAppKit'
 import { buildPublicProfilePath } from '@/lib/platform-routing'
+import { cn } from '@/lib/utils'
 import EventCommentLikeForm from './EventCommentLikeForm'
 import EventCommentMenu from './EventCommentMenu'
 import EventCommentReplyForm from './EventCommentReplyForm'
@@ -160,10 +161,10 @@ export default function EventCommentReplyItem({
           <div className="flex-1">
             <AppLink
               href={parentHref}
-              className={`
+              className={cn(`
                 text-sm font-semibold text-primary underline-offset-2 transition-colors
                 hover:text-primary/80 hover:underline
-              `}
+              `)}
             >
               @
               {parentDisplayName}
@@ -178,10 +179,10 @@ export default function EventCommentReplyItem({
               />
               <button
                 type="button"
-                className={`
+                className={cn(`
                   rounded-sm px-1.5 py-0.5 text-sm text-muted-foreground transition-colors
                   hover:bg-accent hover:text-foreground
-                `}
+                `)}
                 onClick={handleReplyClick}
               >
                 {t('Reply')}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentsLoadMoreReplies.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentsLoadMoreReplies.tsx
@@ -1,5 +1,6 @@
 import type { Comment } from '@/types'
 import { AlertCircleIcon, LoaderIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
 interface EventCommentsLoadMoreRepliesProps {
   comment: Comment
@@ -43,11 +44,11 @@ export default function EventCommentsLoadMoreReplies({
   return (
     <button
       type="button"
-      className={`
+      className={cn(`
         flex items-center gap-2 text-left text-xs text-muted-foreground transition-colors
         hover:text-foreground
         disabled:cursor-not-allowed disabled:opacity-50
-      `}
+      `)}
       onClick={handleLoadMoreReplies}
       disabled={isLoading}
     >

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventConvertPositionsDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventConvertPositionsDialog.tsx
@@ -486,9 +486,9 @@ function EventConvertPositionsDialogContent({
                 />
                 <div className="flex flex-1 items-center gap-2">
                   <span className="text-sm font-semibold text-foreground">{option.label}</span>
-                  <span className={`
+                  <span className={cn(`
                     inline-flex size-5 items-center justify-center rounded-sm bg-no/20 text-2xs font-semibold text-no
-                  `}
+                  `)}
                   >
                     {t('No')}
                   </span>
@@ -554,10 +554,10 @@ function EventConvertPositionsDialogContent({
                 >
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-semibold text-foreground">{option.label}</span>
-                    <span className={`
+                    <span className={cn(`
                       inline-flex h-5 min-w-5 items-center justify-center rounded-sm bg-no/20 px-1 text-2xs
                       font-semibold text-no
-                    `}
+                    `)}
                     >
                       {t('No')}
                     </span>
@@ -588,10 +588,10 @@ function EventConvertPositionsDialogContent({
                 >
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-semibold text-foreground">{outcome.label}</span>
-                    <span className={`
+                    <span className={cn(`
                       inline-flex h-5 min-w-5 items-center justify-center rounded-sm bg-yes/20 px-1 text-2xs
                       font-semibold text-yes
-                    `}
+                    `)}
                     >
                       {t('Yes')}
                     </span>
@@ -608,10 +608,10 @@ function EventConvertPositionsDialogContent({
                 <div className="flex items-center justify-between text-sm">
                   <div className="flex items-center gap-2">
                     <span className="text-sm font-semibold text-foreground">Other</span>
-                    <span className={`
+                    <span className={cn(`
                       inline-flex h-5 min-w-5 items-center justify-center gap-1 rounded-sm bg-yes/20 px-1 text-2xs
                       font-semibold text-yes
-                    `}
+                    `)}
                     >
                       <LockKeyholeIcon className="size-3" />
                       {t('Yes')}
@@ -661,10 +661,10 @@ function EventConvertPositionsDialogContent({
   const reviewHeader = (
     <button
       type="button"
-      className={`
+      className={cn(`
         inline-flex items-center gap-2 text-sm font-semibold text-foreground transition-colors
         hover:text-foreground/80
-      `}
+      `)}
       onClick={() => setStep('select')}
     >
       <MoveLeftIcon className="size-4" />

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventFaq.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventFaq.tsx
@@ -53,11 +53,11 @@ export default function EventFaq({ items }: EventFaqProps) {
         {visibleItems.map(item => (
           <AccordionItem key={item.id} value={item.id}>
             <AccordionTrigger
-              className="
+              className={cn(`
                 w-full cursor-pointer py-5 text-[14px] text-foreground
                 hover:text-muted-foreground hover:no-underline
                 lg:py-6
-              "
+              `)}
             >
               {item.question}
             </AccordionTrigger>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLimitExpirationCalendar.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLimitExpirationCalendar.tsx
@@ -9,6 +9,7 @@ import { Card, CardContent, CardFooter, CardHeader } from '@/components/ui/card'
 import { DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
 
 interface EventLimitExpirationCalendarProps {
   value?: Date
@@ -105,10 +106,10 @@ export default function EventLimitExpirationCalendar({
                 const nextTime = event.target.value || '00:00'
                 handleChange(selectedDate, nextTime)
               }}
-              className={`
+              className={cn(`
                 appearance-none pl-8
                 [&::-webkit-calendar-picker-indicator]:hidden [&::-webkit-calendar-picker-indicator]:appearance-none
-              `}
+              `)}
             />
           </div>
         </div>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
@@ -158,9 +158,9 @@ export default function EventLiveSeriesChartHeader({
                     <div className="inline-flex items-center gap-2 text-red-500">
                       <span className="relative inline-flex size-2.5 items-center justify-center">
                         <span
-                          className="
+                          className={cn(`
                             absolute inset-0 m-auto inline-flex size-2.5 animate-ping rounded-full bg-red-500/45
-                          "
+                          `)}
                         />
                         <span
                           className="relative inline-flex size-2 rounded-full bg-red-500"
@@ -179,10 +179,10 @@ export default function EventLiveSeriesChartHeader({
                   <div className="grid gap-2 text-sm text-foreground">
                     <div className="flex items-center gap-2">
                       <span
-                        className="
+                        className={cn(`
                           inline-flex h-6 min-w-9 items-center justify-center rounded-md bg-muted px-2 text-xs
                           font-semibold
-                        "
+                        `)}
                       >
                         ET
                       </span>
@@ -191,10 +191,10 @@ export default function EventLiveSeriesChartHeader({
                     </div>
                     <div className="flex items-center gap-2">
                       <span
-                        className="
+                        className={cn(`
                           inline-flex h-6 min-w-9 items-center justify-center rounded-md bg-muted px-2 text-xs
                           font-semibold
-                        "
+                        `)}
                       >
                         UTC
                       </span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartOverlay.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartOverlay.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { ChevronsDownIcon, ChevronsUpIcon } from 'lucide-react'
+import { cn } from '@/lib/utils'
 
 interface TargetLine {
   badgeTop: number
@@ -50,10 +51,10 @@ export default function EventLiveSeriesChartOverlay({
               style={{ backgroundColor: targetBadgeColor }}
             />
             <span
-              className="
+              className={cn(`
                 relative z-1 inline-flex items-center gap-0.5 rounded-[4px] px-2 py-1 pl-2 text-xs font-semibold
                 text-white
-              "
+              `)}
               style={{ backgroundColor: targetBadgeColor }}
             >
               <span>Target</span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketCard.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketCard.tsx
@@ -341,10 +341,10 @@ function PositionTags({
   return (
     <div className="flex flex-wrap gap-1">
       {hasOpenOrders && (
-        <div className={`
+        <div className={cn(`
           inline-flex items-center rounded-sm bg-amber-500/15 px-1.5 py-0.5 text-xs/tight font-semibold text-amber-700
           dark:text-amber-200
-        `}
+        `)}
         >
           {openOrdersLabel}
         </div>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChance.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChance.tsx
@@ -67,11 +67,11 @@ export default function EventMarketChance({
         {showInReviewTag && (
           <button
             type="button"
-            className={`
+            className={cn(`
               inline-flex shrink-0 items-center rounded-sm px-1.5 py-0.5 text-xs/tight font-semibold whitespace-nowrap
               text-primary transition-colors
               hover:bg-primary/15
-            `}
+            `)}
             onClick={(event) => {
               event.stopPropagation()
               setIsResolutionDialogOpen(true)

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
@@ -445,10 +445,10 @@ function EventMarketContextContent({ event, resolvedMarketConditionId }: EventMa
             >
               <span className="text-base font-medium">{t('Market Context')}</span>
               <span
-                className={`
+                className={cn(`
                   flex items-center gap-1 rounded-md border bg-background px-3 py-1 text-sm font-medium text-foreground
                   shadow-sm transition
-                `}
+                `)}
               >
                 {isPending ? <LoaderIcon className="size-3 animate-spin" /> : <SparkleIcon className="size-3" />}
                 {isPending ? t('Generating...') : t('Generate')}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
@@ -255,10 +255,10 @@ export default function EventMarketHistory({ market }: EventMarketHistoryProps) 
                       href={txUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className={`
+                      className={cn(`
                         text-xs whitespace-nowrap text-muted-foreground transition-colors
                         hover:text-foreground
-                      `}
+                      `)}
                       title={fullDateLabel}
                     >
                       {timeAgoLabel}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
@@ -671,10 +671,10 @@ export default function EventMarketOpenOrders({ market, eventSlug }: EventMarket
               <th className={cn(tableHeaderClass, 'text-right')}>
                 <button
                   type="button"
-                  className={`
+                  className={cn(`
                     text-2xs font-semibold tracking-wide whitespace-nowrap text-destructive uppercase transition-opacity
                     disabled:opacity-40
-                  `}
+                  `)}
                   onClick={() => setIsCancelAllDialogOpen(true)}
                   disabled={isCancellingAll || !hasOrders}
                 >

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
@@ -748,10 +748,10 @@ function NetPositionsDialog({
       </div>
 
       <div className="space-y-2">
-        <div className={`
+        <div className={cn(`
           grid grid-cols-[minmax(0,2fr)_minmax(0,1fr)_minmax(0,1fr)] gap-4 text-sm font-semibold text-muted-foreground
           uppercase
-        `}
+        `)}
         >
           <span>{t('Outcome')}</span>
           <span className="text-right">{t('Payout')}</span>
@@ -779,10 +779,10 @@ function NetPositionsDialog({
                         />
                       )
                     : (
-                        <div className={`
+                        <div className={cn(`
                           flex size-9 items-center justify-center rounded-md bg-muted text-sm font-semibold
                           text-muted-foreground
-                        `}
+                        `)}
                         >
                           {row.outcomeLabel.slice(0, 1)}
                         </div>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook.tsx
@@ -427,11 +427,11 @@ export default function EventOrderBook({
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    className={`
+                    className={cn(`
                       inline-flex size-6 translate-y-[-1.5px] items-center justify-center rounded-sm
                       text-muted-foreground transition-colors
                       hover:bg-muted/70 hover:text-foreground
-                    `}
+                    `)}
                     onClick={onToggleOutcome}
                     aria-label={toggleOutcomeTooltip}
                   >
@@ -447,11 +447,11 @@ export default function EventOrderBook({
               <TooltipTrigger asChild>
                 <button
                   type="button"
-                  className={`
+                  className={cn(`
                     inline-flex size-6 translate-y-[-1.5px] items-center justify-center rounded-sm text-muted-foreground
                     transition-colors
                     hover:bg-muted/70 hover:text-foreground
-                  `}
+                  `)}
                   onClick={() => recenterOrderBook()}
                   aria-label={t('Recenter order book')}
                 >

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBookRow.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBookRow.tsx
@@ -38,10 +38,10 @@ export default function EventOrderBookRow({
   return (
     <div
       className={
-        `
+        cn(`
           relative grid h-9 cursor-pointer grid-cols-[40%_20%_20%_20%] items-center pr-4 pl-0 transition-colors
           ${hoverClass}
-        `
+        `)
       }
       onClick={() => onSelect?.(level)}
     >

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
@@ -210,21 +210,21 @@ export default function EventOrderPanelBuySellTabs({
               <DropdownMenuRadioGroup value={type} onValueChange={value => onTypeChange(value as OrderType)}>
                 <DropdownMenuRadioItem
                   value={ORDER_TYPE.MARKET}
-                  className={`
+                  className={cn(`
                     cursor-pointer pl-2
                     data-[state=checked]:font-semibold data-[state=checked]:text-foreground
                     [&>span:first-of-type]:hidden
-                  `}
+                  `)}
                 >
                   {t('Market')}
                 </DropdownMenuRadioItem>
                 <DropdownMenuRadioItem
                   value={ORDER_TYPE.LIMIT}
-                  className={`
+                  className={cn(`
                     cursor-pointer pl-2
                     data-[state=checked]:font-semibold data-[state=checked]:text-foreground
                     [&>span:first-of-type]:hidden
-                  `}
+                  `)}
                 >
                   {t('Limit')}
                 </DropdownMenuRadioItem>
@@ -234,12 +234,12 @@ export default function EventOrderPanelBuySellTabs({
 
               <DropdownMenuSub>
                 <DropdownMenuSubTrigger
-                  className="
+                  className={cn(`
                     cursor-pointer text-muted-foreground
                     focus:text-muted-foreground
                     data-[state=open]:text-muted-foreground
                     [&_svg]:text-muted-foreground
-                  "
+                  `)}
                 >
                   {t('More')}
                 </DropdownMenuSubTrigger>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelEarnings.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelEarnings.tsx
@@ -115,10 +115,10 @@ export default function EventOrderPanelEarnings({
                 </TooltipTrigger>
                 <TooltipContent
                   side="top"
-                  className={`
+                  className={cn(`
                     w-52 border border-border bg-background px-4 py-3 text-sm font-semibold text-muted-foreground
                     shadow-xl
-                  `}
+                  `)}
                 >
                   <div className="flex flex-col gap-2">
                     <div className="flex items-center justify-between gap-3">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput.tsx
@@ -228,10 +228,10 @@ export default function EventOrderPanelInput({
                       : (
                           <button
                             type="button"
-                            className={`
+                            className={cn(`
                               cursor-pointer bg-transparent p-0 text-left transition-colors
                               hover:text-foreground
-                            `}
+                            `)}
                             onClick={handleBalanceClick}
                           >
                             {t('Balance')}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
@@ -392,10 +392,10 @@ export default function EventOrderPanelLimitControls({
             <Tooltip>
               <TooltipTrigger asChild>
                 <span
-                  className={`
+                  className={cn(`
                     inline-flex items-center gap-1 rounded-md bg-yes/15 p-1 text-xs font-semibold text-yes-foreground
                     transition-colors
-                  `}
+                  `)}
                 >
                   <InfoIcon className="size-3" aria-hidden />
                   <span>{t('{shares} matching', { shares: matchingSharesLabel })}</span>
@@ -452,9 +452,9 @@ export default function EventOrderPanelLimitControls({
             </Select>
 
             {limitExpirationOption === 'custom' && (
-              <div className={`
+              <div className={cn(`
                 flex items-center justify-between rounded-md bg-muted/60 px-3 py-2 text-xs text-muted-foreground
-              `}
+              `)}
               >
                 <div className="flex flex-col">
                   <span className="font-semibold text-foreground">{t('Custom expiration')}</span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOrderInput.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOrderInput.tsx
@@ -210,10 +210,10 @@ export default function EventOrderPanelOrderInput({
               </div>
               {shouldShowResolvedMarketMinimumWarning && (
                 <div
-                  className={`
+                  className={cn(`
                     mt-3 flex animate-order-shake items-center justify-center gap-2 pb-1 text-sm font-semibold
                     text-orange-500
-                  `}
+                  `)}
                 >
                   <TriangleAlertIcon className="size-4" />
                   {t('Market buys must be at least $1')}
@@ -221,10 +221,10 @@ export default function EventOrderPanelOrderInput({
               )}
               {shouldShowResolvedNoLiquidityWarning && (
                 <div
-                  className={`
+                  className={cn(`
                     mt-3 flex animate-order-shake items-center justify-center gap-2 pb-1 text-sm font-semibold
                     text-orange-500
-                  `}
+                  `)}
                 >
                   <TriangleAlertIcon className="size-4" />
                   {t('No liquidity for this market order')}
@@ -235,9 +235,9 @@ export default function EventOrderPanelOrderInput({
 
       {(showInsufficientSharesWarning || showInsufficientBalanceWarning || showAmountTooLowWarning) && (
         <div
-          className={`
+          className={cn(`
             mt-2 mb-3 flex animate-order-shake items-center justify-center gap-2 text-sm font-semibold text-orange-500
-          `}
+          `)}
         >
           <TriangleAlertIcon className="size-4" />
           {showAmountTooLowWarning

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRelated.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRelated.tsx
@@ -327,9 +327,9 @@ export default function EventRelated({ event }: EventRelatedProps) {
           <div ref={buttonsWrapperRef} className="relative flex flex-nowrap items-center gap-2">
             {backgroundStyle.isInitialized && (
               <div
-                className={`
+                className={cn(`
                   pointer-events-none absolute z-0 rounded-md bg-muted shadow-sm transition-all duration-300 ease-out
-                `}
+                `)}
                 style={{
                   left: `${backgroundStyle.left}px`,
                   width: `${backgroundStyle.width}px`,
@@ -396,9 +396,9 @@ export default function EventRelated({ event }: EventRelatedProps) {
                           <strong className="line-clamp-2 text-sm font-medium text-foreground">
                             {relatedEvent.title}
                           </strong>
-                          <span className={`
+                          <span className={cn(`
                             min-w-13 text-right text-xl leading-none font-semibold text-foreground tabular-nums
-                          `}
+                          `)}
                           >
                             {Number.isFinite(relatedEvent.chance)
                               ? `${Math.round(relatedEvent.chance ?? 0)}%`

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
@@ -216,9 +216,9 @@ export default function EventRules({ event, mode = 'accordion', showEndDate = fa
   const resolverDetails = (
     <div className="flex items-start gap-3">
       <div
-        className={`size-10 ${resolverBadgeClassName}
+        className={cn(`size-10 ${resolverBadgeClassName}
           flex shrink-0 items-center justify-center rounded-sm
-        `}
+        `)}
       >
         {isUmaResolver && (
           <Image

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventSeriesPills.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventSeriesPills.tsx
@@ -262,9 +262,9 @@ function ResolutionTimeTooltipRows({ event }: { event: EventSeriesEntry }) {
   return (
     <div className="grid gap-2 text-sm text-foreground">
       <div className="flex items-center gap-2">
-        <span className="
+        <span className={cn(`
           inline-flex h-6 min-w-9 items-center justify-center rounded-md bg-muted px-2 text-xs font-semibold
-        "
+        `)}
         >
           ET
         </span>
@@ -272,9 +272,9 @@ function ResolutionTimeTooltipRows({ event }: { event: EventSeriesEntry }) {
         <span className="ml-auto tabular-nums">{etTimeLabel}</span>
       </div>
       <div className="flex items-center gap-2">
-        <span className="
+        <span className={cn(`
           inline-flex h-6 min-w-9 items-center justify-center rounded-md bg-muted px-2 text-xs font-semibold
-        "
+        `)}
         >
           UTC
         </span>
@@ -578,11 +578,11 @@ export default function EventSeriesPills({
             <DropdownMenuTrigger asChild>
               <button
                 type="button"
-                className={`
+                className={cn(`
                   inline-flex h-8 items-center gap-1.5 rounded-full bg-muted px-3 text-xs leading-none font-semibold
                   text-foreground transition-colors
                   hover:bg-muted/80
-                `}
+                `)}
               >
                 <span>Past</span>
                 <ChevronDownIcon className={cn('size-4 transition-transform', isPastMenuOpen && 'rotate-180')} />
@@ -590,10 +590,10 @@ export default function EventSeriesPills({
             </DropdownMenuTrigger>
             <DropdownMenuContent
               align="start"
-              className="
+              className={cn(`
                 z-20 max-h-80 min-w-44 overflow-y-auto p-1 [-ms-overflow-style:none] [scrollbar-width:none]
                 [&::-webkit-scrollbar]:hidden
-              "
+              `)}
             >
               {pastResolvedEvents.map((event) => {
                 const isCurrentEvent = event.slug === currentEventSlug
@@ -603,10 +603,10 @@ export default function EventSeriesPills({
                     <DropdownMenuItem
                       key={event.id}
                       disabled
-                      className={`
+                      className={cn(`
                         cursor-default bg-muted/70 py-1.5 text-xs font-medium text-muted-foreground
                         data-disabled:opacity-100
-                      `}
+                      `)}
                     >
                       <span className="flex w-full items-center gap-2">
                         <GavelIcon className="size-3.5 shrink-0 text-muted-foreground" />
@@ -635,10 +635,10 @@ export default function EventSeriesPills({
 
         {hasSeriesNavigation && currentResolvedEvent && (
           <span
-            className={`
+            className={cn(`
               inline-flex h-8 items-center rounded-full bg-foreground px-3 text-xs leading-none font-semibold
               text-background
-            `}
+            `)}
           >
             Ended:
             {' '}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventTweetMarketsPanel.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventTweetMarketsPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import { formatCompactCount } from '@/lib/formatters'
+import { cn } from '@/lib/utils'
 
 interface EventTweetMarketsPanelProps {
   tweetCount: number | null
@@ -137,19 +138,19 @@ export default function EventTweetMarketsPanel({
     : '--'
 
   return (
-    <div className={`
+    <div className={cn(`
       w-full rounded-xl border border-border bg-background px-4 py-3 transition-transform duration-200
       hover:scale-[1.01]
       sm:px-5 sm:py-4
-    `}
+    `)}
     >
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="grid gap-2">
           {isResolved
             ? (
-                <span className={`
+                <span className={cn(`
                   inline-flex w-fit text-xs font-semibold tracking-[0.12em] text-muted-foreground uppercase
-                `}
+                `)}
                 >
                   FINAL
                 </span>
@@ -162,16 +163,16 @@ export default function EventTweetMarketsPanel({
                   className="group inline-flex w-fit items-center gap-2 text-red-500"
                 >
                   <span className="relative inline-flex size-2.5 items-center justify-center">
-                    <span className={`
+                    <span className={cn(`
                       absolute inset-0 m-auto inline-flex size-2.5 animate-ping rounded-full bg-red-500/45
-                    `}
+                    `)}
                     />
                     <span className="relative inline-flex size-2 rounded-full bg-red-500" />
                   </span>
-                  <span className={`
+                  <span className={cn(`
                     text-xs font-semibold tracking-[0.12em] uppercase
                     group-hover:underline group-hover:decoration-red-500 group-hover:underline-offset-3
-                  `}
+                  `)}
                   >
                     TWEET COUNT
                   </span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/ResolutionTimelinePanel.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/ResolutionTimelinePanel.tsx
@@ -75,9 +75,9 @@ function TimelineIcon({ item }: { item: ResolutionTimelineItem }) {
   if (item.icon === 'open') {
     return (
       <span
-        className={`
+        className={cn(`
           relative flex size-6 shrink-0 items-center justify-center rounded-full border-2 border-primary bg-background
-        `}
+        `)}
       />
     )
   }

--- a/src/app/[locale]/(platform)/leaderboard/_components/BiggestWinsSidebar.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/BiggestWinsSidebar.tsx
@@ -27,10 +27,10 @@ export default function BiggestWinsSidebar({
   biggestWinsPeriodLabel,
 }: BiggestWinsSidebarProps) {
   return (
-    <aside className={`
+    <aside className={cn(`
       w-full overflow-hidden rounded-2xl border bg-background shadow-md
       lg:sticky lg:top-35 lg:h-fit lg:self-start
-    `}
+    `)}
     >
       <div className="max-h-152 min-h-88 overflow-y-auto">
         <div className="sticky top-0 z-10 bg-background px-6 pt-6 pb-2">
@@ -182,10 +182,10 @@ function BiggestWinRow({ entry, index }: { entry: BiggestWinEntry, index: number
                     ? (
                         <AppLink
                           href={eventHref as Route}
-                          className={`
+                          className={cn(`
                             block max-w-[20ch] truncate text-muted-foreground transition-colors
                             hover:text-foreground hover:underline
-                          `}
+                          `)}
                           title={eventTitle}
                         >
                           {eventTitle}

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient.tsx
@@ -345,11 +345,11 @@ export default function LeaderboardClient({ initialFilters }: { initialFilters: 
 
   return (
     <div className="relative w-full">
-      <div className={`
+      <div className={cn(`
         grid w-full gap-8
         lg:grid-cols-[minmax(0,1fr)_380px]
         xl:grid-cols-[minmax(0,54.5rem)_23.75rem] xl:justify-between xl:gap-6
-      `}
+      `)}
       >
         <section className="flex min-w-0 flex-col gap-6">
           <h1 className="text-2xl font-semibold text-foreground md:text-3xl">Leaderboard</h1>

--- a/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardFiltersBar.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/_components/LeaderboardFiltersBar.tsx
@@ -77,13 +77,13 @@ export default function LeaderboardFiltersBar({
           value={filters.category}
           onValueChange={value => onUpdateFilters({ ...filters, category: value as LeaderboardFilters['category'] })}
         >
-          <SelectTrigger className={`
+          <SelectTrigger className={cn(`
             h-10 min-w-40 bg-transparent px-4 text-sm font-medium text-foreground
             hover:bg-transparent
             data-[size=default]:h-10
             dark:bg-transparent
             dark:hover:bg-transparent
-          `}
+          `)}
           >
             <SelectValue asChild>
               <span className="line-clamp-1">{categoryLabel}</span>
@@ -110,9 +110,9 @@ export default function LeaderboardFiltersBar({
         )}
       >
         <div className="relative w-full">
-          <SearchIcon className={`
+          <SearchIcon className={cn(`
             pointer-events-none absolute top-1/2 left-0 size-4 -translate-y-1/2 text-muted-foreground
-          `}
+          `)}
           />
           <input
             type="text"
@@ -120,11 +120,11 @@ export default function LeaderboardFiltersBar({
             onChange={event => onSearchInputChange(event.target.value)}
             placeholder="Search by name"
             aria-label="Search by name"
-            className={`
+            className={cn(`
               h-7 w-full bg-transparent pr-2 pl-6 text-sm text-foreground
               placeholder:text-muted-foreground
               focus:ring-0 focus:outline-none
-            `}
+            `)}
           />
         </div>
         <div className="flex items-center justify-end md:hidden">
@@ -133,13 +133,13 @@ export default function LeaderboardFiltersBar({
             onValueChange={value => onUpdateFilters({ ...filters, order: value as LeaderboardFilters['order'] })}
           >
             <SelectTrigger
-              className={`
+              className={cn(`
                 h-7 border-0 bg-transparent px-0 text-sm font-medium text-muted-foreground shadow-none
                 hover:bg-transparent
                 data-[size=default]:h-7
                 dark:bg-transparent
                 dark:hover:bg-transparent
-              `}
+              `)}
             >
               <SelectValue />
             </SelectTrigger>

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioMarketsWonCardClient.tsx
@@ -28,7 +28,7 @@ import { isCurrentNegRiskAdapterAddress } from '@/lib/neg-risk-adapter'
 import { removeClaimedPublicPositions, updateQueryDataWhere } from '@/lib/optimistic-trading'
 import { buildPublicProfilePath } from '@/lib/platform-routing'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
-import { triggerConfetti } from '@/lib/utils'
+import { cn, triggerConfetti } from '@/lib/utils'
 import { normalizeAddress } from '@/lib/wallet'
 import {
   DepositWalletCallItemsSplitFallbackError,
@@ -401,11 +401,11 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
     <Dialog open={isDialogOpen} onOpenChange={handleDialogOpenChange}>
       <Card className="relative z-0 w-full rounded-lg border bg-transparent">
         <CardContent
-          className={`
+          className={cn(`
             flex flex-nowrap items-center justify-between gap-2 p-3
             sm:gap-4 sm:pl-4
             md:gap-6 md:py-4 md:pr-4 md:pl-6
-          `}
+          `)}
         >
           <div className="flex min-w-0 flex-1 items-center gap-3 sm:gap-5">
             <div className="relative isolate h-10 w-14 shrink-0 sm:ml-2 sm:h-12 sm:w-17">
@@ -423,13 +423,13 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
                 return (
                   <div
                     key={market.conditionId}
-                    className={`
+                    className={cn(`
                       absolute size-9 overflow-hidden rounded-lg border-2 border-foreground bg-muted shadow-sm
                       motion-safe:animate-in motion-safe:duration-300 motion-safe:fade-in-0 motion-safe:zoom-in-95
                       motion-reduce:animate-none
                       sm:size-11
                       ${stackClass}
-                    `}
+                    `)}
                     style={{ animationDelay: `${index * 55}ms` }}
                   >
                     {market?.imageUrl
@@ -448,10 +448,10 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
                         )}
                     {showOverflowCount && (
                       <div
-                        className="
+                        className={cn(`
                           absolute inset-0 grid place-items-center bg-black/40 text-xs font-bold text-white
                           sm:text-sm
-                        "
+                        `)}
                       >
                         +
                         {previewExtraCount}
@@ -464,11 +464,11 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
 
             <div className="min-w-0 flex-1 text-left sm:pl-2">
               <p
-                className="
+                className={cn(`
                   inline-flex max-w-full items-center gap-1.5 text-sm font-semibold whitespace-nowrap
                   text-muted-foreground
                   sm:gap-2 sm:text-base
-                "
+                `)}
               >
                 <span>{t('You won')}</span>
                 <span className="text-lg leading-none font-semibold text-foreground tabular-nums sm:text-2xl">
@@ -496,9 +496,9 @@ export default function PortfolioMarketsWonCardClient({ data }: PortfolioMarkets
         </VisuallyHidden>
 
         <div className="flex justify-center">
-          <div className="
+          <div className={cn(`
             pointer-events-none inline-flex items-center gap-2 text-2xl font-semibold text-foreground select-none
-          "
+          `)}
           >
             <SiteLogoIcon
               logoSvg={site.logoSvg}

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersFilters.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersFilters.tsx
@@ -4,6 +4,7 @@ import { ArrowDownNarrowWideIcon, SearchIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 
 interface PortfolioOpenOrdersFiltersProps {
   searchQuery: string
@@ -40,14 +41,14 @@ export default function PortfolioOpenOrdersFilters({
           <Select value={sortBy} onValueChange={value => onSortChange(value as PortfolioOpenOrdersSort)}>
             <SelectTrigger
               aria-label={t('Sort open orders')}
-              className="
+              className={cn(`
                 w-9 justify-center gap-0 px-0
                 *:data-[slot=select-value]:hidden
                 sm:w-fit sm:justify-between sm:gap-1.5 sm:px-2.5
                 sm:*:data-[slot=select-value]:flex
                 dark:bg-transparent
                 [&>svg:last-of-type]:hidden
-              "
+              `)}
             >
               <ArrowDownNarrowWideIcon className="size-4 text-muted-foreground" />
               <SelectValue />

--- a/src/app/[locale]/(platform)/portfolio/loading.tsx
+++ b/src/app/[locale]/(platform)/portfolio/loading.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
 
 export default function Loading() {
   return (
@@ -62,9 +63,9 @@ export default function Loading() {
           <div className="overflow-x-auto">
             <div className="min-w-[920px]">
               <div
-                className={`
+                className={cn(`
                   grid grid-cols-[2.2fr_1fr_1fr_1fr_1fr_auto] items-center gap-3 border-b px-2 pb-3 text-xs uppercase
-                `}
+                `)}
               >
                 <Skeleton className="h-4 w-24" />
                 <Skeleton className="h-4 w-16 justify-self-center" />

--- a/src/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsClient.tsx
+++ b/src/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsClient.tsx
@@ -759,11 +759,11 @@ export default function PredictionResultsClient({
                   <button
                     type="button"
                     onClick={handleClearFilters}
-                    className="
+                    className={cn(`
                       mt-4 inline-flex h-10 w-full items-center justify-center text-[13px] font-medium
                       tracking-[-0.09px] text-muted-foreground transition-colors
                       hover:text-foreground
-                    "
+                    `)}
                   >
                     {t('Clear filters')}
                   </button>
@@ -797,9 +797,9 @@ export default function PredictionResultsClient({
                 )}
 
             {error && (
-              <div className="
+              <div className={cn(`
                 rounded-xl border border-destructive/30 bg-destructive/5 px-4 py-3 text-sm text-destructive
-              "
+              `)}
               >
                 {t('Could not load prediction results. Please try again.')}
               </div>
@@ -824,10 +824,10 @@ export default function PredictionResultsClient({
 
       <aside
         data-testid="prediction-filters-aside"
-        className="
+        className={cn(`
           hidden w-full self-start
           lg:sticky lg:top-[150px] lg:flex lg:w-[350px] lg:shrink-0 lg:flex-col lg:gap-4
-        "
+        `)}
       >
         <div className="overflow-hidden rounded-lg border border-border/70 bg-card shadow-md">
           <div className="w-full shrink-0 bg-card">
@@ -838,11 +838,11 @@ export default function PredictionResultsClient({
         <button
           type="button"
           onClick={handleClearFilters}
-          className="
+          className={cn(`
             inline-flex h-10 w-full items-center justify-center text-[13px] font-medium tracking-[-0.09px]
             text-muted-foreground transition-colors
             hover:text-foreground
-          "
+          `)}
         >
           {t('Clear filters')}
         </button>

--- a/src/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsFilters.tsx
+++ b/src/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsFilters.tsx
@@ -57,9 +57,9 @@ export default function PredictionResultsFilters({
   return (
     <div className={cn('flex flex-col', className)}>
       <div className="relative">
-        <SearchIcon className="
+        <SearchIcon className={cn(`
           pointer-events-none absolute top-1/2 left-3 size-4 -translate-y-1/2 text-muted-foreground
-        "
+        `)}
         />
         <Input
           type="text"
@@ -67,10 +67,10 @@ export default function PredictionResultsFilters({
           onChange={event => onSearchValueChange(event.target.value)}
           placeholder={t('Search predictions')}
           data-testid="prediction-search-input"
-          className="
+          className={cn(`
             h-12 rounded-none border-0 bg-transparent px-10 shadow-none
             focus-visible:ring-2 focus-visible:ring-ring/30
-          "
+          `)}
         />
       </div>
 

--- a/src/app/[locale]/(platform)/profile/[slug]/loading.tsx
+++ b/src/app/[locale]/(platform)/profile/[slug]/loading.tsx
@@ -1,4 +1,5 @@
 import { Skeleton } from '@/components/ui/skeleton'
+import { cn } from '@/lib/utils'
 
 export default function Loading() {
   return (
@@ -62,9 +63,9 @@ export default function Loading() {
           <div className="overflow-x-auto">
             <div className="min-w-230">
               <div
-                className={`
+                className={cn(`
                   grid grid-cols-[2.2fr_1fr_1fr_1fr_1fr_auto] items-center gap-3 border-b px-2 pb-3 text-xs uppercase
-                `}
+                `)}
               >
                 <Skeleton className="h-4 w-24" />
                 <Skeleton className="h-4 w-16 justify-self-center" />

--- a/src/app/[locale]/(platform)/profile/_components/PublicActivityFilters.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicActivityFilters.tsx
@@ -4,6 +4,7 @@ import { useExtracted } from 'next-intl'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 
 interface PublicActivityFiltersProps {
   searchQuery: string
@@ -46,14 +47,14 @@ export default function PublicActivityFilters({
           <Select value={typeFilter} onValueChange={value => onTypeChange(value as ActivityTypeFilter)}>
             <SelectTrigger
               aria-label={t('Filter activity type')}
-              className="
+              className={cn(`
                 w-9 justify-center gap-0 px-0
                 *:data-[slot=select-value]:hidden
                 sm:w-fit sm:justify-between sm:gap-1.5 sm:px-2.5
                 sm:*:data-[slot=select-value]:flex
                 dark:bg-transparent
                 [&>svg:last-of-type]:hidden
-              "
+              `)}
             >
               <ListFilterIcon className="size-4 text-muted-foreground" />
               <SelectValue />
@@ -70,14 +71,14 @@ export default function PublicActivityFilters({
           <Select value={sortFilter} onValueChange={value => onSortChange(value as ActivitySort)}>
             <SelectTrigger
               aria-label={t('Sort activity')}
-              className="
+              className={cn(`
                 w-9 justify-center gap-0 px-0
                 *:data-[slot=select-value]:hidden
                 sm:w-fit sm:justify-between sm:gap-1.5 sm:px-2.5
                 sm:*:data-[slot=select-value]:flex
                 dark:bg-transparent
                 [&>svg:last-of-type]:hidden
-              "
+              `)}
             >
               <ArrowDownNarrowWideIcon className="size-4 text-muted-foreground" />
               <SelectValue />

--- a/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
@@ -39,9 +39,9 @@ export default function PublicActivityRow({ activity }: PublicActivityRowProps) 
   const marketContent = isFundsFlow
     ? (
         <div className="flex min-w-0 items-center gap-2.5 pl-1">
-          <div className="
+          <div className={cn(`
             grid size-12 shrink-0 place-items-center overflow-hidden rounded-sm bg-primary/10 text-primary
-          "
+          `)}
           >
             <CircleDollarSignIcon className="size-5" />
           </div>
@@ -80,10 +80,10 @@ export default function PublicActivityRow({ activity }: PublicActivityRowProps) 
               intentPrefetch
               href={eventHref}
               className={
-                `
+                cn(`
                   block max-w-full truncate text-sm/tight font-semibold text-foreground underline-offset-2
                   hover:underline
-                `
+                `)
               }
               title={activity.market.title}
             >

--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsFilters.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsFilters.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
 
 interface PublicPositionsFiltersProps {
   searchQuery: string
@@ -43,14 +44,14 @@ export default function PublicPositionsFilters({
           <Select value={sortBy} onValueChange={value => onSortChange(value as SortOption)}>
             <SelectTrigger
               aria-label={t('Sort positions')}
-              className="
+              className={cn(`
                 w-9 justify-center gap-0 px-0
                 *:data-[slot=select-value]:hidden
                 sm:w-fit sm:justify-between sm:gap-1.5 sm:px-2.5
                 sm:*:data-[slot=select-value]:flex
                 dark:bg-transparent
                 [&>svg:last-of-type]:hidden
-              "
+              `)}
             >
               <ArrowDownNarrowWideIcon className="size-4 text-muted-foreground" />
               <SelectValue />

--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsLoadingState.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsLoadingState.tsx
@@ -2,6 +2,7 @@
 
 import { SearchIcon } from 'lucide-react'
 import { useSyncExternalStore } from 'react'
+import { cn } from '@/lib/utils'
 import PublicPositionItemSkeleton from './PublicPositionItemSkeleton'
 
 interface PositionsLoadingStateProps {
@@ -62,10 +63,10 @@ export default function PublicPositionsLoadingState({
           </div>
 
           {isSearchActive && searchQuery.trim() && retryCount === 0 && (
-            <div className={`
+            <div className={cn(`
               inline-flex items-center gap-2 rounded-full bg-orange-100 px-3 py-1 text-xs font-medium text-orange-800
               dark:bg-orange-900/30 dark:text-orange-300
-            `}
+            `)}
             >
               <SearchIcon className="size-3" />
               Active search

--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsRow.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsRow.tsx
@@ -63,10 +63,10 @@ export default function PublicPositionsRow({
             <AppLink
               intentPrefetch
               href={eventHref}
-              className={`
+              className={cn(`
                 block max-w-full truncate text-[13px] leading-tight font-semibold text-foreground underline-offset-2
                 hover:underline
-              `}
+              `)}
               title={position.title}
             >
               {position.title}
@@ -97,18 +97,18 @@ export default function PublicPositionsRow({
         </div>
       </td>
 
-      <td className={`
+      <td className={cn(`
         px-2 py-3 text-center align-middle text-sm font-semibold text-muted-foreground tabular-nums
         sm:px-3
-      `}
+      `)}
       >
         {formatCurrencyValue(tradeValue)}
       </td>
 
-      <td className={`
+      <td className={cn(`
         px-2 py-3 text-center align-middle text-sm font-semibold text-muted-foreground tabular-nums
         sm:px-3
-      `}
+      `)}
       >
         {formatCurrencyValue(toWinValue)}
       </td>

--- a/src/app/[locale]/(platform)/profile/_components/PublicProfileHeroCards.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicProfileHeroCards.tsx
@@ -683,9 +683,9 @@ function ProfitLossCard({
           </div>
 
           <div
-            className="
+            className={cn(`
               pointer-events-none flex items-center gap-2 text-xl text-muted-foreground/50 opacity-80 select-none
-            "
+            `)}
             aria-hidden="true"
             draggable={false}
           >

--- a/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
@@ -511,12 +511,12 @@ export default function AffiliateWidgetDialog({
                   onValueChange={handleSelectedCategoryChange}
                   disabled={categories.length === 0}
                 >
-                  <SelectTrigger className={`
+                  <SelectTrigger className={cn(`
                     w-full bg-transparent text-sm
                     hover:bg-transparent
                     dark:bg-transparent
                     dark:hover:bg-transparent
-                  `}
+                  `)}
                   >
                     <SelectValue placeholder={t('Categories')} />
                   </SelectTrigger>

--- a/src/app/[locale]/(platform)/settings/_components/SettingsAffiliateContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsAffiliateContent.tsx
@@ -12,6 +12,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { useClipboard } from '@/hooks/useClipboard'
 import { formatCurrency, formatPercent } from '@/lib/formatters'
 import { buildPublicProfilePath } from '@/lib/platform-routing'
+import { cn } from '@/lib/utils'
 
 interface AffiliateMainCategory {
   slug: string
@@ -75,11 +76,11 @@ export default function SettingsAffiliateContent({ affiliateData, mainCategories
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    className={`
+                    className={cn(`
                       inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors
                       hover:text-foreground
                       focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none
-                    `}
+                    `)}
                     aria-label={t('Commission info')}
                   >
                     <InfoIcon className="size-3" aria-hidden />

--- a/src/app/[locale]/(platform)/settings/_components/SettingsSidebar.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsSidebar.tsx
@@ -33,10 +33,10 @@ export default function SettingsSidebar() {
   return (
     <aside className="min-w-0 lg:sticky lg:top-28 lg:self-start">
       <nav
-        className={`
+        className={cn(`
           flex w-full max-w-full snap-x snap-mandatory gap-2 overflow-x-auto rounded-sm
           lg:grid lg:gap-1 lg:overflow-visible lg:rounded-none lg:bg-transparent
-        `}
+        `)}
       >
         {menuItems.map(item => (
           <Button

--- a/src/app/[locale]/(platform)/settings/_components/SettingsTradingContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsTradingContent.tsx
@@ -158,10 +158,10 @@ export default function SettingsTradingContent({ user }: { user: User }) {
       <section className="grid gap-3">
         <h2 className="text-xl font-semibold tracking-tight">{t('Auto-Redeem')}</h2>
 
-        <div className="
+        <div className={cn(`
           flex flex-col gap-4 rounded-md border border-border p-4
           sm:flex-row sm:items-center sm:justify-between
-        "
+        `)}
         >
           <div className="grid gap-1.5">
             <h3 className="text-sm font-medium">{t('Auto-redeem your wins')}</h3>

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventAboutPanel.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventAboutPanel.tsx
@@ -151,11 +151,11 @@ export default function SportsEventAboutPanel({
                 href={resolutionDetailsUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="
+                className={cn(`
                   inline-flex items-center gap-1.5 justify-self-start text-sm font-medium text-muted-foreground
                   hover:underline
                   sm:justify-self-end
-                "
+                `)}
               >
                 <span>{t('View details')}</span>
                 <ExternalLinkIcon className="size-3.5" />

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -717,10 +717,10 @@ export default function SportsEventCenter({
 
           {shouldShowRedeemButton && (
             <div
-              className="
+              className={cn(`
                 min-w-0 flex-1
                 min-[1200px]:ml-auto min-[1200px]:w-[calc((248px-0.5rem)/2)] min-[1200px]:flex-none
-              "
+              `)}
             >
               <div className="relative min-w-0 overflow-hidden rounded-lg pb-1.25">
                 <div className="pointer-events-none absolute inset-x-0 bottom-0 h-4 rounded-b-lg bg-primary" />
@@ -732,12 +732,12 @@ export default function SportsEventCenter({
                     setRedeemDefaultConditionId(singleConditionId)
                     setRedeemSectionKey('moneyline')
                   }}
-                  className={`
+                  className={cn(`
                     relative flex h-9 w-full translate-y-0 items-center justify-center rounded-lg bg-primary px-3
                     text-xs font-semibold text-primary-foreground shadow-sm transition-transform duration-150 ease-out
                     hover:translate-y-px hover:bg-primary
                     active:translate-y-0.5
-                  `}
+                  `)}
                 >
                   Redeem
                 </button>
@@ -1041,10 +1041,10 @@ export default function SportsEventCenter({
                                     return (
                                       <div
                                         key={`${section.key}-${button.key}`}
-                                        className="
+                                        className={cn(`
                                           relative w-full min-w-0 overflow-hidden rounded-lg pb-1.25
                                           sm:w-[118px] sm:shrink-0
-                                        "
+                                        `)}
                                       >
                                         <div
                                           className={cn(
@@ -1160,10 +1160,10 @@ export default function SportsEventCenter({
 
                       {shouldShowRedeemButton && (
                         <div
-                          className="
+                          className={cn(`
                             min-w-0 flex-1
                             min-[1200px]:ml-auto min-[1200px]:w-[calc((372px-1rem)/3)] min-[1200px]:flex-none
-                          "
+                          `)}
                         >
                           <div className="relative min-w-0 overflow-hidden rounded-lg pb-1.25">
                             <div className="pointer-events-none absolute inset-x-0 bottom-0 h-4 rounded-b-lg bg-primary" />
@@ -1178,13 +1178,13 @@ export default function SportsEventCenter({
                                 setRedeemDefaultConditionId(sectionDefaultConditionId)
                                 setRedeemSectionKey(section.key)
                               }}
-                              className={`
+                              className={cn(`
                                 relative flex h-9 w-full translate-y-0 items-center justify-center rounded-lg bg-primary
                                 px-3 text-xs font-semibold text-primary-foreground shadow-sm transition-transform
                                 duration-150 ease-out
                                 hover:translate-y-px hover:bg-primary
                                 active:translate-y-0.5
-                              `}
+                              `)}
                             >
                               Redeem
                             </button>
@@ -1328,11 +1328,11 @@ export default function SportsEventCenter({
                 logoSvg={site.logoSvg}
                 logoImageUrl={site.logoImageUrl}
                 alt={`${site.name} logo`}
-                className="
+                className={cn(`
                   pointer-events-none size-4 text-current select-none
                   [&_svg]:size-4
                   [&_svg_*]:fill-current [&_svg_*]:stroke-current
-                "
+                `)}
                 imageClassName="pointer-events-none size-4 object-contain select-none"
                 size={16}
               />
@@ -1349,11 +1349,11 @@ export default function SportsEventCenter({
                   url: heroCard.event.livestream_url!,
                   title: heroCard.event.title || heroCard.title,
                 })}
-                className={`
+                className={cn(`
                   inline-flex cursor-pointer items-center gap-1.5 rounded-md border border-border/80 bg-background px-3
                   py-1.5 text-xs font-medium text-muted-foreground transition-colors
                   hover:bg-secondary/50 hover:text-foreground
-                `}
+                `)}
               >
                 <SportsEventLiveStatusIcon
                   className="size-3.5"
@@ -1538,11 +1538,11 @@ export default function SportsEventCenter({
                   logoSvg={site.logoSvg}
                   logoImageUrl={site.logoImageUrl}
                   alt={`${site.name} logo`}
-                  className="
+                  className={cn(`
                     pointer-events-none size-4 text-current select-none
                     [&_svg]:size-4
                     [&_svg_*]:fill-current [&_svg_*]:stroke-current
-                  "
+                  `)}
                   imageClassName="pointer-events-none size-4 object-contain select-none"
                   size={16}
                 />
@@ -1576,11 +1576,11 @@ export default function SportsEventCenter({
 
         <aside
           data-sports-scroll-pane="aside"
-          className={`
+          className={cn(`
             hidden gap-4
             min-[1200px]:sticky min-[1200px]:top-0 min-[1200px]:block min-[1200px]:h-fit min-[1200px]:max-h-full
             min-[1200px]:self-start min-[1200px]:overflow-y-auto
-          `}
+          `)}
         >
           {activeTradeContext
             ? (

--- a/src/app/[locale]/(platform)/sports/_components/SportsGamesCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsGamesCenter.tsx
@@ -475,9 +475,9 @@ export default function SportsGamesCenter({
               {options.topBadgeMode === 'live'
                 ? isFinalizedCard
                   ? (
-                      <span className="
+                      <span className={cn(`
                         rounded-sm bg-secondary px-2 py-1 text-xs font-semibold text-foreground uppercase
-                      "
+                      `)}
                       >
                         FINAL
                       </span>
@@ -493,9 +493,9 @@ export default function SportsGamesCenter({
                     )
                 : isFinalizedCard
                   ? (
-                      <span className="
+                      <span className={cn(`
                         rounded-sm bg-secondary px-2 py-1 text-xs font-semibold text-foreground uppercase
-                      "
+                      `)}
                       >
                         FINAL
                       </span>

--- a/src/app/[locale]/(platform)/sports/_components/SportsLivestreamFloatingPlayer.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsLivestreamFloatingPlayer.tsx
@@ -4,6 +4,7 @@ import type { RefObject } from 'react'
 import { ExternalLinkIcon, GripVerticalIcon, RadioIcon, XIcon } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import { resolveLivestreamEmbedTarget } from '@/lib/livestream-embed'
+import { cn } from '@/lib/utils'
 import { useSportsLivestream } from '@/stores/useSportsLivestream'
 
 const MIN_PLAYER_WIDTH = 280
@@ -104,10 +105,10 @@ export default function SportsLivestreamFloatingPlayer() {
 
   return (
     <div
-      className={`
+      className={cn(`
         fixed right-3 bottom-3 z-55 overflow-hidden rounded-xl border bg-card shadow-2xl shadow-black/40
         md:right-4 md:bottom-4
-      `}
+      `)}
       style={{ width: `${effectiveWidth}px` }}
     >
       <div className="group/stream-header relative flex items-center gap-2 border-b bg-secondary/40 px-2.5 py-2">
@@ -138,17 +139,17 @@ export default function SportsLivestreamFloatingPlayer() {
             window.addEventListener('pointerup', stopResize)
             dragCleanupRef.current = stopResize
           }}
-          className={`
+          className={cn(`
             absolute top-0 left-0 z-10 size-6 cursor-nwse-resize bg-linear-to-br from-border/90 via-border/35
             to-transparent
-          `}
+          `)}
         >
           <GripVerticalIcon
-            className={`
+            className={cn(`
               pointer-events-none absolute top-0.5 left-0.5 size-3 rotate-45 text-muted-foreground/70 opacity-0
               transition-all
               group-hover/stream-header:text-foreground/80 group-hover/stream-header:opacity-100
-            `}
+            `)}
           />
         </button>
 
@@ -163,10 +164,10 @@ export default function SportsLivestreamFloatingPlayer() {
               dragCleanupRef.current?.()
               closeStream()
             }}
-            className={`
+            className={cn(`
               inline-flex size-6 items-center justify-center rounded-sm text-muted-foreground transition-colors
               hover:bg-muted/80 hover:text-foreground
-            `}
+            `)}
             aria-label="Close stream"
             title="Close stream"
           >
@@ -196,11 +197,11 @@ export default function SportsLivestreamFloatingPlayer() {
                 href={embedTarget.externalUrl}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="
+                className={cn(`
                   inline-flex items-center gap-1.5 rounded-md bg-white/10 px-3 py-1.5 text-xs font-semibold text-white
                   transition-colors
                   hover:bg-white/20
-                "
+                `)}
               >
                 <ExternalLinkIcon className="size-3.5" />
                 Open stream

--- a/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsRedeemModal.tsx
@@ -536,11 +536,11 @@ export default function SportsRedeemModal({
                             </button>
                             <button
                               type="button"
-                              className="
+                              className={cn(`
                                 inline-flex size-6 items-center justify-center rounded-sm bg-muted text-muted-foreground
                                 transition-colors
                                 hover:bg-muted/80 hover:text-foreground
-                              "
+                              `)}
                               onClick={() => toggleConditionExpansion(group.conditionId)}
                             >
                               <ChevronDownIcon
@@ -558,9 +558,9 @@ export default function SportsRedeemModal({
                                 {group.positions.map(position => (
                                   <div key={position.key} className="flex items-center justify-between gap-2">
                                     <span
-                                      className="
+                                      className={cn(`
                                         inline-flex min-w-0 items-center rounded-sm px-2.5 py-1 text-xs font-semibold
-                                      "
+                                      `)}
                                       style={position.badgeStyle}
                                     >
                                       <span className={cn('truncate', position.badgeClassName)}>

--- a/src/app/[locale]/(platform)/sports/_components/SportsSegmentNumberPicker.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsSegmentNumberPicker.tsx
@@ -57,19 +57,19 @@ function SportsSegmentNumberPicker({
           <div className="relative min-w-0 flex-1">
             <span
               aria-hidden
-              className="
+              className={cn(`
                 pointer-events-none absolute -top-2 left-1/2 h-2 w-3 -translate-x-1/2 bg-primary
                 [clip-path:polygon(50%_100%,0_0,100%_0)]
-              "
+              `)}
             />
 
             <div
               ref={scrollerRef}
-              className={`
+              className={cn(`
                 flex min-w-0 snap-x snap-mandatory items-center gap-2 overflow-x-auto scroll-smooth
                 [scrollbar-width:none]
                 [&::-webkit-scrollbar]:hidden
-              `}
+              `)}
             >
               <span aria-hidden className="shrink-0" style={{ width: startSpacer }} />
               {options.map((option, index) => (

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameDetailsPanel.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameDetailsPanel.tsx
@@ -237,19 +237,19 @@ export default function SportsGameDetailsPanel({
                 >
                   <span
                     aria-hidden
-                    className="
+                    className={cn(`
                       pointer-events-none absolute -top-2 left-1/2 h-2 w-3 -translate-x-1/2 bg-primary
                       [clip-path:polygon(50%_100%,0_0,100%_0)]
-                    "
+                    `)}
                   />
 
                   <div
                     ref={linePickerScrollerRef}
-                    className={`
+                    className={cn(`
                       flex min-w-0 snap-x snap-mandatory items-center gap-2 overflow-x-auto scroll-smooth
                       [scrollbar-width:none]
                       [&::-webkit-scrollbar]:hidden
-                    `}
+                    `)}
                   >
                     <span aria-hidden className="shrink-0" style={{ width: linePickerSpacerWidth }} />
                     {linePickerOptions.map((option, index) => (
@@ -587,11 +587,11 @@ export default function SportsGameDetailsPanel({
                                   <button
                                     type="button"
                                     data-sports-card-control="true"
-                                    className={`
+                                    className={cn(`
                                       inline-flex h-7 items-center justify-center rounded-sm bg-secondary/70 px-2
                                       text-xs font-semibold text-foreground transition-colors
                                       hover:bg-secondary
-                                    `}
+                                    `)}
                                     onClick={event => handleOpenConvert(tag, event)}
                                   >
                                     Convert
@@ -602,11 +602,11 @@ export default function SportsGameDetailsPanel({
                                       <button
                                         type="button"
                                         data-sports-card-control="true"
-                                        className={`
+                                        className={cn(`
                                           inline-flex h-7 items-center justify-center rounded-sm border border-border/70
                                           bg-background px-2 text-xs font-semibold text-foreground transition-colors
                                           hover:bg-secondary/35
-                                        `}
+                                        `)}
                                         onClick={(event) => {
                                           event.stopPropagation()
                                           onOpenRedeemForCondition?.(tag.conditionId)
@@ -619,11 +619,11 @@ export default function SportsGameDetailsPanel({
                                       <button
                                         type="button"
                                         data-sports-card-control="true"
-                                        className={`
+                                        className={cn(`
                                           inline-flex h-7 items-center justify-center rounded-sm border border-border/70
                                           bg-background/40 px-2 text-xs font-semibold text-foreground transition-colors
                                           hover:bg-secondary/40
-                                        `}
+                                        `)}
                                         onClick={event => void handleCashOutTag(tag, event)}
                                       >
                                         Sell

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameGraph.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameGraph.tsx
@@ -166,10 +166,10 @@ export default function SportsGameGraph({
               <div className="size-2 shrink-0 rounded-full" style={{ backgroundColor: entry.color }} />
               <span className="inline-flex w-fit items-center gap-2 text-xs font-medium text-muted-foreground">
                 <span>{entry.name}</span>
-                <span className={`
+                <span className={cn(`
                   inline-flex min-w-8 shrink-0 items-baseline justify-end text-sm font-semibold text-foreground
                   tabular-nums
-                `}
+                `)}
                 >
                   {entry.value.toFixed(0)}
                   <span className="ml-0.5 text-sm text-foreground">%</span>
@@ -293,9 +293,9 @@ export default function SportsGameGraph({
           )}
 
           {isSportsEventHeroVariant && hasTradeFlowLabels && (
-            <div className={`
+            <div className={cn(`
               pointer-events-none absolute bottom-6 left-4 flex flex-col gap-1 text-sm font-semibold tabular-nums
-            `}
+            `)}
             >
               {tradeFlowItems.map(item => (
                 <span

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
@@ -90,9 +90,9 @@ function TotalBadge({ button }: { button: SportsGamesButton }) {
 
   return (
     <div
-      className={`
+      className={cn(`
         relative inline-flex size-11 items-center justify-center overflow-hidden rounded-lg text-white shadow-sm
-      `}
+      `)}
     >
       <span
         className={cn(
@@ -130,9 +130,9 @@ function BttsBadge({ button }: { button: SportsGamesButton }) {
 
   return (
     <div
-      className={`
+      className={cn(`
         relative inline-flex size-11 items-center justify-center overflow-hidden rounded-lg text-white shadow-sm
-      `}
+      `)}
     >
       <span
         className={cn(

--- a/src/app/[locale]/admin/(general)/_components/AllowedMarketCreatorsManager.tsx
+++ b/src/app/[locale]/admin/(general)/_components/AllowedMarketCreatorsManager.tsx
@@ -21,6 +21,7 @@ import {
   DEMO_ALLOWED_MARKET_CREATOR_DISPLAY_NAME,
   isAdminAllowedMarketCreatorsResponse,
 } from '@/lib/allowed-market-creators'
+import { cn } from '@/lib/utils'
 
 type CreatorInputMode = 'site' | 'wallet'
 
@@ -294,9 +295,9 @@ export default function AllowedMarketCreatorsManager({
         {isLoading
           ? (
               <div
-                className="
+                className={cn(`
                   flex items-center gap-2 rounded-lg border border-dashed px-4 py-3 text-sm text-muted-foreground
-                "
+                `)}
               >
                 <Loader2Icon className="size-4 animate-spin" />
                 {t('Loading sources...')}
@@ -327,10 +328,10 @@ export default function AllowedMarketCreatorsManager({
                         : null}
                       <button
                         type="button"
-                        className="
+                        className={cn(`
                           rounded-sm p-0.5 text-muted-foreground transition
                           hover:bg-muted hover:text-foreground
-                        "
+                        `)}
                         onClick={() => handleRemoveClick(item)}
                         disabled={disabled || isRemoving}
                         aria-label={`Remove ${item.displayName}`}

--- a/src/app/[locale]/admin/(general)/_components/BrandIdentitySection.tsx
+++ b/src/app/[locale]/admin/(general)/_components/BrandIdentitySection.tsx
@@ -131,10 +131,10 @@ function BrandIdentitySection({
                   { 'cursor-not-allowed opacity-60 hover:border-border hover:bg-muted/20': isPending },
                 )}
               >
-                <span className={`
+                <span className={cn(`
                   pointer-events-none absolute inset-0 bg-foreground/0 transition
                   group-hover:bg-foreground/5
-                `}
+                `)}
                 />
                 {imagePreview && (
                   <Image
@@ -166,12 +166,12 @@ function BrandIdentitySection({
                   )}
                 />
                 <span
-                  className={`
+                  className={cn(`
                     pointer-events-none absolute bottom-2 left-1/2 z-10 w-30 -translate-x-1/2 rounded-md
                     bg-background/80 px-2 py-1 text-center text-2xs leading-tight font-medium text-muted-foreground
                     opacity-0 transition
                     group-hover:opacity-100
-                  `}
+                  `)}
                 >
                   {t('SVG, PNG, JPG or WebP')}
                 </span>
@@ -247,10 +247,10 @@ function BrandIdentitySection({
                   { 'cursor-not-allowed opacity-60 hover:border-border hover:bg-muted/20': isPending },
                 )}
               >
-                <span className={`
+                <span className={cn(`
                   pointer-events-none absolute inset-0 bg-foreground/0 transition
                   group-hover:bg-foreground/5
-                `}
+                `)}
                 />
                 {pwaIcon192Preview && (
                   <Image
@@ -272,12 +272,12 @@ function BrandIdentitySection({
                   )}
                 />
                 <span
-                  className={`
+                  className={cn(`
                     pointer-events-none absolute bottom-1.5 left-1/2 z-10 w-20 -translate-x-1/2 rounded-md
                     bg-background/80 px-1.5 py-0.5 text-center text-2xs leading-tight font-medium text-muted-foreground
                     opacity-0 transition
                     group-hover:opacity-100
-                  `}
+                  `)}
                 >
                   {t('PNG, JPG, WebP or SVG')}
                 </span>
@@ -312,10 +312,10 @@ function BrandIdentitySection({
                   { 'cursor-not-allowed opacity-60 hover:border-border hover:bg-muted/20': isPending },
                 )}
               >
-                <span className={`
+                <span className={cn(`
                   pointer-events-none absolute inset-0 bg-foreground/0 transition
                   group-hover:bg-foreground/5
-                `}
+                `)}
                 />
                 {pwaIcon512Preview && (
                   <Image
@@ -337,12 +337,12 @@ function BrandIdentitySection({
                   )}
                 />
                 <span
-                  className={`
+                  className={cn(`
                     pointer-events-none absolute bottom-1.5 left-1/2 z-10 w-20 -translate-x-1/2 rounded-md
                     bg-background/80 px-1.5 py-0.5 text-center text-2xs leading-tight font-medium text-muted-foreground
                     opacity-0 transition
                     group-hover:opacity-100
-                  `}
+                  `)}
                 >
                   {t('PNG, JPG, WebP or SVG')}
                 </span>

--- a/src/app/[locale]/admin/(general)/_components/LegalSection.tsx
+++ b/src/app/[locale]/admin/(general)/_components/LegalSection.tsx
@@ -181,10 +181,10 @@ function LegalSection({
 
         {hasUploadedTermsOfServicePdf
           && (
-            <div className="
+            <div className={cn(`
               flex flex-col gap-3 rounded-xl border border-border/60 bg-muted/10 p-4
               sm:flex-row sm:items-center sm:justify-between
-            "
+            `)}
             >
               <div className="grid gap-1">
                 <p className="text-sm font-medium">{t('An uploaded Terms of Use PDF is currently active on /tos.')}</p>

--- a/src/app/[locale]/admin/(general)/_components/SettingsAccordionSection.tsx
+++ b/src/app/[locale]/admin/(general)/_components/SettingsAccordionSection.tsx
@@ -38,12 +38,12 @@ function SettingsAccordionSection({
         aria-controls={contentId}
         aria-expanded={isOpen}
         onClick={() => onToggle(value)}
-        className="
+        className={cn(`
           flex h-18 w-full items-center justify-between gap-4 px-4 py-0 text-left transition-colors
           hover:bg-muted/50 hover:no-underline
           focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background
           focus-visible:outline-none
-        "
+        `)}
       >
         {header}
         <ChevronDownIcon

--- a/src/app/[locale]/admin/_components/AdminHeader.tsx
+++ b/src/app/[locale]/admin/_components/AdminHeader.tsx
@@ -1,14 +1,15 @@
 import AdminHeaderActions from '@/app/[locale]/admin/_components/AdminHeaderActions'
 import HeaderLogo from '@/components/HeaderLogo'
+import { cn } from '@/lib/utils'
 
 export default async function AdminHeader() {
   return (
     <header className="sticky top-0 z-30 bg-background">
       <div
-        className={`
+        className={cn(`
           relative z-50 container mx-auto flex min-h-15 w-full items-center gap-4 py-3 pb-1
           md:min-h-17 md:pb-2
-        `}
+        `)}
       >
         <HeaderLogo labelSuffix="Admin" />
         <AdminHeaderActions />

--- a/src/app/[locale]/admin/_components/AdminSidebar.tsx
+++ b/src/app/[locale]/admin/_components/AdminSidebar.tsx
@@ -42,10 +42,10 @@ export default function AdminSidebar() {
   return (
     <aside className="min-w-0 lg:sticky lg:top-28 lg:self-start">
       <nav
-        className={`
+        className={cn(`
           flex w-full max-w-full snap-x snap-mandatory gap-2 overflow-x-auto rounded-sm
           lg:grid lg:gap-1 lg:overflow-visible lg:rounded-none lg:bg-transparent
-        `}
+        `)}
       >
         {adminMenuItems.map(item => (
           <Button

--- a/src/app/[locale]/admin/_components/DataTable.tsx
+++ b/src/app/[locale]/admin/_components/DataTable.tsx
@@ -212,12 +212,12 @@ export function DataTable<TData, TValue>({
               <button
                 type="button"
                 onClick={onRetry}
-                className={`
+                className={cn(`
                   inline-flex items-center rounded-md border border-transparent bg-primary px-4 py-2 text-sm font-medium
                   text-white shadow-sm
                   hover:bg-primary/90
                   focus:ring-2 focus:ring-primary focus:ring-offset-2 focus:outline-none
-                `}
+                `)}
               >
                 {t('Try again')}
               </button>

--- a/src/app/[locale]/admin/_components/DataTablePagination.tsx
+++ b/src/app/[locale]/admin/_components/DataTablePagination.tsx
@@ -17,6 +17,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import { cn } from '@/lib/utils'
 
 interface DataTablePaginationProps<TData> {
   table: Table<TData>
@@ -61,10 +62,10 @@ export function DataTablePagination<TData>({
 
   return (
     <div className="flex flex-col space-y-2 px-2 sm:flex-row sm:items-center sm:justify-between sm:space-y-0">
-      <div className={`
+      <div className={cn(`
         flex flex-col space-y-1 text-sm text-muted-foreground
         sm:flex-row sm:items-center sm:space-y-0 sm:space-x-4
-      `}
+      `)}
       >
         <div>
           {t('{selected} of {total} row(s) selected.', {

--- a/src/app/[locale]/admin/affiliate/_components/AdminAffiliateClaimableFeesCard.tsx
+++ b/src/app/[locale]/admin/affiliate/_components/AdminAffiliateClaimableFeesCard.tsx
@@ -15,6 +15,7 @@ import { CTF_EXCHANGE_ADDRESS, NEG_RISK_CTF_EXCHANGE_ADDRESS } from '@/lib/contr
 import { baseUnitsToNumber } from '@/lib/data-api/fees'
 import { usdFormatter } from '@/lib/formatters'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
+import { cn } from '@/lib/utils'
 import { isUserRejectedRequestError, normalizeAddress } from '@/lib/wallet'
 import { signAndSubmitDepositWalletCalls } from '@/lib/wallet/client'
 import { buildClaimFeesCalls } from '@/lib/wallet/transactions'
@@ -297,11 +298,11 @@ export default function AdminAffiliateClaimableFeesCard({
               <Button
                 type="button"
                 size="icon"
-                className="
+                className={cn(`
                   size-8 rounded-md bg-primary text-primary-foreground
                   hover:bg-primary/90
                   disabled:bg-primary disabled:text-primary-foreground disabled:opacity-100
-                "
+                `)}
                 disabled={isButtonDisabled}
                 onClick={() => void handleClaim()}
                 aria-label={buttonTooltip ?? buttonAriaLabel}

--- a/src/app/[locale]/admin/affiliate/_components/AdminAffiliateContentClient.tsx
+++ b/src/app/[locale]/admin/affiliate/_components/AdminAffiliateContentClient.tsx
@@ -7,6 +7,7 @@ import AdminAffiliateClaimableFeesCard from '@/app/[locale]/admin/affiliate/_com
 import AdminAffiliateSettingsForm from '@/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { usdFormatter } from '@/lib/formatters'
+import { cn } from '@/lib/utils'
 
 interface AdminAffiliateContentClientProps {
   builderTakerFeeBps: number
@@ -76,11 +77,11 @@ export default function AdminAffiliateContentClient({
                 <TooltipTrigger asChild>
                   <button
                     type="button"
-                    className={`
+                    className={cn(`
                       inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors
                       hover:text-foreground
                       focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none
-                    `}
+                    `)}
                     aria-label={t('Affiliate fee info')}
                   >
                     <InfoIcon className="size-3" aria-hidden />

--- a/src/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm.tsx
+++ b/src/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm.tsx
@@ -13,6 +13,7 @@ import { InputError } from '@/components/ui/input-error'
 import { Label } from '@/components/ui/label'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { formatBpsPercent } from '@/lib/affiliate-fee-settings'
+import { cn } from '@/lib/utils'
 import { useUser } from '@/stores/useUser'
 
 const initialState = {
@@ -42,11 +43,11 @@ function AdminInfoTooltip({ content }: AdminInfoTooltipProps) {
       <TooltipTrigger asChild>
         <button
           type="button"
-          className={`
+          className={cn(`
             inline-flex size-4 items-center justify-center rounded-sm text-muted-foreground transition-colors
             hover:text-foreground
             focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-none
-          `}
+          `)}
           aria-label={content}
         >
           <InfoIcon className="size-4" aria-hidden />

--- a/src/app/[locale]/admin/categories/_components/MainCategorySortDialog.tsx
+++ b/src/app/[locale]/admin/categories/_components/MainCategorySortDialog.tsx
@@ -30,6 +30,7 @@ import {
 import { InputError } from '@/components/ui/input-error'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useIsMobile } from '@/hooks/useIsMobile'
+import { cn } from '@/lib/utils'
 
 interface MainCategorySortDialogProps {
   open: boolean
@@ -223,10 +224,10 @@ export default function MainCategorySortDialog({
                 <ul className="max-h-[55vh] space-y-2 overflow-y-auto pr-1">
                   {orderedCategories.map((category, index) => (
                     <li key={category.id} className="flex items-center gap-3 rounded-xl border bg-background p-3">
-                      <div className="
+                      <div className={cn(`
                         flex size-9 shrink-0 items-center justify-center rounded-full bg-muted text-sm font-semibold
                         text-foreground
-                      "
+                      `)}
                       >
                         {index + 1}
                       </div>

--- a/src/app/[locale]/admin/events/_components/AdminEventsTable.tsx
+++ b/src/app/[locale]/admin/events/_components/AdminEventsTable.tsx
@@ -38,6 +38,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Switch } from '@/components/ui/switch'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useIsMobile } from '@/hooks/useIsMobile'
+import { cn } from '@/lib/utils'
 
 interface AdminEventsTableProps {
   initialAutoDeployNewEventsEnabled: boolean
@@ -544,10 +545,10 @@ export default function AdminEventsTable({
             event.stopPropagation()
             handleClearFilters()
           }}
-          className={`
+          className={cn(`
             absolute -top-1 -right-1 flex size-4 items-center justify-center rounded-full border border-background
             bg-foreground text-background
-          `}
+          `)}
           aria-label={t('Clear filters')}
         >
           <XIcon className="size-2.5" />

--- a/src/app/[locale]/admin/events/_components/columns.tsx
+++ b/src/app/[locale]/admin/events/_components/columns.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { formatCompactCurrency, formatDate } from '@/lib/formatters'
 import { isSportsAuxiliaryEventSlug } from '@/lib/sports-event-slugs'
+import { cn } from '@/lib/utils'
 
 interface EventColumnOptions {
   onToggleHidden: (event: AdminEventRow, nextValue: boolean) => void
@@ -84,9 +85,9 @@ export function useAdminEventsColumns({
                       />
                     )
                   : (
-                      <div className="
+                      <div className={cn(`
                         flex size-full items-center justify-center text-xs font-semibold text-muted-foreground
-                      "
+                      `)}
                       >
                         {event.title.slice(0, 1).toUpperCase()}
                       </div>
@@ -98,11 +99,11 @@ export function useAdminEventsColumns({
                   <AppLink
                     intentPrefetch
                     href={`/event/${event.slug}`}
-                    className={`
+                    className={cn(`
                       line-clamp-2 text-sm font-medium text-wrap underline-offset-4
                       hover:underline
                       ${event.is_hidden ? 'text-muted-foreground' : 'text-foreground'}
-                    `}
+                    `)}
                   >
                     {event.title}
                   </AppLink>
@@ -112,10 +113,10 @@ export function useAdminEventsColumns({
                   <span className="min-w-0 truncate">{event.slug}</span>
                   {event.series_slug && (
                     <span
-                      className="
+                      className={cn(`
                         inline-flex items-center gap-1 rounded-sm border border-border/70 bg-background px-1.5 py-0.5
                         text-2xs font-medium text-muted-foreground
-                      "
+                      `)}
                     >
                       <RepeatIcon className="size-3" />
                       <span>{formatSeriesRecurrenceLabel(event.series_recurrence ?? event.series_slug) ?? t('Series')}</span>

--- a/src/app/[locale]/admin/events/calendar/_components/AdminCreateEventForm.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/AdminCreateEventForm.tsx
@@ -4720,10 +4720,10 @@ export default function AdminCreateEventForm({
                   <div className="mt-0.5 flex items-center justify-between gap-2">
                     <p className="text-base font-medium text-foreground">{label}</p>
                     {done && (
-                      <span className="
+                      <span className={cn(`
                         flex size-5 shrink-0 items-center justify-center rounded-full border border-emerald-600
                         bg-emerald-600 text-background
-                      "
+                      `)}
                       >
                         <CheckIcon className="size-3" />
                       </span>
@@ -4758,16 +4758,16 @@ export default function AdminCreateEventForm({
                   />
                   <label
                     htmlFor="event-image"
-                    className={`
+                    className={cn(`
                       group relative flex size-56 cursor-pointer items-center justify-center overflow-hidden rounded-xl
                       border border-dashed border-border bg-muted/20 text-muted-foreground transition
                       hover:border-primary/60
-                    `}
+                    `)}
                   >
-                    <span className={`
+                    <span className={cn(`
                       pointer-events-none absolute inset-0 bg-foreground/0 transition
                       group-hover:bg-foreground/5
-                    `}
+                    `)}
                     />
                     {eventImagePreviewUrl
                       ? (
@@ -4783,11 +4783,11 @@ export default function AdminCreateEventForm({
                           <div className="text-sm text-muted-foreground">256 × 256 preview</div>
                         )}
                     <ImageUp
-                      className={`
+                      className={cn(`
                         pointer-events-none absolute top-1/2 left-1/2 z-10 size-7 -translate-1/2 text-foreground/70
                         opacity-0 transition
                         group-hover:opacity-100
-                      `}
+                      `)}
                     />
                   </label>
                 </div>
@@ -5169,17 +5169,17 @@ export default function AdminCreateEventForm({
                                   />
                                   <label
                                     htmlFor={`sports-team-logo-${team.hostStatus}`}
-                                    className={`
+                                    className={cn(`
                                       group relative flex size-28 cursor-pointer items-center justify-center
                                       overflow-hidden rounded-xl border border-dashed border-border bg-muted/20
                                       text-muted-foreground transition
                                       hover:border-primary/60
-                                    `}
+                                    `)}
                                   >
-                                    <span className={`
+                                    <span className={cn(`
                                       pointer-events-none absolute inset-0 bg-foreground/0 transition
                                       group-hover:bg-foreground/5
-                                    `}
+                                    `)}
                                     />
                                     {teamLogoPreviewUrls[team.hostStatus]
                                       ? (
@@ -5195,11 +5195,11 @@ export default function AdminCreateEventForm({
                                           <div className="text-sm text-muted-foreground">Upload logo</div>
                                         )}
                                     <ImageUp
-                                      className={`
+                                      className={cn(`
                                         pointer-events-none absolute top-1/2 left-1/2 z-10 size-6 -translate-1/2
                                         text-foreground/70 opacity-0 transition
                                         group-hover:opacity-100
-                                      `}
+                                      `)}
                                     />
                                   </label>
                                 </div>
@@ -5817,10 +5817,10 @@ export default function AdminCreateEventForm({
 
                         <div className="space-y-2">
                           <Label>Outcomes</Label>
-                          <div className="
+                          <div className={cn(`
                             grid grid-cols-1 items-center gap-2
                             md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2.5rem]
-                          "
+                          `)}
                           >
                             <Input
                               id="binary-outcome-yes"
@@ -5907,10 +5907,10 @@ export default function AdminCreateEventForm({
                                 </div>
                                 <div className="space-y-2 md:col-span-2">
                                   <Label>Outcomes</Label>
-                                  <div className="
+                                  <div className={cn(`
                                     grid grid-cols-1 items-center gap-2
                                     md:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_2.5rem]
-                                  "
+                                  `)}
                                   >
                                     <Input
                                       value={option.outcomeYes}
@@ -5949,17 +5949,17 @@ export default function AdminCreateEventForm({
                                 />
                                 <label
                                   htmlFor={`option-image-${option.id}`}
-                                  className={`
+                                  className={cn(`
                                     group relative flex size-28 cursor-pointer items-center justify-center
                                     overflow-hidden rounded-xl border border-dashed border-border bg-muted/20
                                     text-muted-foreground transition
                                     hover:border-primary/60
-                                  `}
+                                  `)}
                                 >
-                                  <span className={`
+                                  <span className={cn(`
                                     pointer-events-none absolute inset-0 bg-foreground/0 transition
                                     group-hover:bg-foreground/5
-                                  `}
+                                  `)}
                                   />
                                   {optionImagePreviewUrls[option.id]
                                     ? (
@@ -5975,11 +5975,11 @@ export default function AdminCreateEventForm({
                                         <div className="text-xs text-muted-foreground">No image</div>
                                       )}
                                   <ImageUp
-                                    className={`
+                                    className={cn(`
                                       pointer-events-none absolute top-1/2 left-1/2 z-10 size-6 -translate-1/2
                                       text-foreground/70 opacity-0 transition
                                       group-hover:opacity-100
-                                    `}
+                                    `)}
                                   />
                                 </label>
                               </div>
@@ -6258,10 +6258,10 @@ export default function AdminCreateEventForm({
 
           <div className="flex max-h-[90vh] flex-col">
             <div className="border-b px-6 py-3">
-              <div className="
+              <div className={cn(`
                 mx-auto w-full max-w-2xl rounded-md border bg-muted/20 px-3 py-2 text-center font-mono text-xs
                 text-muted-foreground
-              "
+              `)}
               >
                 {previewEventUrl}
               </div>
@@ -6314,34 +6314,34 @@ export default function AdminCreateEventForm({
                               <p className="text-xs text-muted-foreground">{market.question || 'Question pending'}</p>
                             </div>
                             <div className="hidden shrink-0 items-center gap-1.5 sm:flex">
-                              <span className="
+                              <span className={cn(`
                                 rounded-md border border-emerald-500/40 bg-emerald-500/15 px-2.5 py-1.5 text-sm
                                 font-semibold text-emerald-600
-                              "
+                              `)}
                               >
                                 {market.outcomeYes}
                               </span>
-                              <span className="
+                              <span className={cn(`
                                 rounded-md border border-red-500/40 bg-red-500/15 px-2.5 py-1.5 text-sm font-semibold
                                 text-red-500
-                              "
+                              `)}
                               >
                                 {market.outcomeNo}
                               </span>
                             </div>
                           </div>
                           <div className="mt-2 flex items-center gap-1.5 sm:hidden">
-                            <span className="
+                            <span className={cn(`
                               rounded-md border border-emerald-500/40 bg-emerald-500/15 px-2.5 py-1.5 text-sm
                               font-semibold text-emerald-600
-                            "
+                            `)}
                             >
                               {market.outcomeYes}
                             </span>
-                            <span className="
+                            <span className={cn(`
                               rounded-md border border-red-500/40 bg-red-500/15 px-2.5 py-1.5 text-sm font-semibold
                               text-red-500
-                            "
+                            `)}
                             >
                               {market.outcomeNo}
                             </span>
@@ -6387,19 +6387,19 @@ export default function AdminCreateEventForm({
                     <button
                       type="button"
                       disabled
-                      className="
+                      className={cn(`
                         rounded-md border border-emerald-500/40 bg-emerald-500/15 px-3 py-2 text-sm font-semibold
                         text-emerald-600
-                      "
+                      `)}
                     >
                       {tradePreviewMarket?.outcomeYes || 'Yes'}
                     </button>
                     <button
                       type="button"
                       disabled
-                      className="
+                      className={cn(`
                         rounded-md border border-red-500/40 bg-red-500/15 px-3 py-2 text-sm font-semibold text-red-500
-                      "
+                      `)}
                     >
                       {tradePreviewMarket?.outcomeNo || 'No'}
                     </button>
@@ -6416,17 +6416,17 @@ export default function AdminCreateEventForm({
                   <p className="text-xs font-semibold text-muted-foreground uppercase">Categories</p>
                   {selectedCategoryChips.length > 0
                     ? (
-                        <div className="
+                        <div className={cn(`
                           flex gap-2 overflow-x-auto pb-1 [-ms-overflow-style:none] [scrollbar-width:none]
                           [&::-webkit-scrollbar]:hidden
-                        "
+                        `)}
                         >
                           {selectedCategoryChips.map(item => (
                             <span
                               key={item.slug}
-                              className="
+                              className={cn(`
                                 shrink-0 rounded-full border bg-background px-2.5 py-1 text-xs text-muted-foreground
-                              "
+                              `)}
                             >
                               {item.label}
                             </span>
@@ -7142,10 +7142,10 @@ export default function AdminCreateEventForm({
             <Button
               type="button"
               variant="outline"
-              className="
+              className={cn(`
                 border-destructive/30 text-destructive
                 hover:border-destructive/40 hover:bg-destructive/10 hover:text-destructive
-              "
+              `)}
               onClick={handleResetFormClick}
               disabled={
                 isLoadingPendingRequest

--- a/src/app/[locale]/admin/events/calendar/_components/admin-create-event-form-indicators.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/admin-create-event-form-indicators.tsx
@@ -41,10 +41,10 @@ function CheckIndicator({
 function SignatureTxIndicator({ status }: { status: SignatureTxStatus }) {
   if (status === 'success') {
     return (
-      <span className="
+      <span className={cn(`
         inline-flex size-6 items-center justify-center rounded-full border border-emerald-500/60 bg-emerald-500/15
         text-emerald-500
-      "
+      `)}
       >
         <CheckIcon className="size-3.5" />
       </span>
@@ -53,9 +53,9 @@ function SignatureTxIndicator({ status }: { status: SignatureTxStatus }) {
 
   if (status === 'error') {
     return (
-      <span className="
+      <span className={cn(`
         inline-flex size-6 items-center justify-center rounded-full border border-red-500/60 bg-red-500/15 text-red-500
-      "
+      `)}
       >
         <XIcon className="size-3.5" />
       </span>
@@ -64,10 +64,10 @@ function SignatureTxIndicator({ status }: { status: SignatureTxStatus }) {
 
   if (status === 'awaiting_wallet' || status === 'confirming') {
     return (
-      <span className="
+      <span className={cn(`
         inline-flex size-6 items-center justify-center rounded-full border border-yellow-500/60 bg-yellow-500/15
         text-yellow-500
-      "
+      `)}
       >
         <Loader2Icon className="size-3.5 animate-spin" />
       </span>
@@ -75,10 +75,10 @@ function SignatureTxIndicator({ status }: { status: SignatureTxStatus }) {
   }
 
   return (
-    <span className="
+    <span className={cn(`
       inline-flex size-6 items-center justify-center rounded-full border border-muted-foreground/30 bg-muted/20
       text-muted-foreground
-    "
+    `)}
     >
       <span className="size-2 rounded-full bg-current" />
     </span>

--- a/src/app/[locale]/admin/theme/_components/RadiusControl.tsx
+++ b/src/app/[locale]/admin/theme/_components/RadiusControl.tsx
@@ -5,6 +5,7 @@ import { useExtracted } from 'next-intl'
 import { useMemo } from 'react'
 import { DEFAULT_RADIUS_VALUE, getRadiusPresetButtonStyle, parseRadiusPixels, RADIUS_PRESETS } from '@/app/[locale]/admin/theme/_components/admin-theme-utils'
 import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
 
 function RadiusControl({
   radiusValue,
@@ -49,11 +50,11 @@ function RadiusControl({
           type="button"
           onClick={onRadiusReset}
           disabled={disabled || !normalizedRadius}
-          className={`
+          className={cn(`
             text-muted-foreground transition
             hover:text-foreground
             disabled:cursor-not-allowed disabled:opacity-40
-          `}
+          `)}
           title={t('Use default')}
           aria-label={t('Use default roundness')}
         >

--- a/src/app/[locale]/admin/theme/_components/ThemePreviewCard.tsx
+++ b/src/app/[locale]/admin/theme/_components/ThemePreviewCard.tsx
@@ -5,6 +5,7 @@ import { useExtracted } from 'next-intl'
 import { useMemo } from 'react'
 import { buildPreviewStyle } from '@/app/[locale]/admin/theme/_components/admin-theme-utils'
 import SiteLogoIcon from '@/components/SiteLogoIcon'
+import { cn } from '@/lib/utils'
 
 function ThemePreviewCard({
   presetId,
@@ -51,9 +52,9 @@ function ThemePreviewCard({
           <span className="inline-flex rounded-sm bg-primary px-2 py-1 text-xs font-semibold text-primary-foreground">
             {t('Primary')}
           </span>
-          <span className={`
+          <span className={cn(`
             inline-flex rounded-sm bg-secondary px-2 py-1 text-xs font-semibold text-secondary-foreground
-          `}
+          `)}
           >
             {t('Secondary')}
           </span>
@@ -70,11 +71,11 @@ function ThemePreviewCard({
             <input
               type="text"
               placeholder={t('Type here')}
-              className={`
+              className={cn(`
                 h-8 w-full rounded-md border border-input bg-background px-2 text-xs text-foreground shadow-none
                 ring-offset-background outline-none
                 focus-visible:ring-2 focus-visible:ring-ring
-              `}
+              `)}
             />
           </div>
           <div className="rounded-md border border-border bg-popover p-2 text-xs">

--- a/src/app/[locale]/admin/theme/_components/ThemeTokenMatrix.tsx
+++ b/src/app/[locale]/admin/theme/_components/ThemeTokenMatrix.tsx
@@ -105,10 +105,10 @@ function ThemeTokenMatrix({
                 {isOpen && (
                   <div id={`theme-group-${group.id}`} className="p-2">
                     <div className="grid gap-1">
-                      <div className={`
+                      <div className={cn(`
                         grid grid-cols-[minmax(0,1fr)_3.5rem_3.5rem] items-center gap-2 px-2 text-2xs
                         text-muted-foreground uppercase
-                      `}
+                      `)}
                       >
                         <span>{t('Token')}</span>
                         <span className="text-left">{t('Light')}</span>
@@ -124,10 +124,10 @@ function ThemeTokenMatrix({
                           return (
                             <div
                               key={token}
-                              className={`
+                              className={cn(`
                                 grid grid-cols-[minmax(0,1fr)_3.5rem_3.5rem] items-center gap-2 rounded-md border
                                 border-border px-2 py-1.5
-                              `}
+                              `)}
                             >
                               <code className="text-xs font-medium text-foreground">{token}</code>
                               <ColorPickerSwatch

--- a/src/app/[locale]/admin/users/_components/columns.tsx
+++ b/src/app/[locale]/admin/users/_components/columns.tsx
@@ -7,6 +7,7 @@ import ProfileLink from '@/components/ProfileLink'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
+import { cn } from '@/lib/utils'
 
 interface AdminUserRow {
   id: string
@@ -109,10 +110,10 @@ export function useAdminUsersColumns(): ColumnDef<AdminUserRow>[] {
               ? (
                   <a
                     href={`mailto:${user.email}`}
-                    className={`
+                    className={cn(`
                       inline-flex touch-manipulation items-center gap-1 text-muted-foreground
                       hover:text-primary
-                    `}
+                    `)}
                   >
                     <MailIcon className="size-4 shrink-0" />
                     <span className="sr-only">
@@ -149,11 +150,11 @@ export function useAdminUsersColumns(): ColumnDef<AdminUserRow>[] {
                     href={user.referred_by_profile_url ?? '#'}
                     target={user.referred_by_profile_url ? '_blank' : undefined}
                     rel={user.referred_by_profile_url ? 'noreferrer' : undefined}
-                    className={`
+                    className={cn(`
                       block max-w-15 touch-manipulation truncate text-xs font-medium text-foreground
                       hover:text-primary
                       sm:max-w-25
-                    `}
+                    `)}
                   >
                     {user.referred_by_display}
                   </a>

--- a/src/app/[locale]/docs/_components/LLMPageActions.tsx
+++ b/src/app/[locale]/docs/_components/LLMPageActions.tsx
@@ -9,6 +9,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+import { cn } from '@/lib/utils'
 
 interface ViewOptionsProps {
   markdownUrl: string
@@ -215,10 +216,10 @@ export function ViewOptions({ markdownUrl }: ViewOptionsProps) {
 
   return (
     <div
-      className="
+      className={cn(`
         inline-flex items-center overflow-hidden rounded-sm border bg-background shadow-xs
         dark:border-input dark:bg-input/30
-      "
+      `)}
     >
       <Button
         type="button"

--- a/src/components/HeaderDropdownUserMenuAuth.tsx
+++ b/src/components/HeaderDropdownUserMenuAuth.tsx
@@ -26,6 +26,7 @@ import { usePwaInstall } from '@/hooks/usePwaInstall'
 import { usePathname } from '@/i18n/navigation'
 import { getAvatarPlaceholderStyle, shouldUseAvatarPlaceholder } from '@/lib/avatar'
 import { signOutAndRedirect } from '@/lib/logout'
+import { cn } from '@/lib/utils'
 import { useUser } from '@/stores/useUser'
 
 function useHoverMenu(enableHoverOpen: boolean) {
@@ -194,11 +195,11 @@ export default function HeaderDropdownUserMenuAuth() {
             variant="ghost"
             size="header"
             aria-label="User menu"
-            className={`
+            className={cn(`
               group flex cursor-pointer items-center gap-2 px-2 transition-colors
               hover:bg-accent/70 hover:text-accent-foreground
               data-[state=open]:bg-accent/70 data-[state=open]:text-accent-foreground
-            `}
+            `)}
             data-testid="header-menu-button"
           >
             {showPlaceholder
@@ -218,11 +219,11 @@ export default function HeaderDropdownUserMenuAuth() {
                     className="aspect-square shrink-0 rounded-full object-cover"
                   />
                 )}
-            <ChevronDownIcon className={`
+            <ChevronDownIcon className={cn(`
               size-4 transition-transform duration-150
               group-hover:rotate-180
               group-data-[state=open]:rotate-180
-            `}
+            `)}
             />
           </Button>
         </DropdownMenuTrigger>

--- a/src/components/HeaderLogo.tsx
+++ b/src/components/HeaderLogo.tsx
@@ -3,6 +3,7 @@
 import AppLink from '@/components/AppLink'
 import SiteLogoIcon from '@/components/SiteLogoIcon'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
+import { cn } from '@/lib/utils'
 
 interface HeaderLogoProps {
   labelSuffix?: string
@@ -16,10 +17,10 @@ export default function HeaderLogo({ labelSuffix }: HeaderLogoProps) {
     <AppLink
       intentPrefetch
       href="/"
-      className={`
+      className={cn(`
         flex h-10 shrink-0 items-center gap-2 text-2xl font-medium text-foreground transition-opacity
         hover:opacity-80
-      `}
+      `)}
     >
       <SiteLogoIcon
         logoSvg={site.logoSvg}

--- a/src/components/PredictionChartAnnotations.tsx
+++ b/src/components/PredictionChartAnnotations.tsx
@@ -2,6 +2,7 @@
 
 import type { Dispatch, ReactElement, SetStateAction } from 'react'
 import type { PredictionChartAnnotationMarker } from '@/types/PredictionChartTypes'
+import { cn } from '@/lib/utils'
 
 const ANNOTATION_CLUSTER_DISTANCE_PX = 10
 
@@ -184,10 +185,10 @@ function PredictionChartAnnotationTooltip({
 }: PredictionChartAnnotationTooltipProps): ReactElement {
   return (
     <div
-      className="
+      className={cn(`
         pointer-events-none absolute z-30 -translate-x-1/2 -translate-y-full rounded-lg border border-border bg-popover
         px-2.5 py-1.5 shadow-md
-      "
+      `)}
       style={{
         left: position.left,
         top: position.top,

--- a/src/components/PredictionChartHeader.tsx
+++ b/src/components/PredictionChartHeader.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import { sanitizeSvg } from '@/lib/utils'
+import { cn, sanitizeSvg } from '@/lib/utils'
 
 interface PredictionChartHeaderProps {
   shouldRenderLegend: boolean
@@ -25,10 +25,10 @@ export default function PredictionChartHeader({
       </div>
 
       {shouldRenderWatermark && (
-        <div className={`
+        <div className={cn(`
           mr-2 flex items-center gap-1 self-end text-xl text-muted-foreground opacity-50 select-none
           lg:self-auto
-        `}
+        `)}
         >
           {watermark?.iconSvg
             ? (

--- a/src/components/PredictionChartTooltipOverlay.tsx
+++ b/src/components/PredictionChartTooltipOverlay.tsx
@@ -1,5 +1,6 @@
 import type { DataPoint } from '@/types/PredictionChartTypes'
 import { TOOLTIP_LABEL_MAX_WIDTH } from '@/lib/prediction-chart'
+import { cn } from '@/lib/utils'
 
 interface TooltipEntry {
   key: string
@@ -167,10 +168,10 @@ export default function PredictionChartTooltipOverlay({
         <div
           key={`${entry.key}-label`}
           className={
-            `
+            cn(`
               absolute inline-flex h-5 w-fit items-center gap-1 rounded-sm px-1.5 py-0.5 text-[10px]/5 font-semibold
               text-background
-            `
+            `)
           }
           style={{
             top: entry.top,

--- a/src/components/ProfileActivityTooltipCard.tsx
+++ b/src/components/ProfileActivityTooltipCard.tsx
@@ -141,10 +141,10 @@ export default function ProfileActivityTooltipCard({
         <div className="min-w-0 flex-1 text-left">
           <AppLink
             href={profileHref}
-            className="
+            className={cn(`
               block truncate text-left text-sm font-semibold text-foreground transition-colors
               hover:text-foreground
-            "
+            `)}
             title={profile.username}
           >
             {profile.username}

--- a/src/components/SignaturePrompt.tsx
+++ b/src/components/SignaturePrompt.tsx
@@ -13,6 +13,7 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog'
 import { useAppKit } from '@/hooks/useAppKit'
+import { cn } from '@/lib/utils'
 import { useSignaturePrompt } from '@/stores/useSignaturePrompt'
 
 export function SignaturePrompt() {
@@ -42,20 +43,20 @@ export function SignaturePrompt() {
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         showCloseButton={false}
-        className="
+        className={cn(`
           w-[320px] max-w-[calc(100%-2rem)] rounded-2xl border border-border/80 bg-background p-6 shadow-2xl
           sm:w-[340px]
-        "
+        `)}
         onEscapeKeyDown={event => event.preventDefault()}
         onInteractOutside={event => event.preventDefault()}
       >
         <DialogClose
-          className="
+          className={cn(`
             absolute top-5 right-5 z-20 inline-flex size-9 items-center justify-center rounded-md p-2
             text-muted-foreground/80 transition
             hover:bg-muted hover:text-foreground
             focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:outline-none
-          "
+          `)}
           aria-label={t('Close')}
         >
           <XIcon className="size-4" aria-hidden="true" />
@@ -68,10 +69,10 @@ export function SignaturePrompt() {
         <div className="mt-3 flex flex-col items-center gap-5">
           <div className="relative size-32 overflow-hidden rounded-[28px] bg-background text-primary">
             <div
-              className="
+              className={cn(`
                 pointer-events-none absolute inset-0 animate-[spin_1400ms_linear_infinite]
                 bg-[conic-gradient(from_0deg,transparent_0deg,transparent_292deg,currentColor_315deg,currentColor_350deg,transparent_360deg)]
-              "
+              `)}
             />
             <div className="absolute inset-[3px] rounded-[23px] bg-background" />
             <div className="relative flex size-full items-center justify-center">

--- a/src/components/TestModeBanner.tsx
+++ b/src/components/TestModeBanner.tsx
@@ -1,6 +1,7 @@
 import { useExtracted } from 'next-intl'
 import Image from 'next/image'
 import { useState } from 'react'
+import { cn } from '@/lib/utils'
 
 interface TestModeBannerProps {
   persistKey?: string
@@ -46,11 +47,11 @@ export default function TestModeBanner({
           <button
             type="button"
             onClick={closeBanner}
-            className={`
+            className={cn(`
               absolute -top-2 -right-2 inline-flex size-7 items-center justify-center rounded-full border bg-background
               text-sm text-foreground/80 shadow-md transition-colors
               hover:text-foreground
-            `}
+            `)}
             aria-label="Dismiss test mode banner"
           >
             &times;
@@ -71,11 +72,11 @@ export default function TestModeBanner({
                 href={discordUrl}
                 target="_blank"
                 rel="noreferrer"
-                className={`
+                className={cn(`
                   inline-flex w-fit items-center gap-2 rounded-md bg-[#5865F2] px-3 py-1.5 text-xs font-semibold
                   text-white transition
                   hover:bg-[#4752C4]
-                `}
+                `)}
               >
                 <Image
                   src="/images/deposit/social-media/discord.svg"

--- a/src/components/UserInfoSection.tsx
+++ b/src/components/UserInfoSection.tsx
@@ -6,6 +6,7 @@ import { useClipboard } from '@/hooks/useClipboard'
 import { getAvatarPlaceholderStyle, shouldUseAvatarPlaceholder } from '@/lib/avatar'
 import { truncateAddress } from '@/lib/formatters'
 import { buildPublicProfilePath, buildUsernameProfilePath } from '@/lib/platform-routing'
+import { cn } from '@/lib/utils'
 import { useUser } from '@/stores/useUser'
 
 export default function UserInfoSection() {
@@ -52,11 +53,11 @@ export default function UserInfoSection() {
                 alt="User avatar"
                 width={48}
                 height={48}
-                className={`
+                className={cn(`
                   aspect-square rounded-full object-cover object-center ring-2 ring-border/20 transition-all
                   duration-200
                   hover:ring-border/40
-                `}
+                `)}
               />
             )}
       </div>
@@ -65,11 +66,11 @@ export default function UserInfoSection() {
           ? (
               <AppLink
                 href={profileHref as any}
-                className={`
+                className={cn(`
                   truncate text-base/tight font-semibold text-foreground underline-offset-2 transition-colors
                   duration-200
                   hover:underline
-                `}
+                `)}
               >
                 {displayUsername}
               </AppLink>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -79,7 +79,7 @@ function DialogContent({
         {showCloseButton && (
           <DialogPrimitive.Close
             data-slot="dialog-close"
-            className={`
+            className={cn(`
               absolute top-4 right-4 rounded-md p-2 opacity-70 ring-offset-background transition
               hover:bg-muted hover:opacity-100
               focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:outline-hidden
@@ -87,7 +87,7 @@ function DialogContent({
               data-[state=open]:bg-accent data-[state=open]:text-muted-foreground
               [&_svg]:pointer-events-none [&_svg]:shrink-0
               [&_svg:not([class*='size-'])]:size-4
-            `}
+            `)}
           >
             <XIcon />
             <span className="sr-only">Close</span>

--- a/src/components/ui/number-input.tsx
+++ b/src/components/ui/number-input.tsx
@@ -127,10 +127,10 @@ export function NumberInput({
           }}
           maxLength={5}
           placeholder="0.0"
-          className={`
+          className={cn(`
             h-10 w-auto rounded-none border-none bg-transparent! px-0 text-right text-lg! font-bold shadow-none
             focus-visible:ring-0 focus-visible:ring-offset-0
-          `}
+          `)}
           style={{ width: `${inputSize}ch` }}
         />
         <span

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -64,9 +64,9 @@ function TooltipContent({
       >
         {children}
         {!hideArrow && (
-          <TooltipPrimitive.Arrow className={`
+          <TooltipPrimitive.Arrow className={cn(`
             z-50 size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-background fill-background
-          `}
+          `)}
           />
         )}
       </TooltipPrimitive.Content>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Normalize multiline className strings with `cn()` across the app to prevent SSR/CSR hydration mismatches and UI flicker. No visual or behavioral changes expected.

- **Bug Fixes**
  - Wrapped multi-line `className` strings in `cn()` to collapse whitespace and keep class output stable between server and client.
  - Added missing `cn` imports where needed; no logic or style changes.
  - Reduces hydration warnings and transient layout shifts across platform, sports, wallet, profile, leaderboard, admin, and event components.

<sup>Written for commit 1d7b6c1a75ff50c155bdfee766e5a7613505aa15. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1034?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

