### PR TITLE
feat: add fee signature modal on withdrawal

### DIFF
--- a/src/app/[locale]/(platform)/settings/_components/SettingsAffiliateFeeClaim.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsAffiliateFeeClaim.tsx
@@ -9,6 +9,7 @@ import { usePublicClient, useSignTypedData } from 'wagmi'
 import { useTradingOnboarding } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { Button } from '@/components/ui/button'
 import { useAppKit } from '@/hooks/useAppKit'
+import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { CTF_EXCHANGE_ADDRESS, NEG_RISK_CTF_EXCHANGE_ADDRESS } from '@/lib/contracts'
 import { formatCurrency } from '@/lib/formatters'
@@ -43,6 +44,7 @@ export default function SettingsAffiliateFeeClaim() {
   const { signTypedDataAsync } = useSignTypedData()
   const publicClient = usePublicClient()
   const { open } = useAppKit()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
   const { openTradeRequirements } = useTradingOnboarding()
   const user = useUser()
   const { isConnected } = useAppKitAccount()
@@ -159,7 +161,7 @@ export default function SettingsAffiliateFeeClaim() {
         return
       }
 
-      const submitted = await submitDepositWalletClaim(exchanges)
+      const submitted = await runWithSignaturePrompt(() => submitDepositWalletClaim(exchanges))
       if (submitted) {
         toast.success(t('Fee claim submitted successfully.'))
       }

--- a/src/app/[locale]/admin/affiliate/_components/AdminAffiliateClaimableFeesCard.tsx
+++ b/src/app/[locale]/admin/affiliate/_components/AdminAffiliateClaimableFeesCard.tsx
@@ -10,6 +10,7 @@ import { usePublicClient, useSignTypedData, useWalletClient } from 'wagmi'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useAppKit } from '@/hooks/useAppKit'
+import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { CTF_EXCHANGE_ADDRESS, NEG_RISK_CTF_EXCHANGE_ADDRESS } from '@/lib/contracts'
 import { baseUnitsToNumber } from '@/lib/data-api/fees'
@@ -57,6 +58,7 @@ export default function AdminAffiliateClaimableFeesCard({
 }: AdminAffiliateClaimableFeesCardProps) {
   const t = useExtracted()
   const { open } = useAppKit()
+  const { runWithSignaturePrompt } = useSignaturePromptRunner()
   const { signTypedDataAsync } = useSignTypedData()
   const { data: walletClient } = useWalletClient()
   const publicClient = usePublicClient()
@@ -264,8 +266,8 @@ export default function AdminAffiliateClaimableFeesCard({
     setIsClaiming(true)
     try {
       const submitted = canClaimWithDepositWallet
-        ? await submitDepositWalletClaim(claimableExchanges)
-        : await submitConnectedWalletClaim(claimableExchanges)
+        ? await runWithSignaturePrompt(() => submitDepositWalletClaim(claimableExchanges))
+        : await runWithSignaturePrompt(() => submitConnectedWalletClaim(claimableExchanges))
 
       if (submitted) {
         toast.success(t('Fee claim submitted successfully.'))

--- a/src/components/SignaturePromptHost.tsx
+++ b/src/components/SignaturePromptHost.tsx
@@ -1,0 +1,23 @@
+'use client'
+
+import { lazy, Suspense } from 'react'
+import { useSignaturePrompt } from '@/stores/useSignaturePrompt'
+
+const SignaturePrompt = lazy(async () => {
+  const mod = await import('@/components/SignaturePrompt')
+  return { default: mod.SignaturePrompt }
+})
+
+export function SignaturePromptHost() {
+  const open = useSignaturePrompt(state => state.open)
+
+  if (!open) {
+    return null
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <SignaturePrompt />
+    </Suspense>
+  )
+}

--- a/src/providers/AppKitProvider.tsx
+++ b/src/providers/AppKitProvider.tsx
@@ -9,9 +9,10 @@ import { createAppKit, useAppKitTheme } from '@reown/appkit/react'
 import { generateRandomString } from 'better-auth/crypto'
 import { useExtracted } from 'next-intl'
 import { useTheme } from 'next-themes'
-import { lazy, Suspense, useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
 import { toast } from 'sonner'
 import { WagmiProvider } from 'wagmi'
+import { SignaturePromptHost } from '@/components/SignaturePromptHost'
 import { AppKitContext, defaultAppKitValue } from '@/hooks/useAppKit'
 import { useHasHydrated } from '@/hooks/useHasHydrated'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
@@ -26,11 +27,6 @@ let hasInitializedAppKit = false
 let appKitInstance: AppKit | null = null
 const appKitStateListeners = new Set<() => void>()
 const APPKIT_INIT_RETRY_DELAY_MS = 3000
-
-const SignaturePrompt = lazy(async () => {
-  const mod = await import('@/components/SignaturePrompt')
-  return { default: mod.SignaturePrompt }
-})
 
 function clearAppKitState() {
   if (!IS_BROWSER) {
@@ -329,11 +325,7 @@ export default function AppKitProvider({ children }: { children: ReactNode }) {
     <WagmiProvider config={wagmiConfig}>
       <AppKitContext value={appKitValue}>
         {children}
-        {hasHydrated && (
-          <Suspense fallback={null}>
-            <SignaturePrompt />
-          </Suspense>
-        )}
+        {hasHydrated && <SignaturePromptHost />}
         {canSyncTheme && <AppKitThemeSynchronizer themeMode={appKitThemeMode} />}
       </AppKitContext>
     </WagmiProvider>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a signature modal for affiliate fee withdrawals so users are prompted to sign before submitting claims. This improves clarity during signing and only loads the modal when needed.

- **New Features**
  - Show the signature prompt during affiliate fee claims in Settings and Admin flows.
  - Run claim submissions through a signature runner to ensure the modal appears when a signature is required.

- **Refactors**
  - Added SignaturePromptHost to lazy-load the signature UI only when open.
  - Simplified AppKitProvider by delegating signature prompt rendering to the host.

<sup>Written for commit e10933f49d1cef84e3479bf340891e65a72a88a2. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1044?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

