### PR TITLE
refactor: batch migration check

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -29,7 +29,7 @@ COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=build --chown=nextjs:nodejs /app/node_modules/postgres ./node_modules/postgres
 COPY --from=build --chown=nextjs:nodejs /app/package.json ./package.json
-COPY --from=build --chown=nextjs:nodejs /app/scripts/migrate.js ./scripts/migrate.js
+COPY --from=build --chown=nextjs:nodejs /app/scripts/migrate.ts ./scripts/migrate.ts
 COPY --from=build --chown=nextjs:nodejs /app/src/lib/site-url.js ./src/lib/site-url.js
 COPY --from=build --chown=nextjs:nodejs /app/src/lib/db/migrations ./src/lib/db/migrations
 

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -30,7 +30,7 @@ COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=build --chown=nextjs:nodejs /app/node_modules/postgres ./node_modules/postgres
 COPY --from=build --chown=nextjs:nodejs /app/package.json ./package.json
 COPY --from=build --chown=nextjs:nodejs /app/scripts/migrate.ts ./scripts/migrate.ts
-COPY --from=build --chown=nextjs:nodejs /app/src/lib/site-url.js ./src/lib/site-url.js
+COPY --from=build --chown=nextjs:nodejs /app/src/lib/site-url.ts ./src/lib/site-url.ts
 COPY --from=build --chown=nextjs:nodejs /app/src/lib/db/migrations ./src/lib/db/migrations
 
 USER nextjs

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -8,7 +8,7 @@ const config: KnipConfig = {
     'scripts/**',
     'src/components/ui/**',
     'src/lib/image/**',
-    'src/lib/site-url.js',
+    'src/lib/site-url.ts',
     'vitest.setup.ts',
   ],
   ignoreDependencies: [

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -3,16 +3,8 @@ import type { KnipConfig } from 'knip'
 const config: KnipConfig = {
   ignore: [
     'docs.config.ts',
-    'next-env.d.ts',
     'public/**/*',
-    'scripts/**',
     'src/components/ui/**',
-    'src/lib/image/**',
-    'src/lib/site-url.ts',
-    'vitest.setup.ts',
-  ],
-  ignoreDependencies: [
-    'date-fns',
   ],
   treatConfigHintsAsErrors: false,
   rules: {

--- a/next.config.ts
+++ b/next.config.ts
@@ -3,9 +3,8 @@ import { withSentryConfig } from '@sentry/nextjs'
 import { createMDX } from 'fumadocs-mdx/next'
 import createNextIntlPlugin from 'next-intl/plugin'
 import { getOptimizedImageHostPatterns } from '@/lib/image/image-optimization'
-import siteUrlUtils from './src/lib/site-url'
+import resolveSiteUrl from './src/lib/site-url'
 
-const { resolveSiteUrl } = siteUrlUtils
 const siteUrl = resolveSiteUrl(process.env)
 const optimizedImageHostPatterns = getOptimizedImageHostPatterns(process.env)
 

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "test:e2e": "npx playwright test",
     "test:unit": "vitest run",
     "prepare": "husky",
-    "db:push": "node scripts/migrate.js"
+    "db:push": "node scripts/migrate.ts"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "3.1044.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "canvas-confetti": "1.9.4",
     "class-variance-authority": "0.7.1",
     "clsx": "2.1.1",
-    "date-fns": "4.1.0",
     "drizzle-orm": "0.45.2",
     "fumadocs-core": "16.8.7",
     "fumadocs-mdx": "14.3.2",

--- a/scripts/migrate.js
+++ b/scripts/migrate.js
@@ -142,17 +142,26 @@ async function applyMigrations(sql, isSupabase) {
 
   console.log(`Found ${migrationFiles.length} migration files`)
 
-  for (const file of migrationFiles) {
+  const appliedMigrationRows = await sql`SELECT version FROM migrations`
+  const appliedMigrationVersions = new Set(appliedMigrationRows.map(row => row.version))
+  const pendingMigrationFiles = migrationFiles.filter((file) => {
     const version = file.replace('.sql', '')
+    return !appliedMigrationVersions.has(version)
+  })
 
-    const result = await sql`
-      SELECT version FROM migrations WHERE version = ${version}
-    `
+  const skippedMigrationCount = migrationFiles.length - pendingMigrationFiles.length
 
-    if (result.length > 0) {
-      console.log(`⏭️ Skipping ${file} (already applied)`)
-      continue
-    }
+  if (skippedMigrationCount > 0) {
+    console.log(`⏭️ Skipping ${skippedMigrationCount} already applied migrations`)
+  }
+
+  if (pendingMigrationFiles.length === 0) {
+    console.log('No pending migrations')
+    return
+  }
+
+  for (const file of pendingMigrationFiles) {
+    const version = file.replace('.sql', '')
 
     console.log(`🔄 Applying ${file}`)
     const rawMigrationSql = fs.readFileSync(

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -9,6 +9,7 @@ type Postgres = typeof import('postgres')
 type ResolveSiteUrl = (env?: NodeJS.ProcessEnv) => string
 type Sql = ReturnType<Postgres>
 type ReservedSql = Awaited<ReturnType<Sql['reserve']>>
+const SITE_URL_MODULE_PATH = '../src/lib/site-url.ts'
 
 let fs: NodeFs
 let path: NodePath
@@ -43,18 +44,18 @@ async function loadScriptDependencies(): Promise<void> {
     import('node:fs'),
     import('node:path'),
     import('postgres'),
-    import('../src/lib/site-url'),
+    import(SITE_URL_MODULE_PATH),
   ])
   const postgresImport = postgresModule as unknown as { default?: Postgres } & Postgres
   const siteUrlImport = siteUrlModule as unknown as {
-    default?: { resolveSiteUrl: ResolveSiteUrl }
+    default?: ResolveSiteUrl
     resolveSiteUrl?: ResolveSiteUrl
   }
 
   fs = fsModule
   path = pathModule
   postgres = postgresImport.default ?? postgresImport
-  const importedResolveSiteUrl = siteUrlImport.default?.resolveSiteUrl ?? siteUrlImport.resolveSiteUrl
+  const importedResolveSiteUrl = siteUrlImport.default ?? siteUrlImport.resolveSiteUrl
 
   if (!importedResolveSiteUrl) {
     throw new Error('Failed to load resolveSiteUrl from src/lib/site-url.ts')

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -1,18 +1,73 @@
 #!/usr/bin/env node
 
-const fs = require('node:fs')
-const path = require('node:path')
-const postgres = require('postgres')
-const { resolveSiteUrl } = require('../src/lib/site-url')
-
 const MIGRATION_LOCK_NAMESPACE = 20817
 const MIGRATION_LOCK_KEY = 1
 
-function escapeSqlLiteral(value) {
+type NodeFs = typeof import('node:fs')
+type NodePath = typeof import('node:path')
+type Postgres = typeof import('postgres')
+type ResolveSiteUrl = (env?: NodeJS.ProcessEnv) => string
+type Sql = ReturnType<Postgres>
+type ReservedSql = Awaited<ReturnType<Sql['reserve']>>
+
+let fs: NodeFs
+let path: NodePath
+let postgres: Postgres
+let resolveSiteUrl: ResolveSiteUrl
+
+interface SyncCronOptions {
+  jobName: string
+  schedule: string
+  endpointPath: string
+  siteUrl: string
+  cronSecret: string
+  timeoutMilliseconds?: number
+}
+
+interface MigrationRow {
+  version: string
+}
+
+interface CronExtensionCapabilitiesRow {
+  has_pg_cron: boolean
+  has_pg_net: boolean
+}
+
+interface CronExtensionCapabilities {
+  hasPgCron: boolean
+  hasPgNet: boolean
+}
+
+async function loadScriptDependencies(): Promise<void> {
+  const [fsModule, pathModule, postgresModule, siteUrlModule] = await Promise.all([
+    import('node:fs'),
+    import('node:path'),
+    import('postgres'),
+    import('../src/lib/site-url.js'),
+  ])
+  const postgresImport = postgresModule as unknown as { default?: Postgres } & Postgres
+  const siteUrlImport = siteUrlModule as unknown as {
+    default?: { resolveSiteUrl: ResolveSiteUrl }
+    resolveSiteUrl?: ResolveSiteUrl
+  }
+
+  fs = fsModule
+  path = pathModule
+  postgres = postgresImport.default ?? postgresImport
+  const importedResolveSiteUrl = siteUrlImport.default?.resolveSiteUrl ?? siteUrlImport.resolveSiteUrl
+
+  if (!importedResolveSiteUrl) {
+    throw new Error('Failed to load resolveSiteUrl from src/lib/site-url.js')
+  }
+
+  resolveSiteUrl = importedResolveSiteUrl
+}
+
+function escapeSqlLiteral(value: unknown): string {
   return String(value).replace(/'/g, '\'\'')
 }
 
-function joinSiteUrlPath(siteUrl, endpointPath) {
+function joinSiteUrlPath(siteUrl: string, endpointPath: string): string {
   const normalizedSiteUrl = String(siteUrl).trim().replace(/\/+$/, '')
   const normalizedEndpointPath = String(endpointPath).trim().replace(/^\/+/, '')
 
@@ -30,7 +85,7 @@ function buildSyncCronSql({
   siteUrl,
   cronSecret,
   timeoutMilliseconds = 20000,
-}) {
+}: SyncCronOptions): string {
   const endpointUrl = joinSiteUrlPath(siteUrl, endpointPath)
   const escapedJobName = escapeSqlLiteral(jobName)
   const escapedSchedule = escapeSqlLiteral(schedule)
@@ -65,7 +120,7 @@ function buildSyncCronSql({
   END $$;`
 }
 
-function resolveSupabaseMode(env = process.env) {
+function resolveSupabaseMode(env: NodeJS.ProcessEnv = process.env): boolean {
   const supabaseUrl = env.SUPABASE_URL?.trim()
   const supabaseServiceRoleKey = env.SUPABASE_SERVICE_ROLE_KEY?.trim()
 
@@ -81,7 +136,7 @@ function resolveSupabaseMode(env = process.env) {
   return true
 }
 
-function rewriteMigrationSqlForMode(migrationSql, isSupabase) {
+function rewriteMigrationSqlForMode(migrationSql: string, isSupabase: boolean): string {
   if (isSupabase) {
     return migrationSql
   }
@@ -91,7 +146,10 @@ function rewriteMigrationSqlForMode(migrationSql, isSupabase) {
     .replace(/\bTO\s+service_role\b/gi, 'TO CURRENT_USER')
 }
 
-async function withReservedTransaction(sql, fn) {
+async function withReservedTransaction<T>(
+  sql: ReservedSql,
+  fn: (tx: ReservedSql) => Promise<T>,
+): Promise<T> {
   await sql`BEGIN`
 
   try {
@@ -111,7 +169,7 @@ async function withReservedTransaction(sql, fn) {
   }
 }
 
-async function applyMigrations(sql, isSupabase) {
+async function applyMigrations(sql: ReservedSql, isSupabase: boolean): Promise<void> {
   console.log('Applying migrations...')
 
   console.log('Creating migrations tracking table...')
@@ -132,7 +190,7 @@ async function applyMigrations(sql, isSupabase) {
         END IF;
       END
     $$;
-  `, [], { simple: true })
+  `, []).simple()
   console.log('Migrations table ready')
 
   const migrationsDir = path.join(__dirname, '../src/lib/db/migrations')
@@ -142,7 +200,7 @@ async function applyMigrations(sql, isSupabase) {
 
   console.log(`Found ${migrationFiles.length} migration files`)
 
-  const appliedMigrationRows = await sql`SELECT version FROM migrations`
+  const appliedMigrationRows = await sql<MigrationRow[]>`SELECT version FROM migrations`
   const appliedMigrationVersions = new Set(appliedMigrationRows.map(row => row.version))
   const pendingMigrationFiles = migrationFiles.filter((file) => {
     const version = file.replace('.sql', '')
@@ -175,7 +233,7 @@ async function applyMigrations(sql, isSupabase) {
     }
 
     await withReservedTransaction(sql, async (tx) => {
-      await tx.unsafe(migrationSql, [], { simple: true })
+      await tx.unsafe(migrationSql, []).simple()
       await tx`INSERT INTO migrations (version) VALUES (${version})`
     })
 
@@ -185,7 +243,7 @@ async function applyMigrations(sql, isSupabase) {
   console.log('✅ All migrations applied successfully')
 }
 
-async function createCleanCronDetailsCron(sql) {
+async function createCleanCronDetailsCron(sql: ReservedSql): Promise<void> {
   console.log('Creating clean cron details job...')
   const sqlQuery = `
   DO $$
@@ -205,11 +263,11 @@ async function createCleanCronDetailsCron(sql) {
     PERFORM cron.schedule('clean-cron-details', '0 0 * * *', cmd);
   END $$;`
 
-  await sql.unsafe(sqlQuery, [], { simple: true })
+  await sql.unsafe(sqlQuery, []).simple()
   console.log('✅ Cron clean-cron-details created successfully')
 }
 
-async function createCleanJobsCron(sql) {
+async function createCleanJobsCron(sql: ReservedSql): Promise<void> {
   console.log('Creating clean-jobs cron job...')
   const sqlQuery = `
   DO $$
@@ -249,18 +307,22 @@ async function createCleanJobsCron(sql) {
     PERFORM cron.schedule('clean-jobs', '15 * * * *', cmd);
   END $$;`
 
-  await sql.unsafe(sqlQuery, [], { simple: true })
+  await sql.unsafe(sqlQuery, []).simple()
   console.log('✅ Cron clean-jobs created successfully')
 }
 
-async function createSyncCron(sql, options) {
+async function createSyncCron(sql: ReservedSql, options: SyncCronOptions): Promise<void> {
   const sqlQuery = buildSyncCronSql(options)
   console.log(`Creating ${options.jobName} cron job...`)
-  await sql.unsafe(sqlQuery, [], { simple: true })
+  await sql.unsafe(sqlQuery, []).simple()
   console.log(`✅ Cron ${options.jobName} created successfully`)
 }
 
-async function createSyncEventsCron(sql, siteUrl, cronSecret) {
+async function createSyncEventsCron(
+  sql: ReservedSql,
+  siteUrl: string,
+  cronSecret: string,
+): Promise<void> {
   await createSyncCron(sql, {
     jobName: 'sync-events',
     schedule: '2,11,20,29,38,47,56 * * * *',
@@ -270,7 +332,11 @@ async function createSyncEventsCron(sql, siteUrl, cronSecret) {
   })
 }
 
-async function createSyncVolumeCron(sql, siteUrl, cronSecret) {
+async function createSyncVolumeCron(
+  sql: ReservedSql,
+  siteUrl: string,
+  cronSecret: string,
+): Promise<void> {
   await createSyncCron(sql, {
     jobName: 'sync-volume',
     schedule: '*/10 * * * *',
@@ -281,7 +347,11 @@ async function createSyncVolumeCron(sql, siteUrl, cronSecret) {
   })
 }
 
-async function createSyncTranslationsCron(sql, siteUrl, cronSecret) {
+async function createSyncTranslationsCron(
+  sql: ReservedSql,
+  siteUrl: string,
+  cronSecret: string,
+): Promise<void> {
   await createSyncCron(sql, {
     jobName: 'sync-translations',
     schedule: '13,37 * * * *',
@@ -291,7 +361,11 @@ async function createSyncTranslationsCron(sql, siteUrl, cronSecret) {
   })
 }
 
-async function createSyncResolutionCron(sql, siteUrl, cronSecret) {
+async function createSyncResolutionCron(
+  sql: ReservedSql,
+  siteUrl: string,
+  cronSecret: string,
+): Promise<void> {
   await createSyncCron(sql, {
     jobName: 'sync-resolution',
     schedule: '5-55/10 * * * *',
@@ -301,7 +375,11 @@ async function createSyncResolutionCron(sql, siteUrl, cronSecret) {
   })
 }
 
-async function createSyncEventCreationsCron(sql, siteUrl, cronSecret) {
+async function createSyncEventCreationsCron(
+  sql: ReservedSql,
+  siteUrl: string,
+  cronSecret: string,
+): Promise<void> {
   await createSyncCron(sql, {
     jobName: 'sync-event-creations',
     schedule: '0,30 * * * *',
@@ -311,8 +389,8 @@ async function createSyncEventCreationsCron(sql, siteUrl, cronSecret) {
   })
 }
 
-async function resolveCronExtensionCapabilities(sql) {
-  const result = await sql`
+async function resolveCronExtensionCapabilities(sql: ReservedSql): Promise<CronExtensionCapabilities> {
+  const result = await sql<CronExtensionCapabilitiesRow[]>`
     SELECT
       EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') AS has_pg_cron,
       EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_net') AS has_pg_net
@@ -324,7 +402,11 @@ async function resolveCronExtensionCapabilities(sql) {
   }
 }
 
-async function configureSupabaseScheduler(sql, siteUrl, cronSecret) {
+async function configureSupabaseScheduler(
+  sql: ReservedSql,
+  siteUrl: string,
+  cronSecret: string,
+): Promise<void> {
   const { hasPgCron, hasPgNet } = await resolveCronExtensionCapabilities(sql)
 
   if (!hasPgCron) {
@@ -352,7 +434,7 @@ async function configureSupabaseScheduler(sql, siteUrl, cronSecret) {
   await createSyncVolumeCron(sql, siteUrl, cronSecret)
 }
 
-function resolveMigrationConnectionString() {
+function resolveMigrationConnectionString(): string | null {
   const migrationUrl = process.env.POSTGRES_URL_NON_POOLING || process.env.POSTGRES_URL
 
   if (!migrationUrl) {
@@ -362,27 +444,29 @@ function resolveMigrationConnectionString() {
   return migrationUrl.replace('require', 'disable')
 }
 
-async function acquireMigrationLock(sql) {
+async function acquireMigrationLock(sql: ReservedSql): Promise<void> {
   await sql`SELECT pg_advisory_lock(${MIGRATION_LOCK_NAMESPACE}, ${MIGRATION_LOCK_KEY})`
 }
 
-async function releaseMigrationLock(sql) {
+async function releaseMigrationLock(sql: ReservedSql): Promise<void> {
   await sql`SELECT pg_advisory_unlock(${MIGRATION_LOCK_NAMESPACE}, ${MIGRATION_LOCK_KEY})`
 }
 
-async function run() {
+async function run(): Promise<void> {
   const connectionString = resolveMigrationConnectionString()
   if (!connectionString) {
     console.log('Skipping db:push because required env vars are missing: POSTGRES_URL_NON_POOLING or POSTGRES_URL')
     return
   }
 
+  await loadScriptDependencies()
+
   const sql = postgres(connectionString, {
     max: 1,
     connect_timeout: 30,
     idle_timeout: 5,
   })
-  let reserved = null
+  let reserved: ReservedSql | null = null
   let lockAcquired = false
 
   try {

--- a/scripts/migrate.ts
+++ b/scripts/migrate.ts
@@ -43,7 +43,7 @@ async function loadScriptDependencies(): Promise<void> {
     import('node:fs'),
     import('node:path'),
     import('postgres'),
-    import('../src/lib/site-url.js'),
+    import('../src/lib/site-url'),
   ])
   const postgresImport = postgresModule as unknown as { default?: Postgres } & Postgres
   const siteUrlImport = siteUrlModule as unknown as {
@@ -57,7 +57,7 @@ async function loadScriptDependencies(): Promise<void> {
   const importedResolveSiteUrl = siteUrlImport.default?.resolveSiteUrl ?? siteUrlImport.resolveSiteUrl
 
   if (!importedResolveSiteUrl) {
-    throw new Error('Failed to load resolveSiteUrl from src/lib/site-url.js')
+    throw new Error('Failed to load resolveSiteUrl from src/lib/site-url.ts')
   }
 
   resolveSiteUrl = importedResolveSiteUrl

--- a/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
@@ -17,10 +17,8 @@ import {
   findDynamicHomeSubcategoryBySlug,
   getMainTagSeoTitle,
 } from '@/lib/platform-routing'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
-
-const { resolveSiteUrl } = siteUrlUtils
 
 async function getMainTags(locale: SupportedLocale) {
   const { data: mainTags } = await loadPlatformMainTags(locale)

--- a/src/app/[locale]/(platform)/_lib/prediction-results-metadata.ts
+++ b/src/app/[locale]/(platform)/_lib/prediction-results-metadata.ts
@@ -1,8 +1,6 @@
 import type { SupportedLocale } from '@/i18n/locales'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
-import siteUrlUtils from '@/lib/site-url'
-
-const { resolveSiteUrl } = siteUrlUtils
+import resolveSiteUrl from '@/lib/site-url'
 
 export function buildLocalizedPagePath(path: string, locale: SupportedLocale) {
   if (locale === DEFAULT_LOCALE) {

--- a/src/app/[locale]/(platform)/_lib/public-profile-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/public-profile-page.tsx
@@ -14,10 +14,8 @@ import { UserRepository } from '@/lib/db/queries/user'
 import { truncateAddress } from '@/lib/formatters'
 import { normalizePublicProfileSlug } from '@/lib/platform-routing'
 import { fetchPortfolioSnapshot } from '@/lib/portfolio'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
-
-const { resolveSiteUrl } = siteUrlUtils
 
 function buildLocalizedPagePath(path: string, locale: SupportedLocale) {
   if (locale === DEFAULT_LOCALE) {

--- a/src/app/[locale]/(platform)/leaderboard/[[...filters]]/page.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/[[...filters]]/page.tsx
@@ -12,10 +12,8 @@ import {
   PERIOD_OPTIONS,
 } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardFilters'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
-
-const { resolveSiteUrl } = siteUrlUtils
 
 function buildLocalizedPagePath(path: string, locale: SupportedLocale) {
   if (locale === DEFAULT_LOCALE) {

--- a/src/app/[locale]/(platform)/settings/sdks/page.tsx
+++ b/src/app/[locale]/(platform)/settings/sdks/page.tsx
@@ -6,9 +6,8 @@ import { getAffiliateFeeSettings } from '@/lib/affiliate-fee-settings'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { UserRepository } from '@/lib/db/queries/user'
 import { getBlockedCountriesFromSettings } from '@/lib/geoblock-settings'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 
-const { resolveSiteUrl } = siteUrlUtils
 const SDK_DOWNLOAD_URL = process.env.SDK_DOWNLOAD_URL!
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/settings/sdks'>): Promise<Metadata> {

--- a/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
+++ b/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
@@ -18,7 +18,7 @@ import {
   validateGlobalAnnouncementInput,
 } from '@/lib/global-announcement-settings'
 import { reportOperatorDomainSnapshot } from '@/lib/operator-domain-register'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { uploadPublicAsset } from '@/lib/storage'
 import { normalizeTermsOfServicePdfPath, TERMS_OF_SERVICE_PDF_PATH_KEY } from '@/lib/terms-of-service'
 import { validateThemeSiteSettingsInput } from '@/lib/theme-settings'
@@ -29,7 +29,6 @@ const MAX_PWA_ICON_FILE_SIZE = 2 * 1024 * 1024
 const ACCEPTED_PWA_ICON_TYPES = ['image/png', 'image/jpeg', 'image/jpg', 'image/webp', 'image/svg+xml']
 const MAX_TERMS_OF_SERVICE_PDF_FILE_SIZE = 2 * 1024 * 1024
 const GEOBLOCK_SYNC_URL = process.env.GEOBLOCK_URL!
-const { resolveSiteUrl } = siteUrlUtils
 
 export interface GeneralSettingsActionState {
   error: string | null

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -14,13 +14,11 @@ import { openSauceOne } from '@/lib/fonts'
 import { loadGlobalAnnouncementSettings } from '@/lib/global-announcement-settings'
 import { IS_TEST_MODE } from '@/lib/network'
 import { resolvePwaThemeColors } from '@/lib/pwa-colors'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 import { AppProviders } from '@/providers/AppProviders'
 import SiteIdentityProvider from '@/providers/SiteIdentityProvider'
 import '../globals.css'
-
-const { resolveSiteUrl } = siteUrlUtils
 
 export async function generateViewport(): Promise<Viewport> {
   const runtimeTheme = await loadRuntimeThemeState()

--- a/src/app/api/og/event/route.tsx
+++ b/src/app/api/og/event/route.tsx
@@ -10,10 +10,8 @@ import { EventRepository } from '@/lib/db/queries/event'
 import { formatCentsLabel, formatCompactCurrency, formatPercent } from '@/lib/formatters'
 import { resolveOutcomeButtonTheme } from '@/lib/outcome-theme'
 import { readResponseBodyWithLimit } from '@/lib/read-response-body-with-limit'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
-
-const { resolveSiteUrl } = siteUrlUtils
 
 const IMAGE_WIDTH = 1200
 const IMAGE_HEIGHT = 630

--- a/src/app/api/og/profile/route.tsx
+++ b/src/app/api/og/profile/route.tsx
@@ -9,13 +9,12 @@ import { UserRepository } from '@/lib/db/queries/user'
 import { truncateAddress } from '@/lib/formatters'
 import { normalizePublicProfileSlug } from '@/lib/platform-routing'
 import { fetchPortfolioSnapshot } from '@/lib/portfolio'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 const OG_IMAGE_WIDTH = 1200
 const OG_IMAGE_HEIGHT = 630
 const DATA_API_URL = process.env.DATA_URL ?? ''
-const { resolveSiteUrl } = siteUrlUtils
 
 interface ProfilePositionRow {
   title: string

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,5 @@
 import type { MetadataRoute } from 'next'
-import siteUrlUtils from '@/lib/site-url'
-
-const { resolveSiteUrl } = siteUrlUtils
+import resolveSiteUrl from '@/lib/site-url'
 
 export default function robots(): MetadataRoute.Robots {
   const siteUrl = resolveSiteUrl(process.env)

--- a/src/app/sitemap.xml/route.ts
+++ b/src/app/sitemap.xml/route.ts
@@ -1,7 +1,5 @@
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { getSitemapIndexEntries } from '@/lib/sitemap'
-
-const { resolveSiteUrl } = siteUrlUtils
 
 const XML_CONTENT_TYPE = 'application/xml; charset=utf-8'
 

--- a/src/app/sitemaps/sitemap.ts
+++ b/src/app/sitemaps/sitemap.ts
@@ -3,7 +3,7 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { loadEnabledLocales } from '@/i18n/locale-settings'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
 import { withLocalePrefix } from '@/lib/locale-path'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import {
   ACTIVE_EVENTS_SITEMAP_PREFIX,
   BASE_SITEMAP_ID,
@@ -15,8 +15,6 @@ import {
   getSitemapIds,
   PREDICTIONS_SITEMAP_PREFIX,
 } from '@/lib/sitemap'
-
-const { resolveSiteUrl } = siteUrlUtils
 
 const BASE_PATHS = [
   '/',

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -12,7 +12,7 @@ import { isAdminWallet } from '@/lib/admin'
 import { AffiliateRepository } from '@/lib/db/queries/affiliate'
 import { db } from '@/lib/drizzle'
 import { reownProjectId } from '@/lib/reown-project-id'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { getPublicAssetUrl } from '@/lib/storage'
 import { DEFAULT_THEME_SITE_NAME } from '@/lib/theme-site-identity'
 import { ensureUserTradingAuthSecretFingerprint } from '@/lib/trading-auth/server'
@@ -26,7 +26,6 @@ const TRUST_DEVICE_COOKIE_MAX_AGE = 720 * 60 * 60
 const TWO_FACTOR_PENDING_MAX_AGE = 3 * 60
 const AFFILIATE_COOKIE_NAME = 'platform_affiliate'
 const AFFILIATE_COOKIE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
-const { resolveSiteUrl } = siteUrlUtils
 const SITE_URL = resolveSiteUrl(process.env)
 const siteUrlObject = new URL(SITE_URL)
 const SIWE_DOMAIN = siteUrlObject.host

--- a/src/lib/event-open-graph.ts
+++ b/src/lib/event-open-graph.ts
@@ -6,10 +6,8 @@ import { DEFAULT_LOCALE } from '@/i18n/locales'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { loadEventPageShellData } from '@/lib/event-page-data'
 import { resolveEventMarketPath, resolveEventPagePath } from '@/lib/events-routing'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import 'server-only'
-
-const { resolveSiteUrl } = siteUrlUtils
 
 interface BuildEventPageMetadataOptions {
   eventSlug: string

--- a/src/lib/operator-domain-register.ts
+++ b/src/lib/operator-domain-register.ts
@@ -1,9 +1,8 @@
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 
 const DEFAULT_REGISTER_ENDPOINT = 'https://kuest.com/api/domain-register'
 const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '0.0.0.0'])
 const REQUEST_TIMEOUT_MS = 2_500
-const { resolveSiteUrl } = siteUrlUtils
 
 function isLocalHostname(hostname: string) {
   const normalized = hostname.toLowerCase().replace(/^\[(.*)\]$/, '$1')

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,7 +1,7 @@
 const HAS_PROTOCOL_PATTERN = /^[a-z][a-z0-9+.-]*:\/\//i
 const LOCAL_HOST_PATTERN = /^(?:localhost|127(?:\.\d{1,3}){3}|0\.0\.0\.0)(?::\d+)?(?:\/|$)/i
 
-function normalizeSiteUrl(value) {
+function normalizeSiteUrl(value: string): string {
   if (typeof value !== 'string' || !value.trim()) {
     throw new Error('SITE_URL must be a non-empty string')
   }
@@ -27,25 +27,24 @@ function normalizeSiteUrl(value) {
   return `${parsed.protocol}//${parsed.host}${normalizedPath}${parsed.search}${parsed.hash}`
 }
 
-function resolveSiteUrl(env = process.env) {
-  const explicitSiteUrl = typeof env.SITE_URL === 'string' && env.SITE_URL.trim()
-    ? env.SITE_URL
-    : null
-  const vercelProductionUrl = typeof env.VERCEL_PROJECT_PRODUCTION_URL === 'string' && env.VERCEL_PROJECT_PRODUCTION_URL.trim()
-    ? env.VERCEL_PROJECT_PRODUCTION_URL
-    : null
-
-  if (explicitSiteUrl) {
-    return normalizeSiteUrl(explicitSiteUrl)
+function resolveSiteUrl(env: NodeJS.ProcessEnv = process.env): string {
+  if (typeof env.SITE_URL === 'string' && env.SITE_URL.trim()) {
+    return normalizeSiteUrl(env.SITE_URL)
   }
 
-  if (vercelProductionUrl) {
-    return normalizeSiteUrl(vercelProductionUrl)
+  if (
+    typeof env.VERCEL_PROJECT_PRODUCTION_URL === 'string'
+    && env.VERCEL_PROJECT_PRODUCTION_URL.trim()
+  ) {
+    return normalizeSiteUrl(env.VERCEL_PROJECT_PRODUCTION_URL)
   }
 
   return 'http://localhost:3000'
 }
 
-module.exports = {
+const siteUrlUtils = {
   resolveSiteUrl,
 }
+
+export { resolveSiteUrl }
+export default siteUrlUtils

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -42,9 +42,4 @@ function resolveSiteUrl(env: NodeJS.ProcessEnv = process.env): string {
   return 'http://localhost:3000'
 }
 
-const siteUrlUtils = {
-  resolveSiteUrl,
-}
-
-export { resolveSiteUrl }
-export default siteUrlUtils
+export default resolveSiteUrl

--- a/src/lib/structured-data.ts
+++ b/src/lib/structured-data.ts
@@ -5,11 +5,9 @@ import type { Event } from '@/types'
 import { buildEventOgImageUrl } from '@/lib/event-open-graph'
 import { withLocalePrefix } from '@/lib/locale-path'
 import { isDynamicHomeCategorySlug } from '@/lib/platform-routing'
-import siteUrlUtils from '@/lib/site-url'
+import resolveSiteUrl from '@/lib/site-url'
 import { getSportsVerticalConfig, resolveSportsVerticalFromTags } from '@/lib/sports-vertical'
 import { getThemeSiteSameAs } from '@/lib/theme-site-identity'
-
-const { resolveSiteUrl } = siteUrlUtils
 
 export interface StructuredDataNode {
   [key: string]: unknown


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Batch-check pending migrations to reduce DB queries and speed up `db:push`. Migrated the migration script and site URL utility to TypeScript, made `resolveSiteUrl` a default export, and cleaned up scheduler setup.

- **Refactors**
  - Query applied migrations once and apply only pending ones; clearer skip logs.
  - Converted `scripts/migrate.js` → `scripts/migrate.ts` and `src/lib/site-url.js` → `src/lib/site-url.ts`; `resolveSiteUrl` is now the default export and callers were updated.
  - Improved migration internals: dynamic module loading, a reserved-transaction helper, and `postgres` `.simple()` usage.
  - Updated Dockerfile, `package.json`, `next.config.ts`, and `knip.config.ts` to reference `.ts` files and simplify config; removed unused `date-fns`.

<sup>Written for commit b07ad0e3a0d93f9ebd1ce57db15cdd31db6dfd79. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1039?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

