### PR TITLE
fix: sign hmac query paths

### DIFF
--- a/src/lib/hmac.ts
+++ b/src/lib/hmac.ts
@@ -6,10 +6,7 @@ function replaceAll(s: string, search: string, replace: string) {
 }
 
 export function buildClobHmacSignature(secret: string, timestamp: number, method: string, requestPath: string, body?: string): string {
-  const normalizedPath = method === 'GET'
-    ? requestPath.split('?')[0]
-    : requestPath
-  let message = timestamp + method + normalizedPath
+  let message = timestamp + method + requestPath
   if (body !== undefined) {
     message += body
   }

--- a/tests/unit/hmac.test.ts
+++ b/tests/unit/hmac.test.ts
@@ -1,0 +1,26 @@
+import { Buffer } from 'node:buffer'
+import crypto from 'node:crypto'
+import { describe, expect, it } from 'vitest'
+import { buildClobHmacSignature } from '@/lib/hmac'
+
+function sign(secret: string, message: string) {
+  return crypto
+    .createHmac('sha256', Buffer.from(secret, 'base64'))
+    .update(message)
+    .digest('base64')
+    .replaceAll('+', '-')
+    .replaceAll('/', '_')
+}
+
+describe('buildClobHmacSignature', () => {
+  it('includes query parameters in GET request signatures', () => {
+    const secret = Buffer.from('12345678901234567890123456789012').toString('base64')
+    const timestamp = 1710000000
+    const requestPath = '/auth/api-keys?metadata=true&includeRevoked=true'
+
+    const signature = buildClobHmacSignature(secret, timestamp, 'GET', requestPath)
+
+    expect(signature).toBe(sign(secret, `${timestamp}GET${requestPath}`))
+    expect(signature).not.toBe(sign(secret, `${timestamp}GET/auth/api-keys`))
+  })
+})

--- a/tests/unit/sdkApiKeyActions.test.ts
+++ b/tests/unit/sdkApiKeyActions.test.ts
@@ -287,6 +287,18 @@ describe('sdk api key actions', () => {
         cache: 'no-store',
       }),
     )
+    expect(mocks.buildClobHmacSignature).toHaveBeenCalledWith(
+      'clob-secret',
+      expect.any(Number),
+      'GET',
+      '/auth/api-keys?metadata=true&includeRevoked=true',
+    )
+    expect(mocks.buildClobHmacSignature).toHaveBeenCalledWith(
+      'relayer-secret',
+      expect.any(Number),
+      'GET',
+      '/auth/api-keys?metadata=true&includeRevoked=true',
+    )
   })
 
   it('fails nonce resolution when one metadata service is unavailable', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix HMAC signing to include query parameters in GET requests so signatures match the full request path. Prevents auth failures for endpoints like `/auth/api-keys?metadata=true&includeRevoked=true`.

- **Bug Fixes**
  - Sign GET requests with the full `requestPath` (including query string) in `buildClobHmacSignature`.
  - Added unit tests for query-inclusive signing and updated `sdkApiKeyActions` tests to assert expected paths.

<sup>Written for commit 5733aaa3c5298c92397a2599a25de7782c3b85a9. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1061?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

