### PR TITLE
fix: activity redeem outcome and withdraw

### DIFF
--- a/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
@@ -20,6 +20,8 @@ export default function PublicActivityRow({ activity }: PublicActivityRowProps) 
   const outcomeText = activity.outcome?.text || 'Outcome'
   const outcomeIsYes = outcomeText.toLowerCase().includes('yes') || activity.outcome?.index === 0
   const outcomeColor = outcomeIsYes ? 'bg-yes/15 text-yes' : 'bg-no/15 text-no'
+  const showOutcomeBadge = (variant === 'buy' || variant === 'sell' || variant === 'redeem')
+    && outcomeText !== 'Outcome'
   const imageUrl = activity.market.icon_url
     ? (
         activity.market.icon_url.startsWith('http')
@@ -96,11 +98,15 @@ export default function PublicActivityRow({ activity }: PublicActivityRowProps) 
               {activity.market.title}
             </AppLink>
             <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-              {(variant === 'buy' || variant === 'sell') && (
+              {showOutcomeBadge && (
                 <span className={cn('inline-flex items-center gap-1 rounded-sm px-1.5 py-0.5 text-xs font-semibold', outcomeColor)}>
                   {outcomeText}
-                  {' '}
-                  {priceText}
+                  {(variant === 'buy' || variant === 'sell') && priceText && (
+                    <>
+                      {' '}
+                      {priceText}
+                    </>
+                  )}
                 </span>
               )}
               {sharesText && <span>{sharesText}</span>}

--- a/src/app/[locale]/admin/events/calendar/_components/AdminCreateEventForm.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/AdminCreateEventForm.tsx
@@ -59,7 +59,7 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { createPublicClient, formatUnits, getAddress, http, isAddress, keccak256, stringToHex, toHex } from 'viem'
+import { createPublicClient, formatUnits, getAddress, http, isAddress, keccak256, stringToHex } from 'viem'
 import { usePublicClient, useWalletClient } from 'wagmi'
 import AppLink from '@/components/AppLink'
 import EventIconImage from '@/components/EventIconImage'
@@ -152,6 +152,7 @@ import { CheckIndicator, OutcomeStateDot, SignatureTxIndicator } from './admin-c
 import {
   areCategoryItemsEqual,
   areOptionItemsEqual,
+  buildRpcTransactionRequest,
   buildStepErrors,
   createInitialForm,
   createOption,
@@ -3768,12 +3769,13 @@ function useAdminCreateEventForm({
               throw sendError
             }
 
-            const txRequest = {
+            const txRequest = buildRpcTransactionRequest({
               from: senderAddress,
               to: toAddress,
               data: tx.data as `0x${string}`,
-              value: toHex(BigInt(tx.value || '0')),
-            }
+              value: BigInt(tx.value || '0'),
+              ...(overrides ?? {}),
+            })
             const rpcHash = await runWithSignaturePrompt(
               () => activeWalletClient.request({
                 method: 'eth_sendTransaction',

--- a/src/app/[locale]/admin/events/calendar/_components/admin-create-event-form-utils.ts
+++ b/src/app/[locale]/admin/events/calendar/_components/admin-create-event-form-utils.ts
@@ -1,3 +1,4 @@
+import type { Hex } from 'viem'
 import type {
   AiRulesResponse,
   AiValidationIssue,
@@ -28,6 +29,7 @@ import type {
 import type { AdminSportsFormState, AdminSportsTeamHostStatus } from '@/lib/admin-sports-create'
 import type { EventCreationDraftRecord } from '@/lib/db/queries/event-creations'
 import type { EventCreationAssetRef, EventCreationRecurrenceUnit } from '@/lib/event-creation'
+import { toHex } from 'viem'
 import { buildAdminSportsStepErrors, isSportsMainCategory } from '@/lib/admin-sports-create'
 import { normalizeDateTimeLocalValue } from '@/lib/datetime-local'
 import { slugifyEventCreationValue as slugify } from '@/lib/event-creation'
@@ -716,7 +718,40 @@ export function isAlreadyInitializedError(message: string): boolean {
 }
 
 export function isBigIntSerializationError(message: string): boolean {
-  return /json\.stringify.*bigint|serialize bigint/i.test(message)
+  return /json\.stringify.*bigint|serialize.*bigint|failed to parse string to bigint|cannot convert .* to a bigint/i.test(message)
+}
+
+export function buildRpcTransactionRequest(params: {
+  from: `0x${string}`
+  to: `0x${string}`
+  data: `0x${string}`
+  value?: bigint
+  maxFeePerGas?: bigint
+  maxPriorityFeePerGas?: bigint
+}) {
+  const request: {
+    from: `0x${string}`
+    to: `0x${string}`
+    data: `0x${string}`
+    value: Hex
+    maxFeePerGas?: Hex
+    maxPriorityFeePerGas?: Hex
+  } = {
+    from: params.from,
+    to: params.to,
+    data: params.data,
+    value: toHex(params.value ?? 0n),
+  }
+
+  if (typeof params.maxFeePerGas === 'bigint') {
+    request.maxFeePerGas = toHex(params.maxFeePerGas)
+  }
+
+  if (typeof params.maxPriorityFeePerGas === 'bigint') {
+    request.maxPriorityFeePerGas = toHex(params.maxPriorityFeePerGas)
+  }
+
+  return request
 }
 
 export function mapSignatureFlowErrorForUser(message: string): string {

--- a/tests/unit/adminCreateEventFormUtils.test.ts
+++ b/tests/unit/adminCreateEventFormUtils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildRpcTransactionRequest,
+  isBigIntSerializationError,
+  mapSignatureFlowErrorForUser,
+} from '@/app/[locale]/admin/events/calendar/_components/admin-create-event-form-utils'
+
+describe('admin create event form utils', () => {
+  describe('isBigIntSerializationError', () => {
+    it('detects provider bigint serialization failures', () => {
+      expect(isBigIntSerializationError('Do not know how to serialize a BigInt')).toBe(true)
+      expect(isBigIntSerializationError('Failed to parse String to BigInt')).toBe(true)
+      expect(isBigIntSerializationError('Cannot convert 78.000000075 to a BigInt')).toBe(true)
+    })
+
+    it('ignores unrelated errors', () => {
+      expect(isBigIntSerializationError('insufficient funds for gas * price + value')).toBe(false)
+    })
+  })
+
+  describe('buildRpcTransactionRequest', () => {
+    it('serializes value and fee overrides as hex for eth_sendTransaction', () => {
+      expect(buildRpcTransactionRequest({
+        from: '0x1111111111111111111111111111111111111111',
+        to: '0x2222222222222222222222222222222222222222',
+        data: '0x1234',
+        value: 0n,
+        maxFeePerGas: 78_000_000_075n,
+        maxPriorityFeePerGas: 78_000_000_000n,
+      })).toEqual({
+        from: '0x1111111111111111111111111111111111111111',
+        to: '0x2222222222222222222222222222222222222222',
+        data: '0x1234',
+        value: '0x0',
+        maxFeePerGas: '0x1229298c4b',
+        maxPriorityFeePerGas: '0x1229298c00',
+      })
+    })
+  })
+
+  describe('mapSignatureFlowErrorForUser', () => {
+    it('maps bigint parsing failures to the wallet provider guidance', () => {
+      expect(mapSignatureFlowErrorForUser('Failed to parse String to BigInt'))
+        .toBe('Could not send transaction with this wallet provider. Please retry or switch wallet.')
+    })
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes outcome badges for redeem activities and makes admin event creation transactions wallet-compatible by hex-encoding BigInt fields. This reduces failed market creation attempts and shows correct outcome info in profiles.

- **Bug Fixes**
  - Activity feed: show outcome badge for `redeem` and hide price on redeem.
  - Admin event creation: hex-encode BigInt fields when calling `eth_sendTransaction` to avoid provider serialization errors; improved user-facing error mapping.
  - Affected APIs: JSON-RPC `eth_sendTransaction` now receives hex strings for `value`, `maxFeePerGas`, and `maxPriorityFeePerGas`.
  - Performance: neutral runtime; fewer failed submissions/retries.

- **Refactors**
  - Added `buildRpcTransactionRequest` util (via `viem` `toHex`) and updated `AdminCreateEventForm` to use it; supports optional EIP-1559 fee overrides.
  - Added unit tests for serialization and error mapping.

<sup>Written for commit c5af8ab461227da7df4f928c776ab2c2ee0f1e07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1072?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

