### PR TITLE
fix: add redeem fallback icon

### DIFF
--- a/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
@@ -68,11 +68,17 @@ export default function PublicActivityRow({ activity }: PublicActivityRowProps) 
                     containerClassName="size-full"
                   />
                 )
-              : (
-                  <div className="grid size-full place-items-center text-2xs text-muted-foreground">
-                    No image
-                  </div>
-                )}
+              : variant === 'redeem'
+                ? (
+                    <div className="grid size-full place-items-center text-primary/80">
+                      <CircleDollarSignIcon className="size-5" />
+                    </div>
+                  )
+                : (
+                    <div className="grid size-full place-items-center text-2xs text-muted-foreground">
+                      No image
+                    </div>
+                  )}
           </AppLink>
 
           <div className="min-w-0 flex-1 space-y-1">


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show a dollar icon as a fallback for redeem activities in the profile activity list when no image is available. This improves clarity and keeps the UI consistent without extra network calls.

- **Impact**
  - PublicActivityRow: `variant === 'redeem'` now shows `CircleDollarSignIcon` instead of "No image".
  - No API changes. Component props and routes unchanged.
  - Performance: No new requests; trivial render cost only.

<sup>Written for commit 2b0e6bd2c0dfcfec90ebc6dbbffe7d3e9f68915e. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1068?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

