### PR TITLE
fix: prefill onboarding username

### DIFF
--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -192,6 +192,7 @@ function UsernameDialog({
 }) {
   const t = useExtracted()
   const [username, setUsername] = useState(defaultValue)
+  const [hasEditedUsername, setHasEditedUsername] = useState(false)
   const [termsAccepted, setTermsAccepted] = useState(false)
   const [availabilityState, setAvailabilityState] = useState<UsernameAvailabilityState>('idle')
   const [availabilityMessage, setAvailabilityMessage] = useState<string | null>(null)
@@ -205,6 +206,17 @@ function UsernameDialog({
     && !localFormatError
     && availabilityState !== 'taken'
   )
+
+  /* eslint-disable react-you-might-not-need-an-effect/no-event-handler, react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-chain-state-updates, react/set-state-in-effect -- Sync the async username prefill into the field until the user starts editing. */
+  useEffect(() => {
+    if (!open) {
+      return
+    }
+    if (!hasEditedUsername) {
+      setUsername(defaultValue)
+    }
+  }, [defaultValue, hasEditedUsername, open])
+  /* eslint-enable react-you-might-not-need-an-effect/no-event-handler, react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-chain-state-updates, react/set-state-in-effect */
 
   /* eslint-disable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react/set-state-in-effect -- Debounced username availability is derived from input and an async data-api response. */
   useEffect(() => {
@@ -315,6 +327,7 @@ function UsernameDialog({
           <Input
             value={username}
             onChange={(event) => {
+              setHasEditedUsername(true)
               setUsername(event.target.value)
               setAvailabilityMessage(null)
               setAvailabilityState('idle')

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -12,7 +12,7 @@ import {
   ZapIcon,
 } from 'lucide-react'
 import { useExtracted } from 'next-intl'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { checkUsernameAvailabilityAction } from '@/app/[locale]/(platform)/_actions/deposit-wallet'
 import { FundAccountDialog } from '@/app/[locale]/(platform)/_components/TradingDialogs'
 import { WalletFlow } from '@/app/[locale]/(platform)/_components/WalletFlow'
@@ -196,6 +196,7 @@ function UsernameDialog({
   const [termsAccepted, setTermsAccepted] = useState(false)
   const [availabilityState, setAvailabilityState] = useState<UsernameAvailabilityState>('idle')
   const [availabilityMessage, setAvailabilityMessage] = useState<string | null>(null)
+  const previousOpenRef = useRef(open)
   const trimmedUsername = username.trim()
   const localFormatErrorCode = resolveUsernameFormatErrorCode(trimmedUsername)
   const localFormatError = formatLocalUsernameFormatError(localFormatErrorCode)
@@ -207,18 +208,35 @@ function UsernameDialog({
     && availabilityState !== 'taken'
   )
 
-  /* eslint-disable react-you-might-not-need-an-effect/no-event-handler, react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-chain-state-updates, react/set-state-in-effect -- Sync the async username prefill into the field until the user starts editing. */
+  useEffect(() => {
+    const justOpened = open && !previousOpenRef.current
+    previousOpenRef.current = open
+
+    if (!justOpened) {
+      return
+    }
+
+    setHasEditedUsername(false)
+    setTermsAccepted(false)
+    setAvailabilityState('idle')
+    setAvailabilityMessage(null)
+    setUsername(defaultValue)
+  }, [defaultValue, open])
+
   useEffect(() => {
     if (!open) {
       return
     }
-    if (!hasEditedUsername) {
+
+    if (hasEditedUsername) {
+      return
+    }
+
+    if (username !== defaultValue) {
       setUsername(defaultValue)
     }
-  }, [defaultValue, hasEditedUsername, open])
-  /* eslint-enable react-you-might-not-need-an-effect/no-event-handler, react-you-might-not-need-an-effect/no-derived-state, react-you-might-not-need-an-effect/no-chain-state-updates, react/set-state-in-effect */
+  }, [defaultValue, hasEditedUsername, open, username])
 
-  /* eslint-disable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react/set-state-in-effect -- Debounced username availability is derived from input and an async data-api response. */
   useEffect(() => {
     if (!open) {
       return
@@ -281,7 +299,6 @@ function UsernameDialog({
       window.clearTimeout(timeoutId)
     }
   }, [defaultValue, localFormatError, open, t, trimmedUsername])
-  /* eslint-enable react-you-might-not-need-an-effect/no-adjust-state-on-prop-change, react/set-state-in-effect */
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()

--- a/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
+++ b/src/app/[locale]/(platform)/_components/TradingOnboardingDialogs.tsx
@@ -12,7 +12,7 @@ import {
   ZapIcon,
 } from 'lucide-react'
 import { useExtracted } from 'next-intl'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { checkUsernameAvailabilityAction } from '@/app/[locale]/(platform)/_actions/deposit-wallet'
 import { FundAccountDialog } from '@/app/[locale]/(platform)/_components/TradingDialogs'
 import { WalletFlow } from '@/app/[locale]/(platform)/_components/WalletFlow'
@@ -43,7 +43,13 @@ type OnboardingModal = 'username' | 'email' | 'enable' | 'enable-status' | 'appr
 type EnableTradingStep = 'idle' | 'enabling' | 'deploying' | 'completed'
 type ApprovalsStep = 'idle' | 'signing' | 'completed'
 type UsernameAvailabilityState = 'idle' | 'checking' | 'available' | 'taken' | 'error'
+type CheckedUsernameAvailabilityState = Exclude<UsernameAvailabilityState, 'idle'>
 type UsernameFormatErrorCode = 'too_short' | 'too_long' | 'invalid_characters' | 'starts_with_separator' | 'ends_with_separator'
+
+interface UsernameAvailabilityCheck {
+  username: string
+  state: CheckedUsernameAvailabilityState
+}
 
 interface TradingOnboardingDialogsProps {
   activeModal: OnboardingModal
@@ -175,6 +181,17 @@ function OnboardingDialogShell({
   )
 }
 
+interface UsernameDialogProps {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  defaultValue: string
+  error: string | null
+  isSubmitting: boolean
+  onSubmit: (username: string, termsAccepted: boolean) => void
+}
+
+type UsernameDialogFormProps = Omit<UsernameDialogProps, 'onOpenChange'>
+
 function UsernameDialog({
   open,
   onOpenChange,
@@ -182,24 +199,57 @@ function UsernameDialog({
   error,
   isSubmitting,
   onSubmit,
-}: {
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  defaultValue: string
-  error: string | null
-  isSubmitting: boolean
-  onSubmit: (username: string, termsAccepted: boolean) => void
-}) {
+}: UsernameDialogProps) {
   const t = useExtracted()
-  const [username, setUsername] = useState(defaultValue)
-  const [hasEditedUsername, setHasEditedUsername] = useState(false)
+
+  return (
+    <OnboardingDialogShell
+      open={open}
+      onOpenChange={onOpenChange}
+      title={t('Choose a username')}
+      description={t('You can update this later.')}
+      dismissible={false}
+    >
+      <UsernameDialogForm
+        key={open ? 'open' : 'closed'}
+        open={open}
+        defaultValue={defaultValue}
+        error={error}
+        isSubmitting={isSubmitting}
+        onSubmit={onSubmit}
+      />
+    </OnboardingDialogShell>
+  )
+}
+
+function UsernameDialogForm({
+  open,
+  defaultValue,
+  error,
+  isSubmitting,
+  onSubmit,
+}: UsernameDialogFormProps) {
+  const t = useExtracted()
+  const [usernameInput, setUsernameInput] = useState<string | null>(null)
   const [termsAccepted, setTermsAccepted] = useState(false)
-  const [availabilityState, setAvailabilityState] = useState<UsernameAvailabilityState>('idle')
-  const [availabilityMessage, setAvailabilityMessage] = useState<string | null>(null)
-  const previousOpenRef = useRef(open)
+  const [availabilityCheck, setAvailabilityCheck] = useState<UsernameAvailabilityCheck | null>(null)
+  const username = usernameInput ?? defaultValue
   const trimmedUsername = username.trim()
   const localFormatErrorCode = resolveUsernameFormatErrorCode(trimmedUsername)
   const localFormatError = formatLocalUsernameFormatError(localFormatErrorCode)
+  const normalizedDefaultUsername = defaultValue.trim().toLowerCase()
+  const matchesDefaultUsername = (
+    normalizedDefaultUsername.length > 0
+    && trimmedUsername.toLowerCase() === normalizedDefaultUsername
+  )
+  const activeAvailabilityCheck = availabilityCheck?.username === trimmedUsername ? availabilityCheck : null
+  const availabilityState = resolveUsernameAvailabilityState({
+    activeAvailabilityCheck,
+    localFormatErrorCode,
+    matchesDefaultUsername,
+    trimmedUsername,
+  })
+  const availabilityMessage = formatUsernameAvailabilityMessage(availabilityState)
   const canSubmit = (
     !isSubmitting
     && termsAccepted
@@ -208,88 +258,37 @@ function UsernameDialog({
     && availabilityState !== 'taken'
   )
 
-  useEffect(() => {
-    const justOpened = open && !previousOpenRef.current
-    previousOpenRef.current = open
-
-    if (!justOpened) {
-      return
-    }
-
-    setHasEditedUsername(false)
-    setTermsAccepted(false)
-    setAvailabilityState('idle')
-    setAvailabilityMessage(null)
-    setUsername(defaultValue)
-  }, [defaultValue, open])
-
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-
-    if (hasEditedUsername) {
-      return
-    }
-
-    if (username !== defaultValue) {
-      setUsername(defaultValue)
-    }
-  }, [defaultValue, hasEditedUsername, open, username])
-
-  useEffect(() => {
-    if (!open) {
-      return
-    }
-
-    if (localFormatError) {
-      setAvailabilityState('idle')
-      setAvailabilityMessage(null)
-      return
-    }
-
-    if (!trimmedUsername) {
-      setAvailabilityState('idle')
-      setAvailabilityMessage(null)
-      return
-    }
-
-    if (defaultValue && trimmedUsername.toLowerCase() === defaultValue.trim().toLowerCase()) {
-      setAvailabilityState('available')
-      setAvailabilityMessage(t('Username is available.'))
+  useEffect(function checkUsernameAvailability() {
+    if (!open || localFormatErrorCode || !trimmedUsername || matchesDefaultUsername) {
       return
     }
 
     let cancelled = false
+    const checkedUsername = trimmedUsername
     const timeoutId = window.setTimeout(() => {
-      setAvailabilityState('checking')
-      setAvailabilityMessage(t('Checking username availability...'))
+      setAvailabilityCheck({ username: checkedUsername, state: 'checking' })
 
-      checkUsernameAvailabilityAction({ username: trimmedUsername })
+      void checkUsernameAvailabilityAction({ username: checkedUsername })
         .then((result) => {
           if (cancelled) {
             return
           }
 
           if (result.available === true) {
-            setAvailabilityState('available')
-            setAvailabilityMessage(t('Username is available.'))
+            setAvailabilityCheck({ username: checkedUsername, state: 'available' })
             return
           }
 
           if (result.available === false || result.code === 'username_taken') {
-            setAvailabilityState('taken')
-            setAvailabilityMessage(t('That username is already taken.'))
+            setAvailabilityCheck({ username: checkedUsername, state: 'taken' })
             return
           }
 
-          setAvailabilityState('error')
-          setAvailabilityMessage(t('We could not check username availability. Try again.'))
+          setAvailabilityCheck({ username: checkedUsername, state: 'error' })
         })
         .catch(() => {
           if (!cancelled) {
-            setAvailabilityState('error')
-            setAvailabilityMessage(t('We could not check username availability. Try again.'))
+            setAvailabilityCheck({ username: checkedUsername, state: 'error' })
           }
         })
     }, 350)
@@ -298,7 +297,7 @@ function UsernameDialog({
       cancelled = true
       window.clearTimeout(timeoutId)
     }
-  }, [defaultValue, localFormatError, open, t, trimmedUsername])
+  }, [localFormatErrorCode, matchesDefaultUsername, open, trimmedUsername])
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault()
@@ -306,6 +305,11 @@ function UsernameDialog({
       return
     }
     onSubmit(trimmedUsername, termsAccepted)
+  }
+
+  function handleUsernameChange(value: string) {
+    setUsernameInput(value)
+    setAvailabilityCheck(null)
   }
 
   function formatLocalUsernameFormatError(code: UsernameFormatErrorCode | null) {
@@ -327,87 +331,110 @@ function UsernameDialog({
     return null
   }
 
+  function formatUsernameAvailabilityMessage(state: UsernameAvailabilityState) {
+    if (state === 'available') {
+      return t('Username is available.')
+    }
+    if (state === 'checking') {
+      return t('Checking username availability...')
+    }
+    if (state === 'taken') {
+      return t('That username is already taken.')
+    }
+    if (state === 'error') {
+      return t('We could not check username availability. Try again.')
+    }
+    return null
+  }
+
   return (
-    <OnboardingDialogShell
-      open={open}
-      onOpenChange={onOpenChange}
-      title={t('Choose a username')}
-      description={t('You can update this later.')}
-      dismissible={false}
-    >
-      <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
-        <div className="relative">
-          <AtSignIcon className={cn(`
-            pointer-events-none absolute top-1/2 left-4 size-5 -translate-y-1/2 text-muted-foreground
-          `)}
-          />
-          <Input
-            value={username}
-            onChange={(event) => {
-              setHasEditedUsername(true)
-              setUsername(event.target.value)
-              setAvailabilityMessage(null)
-              setAvailabilityState('idle')
-            }}
-            placeholder={t('username')}
-            className="h-14 pl-12 text-lg"
-            maxLength={42}
-            disabled={isSubmitting}
-            autoFocus
-          />
-        </div>
+    <form className="mt-6 space-y-5" onSubmit={handleSubmit}>
+      <div className="relative">
+        <AtSignIcon className={cn(`
+          pointer-events-none absolute top-1/2 left-4 size-5 -translate-y-1/2 text-muted-foreground
+        `)}
+        />
+        <Input
+          value={username}
+          onChange={event => handleUsernameChange(event.target.value)}
+          placeholder={t('username')}
+          className="h-14 pl-12 text-lg"
+          maxLength={42}
+          disabled={isSubmitting}
+          autoFocus
+        />
+      </div>
 
-        <label className="flex items-start gap-3 text-sm text-muted-foreground">
-          <Checkbox
-            checked={termsAccepted}
-            onCheckedChange={checked => setTermsAccepted(checked === true)}
-            disabled={isSubmitting}
-            className="mt-0.5"
-          />
-          <span>
-            {t('I agree to the')}
-            {' '}
-            <AppLink
-              href="/tos"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="font-medium text-primary hover:underline"
-            >
-              {t('terms of service')}
-            </AppLink>
-          </span>
-        </label>
+      <label className="flex items-start gap-3 text-sm text-muted-foreground">
+        <Checkbox
+          checked={termsAccepted}
+          onCheckedChange={checked => setTermsAccepted(checked === true)}
+          disabled={isSubmitting}
+          className="mt-0.5"
+        />
+        <span>
+          {t('I agree to the')}
+          {' '}
+          <AppLink
+            href="/tos"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-primary hover:underline"
+          >
+            {t('terms of service')}
+          </AppLink>
+        </span>
+      </label>
 
-        {error && <InputError message={error} />}
-        {!error && localFormatError && <InputError message={localFormatError} />}
-        {!error && !localFormatError && availabilityMessage && (
-          availabilityState === 'available'
+      {error && <InputError message={error} />}
+      {!error && localFormatError && <InputError message={localFormatError} />}
+      {!error && !localFormatError && availabilityMessage && (
+        availabilityState === 'available'
+          ? (
+              <p className="flex items-center gap-1.5 text-sm font-medium text-primary">
+                <CircleCheckIcon className="size-4" />
+                {availabilityMessage}
+              </p>
+            )
+          : availabilityState === 'checking'
             ? (
-                <p className="flex items-center gap-1.5 text-sm font-medium text-primary">
-                  <CircleCheckIcon className="size-4" />
+                <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                  <Loader2Icon className="size-4 animate-spin" />
                   {availabilityMessage}
                 </p>
               )
-            : availabilityState === 'checking'
-              ? (
-                  <p className="flex items-center gap-1.5 text-sm text-muted-foreground">
-                    <Loader2Icon className="size-4 animate-spin" />
-                    {availabilityMessage}
-                  </p>
-                )
-              : <InputError message={availabilityMessage} />
-        )}
+            : <InputError message={availabilityMessage} />
+      )}
 
-        <Button
-          type="submit"
-          className="h-12 w-full text-base"
-          disabled={!canSubmit}
-        >
-          {isSubmitting ? <Loader2Icon className="size-4 animate-spin" /> : t('Continue')}
-        </Button>
-      </form>
-    </OnboardingDialogShell>
+      <Button
+        type="submit"
+        className="h-12 w-full text-base"
+        disabled={!canSubmit}
+      >
+        {isSubmitting ? <Loader2Icon className="size-4 animate-spin" /> : t('Continue')}
+      </Button>
+    </form>
   )
+}
+
+function resolveUsernameAvailabilityState({
+  activeAvailabilityCheck,
+  localFormatErrorCode,
+  matchesDefaultUsername,
+  trimmedUsername,
+}: {
+  activeAvailabilityCheck: UsernameAvailabilityCheck | null
+  localFormatErrorCode: UsernameFormatErrorCode | null
+  matchesDefaultUsername: boolean
+  trimmedUsername: string
+}): UsernameAvailabilityState {
+  if (localFormatErrorCode || !trimmedUsername) {
+    return 'idle'
+  }
+  if (matchesDefaultUsername) {
+    return 'available'
+  }
+  return activeAvailabilityCheck?.state ?? 'idle'
 }
 
 function resolveUsernameFormatErrorCode(username: string): UsernameFormatErrorCode | null {

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -32,7 +32,11 @@ import {
   ensureCommunityToken,
   parseCommunityError,
 } from '@/lib/community-auth'
-import { updateCommunityProfile } from '@/lib/community-profile'
+import {
+  COMMUNITY_PROFILE_LOOKUP_TIMEOUT_MS,
+  fetchCommunityProfileByAddress,
+  updateCommunityProfile,
+} from '@/lib/community-profile'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import {
   COLLATERAL_TOKEN_ADDRESS,
@@ -348,6 +352,7 @@ function TradingOnboardingProviderContent({
   const [autoRedeemStep, setAutoRedeemStep] = useState<ApprovalsStep>('idle')
   const [requiresTradingAuthRefresh, setRequiresTradingAuthRefresh] = useState(false)
   const [shouldContinueTradingAuthPrompt, setShouldContinueTradingAuthPrompt] = useState(false)
+  const [communityUsernameHint, setCommunityUsernameHint] = useState('')
   const { signTypedDataAsync } = useSignTypedData()
   const { signMessageAsync } = useSignMessage()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
@@ -359,6 +364,48 @@ function TradingOnboardingProviderContent({
   const communityApiUrl = process.env.COMMUNITY_URL!
 
   const status = useOnboardingStatus(user, requiresTradingAuthRefresh)
+
+  useEffect(function preloadCommunityUsernameHint() {
+    if (!user?.address || !status.needsUsername || communityUsernameHint || activeModal !== 'username') {
+      return
+    }
+
+    const controller = new AbortController()
+    const timeoutId = window.setTimeout(() => {
+      controller.abort()
+    }, COMMUNITY_PROFILE_LOOKUP_TIMEOUT_MS)
+    let cancelled = false
+
+    fetchCommunityProfileByAddress({
+      communityApiUrl,
+      address: user.address,
+      signal: controller.signal,
+    })
+      .then((profile) => {
+        if (cancelled) {
+          return
+        }
+
+        const username = profile?.username?.trim()
+        if (username) {
+          setCommunityUsernameHint(username)
+        }
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) {
+          return
+        }
+        if (!cancelled) {
+          console.error('Failed to preload community username', error)
+        }
+      })
+
+    return () => {
+      cancelled = true
+      window.clearTimeout(timeoutId)
+      controller.abort()
+    }
+  }, [activeModal, communityApiUrl, communityUsernameHint, status.needsUsername, user?.address])
 
   useDepositWalletPolling({
     userId: user?.id,
@@ -1255,7 +1302,7 @@ function TradingOnboardingProviderContent({
       <TradingOnboardingDialogs
         activeModal={activeModal}
         onModalOpenChange={handleModalOpenChange}
-        usernameDefaultValue={getUsernameDefaultValue(user)}
+        usernameDefaultValue={communityUsernameHint || getUsernameDefaultValue(user)}
         usernameError={usernameError}
         isUsernameSubmitting={isUsernameSubmitting}
         onUsernameSubmit={handleUsernameSubmit}

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -352,7 +352,10 @@ function TradingOnboardingProviderContent({
   const [autoRedeemStep, setAutoRedeemStep] = useState<ApprovalsStep>('idle')
   const [requiresTradingAuthRefresh, setRequiresTradingAuthRefresh] = useState(false)
   const [shouldContinueTradingAuthPrompt, setShouldContinueTradingAuthPrompt] = useState(false)
-  const [communityUsernameHint, setCommunityUsernameHint] = useState('')
+  const [communityUsernameHint, setCommunityUsernameHint] = useState<{
+    address: string
+    username: string
+  } | null>(null)
   const { signTypedDataAsync } = useSignTypedData()
   const { signMessageAsync } = useSignMessage()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
@@ -364,9 +367,16 @@ function TradingOnboardingProviderContent({
   const communityApiUrl = process.env.COMMUNITY_URL!
 
   const status = useOnboardingStatus(user, requiresTradingAuthRefresh)
+  const normalizedUserAddress = user?.address?.trim().toLowerCase() ?? ''
+  const hasMatchingCommunityUsernameHint = Boolean(
+    communityUsernameHint
+    && normalizedUserAddress
+    && communityUsernameHint.address.trim().toLowerCase() === normalizedUserAddress,
+  )
+  const communityUsernameHintForCurrentUser = hasMatchingCommunityUsernameHint ? communityUsernameHint : null
 
   useEffect(function preloadCommunityUsernameHint() {
-    if (!user?.address || !status.needsUsername || communityUsernameHint || activeModal !== 'username') {
+    if (!user?.address || !status.needsUsername || activeModal !== 'username' || hasMatchingCommunityUsernameHint) {
       return
     }
 
@@ -388,7 +398,10 @@ function TradingOnboardingProviderContent({
 
         const username = profile?.username?.trim()
         if (username) {
-          setCommunityUsernameHint(username)
+          setCommunityUsernameHint({
+            address: user.address,
+            username,
+          })
         }
       })
       .catch((error) => {
@@ -405,7 +418,7 @@ function TradingOnboardingProviderContent({
       window.clearTimeout(timeoutId)
       controller.abort()
     }
-  }, [activeModal, communityApiUrl, communityUsernameHint, status.needsUsername, user?.address])
+  }, [activeModal, communityApiUrl, hasMatchingCommunityUsernameHint, status.needsUsername, user?.address])
 
   useDepositWalletPolling({
     userId: user?.id,
@@ -1302,7 +1315,7 @@ function TradingOnboardingProviderContent({
       <TradingOnboardingDialogs
         activeModal={activeModal}
         onModalOpenChange={handleModalOpenChange}
-        usernameDefaultValue={communityUsernameHint || getUsernameDefaultValue(user)}
+        usernameDefaultValue={communityUsernameHintForCurrentUser?.username ?? getUsernameDefaultValue(user)}
         usernameError={usernameError}
         isUsernameSubmitting={isUsernameSubmitting}
         onUsernameSubmit={handleUsernameSubmit}

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -602,7 +602,7 @@
   "Ip26Qb": "Profileinstellungen",
   "jFYw+/": "Verwalte dein Konto-Profil und deine Einstellungen.",
   "I+lMYp": "SDK-Downloads",
-  "AzRJCl": "Lade personalisierte SDK-Bundles für deine Website herunter, getrennt nach Sprache und Anwendungsfall.",
+  "AzRJCl": "Erstelle Trading-Bots und Integrationen mit personalisierten SDK-Bundles. Der CLOB-Client übernimmt den Handel im Orderbuch, während der Relayer-Client beim Weiterleiten und Ausführen signierter Aktionen hilft.",
   "Y0Fy55": "Python-Client",
   "tpwdRG": "CLOB- und Relayer-Bundles für Python-Bots und -Dienste.",
   "oCneEN": "CLOB",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -602,7 +602,7 @@
   "Ip26Qb": "Profile Settings",
   "jFYw+/": "Manage your account profile and preferences.",
   "I+lMYp": "SDK Downloads",
-  "AzRJCl": "Download personalized SDK bundles for your site, split by language and use case.",
+  "AzRJCl": "Build trading bots and integrations with personalized SDK bundles. The CLOB client handles orderbook trading, while the Relayer client helps route and execute signed actions.",
   "Y0Fy55": "Python Client",
   "tpwdRG": "CLOB and relayer bundles for Python bots and services.",
   "oCneEN": "CLOB",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -602,7 +602,7 @@
   "Ip26Qb": "Configuración de perfil",
   "jFYw+/": "Gestiona el perfil y las preferencias de tu cuenta.",
   "I+lMYp": "Descargas de SDK",
-  "AzRJCl": "Descarga paquetes de SDK personalizados para tu sitio, separados por idioma y caso de uso.",
+  "AzRJCl": "Crea bots de trading e integraciones con paquetes de SDK personalizados. El cliente CLOB gestiona el trading en el libro de órdenes, mientras que el cliente Relayer ayuda a enrutar y ejecutar acciones firmadas.",
   "Y0Fy55": "Cliente Python",
   "tpwdRG": "Paquetes de CLOB y relayer para bots y servicios en Python.",
   "oCneEN": "CLOB",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -602,7 +602,7 @@
   "Ip26Qb": "Paramètres du profil",
   "jFYw+/": "Gérez le profil et les préférences de votre compte.",
   "I+lMYp": "Téléchargements de SDK",
-  "AzRJCl": "Télécharge des bundles SDK personnalisés pour ton site, séparés par langue et cas d'utilisation.",
+  "AzRJCl": "Créez des bots de trading et des intégrations avec des bundles SDK personnalisés. Le client CLOB gère le trading sur le carnet d'ordres, tandis que le client Relayer aide à acheminer et exécuter des actions signées.",
   "Y0Fy55": "Client Python",
   "tpwdRG": "Bundles CLOB et relayer pour les bots et services Python.",
   "oCneEN": "CLOB",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -602,7 +602,7 @@
   "Ip26Qb": "Configurações de perfil",
   "jFYw+/": "Gerencie o perfil e as preferências da sua conta.",
   "I+lMYp": "Downloads de SDK",
-  "AzRJCl": "Baixe pacotes de SDK personalizados para o seu site, separados por linguagem e caso de uso.",
+  "AzRJCl": "Crie bots de trading e integrações com pacotes de SDK personalizados. O cliente CLOB cuida das negociações no livro de ordens, enquanto o cliente Relayer ajuda a rotear e executar ações assinadas.",
   "Y0Fy55": "Cliente Python",
   "tpwdRG": "Pacotes de CLOB e relayer para bots e serviços em Python.",
   "oCneEN": "CLOB",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -602,7 +602,7 @@
   "Ip26Qb": "个人资料设置",
   "jFYw+/": "管理你的账户资料和偏好设置。",
   "I+lMYp": "SDK 下载",
-  "AzRJCl": "按语言和用途下载为你的网站定制的 SDK 包。",
+  "AzRJCl": "使用个性化的 SDK 套件构建交易机器人和集成。CLOB 客户端负责订单簿交易，而 Relayer 客户端可帮助路由并执行已签名的操作。",
   "Y0Fy55": "Python 客户端",
   "tpwdRG": "适用于 Python 机器人和服务的 CLOB 与 relayer 包。",
   "oCneEN": "CLOB",


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Prefills the trading onboarding username from the user’s community profile and keeps it synced until the user types. Resets the prefill and form state on each dialog open; skips availability calls when the input matches the default. Also updates the SDK Downloads subtitle translations.

- **Bug Fixes**
  - Preloads community username via `fetchCommunityProfileByAddress` on modal open, with timeout/abort using `COMMUNITY_PROFILE_LOOKUP_TIMEOUT_MS` and `AbortController`.
  - Uses the hint only when it matches the current wallet address; otherwise falls back to `getUsernameDefaultValue(user)`.
  - Debounces and cancels stale availability checks, and treats the default value as available without a network call; resets availability on input change.
  - Updates SDK Downloads subtitle translations across locales.

<sup>Written for commit da3b989ef01977bc3324d942af45fb1402bde2cf. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1048?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

