### PR TITLE
docs: revise security policy

### DIFF
--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,7 +1,10 @@
 # Security Policy
 
-**PLEASE DON'T DISCLOSE SECURITY-RELATED ISSUES PUBLICLY, [SEE BELOW](#reporting-a-vulnerability).**
+If you believe you’ve found a security vulnerability, please email security@kuest.com. Do not open a public issue.
 
-## Reporting a Vulnerability
+Include:
+- A description of the issue and potential impact
+- Steps to reproduce or a minimal proof of concept
+- Any relevant logs or environment details
 
-If you discover a security vulnerability within Kuest, please send an email to us at hello@kuest.com. All security vulnerabilities will be promptly addressed.
+We will acknowledge receipt, investigate, and provide guidance on next steps.


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clarified how to report security vulnerabilities by adding security@kuest.com as the contact and asking reporters not to open public issues. Added required report details (description, repro/PoC, logs/env) and stated we will acknowledge and investigate.

<sup>Written for commit dfd113151c5040e6a1d11f0e863d6eeb49b3f8e0. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1045?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

