### PR TITLE
fix: add front sync tests

### DIFF
--- a/docs/(users)/help-support/faq.mdx
+++ b/docs/(users)/help-support/faq.mdx
@@ -21,6 +21,11 @@ import { Accordions, Accordion } from 'fumadocs-ui/components/accordion'
     <strong>Claim winnings</strong> when displayed.
   </Accordion>
 
+  <Accordion title="How do I claim affiliate fees?" value="affiliate-claim">
+    Open <strong>/settings/affiliate</strong> and use the <strong>Claim</strong> button on the
+    <strong>Affiliate Commissions</strong> card once the balance is available for your deposit wallet.
+  </Accordion>
+
   <Accordion title="What if a market is disputed?" value="dispute">
     Watch the market timeline status (Dispute window/Disputed/Final review).
     When enabled, the market shows a dispute action linking to the oracle dispute flow.

--- a/docs/(users)/my-account/affiliate-program.mdx
+++ b/docs/(users)/my-account/affiliate-program.mdx
@@ -12,6 +12,7 @@ Open <strong>/settings/affiliate</strong> to view:
 - commission rate
 - referrals and active traders
 - referred volume and earned fees
+- the <strong>Affiliate Commissions</strong> card to claim your affiliate fees
 
 ## How commission is calculated
 
@@ -23,6 +24,10 @@ Open <strong>/settings/affiliate</strong> to view:
 </Callout>
 
 <FeeCalculationExample amount={1000} />
+
+## Claiming fees
+
+Affiliate fees can be claimed from the <strong>Affiliate Commissions</strong> card in <strong>/settings/affiliate</strong>.
 
 ## Payout timing
 

--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -2815,7 +2815,8 @@
             "enum": [
               "FOK",
               "FAK",
-              "GTC"
+              "GTC",
+              "GTD"
             ],
             "description": "Time-in-force policy for the order."
           },
@@ -3206,7 +3207,8 @@
             "enum": [
               "FOK",
               "FAK",
-              "GTC"
+              "GTC",
+              "GTD"
             ],
             "description": "Time-in-force policy recorded for the order."
           },

