### PR TITLE
fix: fallback live charts when websocket is unavailable

### DIFF
--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -22,7 +22,7 @@ import { formatCurrency, formatSharePriceLabel, formatTimeAgo, toMicro } from '@
 import { POLYGON_SCAN_BASE } from '@/lib/network'
 import { buildPublicProfilePath, isDynamicHomeCategorySlug } from '@/lib/platform-routing'
 import { cn } from '@/lib/utils'
-import { createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
 
 type LiveActivityPayload = DataApiActivity & {
   category?: string
@@ -450,15 +450,16 @@ function useLiveActivityStream({
       isActive = false
       clearReconnect()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
-      if (ws) {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(buildSubscriptionPayload('unsubscribe'))
-        }
-        ws.removeEventListener('open', handleOpen)
-        ws.removeEventListener('message', handleMessage)
-        ws.removeEventListener('error', handleError)
-        ws.removeEventListener('close', handleClose)
-        ws.close()
+      const socket = ws
+      if (socket) {
+        socket.removeEventListener('open', handleOpen)
+        socket.removeEventListener('message', handleMessage)
+        socket.removeEventListener('error', handleError)
+        socket.removeEventListener('close', handleClose)
+        closeWebSocketWhenReady(socket, (currentSocket) => {
+          currentSocket.send(buildSubscriptionPayload('unsubscribe'))
+          currentSocket.close()
+        })
       }
     }
   }, [allowedCreatorWallets, categoryValues, wsUrl])

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -132,8 +132,12 @@ function EventLiveSeriesChartContent({
   const persistedFallbackPrice = snapshotFallbackPrice ?? initialPersistedFallbackPrice
 
   const { data, status } = useLiveSeriesWebSocket({
+    activeWindowMinutes: config.active_window_minutes,
+    eventEndTimestamp: explicitEndTimestamp,
     topic: config.topic,
     eventType: config.event_type,
+    seriesSlug: config.series_slug,
+    startTimestamp,
     subscriptionSymbol,
     isLiveView,
     setBaselinePrice,

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
@@ -8,7 +8,7 @@ import type {
 import type { Market } from '@/types'
 import { useQueryClient } from '@tanstack/react-query'
 import { createContext, use, useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
 
 type MarketChannelStatus = 'connecting' | 'live' | 'offline'
 type MarketChannelListener = (payload: any) => void
@@ -348,12 +348,13 @@ function useMarketChannelConnection({
       isActive = false
       clearReconnect()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
-      if (ws) {
-        ws.removeEventListener('open', handleOpen)
-        ws.removeEventListener('message', handleMessage)
-        ws.removeEventListener('error', handleError)
-        ws.removeEventListener('close', handleClose)
-        ws.close()
+      const socket = ws
+      if (socket) {
+        socket.removeEventListener('open', handleOpen)
+        socket.removeEventListener('message', handleMessage)
+        socket.removeEventListener('error', handleError)
+        socket.removeEventListener('close', handleClose)
+        closeWebSocketWhenReady(socket)
       }
     }
   }, [hasMarketChannel, queryClient, tokenIds, tokenIdToConditionId, wsUrl])

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
@@ -4,7 +4,7 @@ import type { Comment, User } from '@/types'
 import { useQueryClient } from '@tanstack/react-query'
 import { useEffect, useReducer, useRef } from 'react'
 import { commentMetricsQueryKey } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useCommentMetrics'
-import { createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
 
 interface LiveCommentProfile {
   baseAddress?: string
@@ -348,15 +348,16 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
       setStatus('offline')
       clearReconnect()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
-      if (ws) {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(buildSubscriptionPayload('unsubscribe'))
-        }
-        ws.removeEventListener('open', handleOpen)
-        ws.removeEventListener('message', handleMessage)
-        ws.removeEventListener('error', handleError)
-        ws.removeEventListener('close', handleClose)
-        ws.close()
+      const socket = ws
+      if (socket) {
+        socket.removeEventListener('open', handleOpen)
+        socket.removeEventListener('message', handleMessage)
+        socket.removeEventListener('error', handleError)
+        socket.removeEventListener('close', handleClose)
+        closeWebSocketWhenReady(socket, (currentSocket) => {
+          currentSocket.send(buildSubscriptionPayload('unsubscribe'))
+          currentSocket.close()
+        })
       }
     }
   }, [queryClient, shouldConnect, eventSlug, wsUrl])

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
@@ -1,6 +1,6 @@
 import type { DataPoint } from '@/types/PredictionChartTypes'
 import { useEffect, useState } from 'react'
-import { createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
 import {
   extractLivePriceUpdates,
   isSnapshotMessage,
@@ -13,17 +13,33 @@ import {
   writePersistedLivePrice,
 } from '../_utils/eventLiveSeriesChartUtils'
 
+const PRICE_REFERENCE_POLL_INTERVAL_MS = 5000
+
+interface LiveSeriesPriceReferenceSnapshot {
+  latest_price: number | null
+  latest_source_timestamp_ms: number | null
+  latest_window_end_ms: number | null
+}
+
 interface UseLiveSeriesWebSocketOptions {
+  activeWindowMinutes: number
+  eventEndTimestamp: number | null
   topic: string
   eventType: string
+  seriesSlug: string
+  startTimestamp: number | null
   subscriptionSymbol: string
   isLiveView: boolean
   setBaselinePrice: React.Dispatch<React.SetStateAction<number | null>>
 }
 
 export function useLiveSeriesWebSocket({
+  activeWindowMinutes,
+  eventEndTimestamp,
   topic,
   eventType,
+  seriesSlug,
+  startTimestamp,
   subscriptionSymbol,
   isLiveView,
   setBaselinePrice,
@@ -31,7 +47,7 @@ export function useLiveSeriesWebSocket({
   const wsUrl = process.env.WS_LIVE_DATA_URL
   const [data, setData] = useState<DataPoint[]>([])
   const [status, setStatus] = useState<'connecting' | 'live' | 'offline'>(
-    () => (wsUrl ? 'connecting' : 'offline'),
+    () => ((wsUrl || seriesSlug.trim()) ? 'connecting' : 'offline'),
   )
 
   useEffect(function connectLiveSeriesWebSocket() {
@@ -39,14 +55,43 @@ export function useLiveSeriesWebSocket({
       return
     }
 
-    if (!wsUrl) {
+    const normalizedSeriesSlug = seriesSlug.trim()
+    const canPollPriceReference = Boolean(
+      normalizedSeriesSlug
+      && eventEndTimestamp
+      && eventEndTimestamp > 0,
+    )
+    const shouldUseWebSocket = Boolean(wsUrl)
+
+    if (!shouldUseWebSocket && !canPollPriceReference) {
       return
     }
-    // Intentionally keep WS active regardless of event close to preserve always-live behavior.
-    const resolvedWsUrl = wsUrl
 
+    const resolvedWsUrl = wsUrl
     let isActive = true
     let ws: WebSocket | null = null
+    let fallbackPollTimeout: number | null = null
+    let fallbackAbortController: AbortController | null = null
+    let lastFallbackSignature = ''
+    let lastSuccessfulDataAt = 0
+
+    function clearFallbackPoll() {
+      if (fallbackPollTimeout != null) {
+        window.clearTimeout(fallbackPollTimeout)
+        fallbackPollTimeout = null
+      }
+      fallbackAbortController?.abort()
+      fallbackAbortController = null
+    }
+
+    function markDataAsLive() {
+      lastSuccessfulDataAt = Date.now()
+      setStatus('live')
+    }
+
+    function hasRecentLiveData() {
+      return Date.now() - lastSuccessfulDataAt < PRICE_REFERENCE_POLL_INTERVAL_MS * 2
+    }
 
     function buildSubscriptionPayload(action: 'subscribe' | 'unsubscribe') {
       const filters = JSON.stringify({
@@ -65,28 +110,10 @@ export function useLiveSeriesWebSocket({
       })
     }
 
-    function handleOpen() {
-      if (!ws) {
-        return
-      }
-      setStatus('connecting')
-      ws.send(buildSubscriptionPayload('subscribe'))
-    }
-
-    function handleMessage(eventMessage: MessageEvent<string>) {
-      if (!isActive) {
-        return
-      }
-
-      let payload: any
-      try {
-        payload = JSON.parse(eventMessage.data)
-      }
-      catch {
-        return
-      }
-
-      const updates = extractLivePriceUpdates(payload, topic, subscriptionSymbol, Date.now())
+    function applyUpdates(
+      updates: Array<{ price: number, timestamp: number, symbol: string | null }>,
+      messageIsSnapshot = false,
+    ) {
       const normalizedUpdates = updates
         .map((update) => {
           const normalizedPrice = normalizeLiveChartPrice(update.price, topic)
@@ -101,18 +128,17 @@ export function useLiveSeriesWebSocket({
         })
         .filter((update): update is { price: number, timestamp: number, symbol: string | null } => update !== null)
 
-      const messageIsSnapshot = isSnapshotMessage(payload)
       const messageHasBatchUpdates = normalizedUpdates.length > 1
-      const wsUpdatesForRender = LIVE_WS_USE_ONLY_LAST_UPDATE_PER_MESSAGE
+      const updatesForRender = LIVE_WS_USE_ONLY_LAST_UPDATE_PER_MESSAGE
         ? (messageIsSnapshot || messageHasBatchUpdates ? normalizedUpdates : normalizedUpdates.slice(-1))
         : normalizedUpdates
 
-      if (!wsUpdatesForRender.length) {
-        return
+      if (!updatesForRender.length) {
+        return false
       }
 
-      setStatus('live')
-      const latest = wsUpdatesForRender.at(-1)
+      markDataAsLive()
+      const latest = updatesForRender.at(-1)
       if (latest) {
         writePersistedLivePrice(topic, subscriptionSymbol, latest.price, latest.timestamp)
       }
@@ -121,11 +147,11 @@ export function useLiveSeriesWebSocket({
         const arrivalTimestamp = Date.now()
         const cutoff = arrivalTimestamp - LIVE_DATA_RETENTION_MS
 
-        if (messageIsSnapshot && wsUpdatesForRender.length > 1) {
+        if (messageIsSnapshot && updatesForRender.length > 1) {
           let lastSnapshotTimestamp: number | null = null
           const snapshotPoints: DataPoint[] = []
 
-          for (const update of wsUpdatesForRender) {
+          for (const update of updatesForRender) {
             let pointTimestamp = update.timestamp
             if (!Number.isFinite(pointTimestamp)) {
               continue
@@ -152,8 +178,7 @@ export function useLiveSeriesWebSocket({
         const lastPoint = next.length ? next.at(-1) : null
         let lastTimestamp = lastPoint ? lastPoint.date.getTime() : null
 
-        for (const update of wsUpdatesForRender) {
-          // Anchor incoming points to arrival time to avoid delayed-source timestamp jumps.
+        for (const update of updatesForRender) {
           let pointTimestamp = Math.max(update.timestamp, arrivalTimestamp)
 
           if (lastTimestamp !== null && pointTimestamp <= lastTimestamp) {
@@ -172,11 +197,39 @@ export function useLiveSeriesWebSocket({
         return next
       })
 
-      setBaselinePrice(current => current ?? wsUpdatesForRender[0]?.price ?? null)
+      setBaselinePrice(current => current ?? updatesForRender[0]?.price ?? null)
+      return true
+    }
+
+    function handleOpen() {
+      if (!ws) {
+        return
+      }
+      if (!hasRecentLiveData()) {
+        setStatus('connecting')
+      }
+      ws.send(buildSubscriptionPayload('subscribe'))
+    }
+
+    function handleMessage(eventMessage: MessageEvent<string>) {
+      if (!isActive) {
+        return
+      }
+
+      let payload: any
+      try {
+        payload = JSON.parse(eventMessage.data)
+      }
+      catch {
+        return
+      }
+
+      const updates = extractLivePriceUpdates(payload, topic, subscriptionSymbol, Date.now())
+      applyUpdates(updates, isSnapshotMessage(payload))
     }
 
     function handleError() {
-      if (isActive) {
+      if (isActive && !hasRecentLiveData()) {
         setStatus('offline')
       }
     }
@@ -189,6 +242,9 @@ export function useLiveSeriesWebSocket({
 
     function handleVisibilityChange() {
       reconnectController?.handleVisibilityChange()
+      if (!document.hidden) {
+        scheduleFallbackPoll(0)
+      }
     }
 
     function scheduleReconnect() {
@@ -199,12 +255,14 @@ export function useLiveSeriesWebSocket({
       if (!isActive) {
         return
       }
-      setStatus('offline')
+      if (!hasRecentLiveData()) {
+        setStatus('offline')
+      }
       scheduleReconnect()
     }
 
     function connect() {
-      if (!isActive || ws || document.hidden) {
+      if (!isActive || ws || document.hidden || !resolvedWsUrl) {
         return
       }
       ws = new WebSocket(resolvedWsUrl)
@@ -212,6 +270,91 @@ export function useLiveSeriesWebSocket({
       ws.addEventListener('message', handleMessage)
       ws.addEventListener('error', handleError)
       ws.addEventListener('close', handleClose)
+    }
+
+    function scheduleFallbackPoll(delayMs = PRICE_REFERENCE_POLL_INTERVAL_MS) {
+      clearFallbackPoll()
+      if (!isActive || !canPollPriceReference) {
+        return
+      }
+      fallbackPollTimeout = window.setTimeout(() => {
+        void pollPriceReference()
+      }, delayMs)
+    }
+
+    async function pollPriceReference() {
+      if (!isActive || !canPollPriceReference || document.hidden || !eventEndTimestamp) {
+        scheduleFallbackPoll()
+        return
+      }
+
+      fallbackAbortController = new AbortController()
+
+      try {
+        const query = new URLSearchParams({
+          seriesSlug: normalizedSeriesSlug,
+          eventEndMs: String(eventEndTimestamp),
+          activeWindowMinutes: String(activeWindowMinutes),
+        })
+
+        if (
+          startTimestamp != null
+          && startTimestamp > 0
+          && startTimestamp < eventEndTimestamp
+        ) {
+          query.set('eventStartMs', String(startTimestamp))
+        }
+
+        const response = await fetch(`/api/price-reference/live-series?${query.toString()}`, {
+          cache: 'no-store',
+          signal: fallbackAbortController.signal,
+        })
+
+        if (!response.ok) {
+          return
+        }
+
+        const payload = await response.json() as LiveSeriesPriceReferenceSnapshot
+        if (!isActive) {
+          return
+        }
+
+        const normalizedPrice = normalizeLiveChartPrice(
+          Number(payload.latest_price ?? Number.NaN),
+          topic,
+        )
+        if (normalizedPrice == null) {
+          return
+        }
+
+        const rawTimestamp = Number(
+          payload.latest_source_timestamp_ms
+          ?? payload.latest_window_end_ms
+          ?? Date.now(),
+        )
+        const normalizedTimestamp = Number.isFinite(rawTimestamp) && rawTimestamp > 0
+          ? rawTimestamp
+          : Date.now()
+        const signature = `${normalizedTimestamp}:${normalizedPrice}`
+
+        if (signature === lastFallbackSignature) {
+          markDataAsLive()
+          return
+        }
+
+        lastFallbackSignature = signature
+        applyUpdates([{
+          price: normalizedPrice,
+          timestamp: normalizedTimestamp,
+          symbol: subscriptionSymbol,
+        }])
+      }
+      catch {
+      }
+      finally {
+        fallbackAbortController = null
+        scheduleFallbackPoll()
+      }
     }
 
     reconnectController = createWebSocketReconnectController({
@@ -223,26 +366,42 @@ export function useLiveSeriesWebSocket({
       },
     })
 
-    connect()
+    if (shouldUseWebSocket) {
+      connect()
+    }
+    scheduleFallbackPoll(0)
     document.addEventListener('visibilitychange', handleVisibilityChange)
 
     return function cleanupLiveSeriesWebSocket() {
       isActive = false
       setStatus('offline')
       clearReconnect()
+      clearFallbackPoll()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
-      if (ws) {
-        if (ws.readyState === WebSocket.OPEN) {
-          ws.send(buildSubscriptionPayload('unsubscribe'))
-        }
-        ws.removeEventListener('open', handleOpen)
-        ws.removeEventListener('message', handleMessage)
-        ws.removeEventListener('error', handleError)
-        ws.removeEventListener('close', handleClose)
-        ws.close()
+      const socket = ws
+      if (socket) {
+        socket.removeEventListener('open', handleOpen)
+        socket.removeEventListener('message', handleMessage)
+        socket.removeEventListener('error', handleError)
+        socket.removeEventListener('close', handleClose)
+        closeWebSocketWhenReady(socket, (currentSocket) => {
+          currentSocket.send(buildSubscriptionPayload('unsubscribe'))
+          currentSocket.close()
+        })
       }
     }
-  }, [eventType, topic, isLiveView, wsUrl, subscriptionSymbol, setBaselinePrice])
+  }, [
+    activeWindowMinutes,
+    eventEndTimestamp,
+    eventType,
+    isLiveView,
+    seriesSlug,
+    setBaselinePrice,
+    startTimestamp,
+    subscriptionSymbol,
+    topic,
+    wsUrl,
+  ])
 
   return { data, status }
 }

--- a/src/lib/websocket-reconnect.ts
+++ b/src/lib/websocket-reconnect.ts
@@ -57,3 +57,23 @@ export function createWebSocketReconnectController({
     scheduleReconnect,
   }
 }
+
+export function closeWebSocketWhenReady(
+  ws: WebSocket,
+  close: (socket: WebSocket) => void = socket => socket.close(),
+) {
+  if (ws.readyState === WebSocket.CONNECTING) {
+    ws.addEventListener('open', () => {
+      if (ws.readyState === WebSocket.OPEN) {
+        close(ws)
+      }
+    }, { once: true })
+    return
+  }
+
+  if (ws.readyState !== WebSocket.OPEN) {
+    return
+  }
+
+  close(ws)
+}

--- a/src/lib/websocket-reconnect.ts
+++ b/src/lib/websocket-reconnect.ts
@@ -63,11 +63,7 @@ export function closeWebSocketWhenReady(
   close: (socket: WebSocket) => void = socket => socket.close(),
 ) {
   if (ws.readyState === WebSocket.CONNECTING) {
-    ws.addEventListener('open', () => {
-      if (ws.readyState === WebSocket.OPEN) {
-        close(ws)
-      }
-    }, { once: true })
+    ws.close()
     return
   }
 

--- a/tests/unit/websocketReconnect.test.ts
+++ b/tests/unit/websocketReconnect.test.ts
@@ -1,0 +1,45 @@
+import { closeWebSocketWhenReady } from '@/lib/websocket-reconnect'
+
+function createWebSocketStub(readyState: number) {
+  return {
+    readyState,
+    close: vi.fn(),
+    addEventListener: vi.fn(),
+  } as unknown as WebSocket
+}
+
+describe('closeWebSocketWhenReady', () => {
+  it('closes connecting sockets immediately without waiting for open', () => {
+    const ws = createWebSocketStub(WebSocket.CONNECTING)
+    const closeOpenSocket = vi.fn()
+
+    closeWebSocketWhenReady(ws, closeOpenSocket)
+
+    expect(ws.close).toHaveBeenCalledTimes(1)
+    expect(ws.addEventListener).not.toHaveBeenCalled()
+    expect(closeOpenSocket).not.toHaveBeenCalled()
+  })
+
+  it('runs the graceful close callback for open sockets', () => {
+    const ws = createWebSocketStub(WebSocket.OPEN)
+    const closeOpenSocket = vi.fn()
+
+    closeWebSocketWhenReady(ws, closeOpenSocket)
+
+    expect(closeOpenSocket).toHaveBeenCalledWith(ws)
+    expect(ws.close).not.toHaveBeenCalled()
+  })
+
+  it('ignores sockets that are already closing or closed', () => {
+    const closingSocket = createWebSocketStub(WebSocket.CLOSING)
+    const closedSocket = createWebSocketStub(WebSocket.CLOSED)
+    const closeOpenSocket = vi.fn()
+
+    closeWebSocketWhenReady(closingSocket, closeOpenSocket)
+    closeWebSocketWhenReady(closedSocket, closeOpenSocket)
+
+    expect(closingSocket.close).not.toHaveBeenCalled()
+    expect(closedSocket.close).not.toHaveBeenCalled()
+    expect(closeOpenSocket).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Keeps live charts updating when WebSocket is unavailable by adding a polling fallback and safely closing sockets (including pending) to prevent leaks or flicker.

- **New Features**
  - Added a price-reference polling fallback in `useLiveSeriesWebSocket` that updates every 5s via `/api/price-reference/live-series` using `seriesSlug`, `activeWindowMinutes`, `startTimestamp`, and `eventEndTimestamp`.
  - Merges fallback updates with WS updates and preserves “live” status when recent data exists to reduce UI flicker.

- **Bug Fixes**
  - Added `closeWebSocketWhenReady` across hooks to safely clean up connecting and open sockets (unsubscribe before close), with unit tests.
  - Avoids flipping to “offline” if recent data was received; reconnects/polls on visibility changes; and only opens WS when a URL is present (polls when none).

<sup>Written for commit 91cd8a029e68d0f521720358818b0370a04ff8f1. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1050?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

