### PR TITLE
fix order db sync and merge lock safety

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
@@ -357,7 +357,7 @@ export async function storeOrderAction(payload: StoreOrderInput) {
       return { error: DEFAULT_ERROR_MESSAGE }
     }
 
-    void OrderRepository.createOrder({
+    const persistResult = await OrderRepository.createOrder({
       ...validated.data,
       salt: BigInt(validated.data.salt),
       maker_amount: BigInt(validated.data.maker_amount),
@@ -371,6 +371,15 @@ export async function storeOrderAction(payload: StoreOrderInput) {
       clob_order_id: clobOrderId,
     })
 
+
+    if (persistResult.error) {
+      console.error(
+        'CLOB accepted the order but local persistence failed.',
+        persistResult.error,
+        clobOrderId,
+      )
+      return { error: DEFAULT_ERROR_MESSAGE }
+    }
     updateTag(cacheTags.activity(validated.data.slug))
     updateTag(cacheTags.holders(validated.data.condition_id))
 

--- a/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
+++ b/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
@@ -515,6 +515,7 @@ export async function fetchLockedSharesByCondition(markets: MergeableMarket[]): 
     }
     catch (error) {
       console.error('Failed to fetch open orders for mergeable lock calculation.', error)
+      throw error
     }
   }))
 

--- a/tests/unit/storeOrderAction.test.ts
+++ b/tests/unit/storeOrderAction.test.ts
@@ -162,7 +162,7 @@ describe('storeOrderAction', () => {
     })
   })
 
-  it('submits to CLOB, updates tags, and schedules local order creation', async () => {
+  it('submits to CLOB, updates tags, and persists order locally after clob success', async () => {
     process.env.CLOB_URL = 'https://clob.local'
     const proxy = address('01')
 
@@ -176,6 +176,7 @@ describe('storeOrderAction', () => {
     mocks.getUserTradingAuthSecrets.mockResolvedValueOnce({
       clob: { key: 'k', passphrase: 'p', secret: 's' },
     })
+    mocks.createOrder.mockResolvedValueOnce({ data: { id: 'local-1' }, error: null })
 
     const fetchMock = vi.fn()
       .mockResolvedValueOnce({
@@ -204,7 +205,6 @@ describe('storeOrderAction', () => {
     expect(fetchMock).toHaveBeenCalled()
     expect(mocks.updateTag).toHaveBeenCalledTimes(2)
 
-    await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(mocks.createOrder).toHaveBeenCalledWith(expect.objectContaining({
       clob_order_id: 'clob-123',
@@ -247,5 +247,43 @@ describe('storeOrderAction', () => {
     expect(result).toEqual({
       error: 'Something went wrong while processing your order. Please try again.',
     })
+  })
+
+  it('returns error when local persistence fails after clob accepts order', async () => {
+    process.env.CLOB_URL = 'https://clob.local'
+    const proxy = address('01')
+
+    mocks.getCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      address: address('aa'),
+      proxy_wallet_address: proxy,
+      referred_by_user_id: null,
+      settings: { trading: { market_order_type: 'FAK' } },
+    })
+    mocks.getUserTradingAuthSecrets.mockResolvedValueOnce({
+      clob: { key: 'k', passphrase: 'p', secret: 's' },
+    })
+    mocks.createOrder.mockResolvedValueOnce({ data: null, error: 'db down' })
+
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      status: 201,
+      statusText: 'Created',
+      ok: true,
+      json: async () => ({ orderId: 'clob-456' }),
+    })
+    globalThis.fetch = fetchMock as any
+
+    const { storeOrderAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/store-order')
+    const result = await storeOrderAction(basePayload({
+      maker: proxy,
+      signer: proxy,
+      type: 'MARKET',
+    }))
+
+    expect(result).toEqual({
+      error: 'Something went wrong while processing your order. Please try again.',
+    })
+    expect(mocks.createOrder).toHaveBeenCalled()
+    expect(mocks.updateTag).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
hey team, moondev here. was poking around the trading flow and found two spots that can mislead users when something fails quietly.

first, `storeOrderAction` fired `OrderRepository.createOrder` with `void` right after the clob accepted the order. if postgres insert failed, the handler still returned `{ error: null, orderId }`. activity/holders cache tags got invalidated anyway. now we await the insert and return the generic error if persistence fails, so the ui does not claim success without a local row.

second, `fetchLockedSharesByCondition` logged open-order fetch errors but kept going, so merge math treated locked shares as zero. that can show a merge size bigger than what resting sells actually allow. the per-condition catch now rethrows, and the existing callers already clear merge options or toast on failure.

added a unit test for the db failure path after clob success.

## test plan
- [x] `npx vitest run tests/unit/storeOrderAction.test.ts`
- [ ] place a test order on staging and confirm order row + activity still line up
- [ ] open profile merge with resting sell orders and confirm merge amount respects locks

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wait for local order persistence after CLOB acceptance and surface errors, so we never show a successful order without a DB row. Also rethrow locked-share lookup errors so the merge UI doesn’t assume zero locks and oversize merges.

- Bug Fixes
  - Await `OrderRepository.createOrder`; if it fails, return the default error and skip cache tag invalidation.
  - In `fetchLockedSharesByCondition`, rethrow open-order fetch errors so callers can block unsafe merges.
  - Added a unit test for the DB-failure-after-CLOB-success path.

<sup>Written for commit 34ef698724049022c894783af2e0112289804d03. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1036?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

