### PR TITLE
fix: only require l2 context when explicitly requested

### DIFF
--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -395,7 +395,7 @@
             "name": "next_cursor",
             "in": "query",
             "required": false,
-            "description": "Base64-encoded offset for pagination. Use `MA==` to start; `LTE=` means no more pages.",
+            "description": "Base64-encoded offset for pagination. Use `MA==` to start; an empty response cursor means no more pages.",
             "schema": {
               "type": "string"
             }
@@ -426,7 +426,8 @@
                     },
                     "limit": {
                       "type": "integer",
-                      "description": "Page size used for the query."
+                      "description": "Page size used for the query.",
+                      "example": 100
                     },
                     "count": {
                       "type": "integer",

--- a/src/app/[locale]/(platform)/_actions/deposit-wallet.ts
+++ b/src/app/[locale]/(platform)/_actions/deposit-wallet.ts
@@ -14,8 +14,7 @@ import { captureDepositWalletError, captureDepositWalletEvent } from '@/lib/depo
 import { db } from '@/lib/drizzle'
 import { buildClobHmacSignature } from '@/lib/hmac'
 import {
-  L2_AUTH_CONTEXT_COOKIE_NAME,
-  L2_AUTH_CONTEXT_COOKIE_NAME_SECURE,
+  getL2AuthContextCookieName,
   L2_AUTH_CONTEXT_TTL_SECONDS,
 } from '@/lib/l2-auth-context'
 import { TRADING_AUTH_REQUIRED_ERROR } from '@/lib/trading-auth/errors'
@@ -243,12 +242,12 @@ async function requestApiKey(baseUrl: string, headers: Record<string, string>) {
   }
 }
 
