### PR TITLE
fix: use path-only hmac signatures

### DIFF
--- a/src/app/[locale]/(platform)/_actions/approve-tokens.ts
+++ b/src/app/[locale]/(platform)/_actions/approve-tokens.ts
@@ -149,12 +149,13 @@ async function syncClobCollateralBalanceAllowanceSignatureType3(user: {
   }
 
   const query = 'asset_type=COLLATERAL&signature_type=3'
-  const path = `/balance-allowance/update?${query}`
+  const path = '/balance-allowance/update'
+  const pathWithQuery = `${path}?${query}`
   const timestamp = Math.floor(Date.now() / 1000)
   const signature = buildClobHmacSignature(auth.clob.secret, timestamp, 'GET', path)
 
   try {
-    const response = await fetch(`${clobUrl}${path}`, {
+    const response = await fetch(`${clobUrl}${pathWithQuery}`, {
       method: 'GET',
       headers: {
         Accept: 'application/json',

--- a/src/app/[locale]/(platform)/settings/_actions/sdk-api-keys.ts
+++ b/src/app/[locale]/(platform)/settings/_actions/sdk-api-keys.ts
@@ -201,8 +201,9 @@ async function listApiKeyMetadata(
   address: string,
   credential: SdkApiKeyCredential,
 ) {
-  const path = '/auth/api-keys?metadata=true&includeRevoked=true'
-  const response = await fetch(`${target.baseUrl}${path}`, {
+  const path = '/auth/api-keys'
+  const pathWithQuery = `${path}?metadata=true&includeRevoked=true`
+  const response = await fetch(`${target.baseUrl}${pathWithQuery}`, {
     method: 'GET',
     headers: buildL2Headers(address, credential, path),
     cache: 'no-store',

--- a/src/app/api/events/[slug]/open-orders/route.ts
+++ b/src/app/api/events/[slug]/open-orders/route.ts
@@ -179,7 +179,7 @@ async function fetchClobOpenOrders({
   const pathWithQuery = query ? `${path}?${query}` : path
   const url = `${CLOB_URL}${pathWithQuery}`
   const timestamp = Math.floor(Date.now() / 1000)
-  const signature = buildClobHmacSignature(auth.secret, timestamp, 'GET', pathWithQuery)
+  const signature = buildClobHmacSignature(auth.secret, timestamp, 'GET', path)
 
   const response = await fetch(url, {
     method: 'GET',

--- a/src/app/api/open-orders/route.ts
+++ b/src/app/api/open-orders/route.ts
@@ -130,11 +130,12 @@ async function fetchClobOpenOrders({
   if (nextCursor) {
     params.set('next_cursor', nextCursor)
   }
-  const path = params.toString() ? `/data/orders?${params.toString()}` : '/data/orders'
+  const path = '/data/orders'
+  const pathWithQuery = params.toString() ? `${path}?${params.toString()}` : path
   const timestamp = Math.floor(Date.now() / 1000)
   const signature = buildClobHmacSignature(auth.secret, timestamp, 'GET', path)
 
-  const response = await fetch(`${CLOB_URL}${path}`, {
+  const response = await fetch(`${CLOB_URL}${pathWithQuery}`, {
     method: 'GET',
     headers: {
       Accept: 'application/json',

--- a/src/lib/hmac.ts
+++ b/src/lib/hmac.ts
@@ -6,7 +6,8 @@ function replaceAll(s: string, search: string, replace: string) {
 }
 
 export function buildClobHmacSignature(secret: string, timestamp: number, method: string, requestPath: string, body?: string): string {
-  let message = timestamp + method + requestPath
+  const signingPath = requestPath.split('?')[0]
+  let message = timestamp + method + signingPath
   if (body !== undefined) {
     message += body
   }

--- a/tests/unit/hmac.test.ts
+++ b/tests/unit/hmac.test.ts
@@ -13,14 +13,14 @@ function sign(secret: string, message: string) {
 }
 
 describe('buildClobHmacSignature', () => {
-  it('includes query parameters in GET request signatures', () => {
+  it('excludes query parameters from request signatures', () => {
     const secret = Buffer.from('12345678901234567890123456789012').toString('base64')
     const timestamp = 1710000000
     const requestPath = '/auth/api-keys?metadata=true&includeRevoked=true'
 
     const signature = buildClobHmacSignature(secret, timestamp, 'GET', requestPath)
 
-    expect(signature).toBe(sign(secret, `${timestamp}GET${requestPath}`))
-    expect(signature).not.toBe(sign(secret, `${timestamp}GET/auth/api-keys`))
+    expect(signature).toBe(sign(secret, `${timestamp}GET/auth/api-keys`))
+    expect(signature).not.toBe(sign(secret, `${timestamp}GET${requestPath}`))
   })
 })

--- a/tests/unit/sdkApiKeyActions.test.ts
+++ b/tests/unit/sdkApiKeyActions.test.ts
@@ -291,13 +291,13 @@ describe('sdk api key actions', () => {
       'clob-secret',
       expect.any(Number),
       'GET',
-      '/auth/api-keys?metadata=true&includeRevoked=true',
+      '/auth/api-keys',
     )
     expect(mocks.buildClobHmacSignature).toHaveBeenCalledWith(
       'relayer-secret',
       expect.any(Number),
       'GET',
-      '/auth/api-keys?metadata=true&includeRevoked=true',
+      '/auth/api-keys',
     )
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Switch HMAC signing to use path-only (exclude query params) for CLOB/Relayer requests. This fixes signature mismatches that caused auth failures on GET endpoints with query strings.

- **Bug Fixes**
  - `buildClobHmacSignature` strips query strings before signing.
  - Call sites sign the path, but request with `path?query` (`/data/orders`, `/auth/api-keys`, `/balance-allowance/update`, open-orders routes).
  - Updated unit tests to assert path-only signatures.

<sup>Written for commit fbe6b5374b06ca09b83a1f69751b00831cd07165. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1062?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

