### PR TITLE
fix: open orders polymarket parity

### DIFF
--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -395,7 +395,7 @@
             "name": "next_cursor",
             "in": "query",
             "required": false,
-            "description": "Base64-encoded offset for pagination. Use `MA==` to start; `LTE=` means no more pages.",
+            "description": "Base64-encoded offset for pagination. Use `MA==` to start; an empty response cursor means no more pages.",
             "schema": {
               "type": "string"
             }
@@ -426,7 +426,8 @@
                     },
                     "limit": {
                       "type": "integer",
-                      "description": "Page size used for the query."
+                      "description": "Page size used for the query.",
+                      "example": 100
                     },
                     "count": {
                       "type": "integer",

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useUserOpenOrdersQuery.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useUserOpenOrdersQuery.ts
@@ -76,10 +76,10 @@ export async function fetchUserOpenOrders({
 
   const payload = await response.json()
   if (Array.isArray(payload)) {
-    return { data: payload, next_cursor: 'LTE=' }
+    return { data: payload, next_cursor: '' }
   }
   return {
     data: Array.isArray(payload?.data) ? payload.data : [],
-    next_cursor: typeof payload?.next_cursor === 'string' ? payload.next_cursor : 'LTE=',
+    next_cursor: typeof payload?.next_cursor === 'string' ? payload.next_cursor : '',
   }
 }

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
@@ -26,6 +26,12 @@ interface PortfolioOpenOrdersListProps {
 
 type OpenTradeRequirements = ReturnType<typeof useTradingOnboarding>['openTradeRequirements']
 
+interface LoadMoreStateValue {
+  key: string
+  infiniteScrollError: string | null
+  isLoadingMore: boolean
+}
+
 function useOpenOrdersFilterState(userAddress: string) {
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebounce(searchQuery, 300)
@@ -50,6 +56,27 @@ function useOpenOrdersFilterState(userAddress: string) {
     apiSearchFilters,
     apiSearchKey,
     openOrdersQueryKey,
+  }
+}
+
+function useLoadMoreState(loadMoreScopeKey: string) {
+  const [loadMoreState, setLoadMoreState] = useState<LoadMoreStateValue>({
+    key: loadMoreScopeKey,
+    infiniteScrollError: null,
+    isLoadingMore: false,
+  })
+  const scopedLoadMoreState = loadMoreState.key === loadMoreScopeKey
+    ? loadMoreState
+    : {
+        key: loadMoreScopeKey,
+        infiniteScrollError: null,
+        isLoadingMore: false,
+      }
+
+  return {
+    infiniteScrollError: scopedLoadMoreState.infiniteScrollError,
+    isLoadingMore: scopedLoadMoreState.isLoadingMore,
+    setLoadMoreState,
   }
 }
 
@@ -152,14 +179,54 @@ function useCancelAllOpenOrders({
   return { isCancellingAll, handleCancelAll }
 }
 
+function useLoadMoreOpenOrders({
+  fetchNextPage,
+  loadMoreErrorMessage,
+  loadMoreScopeKey,
+  setLoadMoreState,
+}: {
+  fetchNextPage: () => Promise<unknown>
+  loadMoreErrorMessage: string
+  loadMoreScopeKey: string
+  setLoadMoreState: (value: LoadMoreStateValue) => void
+}) {
+  return useCallback(() => {
+    setLoadMoreState({
+      key: loadMoreScopeKey,
+      infiniteScrollError: null,
+      isLoadingMore: true,
+    })
+
+    fetchNextPage()
+      .then(() => {
+        setLoadMoreState({
+          key: loadMoreScopeKey,
+          infiniteScrollError: null,
+          isLoadingMore: false,
+        })
+      })
+      .catch((error: any) => {
+        setLoadMoreState({
+          key: loadMoreScopeKey,
+          infiniteScrollError: error?.name === 'AbortError' ? null : error?.message || loadMoreErrorMessage,
+          isLoadingMore: false,
+        })
+      })
+  }, [fetchNextPage, loadMoreErrorMessage, loadMoreScopeKey, setLoadMoreState])
+}
+
 function useInfiniteScrollSentinel({
   hasNextPage,
+  infiniteScrollError,
   isFetchingNextPage,
-  fetchNextPage,
+  isLoadingMore,
+  loadMoreOpenOrders,
 }: {
   hasNextPage: boolean
+  infiniteScrollError: string | null
   isFetchingNextPage: boolean
-  fetchNextPage: () => Promise<unknown>
+  isLoadingMore: boolean
+  loadMoreOpenOrders: () => void
 }): { loadMoreRef: RefObject<HTMLDivElement | null> } {
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
 
@@ -170,8 +237,8 @@ function useInfiniteScrollSentinel({
 
     const observer = new IntersectionObserver((entries) => {
       const [entry] = entries
-      if (entry?.isIntersecting && !isFetchingNextPage) {
-        void fetchNextPage()
+      if (entry?.isIntersecting && !isFetchingNextPage && !isLoadingMore && !infiniteScrollError) {
+        loadMoreOpenOrders()
       }
     }, { rootMargin: '200px' })
 
@@ -179,7 +246,7 @@ function useInfiniteScrollSentinel({
     return function disconnectLoadMoreObserver() {
       observer.disconnect()
     }
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+  }, [hasNextPage, infiniteScrollError, isFetchingNextPage, isLoadingMore, loadMoreOpenOrders])
 
   return { loadMoreRef }
 }
@@ -223,6 +290,8 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
     apiSearchKey,
     openOrdersQueryKey,
   } = useOpenOrdersFilterState(userAddress)
+  const loadMoreScopeKey = `${userAddress}:${apiSearchKey}:${searchQuery}:${sortBy}`
+  const { infiniteScrollError, isLoadingMore, setLoadMoreState } = useLoadMoreState(loadMoreScopeKey)
 
   const {
     status,
@@ -263,10 +332,19 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
     openTradeRequirements,
   })
 
+  const loadMoreOpenOrders = useLoadMoreOpenOrders({
+    fetchNextPage,
+    loadMoreErrorMessage: t('Failed to load more open orders'),
+    loadMoreScopeKey,
+    setLoadMoreState,
+  })
+
   const { loadMoreRef } = useInfiniteScrollSentinel({
     hasNextPage,
+    infiniteScrollError,
     isFetchingNextPage,
-    fetchNextPage,
+    isLoadingMore,
+    loadMoreOpenOrders,
   })
 
   const emptyText = userAddress
@@ -302,7 +380,10 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
         isLoading={loading}
         emptyText={emptyText}
         isFetchingNextPage={isFetchingNextPage}
+        infiniteScrollError={infiniteScrollError}
+        isLoadingMore={isLoadingMore}
         loadMoreRef={loadMoreRef}
+        onRetryLoadMore={loadMoreOpenOrders}
       />
     </div>
   )

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersTable.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersTable.tsx
@@ -10,7 +10,10 @@ interface PortfolioOpenOrdersTableProps {
   isLoading: boolean
   emptyText: string
   isFetchingNextPage: boolean
+  infiniteScrollError: string | null
+  isLoadingMore: boolean
   loadMoreRef: RefObject<HTMLDivElement | null>
+  onRetryLoadMore: () => void
 }
 
 export default function PortfolioOpenOrdersTable({
@@ -18,7 +21,10 @@ export default function PortfolioOpenOrdersTable({
   isLoading,
   emptyText,
   isFetchingNextPage,
+  infiniteScrollError,
+  isLoadingMore,
   loadMoreRef,
+  onRetryLoadMore,
 }: PortfolioOpenOrdersTableProps) {
   const t = useExtracted()
   const hasOrders = orders.length > 0
@@ -53,10 +59,21 @@ export default function PortfolioOpenOrdersTable({
         {orders.map(order => (
           <PortfolioOpenOrdersRow key={order.id} order={order} />
         ))}
-        {isFetchingNextPage && (
+        {(isFetchingNextPage || isLoadingMore) && (
           <tr>
             <td colSpan={colSpan} className="py-3 text-center text-xs text-muted-foreground">
-              {t('Loading more...')}
+              {t('Loading more open orders...')}
+            </td>
+          </tr>
+        )}
+        {infiniteScrollError && (
+          <tr>
+            <td colSpan={colSpan} className="py-3 text-center text-xs text-destructive">
+              {infiniteScrollError}
+              {' '}
+              <button type="button" onClick={onRetryLoadMore} className="underline underline-offset-2">
+                {t('Retry')}
+              </button>
             </td>
           </tr>
         )}

--- a/src/app/[locale]/(platform)/portfolio/_hooks/usePortfolioOpenOrdersQuery.ts
+++ b/src/app/[locale]/(platform)/portfolio/_hooks/usePortfolioOpenOrdersQuery.ts
@@ -30,11 +30,11 @@ async function fetchOpenOrders({
   }
   const payload = await response.json()
   if (Array.isArray(payload)) {
-    return { data: payload, next_cursor: 'LTE=' }
+    return { data: payload, next_cursor: '' }
   }
   return {
     data: Array.isArray(payload?.data) ? payload.data : [],
-    next_cursor: typeof payload?.next_cursor === 'string' ? payload.next_cursor : 'LTE=',
+    next_cursor: typeof payload?.next_cursor === 'string' ? payload.next_cursor : '',
   }
 }
 

--- a/src/app/api/events/[slug]/open-orders/route.ts
+++ b/src/app/api/events/[slug]/open-orders/route.ts
@@ -50,7 +50,7 @@ export async function GET(
     }
 
     if (!user) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ data: [], next_cursor: '' })
     }
 
     if (!CLOB_URL) {
@@ -72,7 +72,7 @@ export async function GET(
 
     const { data: marketMetadata, error: marketError } = await EventRepository.getEventMarketMetadata(slug)
     if (marketError || !marketMetadata || marketMetadata.length === 0) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ data: [], next_cursor: '' })
     }
 
     const targetMarkets = conditionId
@@ -80,14 +80,13 @@ export async function GET(
       : marketMetadata
 
     if (!targetMarkets.length) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ data: [], next_cursor: '' })
     }
 
     const { marketMap, outcomeMap } = buildMarketLookups(targetMarkets)
 
     const { data: clobOrders, next_cursor } = await fetchClobOpenOrders({
       market: conditionId,
-      makerAddress: user.deposit_wallet_address ?? undefined,
       userAddress: user.address,
       auth: tradingAuth.clob,
       nextCursor,
@@ -148,13 +147,11 @@ function buildMarketLookups(markets: Array<{
 
 async function fetchClobOpenOrders({
   market,
-  makerAddress,
   auth,
   userAddress,
   nextCursor,
 }: {
   market?: string
-  makerAddress?: string
   auth: { key: string, secret: string, passphrase: string }
   userAddress: string
   nextCursor?: string
@@ -166,9 +163,6 @@ async function fetchClobOpenOrders({
   const searchParams = new URLSearchParams()
   if (market) {
     searchParams.set('market', market)
-  }
-  if (makerAddress) {
-    searchParams.set('maker_address', makerAddress)
   }
   if (nextCursor) {
     searchParams.set('next_cursor', nextCursor)

--- a/src/app/api/open-orders/route.ts
+++ b/src/app/api/open-orders/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: Request) {
   try {
     const user = await UserRepository.getCurrentUser({ minimal: true })
     if (!user) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ data: [], next_cursor: '' })
     }
 
     if (!CLOB_URL) {
@@ -64,7 +64,6 @@ export async function GET(request: Request) {
     const { data: clobOrders, next_cursor } = await fetchClobOpenOrders({
       auth: tradingAuth.clob,
       userAddress: user.address,
-      makerAddress: user.deposit_wallet_address as string,
       id: idFilter,
       market: marketFilter,
       assetId: assetIdFilter,
@@ -100,7 +99,6 @@ export async function GET(request: Request) {
 async function fetchClobOpenOrders({
   auth,
   userAddress,
-  makerAddress,
   id,
   market,
   assetId,
@@ -108,16 +106,12 @@ async function fetchClobOpenOrders({
 }: {
   auth: { key: string, secret: string, passphrase: string }
   userAddress: string
-  makerAddress?: string
   id?: string
   market?: string
   assetId?: string
   nextCursor?: string
 }): Promise<{ data: ClobOpenOrder[], next_cursor: string }> {
   const params = new URLSearchParams()
-  if (makerAddress) {
-    params.set('maker_address', makerAddress)
-  }
   if (id) {
     params.set('id', id)
   }

--- a/src/lib/clob-open-orders.ts
+++ b/src/lib/clob-open-orders.ts
@@ -143,7 +143,7 @@ function clampClobNumber(value: number, min: number, max: number) {
 
 export function normalizeClobOpenOrdersResponse<TOrder>(result: unknown) {
   if (Array.isArray(result)) {
-    return { data: result as TOrder[], next_cursor: 'LTE=' }
+    return { data: result as TOrder[], next_cursor: '' }
   }
 
   if (result && typeof result === 'object') {
@@ -152,10 +152,10 @@ export function normalizeClobOpenOrdersResponse<TOrder>(result: unknown) {
       : []
     const next_cursor = typeof (result as { next_cursor?: unknown }).next_cursor === 'string'
       ? (result as { next_cursor: string }).next_cursor
-      : 'LTE='
+      : ''
 
     return { data, next_cursor }
   }
 
-  return { data: [] as TOrder[], next_cursor: 'LTE=' }
+  return { data: [] as TOrder[], next_cursor: '' }
 }

--- a/tests/unit/openOrdersRoute.test.ts
+++ b/tests/unit/openOrdersRoute.test.ts
@@ -173,11 +173,11 @@ describe('open orders routes', () => {
           },
         },
       ],
-      next_cursor: 'LTE=',
+      next_cursor: '',
     })
 
     expect(mocks.fetch).toHaveBeenCalledWith(
-      'https://clob.local/data/orders?maker_address=0x0000000000000000000000000000000000000002&market=cond-1&next_cursor=cursor-1',
+      'https://clob.local/data/orders?market=cond-1&next_cursor=cursor-1',
       expect.objectContaining({
         method: 'GET',
       }),
@@ -274,11 +274,11 @@ describe('open orders routes', () => {
           },
         },
       ],
-      next_cursor: 'LTE=',
+      next_cursor: '',
     })
 
     expect(mocks.fetch).toHaveBeenCalledWith(
-      'https://clob.local/data/orders?market=cond-2&maker_address=0x0000000000000000000000000000000000000004&next_cursor=cursor-2',
+      'https://clob.local/data/orders?market=cond-2&next_cursor=cursor-2',
       expect.objectContaining({
         method: 'GET',
       }),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligns open orders with Polymarket behavior and fixes pagination. Users now see the correct open orders, with smoother infinite scrolling and a retry on failure.

- **Affected APIs**
  - `GET /api/open-orders` and `GET /api/events/[slug]/open-orders`: `next_cursor` is now an empty string when there are no more pages.
  - Removed forwarding `maker_address` to the CLOB; requests rely on authenticated user context for parity with Polymarket.
  - Updated `openapi-clob.json` to clarify pagination behavior and added a `limit` example.
  - Business impact: prevents missing orders (especially with deposit wallet mismatches) and aligns results with Polymarket.
  - Migration: if any client code checked for `LTE=` to detect the end, update it to treat an empty `next_cursor` as the terminal state.

- **UX and Performance**
  - Added robust infinite scroll state to prevent double fetches and show a clear error with “Retry.”
  - Reduced redundant API calls during pagination; improves load stability and perceived performance.
  - Updated loading copy to “Loading more open orders...”.

<sup>Written for commit 3b058b3c8341237e6c2a064c38f28ec38c566b4d. Summary will update on new commits. <a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1069?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