-async function persistL2AuthCookie(l2AuthContextId: string) {
+async function persistL2AuthCookie(userId: string, l2AuthContextId: string) {
   const cookieStore = await cookies()
   const isProduction = process.env.NODE_ENV === 'production'
 
   cookieStore.set({
-    name: isProduction ? L2_AUTH_CONTEXT_COOKIE_NAME_SECURE : L2_AUTH_CONTEXT_COOKIE_NAME,
+    name: getL2AuthContextCookieName({ secure: isProduction, userId }),
     value: l2AuthContextId,
     httpOnly: true,
     sameSite: 'lax',
@@ -676,7 +675,7 @@ export async function enableTradingAuthAction(
     if (!l2AuthContextId) {
       return { error: DEFAULT_ERROR_MESSAGE, data: null }
     }
-    await persistL2AuthCookie(l2AuthContextId)
+    await persistL2AuthCookie(user.id, l2AuthContextId)
 
     const updatedAt = new Date().toISOString()
     return {

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useUserOpenOrdersQuery.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useUserOpenOrdersQuery.ts
@@ -76,10 +76,10 @@ export async function fetchUserOpenOrders({
 
   const payload = await response.json()
   if (Array.isArray(payload)) {
-    return { data: payload, next_cursor: 'LTE=' }
+    return { data: payload, next_cursor: '' }
   }
   return {
     data: Array.isArray(payload?.data) ? payload.data : [],
-    next_cursor: typeof payload?.next_cursor === 'string' ? payload.next_cursor : 'LTE=',
+    next_cursor: typeof payload?.next_cursor === 'string' ? payload.next_cursor : '',
   }
 }

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
@@ -26,6 +26,12 @@ interface PortfolioOpenOrdersListProps {
 
 type OpenTradeRequirements = ReturnType<typeof useTradingOnboarding>['openTradeRequirements']
 
+interface LoadMoreStateValue {
+  key: string
+  infiniteScrollError: string | null
+  isLoadingMore: boolean
+}
+
 function useOpenOrdersFilterState(userAddress: string) {
   const [searchQuery, setSearchQuery] = useState('')
   const debouncedSearchQuery = useDebounce(searchQuery, 300)
@@ -50,6 +56,27 @@ function useOpenOrdersFilterState(userAddress: string) {
     apiSearchFilters,
     apiSearchKey,
     openOrdersQueryKey,
+  }
+}
+
+function useLoadMoreState(loadMoreScopeKey: string) {
+  const [loadMoreState, setLoadMoreState] = useState<LoadMoreStateValue>({
+    key: loadMoreScopeKey,
+    infiniteScrollError: null,
+    isLoadingMore: false,
+  })
+  const scopedLoadMoreState = loadMoreState.key === loadMoreScopeKey
+    ? loadMoreState
+    : {
+        key: loadMoreScopeKey,
+        infiniteScrollError: null,
+        isLoadingMore: false,
+      }
+
+  return {
+    infiniteScrollError: scopedLoadMoreState.infiniteScrollError,
+    isLoadingMore: scopedLoadMoreState.isLoadingMore,
+    setLoadMoreState,
   }
 }
 
@@ -152,14 +179,54 @@ function useCancelAllOpenOrders({
   return { isCancellingAll, handleCancelAll }
 }
 
+function useLoadMoreOpenOrders({
+  fetchNextPage,
+  loadMoreErrorMessage,
+  loadMoreScopeKey,
+  setLoadMoreState,
+}: {
+  fetchNextPage: () => Promise<unknown>
+  loadMoreErrorMessage: string
+  loadMoreScopeKey: string
+  setLoadMoreState: (value: LoadMoreStateValue) => void
+}) {
+  return useCallback(() => {
+    setLoadMoreState({
+      key: loadMoreScopeKey,
+      infiniteScrollError: null,
+      isLoadingMore: true,
+    })
+
+    fetchNextPage()
+      .then(() => {
+        setLoadMoreState({
+          key: loadMoreScopeKey,
+          infiniteScrollError: null,
+          isLoadingMore: false,
+        })
+      })
+      .catch((error: any) => {
+        setLoadMoreState({
+          key: loadMoreScopeKey,
+          infiniteScrollError: error?.name === 'AbortError' ? null : error?.message || loadMoreErrorMessage,
+          isLoadingMore: false,
+        })
+      })
+  }, [fetchNextPage, loadMoreErrorMessage, loadMoreScopeKey, setLoadMoreState])
+}
+
 function useInfiniteScrollSentinel({
   hasNextPage,
+  infiniteScrollError,
   isFetchingNextPage,
-  fetchNextPage,
+  isLoadingMore,
+  loadMoreOpenOrders,
 }: {
   hasNextPage: boolean
+  infiniteScrollError: string | null
   isFetchingNextPage: boolean
-  fetchNextPage: () => Promise<unknown>
+  isLoadingMore: boolean
+  loadMoreOpenOrders: () => void
 }): { loadMoreRef: RefObject<HTMLDivElement | null> } {
   const loadMoreRef = useRef<HTMLDivElement | null>(null)
 
@@ -170,8 +237,8 @@ function useInfiniteScrollSentinel({
 
     const observer = new IntersectionObserver((entries) => {
       const [entry] = entries
-      if (entry?.isIntersecting && !isFetchingNextPage) {
-        void fetchNextPage()
+      if (entry?.isIntersecting && !isFetchingNextPage && !isLoadingMore && !infiniteScrollError) {
+        loadMoreOpenOrders()
       }
     }, { rootMargin: '200px' })
 
@@ -179,7 +246,7 @@ function useInfiniteScrollSentinel({
     return function disconnectLoadMoreObserver() {
       observer.disconnect()
     }
-  }, [fetchNextPage, hasNextPage, isFetchingNextPage])
+  }, [hasNextPage, infiniteScrollError, isFetchingNextPage, isLoadingMore, loadMoreOpenOrders])
 
   return { loadMoreRef }
 }
@@ -223,6 +290,8 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
     apiSearchKey,
     openOrdersQueryKey,
   } = useOpenOrdersFilterState(userAddress)
+  const loadMoreScopeKey = `${userAddress}:${apiSearchKey}:${searchQuery}:${sortBy}`
+  const { infiniteScrollError, isLoadingMore, setLoadMoreState } = useLoadMoreState(loadMoreScopeKey)
 
   const {
     status,
@@ -263,10 +332,19 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
     openTradeRequirements,
   })
 
+  const loadMoreOpenOrders = useLoadMoreOpenOrders({
+    fetchNextPage,
+    loadMoreErrorMessage: t('Failed to load more open orders'),
+    loadMoreScopeKey,
+    setLoadMoreState,
+  })
+
   const { loadMoreRef } = useInfiniteScrollSentinel({
     hasNextPage,
+    infiniteScrollError,
     isFetchingNextPage,
-    fetchNextPage,
+    isLoadingMore,
+    loadMoreOpenOrders,
   })
 
   const emptyText = userAddress
@@ -302,7 +380,10 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
         isLoading={loading}
         emptyText={emptyText}
         isFetchingNextPage={isFetchingNextPage}
+        infiniteScrollError={infiniteScrollError}
+        isLoadingMore={isLoadingMore}
         loadMoreRef={loadMoreRef}
+        onRetryLoadMore={loadMoreOpenOrders}
       />
     </div>
   )

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersTable.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersTable.tsx
@@ -10,7 +10,10 @@ interface PortfolioOpenOrdersTableProps {
   isLoading: boolean
   emptyText: string
   isFetchingNextPage: boolean
+  infiniteScrollError: string | null
+  isLoadingMore: boolean
   loadMoreRef: RefObject<HTMLDivElement | null>
+  onRetryLoadMore: () => void
 }
 
 export default function PortfolioOpenOrdersTable({
@@ -18,7 +21,10 @@ export default function PortfolioOpenOrdersTable({
   isLoading,
   emptyText,
   isFetchingNextPage,
+  infiniteScrollError,
+  isLoadingMore,
   loadMoreRef,
+  onRetryLoadMore,
 }: PortfolioOpenOrdersTableProps) {
   const t = useExtracted()
   const hasOrders = orders.length > 0
@@ -53,10 +59,21 @@ export default function PortfolioOpenOrdersTable({
         {orders.map(order => (
           <PortfolioOpenOrdersRow key={order.id} order={order} />
         ))}
-        {isFetchingNextPage && (
+        {(isFetchingNextPage || isLoadingMore) && (
           <tr>
             <td colSpan={colSpan} className="py-3 text-center text-xs text-muted-foreground">
-              {t('Loading more...')}
+              {t('Loading more open orders...')}
+            </td>
+          </tr>
+        )}
+        {infiniteScrollError && (
+          <tr>
+            <td colSpan={colSpan} className="py-3 text-center text-xs text-destructive">
+              {infiniteScrollError}
+              {' '}
+              <button type="button" onClick={onRetryLoadMore} className="underline underline-offset-2">
+                {t('Retry')}
+              </button>
             </td>
           </tr>
         )}

--- a/src/app/[locale]/(platform)/portfolio/_hooks/usePortfolioOpenOrdersQuery.ts
+++ b/src/app/[locale]/(platform)/portfolio/_hooks/usePortfolioOpenOrdersQuery.ts
@@ -30,11 +30,11 @@ async function fetchOpenOrders({
   }
   const payload = await response.json()
   if (Array.isArray(payload)) {
-    return { data: payload, next_cursor: 'LTE=' }
+    return { data: payload, next_cursor: '' }
   }
   return {
     data: Array.isArray(payload?.data) ? payload.data : [],
-    next_cursor: typeof payload?.next_cursor === 'string' ? payload.next_cursor : 'LTE=',
+    next_cursor: typeof payload?.next_cursor === 'string' ? payload.next_cursor : '',
   }
 }
 

--- a/src/app/api/events/[slug]/open-orders/route.ts
+++ b/src/app/api/events/[slug]/open-orders/route.ts
@@ -50,7 +50,7 @@ export async function GET(
     }
 
     if (!user) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ data: [], next_cursor: '' })
     }
 
     if (!CLOB_URL) {
@@ -72,7 +72,7 @@ export async function GET(
 
     const { data: marketMetadata, error: marketError } = await EventRepository.getEventMarketMetadata(slug)
     if (marketError || !marketMetadata || marketMetadata.length === 0) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ data: [], next_cursor: '' })
     }
 
     const targetMarkets = conditionId
@@ -80,14 +80,13 @@ export async function GET(
       : marketMetadata
 
     if (!targetMarkets.length) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ data: [], next_cursor: '' })
     }
 
     const { marketMap, outcomeMap } = buildMarketLookups(targetMarkets)
 
     const { data: clobOrders, next_cursor } = await fetchClobOpenOrders({
       market: conditionId,
-      makerAddress: user.deposit_wallet_address ?? undefined,
       userAddress: user.address,
       auth: tradingAuth.clob,
       nextCursor,
@@ -148,13 +147,11 @@ function buildMarketLookups(markets: Array<{
 
 async function fetchClobOpenOrders({
   market,
-  makerAddress,
   auth,
   userAddress,
   nextCursor,
 }: {
   market?: string
-  makerAddress?: string
   auth: { key: string, secret: string, passphrase: string }
   userAddress: string
   nextCursor?: string
@@ -166,9 +163,6 @@ async function fetchClobOpenOrders({
   const searchParams = new URLSearchParams()
   if (market) {
     searchParams.set('market', market)
-  }
-  if (makerAddress) {
-    searchParams.set('maker_address', makerAddress)
   }
   if (nextCursor) {
     searchParams.set('next_cursor', nextCursor)

--- a/src/app/api/open-orders/route.ts
+++ b/src/app/api/open-orders/route.ts
@@ -42,7 +42,7 @@ export async function GET(request: Request) {
   try {
     const user = await UserRepository.getCurrentUser({ minimal: true })
     if (!user) {
-      return NextResponse.json({ data: [], next_cursor: 'LTE=' })
+      return NextResponse.json({ data: [], next_cursor: '' })
     }
 
     if (!CLOB_URL) {
@@ -64,7 +64,6 @@ export async function GET(request: Request) {
     const { data: clobOrders, next_cursor } = await fetchClobOpenOrders({
       auth: tradingAuth.clob,
       userAddress: user.address,
-      makerAddress: user.deposit_wallet_address as string,
       id: idFilter,
       market: marketFilter,
       assetId: assetIdFilter,
@@ -100,7 +99,6 @@ export async function GET(request: Request) {
 async function fetchClobOpenOrders({
   auth,
   userAddress,
-  makerAddress,
   id,
   market,
   assetId,
@@ -108,16 +106,12 @@ async function fetchClobOpenOrders({
 }: {
   auth: { key: string, secret: string, passphrase: string }
   userAddress: string
-  makerAddress?: string
   id?: string
   market?: string
   assetId?: string
   nextCursor?: string
 }): Promise<{ data: ClobOpenOrder[], next_cursor: string }> {
   const params = new URLSearchParams()
-  if (makerAddress) {
-    params.set('maker_address', makerAddress)
-  }
   if (id) {
     params.set('id', id)
   }

--- a/src/lib/clob-open-orders.ts
+++ b/src/lib/clob-open-orders.ts
@@ -143,7 +143,7 @@ function clampClobNumber(value: number, min: number, max: number) {
 
 export function normalizeClobOpenOrdersResponse<TOrder>(result: unknown) {
   if (Array.isArray(result)) {
-    return { data: result as TOrder[], next_cursor: 'LTE=' }
+    return { data: result as TOrder[], next_cursor: '' }
   }
 
   if (result && typeof result === 'object') {
@@ -152,10 +152,10 @@ export function normalizeClobOpenOrdersResponse<TOrder>(result: unknown) {
       : []
     const next_cursor = typeof (result as { next_cursor?: unknown }).next_cursor === 'string'
       ? (result as { next_cursor: string }).next_cursor
-      : 'LTE='
+      : ''
 
     return { data, next_cursor }
   }
 
-  return { data: [] as TOrder[], next_cursor: 'LTE=' }
+  return { data: [] as TOrder[], next_cursor: '' }
 }

--- a/src/lib/l2-auth-context.ts
+++ b/src/lib/l2-auth-context.ts
@@ -4,11 +4,12 @@ import { generateRandomString } from 'better-auth/crypto'
 const L2_AUTH_CONTEXT_PREFIX = 'l2_'
 export const L2_AUTH_CONTEXT_COOKIE_NAME = 'kuest_l2_auth_context'
 export const L2_AUTH_CONTEXT_COOKIE_NAME_SECURE = '__Secure-kuest_l2_auth_context'
-export const L2_AUTH_CONTEXT_COOKIE_NAMES = [
+const L2_AUTH_CONTEXT_COOKIE_NAMES = [
   L2_AUTH_CONTEXT_COOKIE_NAME_SECURE,
   L2_AUTH_CONTEXT_COOKIE_NAME,
 ] as const
 
+const L2_AUTH_CONTEXT_USER_COOKIE_SUFFIX_LENGTH = 24
 const L2_AUTH_CONTEXT_TTL_MS = 30 * 24 * 60 * 60 * 1000
 export const L2_AUTH_CONTEXT_TTL_SECONDS = Math.floor(L2_AUTH_CONTEXT_TTL_MS / 1000)
 export const L2_AUTH_CONTEXT_MAX_PER_USER = 20
@@ -29,6 +30,42 @@ export function isValidL2AuthContextId(value: unknown): value is string {
 
 export function hashL2AuthContextId(contextId: string) {
   return createHash('sha256').update(contextId).digest('hex')
+}
+
+function l2AuthContextUserCookieSuffix(userId: string) {
+  return createHash('sha256')
+    .update(userId)
+    .digest('hex')
+    .slice(0, L2_AUTH_CONTEXT_USER_COOKIE_SUFFIX_LENGTH)
+}
+
+export function getL2AuthContextCookieName({
+  secure,
+  userId,
+}: {
+  secure: boolean
+  userId?: string | null
+}) {
+  const baseName = secure ? L2_AUTH_CONTEXT_COOKIE_NAME_SECURE : L2_AUTH_CONTEXT_COOKIE_NAME
+  const normalizedUserId = userId?.trim()
+  if (!normalizedUserId) {
+    return baseName
+  }
+
+  return `${baseName}_${l2AuthContextUserCookieSuffix(normalizedUserId)}`
+}
+
+export function getL2AuthContextCookieNames(userId?: string | null) {
+  const normalizedUserId = userId?.trim()
+  if (!normalizedUserId) {
+    return [...L2_AUTH_CONTEXT_COOKIE_NAMES]
+  }
+
+  return [
+    getL2AuthContextCookieName({ secure: true, userId: normalizedUserId }),
+    getL2AuthContextCookieName({ secure: false, userId: normalizedUserId }),
+    ...L2_AUTH_CONTEXT_COOKIE_NAMES,
+  ]
 }
 
 export function createL2AuthContextRecord(contextId: string, now = Date.now()): L2AuthContextRecord {

--- a/src/lib/trading-auth/server.ts
+++ b/src/lib/trading-auth/server.ts
@@ -232,7 +232,7 @@ export async function getUserTradingAuthSecrets(
     return null
   }
 
-  if (options.requireL2Context !== false) {
+  if (options.requireL2Context === true) {
     const l2Validation = await validateL2AuthContext(settings)
     if (l2Validation.contextsChanged) {
       await withLockedUserSettings(userId, async ({ settings: lockedSettings, tx }) => {

--- a/src/lib/trading-auth/server.ts
+++ b/src/lib/trading-auth/server.ts
@@ -9,9 +9,9 @@ import { decryptSecret, encryptSecret } from '@/lib/encryption'
 import {
   createL2AuthContextId,
   createL2AuthContextRecord,
+  getL2AuthContextCookieNames,
   hashL2AuthContextId,
   isValidL2AuthContextId,
-  L2_AUTH_CONTEXT_COOKIE_NAMES,
   L2_AUTH_CONTEXT_MAX_PER_USER,
   normalizeL2AuthContextRecords,
 } from '@/lib/l2-auth-context'
@@ -99,7 +99,7 @@ function decodeEntry(entry?: TradingAuthSecretEntry | null) {
   }
 }
 
-async function getL2AuthContextIdFromRequestCookies() {
+async function getL2AuthContextIdFromRequestCookies(userId: string) {
   let cookieStore: Awaited<ReturnType<typeof cookies>>
   try {
     cookieStore = await cookies()
@@ -108,7 +108,7 @@ async function getL2AuthContextIdFromRequestCookies() {
     return null
   }
 
-  for (const cookieName of L2_AUTH_CONTEXT_COOKIE_NAMES) {
+  for (const cookieName of getL2AuthContextCookieNames(userId)) {
     const value = cookieStore.get(cookieName)?.value
     if (isValidL2AuthContextId(value)) {
       return value
@@ -126,7 +126,7 @@ function upsertAndPruneL2AuthContexts(current: unknown, contextId: string, now =
   return [nextContext, ...deduped].slice(0, L2_AUTH_CONTEXT_MAX_PER_USER)
 }
 
-async function validateL2AuthContext(settings: Record<string, any>) {
+async function validateL2AuthContext(userId: string, settings: Record<string, any>) {
   const tradingAuth = (settings.tradingAuth ?? {}) as TradingAuthSecretSettings
   const hasSecrets = hasStoredTradingCredentials(tradingAuth)
 
@@ -141,7 +141,7 @@ async function validateL2AuthContext(settings: Record<string, any>) {
     return { valid: false, contextsChanged, normalizedContexts }
   }
 
-  const contextId = await getL2AuthContextIdFromRequestCookies()
+  const contextId = await getL2AuthContextIdFromRequestCookies(userId)
   if (!contextId) {
     return { valid: false, contextsChanged, normalizedContexts }
   }
@@ -232,8 +232,8 @@ export async function getUserTradingAuthSecrets(
     return null
   }
 
-  if (options.requireL2Context === true) {
-    const l2Validation = await validateL2AuthContext(settings)
+  if (options.requireL2Context !== false) {
+    const l2Validation = await validateL2AuthContext(userId, settings)
     if (l2Validation.contextsChanged) {
       await withLockedUserSettings(userId, async ({ settings: lockedSettings, tx }) => {
         const lockedTradingAuth = (lockedSettings as any)?.tradingAuth as TradingAuthSecretSettings | undefined

--- a/tests/unit/l2AuthContext.test.ts
+++ b/tests/unit/l2AuthContext.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getL2AuthContextCookieName,
+  getL2AuthContextCookieNames,
+  L2_AUTH_CONTEXT_COOKIE_NAME,
+  L2_AUTH_CONTEXT_COOKIE_NAME_SECURE,
+} from '@/lib/l2-auth-context'
+
+describe('l2 auth context cookies', () => {
+  it('scopes context cookies by user before falling back to legacy names', () => {
+    const firstUserCookie = getL2AuthContextCookieName({ secure: false, userId: 'user-a' })
+    const secondUserCookie = getL2AuthContextCookieName({ secure: false, userId: 'user-b' })
+
+    expect(firstUserCookie).toMatch(/^kuest_l2_auth_context_[a-f0-9]{24}$/)
+    expect(secondUserCookie).toMatch(/^kuest_l2_auth_context_[a-f0-9]{24}$/)
+    expect(firstUserCookie).not.toBe(secondUserCookie)
+
+    expect(getL2AuthContextCookieNames('user-a')).toEqual([
+      getL2AuthContextCookieName({ secure: true, userId: 'user-a' }),
+      firstUserCookie,
+      L2_AUTH_CONTEXT_COOKIE_NAME_SECURE,
+      L2_AUTH_CONTEXT_COOKIE_NAME,
+    ])
+  })
+
+  it('keeps legacy cookie names when no user is available', () => {
+    expect(getL2AuthContextCookieNames()).toEqual([
+      L2_AUTH_CONTEXT_COOKIE_NAME_SECURE,
+      L2_AUTH_CONTEXT_COOKIE_NAME,
+    ])
+  })
+})

--- a/tests/unit/openOrdersRoute.test.ts
+++ b/tests/unit/openOrdersRoute.test.ts
@@ -173,11 +173,11 @@ describe('open orders routes', () => {
           },
         },
       ],
-      next_cursor: 'LTE=',
+      next_cursor: '',
     })
 
     expect(mocks.fetch).toHaveBeenCalledWith(
-      'https://clob.local/data/orders?maker_address=0x0000000000000000000000000000000000000002&market=cond-1&next_cursor=cursor-1',
+      'https://clob.local/data/orders?market=cond-1&next_cursor=cursor-1',
       expect.objectContaining({
         method: 'GET',
       }),
@@ -274,11 +274,11 @@ describe('open orders routes', () => {
           },
         },
       ],
-      next_cursor: 'LTE=',
+      next_cursor: '',
     })
 
     expect(mocks.fetch).toHaveBeenCalledWith(
-      'https://clob.local/data/orders?market=cond-2&maker_address=0x0000000000000000000000000000000000000004&next_cursor=cursor-2',
+      'https://clob.local/data/orders?market=cond-2&next_cursor=cursor-2',
       expect.objectContaining({
         method: 'GET',
       }),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make L2 auth context validation opt-in and scope L2 cookies per user. This lowers overhead on non‑L2 flows and prevents cross‑user context collisions in shared sessions.

- **Bug Fixes**
  - Validate L2 context only when `options.requireL2Context` is true in `getUserTradingAuthSecrets` (default no longer enforces L2).
  - Scope L2 auth context cookies by user ID via `getL2AuthContextCookieName`/`getL2AuthContextCookieNames` with legacy fallback; `deposit-wallet` writes per‑user cookies and the server reads user‑scoped names first.
  - Performance: fewer L2 validations and settings locks; avoids unnecessary updates from cookie collisions.

- **Migration**
  - If your feature needs L2, call `getUserTradingAuthSecrets({ requireL2Context: true })`.

<sup>Written for commit d69977149fbbdab1322bdd4e333133b13e56341c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1070?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