--- a/tests/unit/openOrdersRoute.test.ts
+++ b/tests/unit/openOrdersRoute.test.ts
@@ -1,0 +1,287 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  buildClobHmacSignature: vi.fn(() => 'sig'),
+  fetch: vi.fn(),
+  findMany: vi.fn(),
+  getCurrentUser: vi.fn(),
+  getEventMarketMetadata: vi.fn(),
+  getPublicAssetUrl: vi.fn((path: string) => `https://assets.test/${path}`),
+  getUserTradingAuthSecrets: vi.fn(),
+  runQuery: vi.fn(async (callback: () => Promise<unknown>) => await callback()),
+}))
+
+vi.mock('@/lib/db/queries/event', () => ({
+  EventRepository: {
+    getEventMarketMetadata: (...args: any[]) => mocks.getEventMarketMetadata(...args),
+  },
+}))
+
+vi.mock('@/lib/db/queries/user', () => ({
+  UserRepository: {
+    getCurrentUser: (...args: any[]) => mocks.getCurrentUser(...args),
+  },
+}))
+
+vi.mock('@/lib/db/utils/run-query', () => ({
+  runQuery: (...args: any[]) => mocks.runQuery(...args),
+}))
+
+vi.mock('@/lib/drizzle', () => ({
+  db: {
+    query: {
+      markets: {
+        findMany: (...args: any[]) => mocks.findMany(...args),
+      },
+    },
+  },
+}))
+
+vi.mock('@/lib/hmac', () => ({
+  buildClobHmacSignature: (...args: any[]) => mocks.buildClobHmacSignature(...args),
+}))
+
+vi.mock('@/lib/storage', () => ({
+  getPublicAssetUrl: (...args: any[]) => mocks.getPublicAssetUrl(...args),
+}))
+
+vi.mock('@/lib/trading-auth/server', () => ({
+  getUserTradingAuthSecrets: (...args: any[]) => mocks.getUserTradingAuthSecrets(...args),
+}))
+
+function address(lastByte: string) {
+  return (`0x${'0'.repeat(40 - lastByte.length)}${lastByte}`) as const
+}
+
+describe('open orders routes', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubEnv('CLOB_URL', 'https://clob.local')
+    vi.stubGlobal('fetch', mocks.fetch)
+
+    mocks.buildClobHmacSignature.mockReset()
+    mocks.buildClobHmacSignature.mockReturnValue('sig')
+    mocks.fetch.mockReset()
+    mocks.findMany.mockReset()
+    mocks.getCurrentUser.mockReset()
+    mocks.getEventMarketMetadata.mockReset()
+    mocks.getPublicAssetUrl.mockReset()
+    mocks.getPublicAssetUrl.mockImplementation((path: string) => `https://assets.test/${path}`)
+    mocks.getUserTradingAuthSecrets.mockReset()
+    mocks.runQuery.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('normalizes portfolio open orders and keeps GTD intact', async () => {
+    const userAddress = address('01')
+    const depositWallet = address('02')
+
+    mocks.getCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      address: userAddress,
+      deposit_wallet_address: depositWallet,
+    })
+    mocks.getUserTradingAuthSecrets.mockResolvedValueOnce({
+      clob: {
+        key: 'api-key',
+        secret: 'secret',
+        passphrase: 'passphrase',
+      },
+    })
+    mocks.findMany.mockResolvedValueOnce([
+      {
+        condition_id: 'cond-1',
+        title: 'Market title',
+        slug: 'market-slug',
+        icon_url: '',
+        event: {
+          slug: 'event-slug',
+          title: 'Event title',
+          icon_url: 'event-icon.png',
+        },
+        condition: {
+          id: 'cond-1',
+          outcomes: [
+            {
+              token_id: 'token-1',
+              outcome_text: 'Yes',
+              outcome_index: 0,
+            },
+          ],
+        },
+        is_active: true,
+        is_resolved: false,
+      },
+    ])
+    mocks.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([
+        {
+          id: 'order-1',
+          status: 'live',
+          market: 'cond-1',
+          original_size: '12.5',
+          outcome: 'token-1',
+          maker_address: depositWallet,
+          price: '0.7',
+          side: 'BUY',
+          size_matched: '3',
+          asset_id: 'token-1',
+          expiration: '0',
+          type: 'GTD',
+          created_at: '2026-05-23T00:00:00.000Z',
+          updated_at: '2026-05-23T00:01:00.000Z',
+        },
+      ]),
+    })
+
+    const { GET } = await import('@/app/api/open-orders/route')
+    const response = await GET(new Request('https://example.com/api/open-orders?market=cond-1&next_cursor=cursor-1'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      data: [
+        {
+          id: 'order-1',
+          side: 'buy',
+          type: 'GTD',
+          status: 'live',
+          price: 0.7,
+          maker_amount: 8_750_000,
+          taker_amount: 12_500_000,
+          size_matched: 3_000_000,
+          created_at: '2026-05-23T00:00:00.000Z',
+          expiration: 0,
+          outcome: {
+            index: 0,
+            text: 'Yes',
+          },
+          market: {
+            condition_id: 'cond-1',
+            title: 'Market title',
+            slug: 'market-slug',
+            icon_url: 'https://assets.test/event-icon.png',
+            event_slug: 'event-slug',
+            event_title: 'Event title',
+            is_active: true,
+            is_resolved: false,
+          },
+        },
+      ],
+      next_cursor: 'LTE=',
+    })
+
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      'https://clob.local/data/orders?maker_address=0x0000000000000000000000000000000000000002&market=cond-1&next_cursor=cursor-1',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    )
+  })
+
+  it('normalizes event open orders and keeps GTD intact', async () => {
+    const userAddress = address('03')
+    const depositWallet = address('04')
+
+    mocks.getCurrentUser.mockResolvedValueOnce({
+      id: 'user-2',
+      address: userAddress,
+      deposit_wallet_address: depositWallet,
+    })
+    mocks.getUserTradingAuthSecrets.mockResolvedValueOnce({
+      clob: {
+        key: 'api-key',
+        secret: 'secret',
+        passphrase: 'passphrase',
+      },
+    })
+    mocks.getEventMarketMetadata.mockResolvedValueOnce({
+      data: [
+        {
+          condition_id: 'cond-2',
+          title: 'Event market',
+          slug: 'event-market-slug',
+          is_active: true,
+          is_resolved: false,
+          outcomes: [
+            {
+              token_id: 'token-2',
+              outcome_text: 'No',
+              outcome_index: 1,
+            },
+          ],
+        },
+      ],
+      error: null,
+    })
+    mocks.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ([
+        {
+          id: 'order-2',
+          status: 'live',
+          market: 'cond-2',
+          original_size: '8',
+          outcome: 'token-2',
+          maker_address: depositWallet,
+          price: '0.25',
+          side: 'SELL',
+          size_matched: '2',
+          asset_id: 'token-2',
+          expiration: '0',
+          type: 'GTD',
+          created_at: '2026-05-23T00:00:00.000Z',
+          updated_at: '2026-05-23T00:01:00.000Z',
+        },
+      ]),
+    })
+
+    const { GET } = await import('@/app/api/events/[slug]/open-orders/route')
+    const response = await GET(
+      new Request('https://example.com/api/events/event-slug/open-orders?conditionId=cond-2&next_cursor=cursor-2'),
+      { params: Promise.resolve({ slug: 'event-slug' }) },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      data: [
+        {
+          id: 'order-2',
+          side: 'sell',
+          type: 'GTD',
+          status: 'live',
+          price: 0.25,
+          maker_amount: 8_000_000,
+          taker_amount: 2_000_000,
+          size_matched: 2_000_000,
+          created_at: '2026-05-23T00:00:00.000Z',
+          expiration: 0,
+          outcome: {
+            index: 1,
+            text: 'No',
+          },
+          market: {
+            condition_id: 'cond-2',
+            title: 'Event market',
+            slug: 'event-market-slug',
+            is_active: true,
+            is_resolved: false,
+          },
+        },
+      ],
+      next_cursor: 'LTE=',
+    })
+
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      'https://clob.local/data/orders?market=cond-2&maker_address=0x0000000000000000000000000000000000000004&next_cursor=cursor-2',
+      expect.objectContaining({
+        method: 'GET',
+      }),
+    )
+  })
+})

