### PR TITLE
fix: add redeem fallback icon

### DIFF
--- a/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
@@ -68,11 +68,17 @@ export default function PublicActivityRow({ activity }: PublicActivityRowProps) 
                     containerClassName="size-full"
                   />
                 )
-              : (
-                  <div className="grid size-full place-items-center text-2xs text-muted-foreground">
-                    No image
-                  </div>
-                )}
+              : variant === 'redeem'
+                ? (
+                    <div className="grid size-full place-items-center text-primary/80">
+                      <CircleDollarSignIcon className="size-5" />
+                    </div>
+                  )
+                : (
+                    <div className="grid size-full place-items-center text-2xs text-muted-foreground">
+                      No image
+                    </div>
+                  )}
           </AppLink>
 
           <div className="min-w-0 flex-1 space-y-1">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show a redeem fallback icon when a reward activity has no image, replacing the "No image" placeholder. This improves readability and makes redeem events clear in the activity feed.

<sup>Written for commit 2b0e6bd2c0dfcfec90ebc6dbbffe7d3e9f68915e. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1063?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

