### PR TITLE
fix: send builder code in sdk downloads

### DIFF
--- a/docs/api-reference/clients-sdks.mdx
+++ b/docs/api-reference/clients-sdks.mdx
@@ -30,7 +30,7 @@ description: Official SDKs for interacting with Kuest CLOB services in Python, R
 </Cards>
 
 <Callout type="info">
-  Download personalized SDK packages from <a href="/settings/sdks">Settings → SDKs</a> to receive your site URL, fee settings, and geoblock behavior prefilled.
+  Download personalized SDK packages from <a href="/settings/sdks">Settings → SDKs</a> to receive your site URL, builder attribution, and geoblock behavior prefilled.
 </Callout>
 
 ## Python quickstart
@@ -82,4 +82,6 @@ Use <a href="/settings/sdks">Settings → SDKs</a> to download the TypeScript pa
 
 - Review [Authentication](/docs/api-reference/authentication) before placing orders.
 - Trading uses Deposit Wallet orders with signature type 3.
+- Personalized SDKs include the fork builder code automatically; do not add fee receiver or fee bps fields to order payloads.
+- Affiliate/referral setup is handled onchain by the app onboarding flow and is not an order payload field.
 - USDC is used as settlement collateral.

--- a/src/app/[locale]/(platform)/settings/sdks/page.tsx
+++ b/src/app/[locale]/(platform)/settings/sdks/page.tsx
@@ -1,8 +1,10 @@
 import type { Metadata } from 'next'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
+import { isAddress, zeroAddress } from 'viem'
 import SettingsSdkDownloadsContent from '@/app/[locale]/(platform)/settings/_components/SettingsSdkDownloadsContent'
-import { getAffiliateFeeSettings } from '@/lib/affiliate-fee-settings'
+import { addressToBuilderCode } from '@/lib/builder-code'
+import { DEFAULT_FEE_RECEIVER_WALLET_ADDRESS } from '@/lib/contracts'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { UserRepository } from '@/lib/db/queries/user'
 import { getBlockedCountriesFromSettings } from '@/lib/geoblock-settings'
@@ -33,17 +35,19 @@ export default async function SdkDownloadsSettingsPage({ params }: PageProps<'/[
 
   const { data: allSettings } = await SettingsRepository.getSettings()
   const siteUrl = resolveSiteUrl(process.env)
-  const affiliateFeeSettings = getAffiliateFeeSettings(allSettings)
-  const feeReceiver = allSettings?.general?.fee_recipient_wallet?.value || ''
+  const feeReceiverSetting = allSettings?.general?.fee_recipient_wallet?.value
+  const feeReceiver
+    = feeReceiverSetting && isAddress(feeReceiverSetting) && feeReceiverSetting.toLowerCase() !== zeroAddress
+      ? feeReceiverSetting
+      : DEFAULT_FEE_RECEIVER_WALLET_ADDRESS
+  const builderCode = addressToBuilderCode(feeReceiver)
   const geoblock = getBlockedCountriesFromSettings(allSettings ?? undefined).length > 0
 
   function buildDownloadUrl(language: 'python' | 'rust' | 'typescript') {
     const url = new URL('/download', SDK_DOWNLOAD_URL)
     url.searchParams.set('language', language)
     url.searchParams.set('site_url', siteUrl)
-    url.searchParams.set('builder_taker_fee_bps', affiliateFeeSettings.builderTakerFeeBps.toString())
-    url.searchParams.set('builder_maker_fee_bps', affiliateFeeSettings.builderMakerFeeBps.toString())
-    url.searchParams.set('fee_receiver', feeReceiver)
+    url.searchParams.set('builder_code', builderCode)
     url.searchParams.set('geoblock', geoblock ? 'true' : 'false')
     return url.toString()
   }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Send builder code in SDK downloads instead of fee fields, so personalized SDKs auto-attribute builders and remove fee setup from order payloads. Docs updated to reflect the new flow.

- **Bug Fixes**
  - Replaced `builder_taker_fee_bps`, `builder_maker_fee_bps`, and `fee_receiver` with `builder_code` in Settings → SDKs downloads.
  - Compute `builder_code` from the validated fee receiver using `addressToBuilderCode`; fallback to `DEFAULT_FEE_RECEIVER_WALLET_ADDRESS` when missing/invalid/zero (`viem` `isAddress`/`zeroAddress`).
  - Docs: emphasize builder attribution is prefilled; personalized SDKs include fork builder code; fee receiver/BPS are not order payload fields; affiliate is handled onchain.

<sup>Written for commit 0dd336c40b4f1dfd01d4d31cdac769728d68abe1. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1040?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