--- a/tests/unit/syncEventsRoute.test.ts
+++ b/tests/unit/syncEventsRoute.test.ts
@@ -1,0 +1,119 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+  isCronAuthorized: vi.fn(),
+  loadAllowedMarketCreatorWallets: vi.fn(),
+  loadAutoDeployNewEventsEnabled: vi.fn(),
+  select: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-cron', () => ({
+  isCronAuthorized: (...args: any[]) => mocks.isCronAuthorized(...args),
+}))
+
+vi.mock('@/lib/allowed-market-creators-server', () => ({
+  loadAllowedMarketCreatorWallets: (...args: any[]) => mocks.loadAllowedMarketCreatorWallets(...args),
+}))
+
+vi.mock('@/lib/db/utils/run-query', () => ({
+  runQuery: async (callback: () => Promise<unknown>) => await callback(),
+}))
+
+vi.mock('@/lib/drizzle', () => ({
+  db: {
+    select: (...args: any[]) => mocks.select(...args),
+    update: (...args: any[]) => mocks.update(...args),
+  },
+}))
+
+vi.mock('@/lib/event-sync-settings', () => ({
+  loadAutoDeployNewEventsEnabled: (...args: any[]) => mocks.loadAutoDeployNewEventsEnabled(...args),
+}))
+
+function makeSelectChain(result: unknown[]) {
+  return {
+    from: () => ({
+      where: () => ({
+        limit: async () => result,
+      }),
+    }),
+  }
+}
+
+function makeUpdateChain(result: Array<{ id: string }>) {
+  return {
+    set: () => ({
+      where: () => ({
+        returning: async () => result,
+      }),
+    }),
+  }
+}
+
+describe('sync events route', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubGlobal('fetch', mocks.fetch)
+
+    mocks.fetch.mockReset()
+    mocks.isCronAuthorized.mockReset()
+    mocks.loadAllowedMarketCreatorWallets.mockReset()
+    mocks.loadAutoDeployNewEventsEnabled.mockReset()
+    mocks.select.mockReset()
+    mocks.update.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('hits the PnL subgraph and exits cleanly when no markets are returned', async () => {
+    mocks.isCronAuthorized.mockReturnValue(true)
+    mocks.loadAllowedMarketCreatorWallets.mockResolvedValue({
+      data: ['0xABCDEF0000000000000000000000000000000001'],
+      error: null,
+    })
+    mocks.loadAutoDeployNewEventsEnabled.mockResolvedValue(false)
+    mocks.select.mockImplementation(() => makeSelectChain([]))
+    mocks.update.mockImplementation(() => makeUpdateChain([{ id: 'sync-row' }]))
+    mocks.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          conditions: [],
+        },
+      }),
+    })
+
+    const { GET } = await import('@/app/api/sync/events/route')
+    const response = await GET(new Request('https://example.com/api/sync/events', {
+      headers: {
+        authorization: 'Bearer cron-secret',
+      },
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      message: 'No new markets to process',
+      processed: 0,
+      fetched: 0,
+    })
+
+    expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      'https://subgraphs.kuest.com/pnl-subgraph',
+      expect.objectContaining({
+        method: 'POST',
+        keepalive: true,
+      }),
+    )
+
+    const requestBody = JSON.parse(String(mocks.fetch.mock.calls[0][1].body))
+    expect(requestBody.variables.creators).toEqual(['0xabcdef0000000000000000000000000000000001'])
+    expect(mocks.update).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/syncResolutionRoute.test.ts
+++ b/tests/unit/syncResolutionRoute.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+  fetch: vi.fn(),
+  isCronAuthorized: vi.fn(),
+  select: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock('@/lib/auth-cron', () => ({
+  isCronAuthorized: (...args: any[]) => mocks.isCronAuthorized(...args),
+}))
+
+vi.mock('@/lib/db/utils/run-query', () => ({
+  runQuery: async (callback: () => Promise<unknown>) => await callback(),
+}))
+
+vi.mock('@/lib/drizzle', () => ({
+  db: {
+    execute: (...args: any[]) => mocks.execute(...args),
+    select: (...args: any[]) => mocks.select(...args),
+    update: (...args: any[]) => mocks.update(...args),
+  },
+}))
+
+function makeSelectChain(result: unknown[]) {
+  return {
+    from: () => ({
+      where: () => ({
+        limit: async () => result,
+      }),
+    }),
+  }
+}
+
+function makeUpdateChain(result: Array<{ id: string }>) {
+  return {
+    set: () => ({
+      where: () => ({
+        returning: async () => result,
+      }),
+    }),
+  }
+}
+
+describe('sync resolution route', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.stubGlobal('fetch', mocks.fetch)
+
+    mocks.execute.mockReset()
+    mocks.fetch.mockReset()
+    mocks.isCronAuthorized.mockReset()
+    mocks.select.mockReset()
+    mocks.update.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('hits the resolution subgraph and exits cleanly when no tracked authors are returned', async () => {
+    mocks.isCronAuthorized.mockReturnValue(true)
+    mocks.execute.mockResolvedValue([
+      {
+        creator: '0xABCDEF0000000000000000000000000000000001',
+      },
+    ])
+    mocks.select.mockImplementation(() => makeSelectChain([]))
+    mocks.update.mockImplementation(() => makeUpdateChain([{ id: 'sync-row' }]))
+    mocks.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        data: {
+          marketResolutions: [],
+        },
+      }),
+    })
+
+    const { GET } = await import('@/app/api/sync/resolution/route')
+    const response = await GET(new Request('https://example.com/api/sync/resolution', {
+      headers: {
+        authorization: 'Bearer cron-secret',
+      },
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      fetched: 0,
+      processed: 0,
+      skipped: 0,
+      errors: 0,
+      errorDetails: [],
+      timeLimitReached: false,
+    })
+
+    expect(mocks.fetch).toHaveBeenCalledTimes(1)
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      'https://subgraphs.kuest.com/resolution-subgraph',
+      expect.objectContaining({
+        method: 'POST',
+        keepalive: true,
+      }),
+    )
+
+    const requestBody = JSON.parse(String(mocks.fetch.mock.calls[0][1].body))
+    expect(requestBody.variables.authors).toEqual(['0xabcdef0000000000000000000000000000000001'])
+    expect(mocks.update).toHaveBeenCalledTimes(2)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add unit tests for open orders and sync routes to verify GTD handling and clean exits when subgraphs return no data. Update user docs to explain how to claim affiliate fees from `/settings/affiliate`.

- **Bug Fixes**
  - Documented `GTD` alongside `FOK`, `FAK`, and `GTC` in the CLOB time-in-force enums (request and record).

<sup>Written for commit b7d11fe28e126aa4d4ea6651a5042528ac50b314. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1046?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

