### PR TITLE
fix: derive market status from metadata

### DIFF
--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -640,12 +640,11 @@ async function fetchMetadata(metadataHash: string) {
 }
 
 async function syncEventHiddenFromArchivedMarkets(eventId: string): Promise<boolean> {
-  const [archivedMarketRows, eventRows] = await Promise.all([
+  const [marketRows, eventRows] = await Promise.all([
     db
-      .select({ condition_id: marketsTable.condition_id })
+      .select({ metadata: marketsTable.metadata })
       .from(marketsTable)
-      .where(and(eq(marketsTable.event_id, eventId), eq(marketsTable.archived, true)))
-      .limit(1),
+      .where(eq(marketsTable.event_id, eventId)),
     db
       .select({ is_hidden: eventsTable.is_hidden })
       .from(eventsTable)
@@ -653,7 +652,9 @@ async function syncEventHiddenFromArchivedMarkets(eventId: string): Promise<bool
       .limit(1),
   ])
 
-  const shouldHide = archivedMarketRows.length > 0
+  const shouldHide = marketRows.some(row =>
+    resolveStoredMetadataStatusFlag(row.metadata, ['archived'], false),
+  )
   const currentHidden = Boolean(eventRows[0]?.is_hidden)
 
   if (currentHidden === shouldHide) {
@@ -1087,8 +1088,7 @@ async function processMarketData(
       condition_id: marketsTable.condition_id,
       event_id: marketsTable.event_id,
       is_resolved: marketsTable.is_resolved,
-      accepting_orders: marketsTable.accepting_orders,
-      archived: marketsTable.archived,
+      metadata: marketsTable.metadata,
       updated_at: marketsTable.updated_at,
       slug: marketsTable.slug,
     })
@@ -1102,6 +1102,12 @@ async function processMarketData(
     true,
   )
   const archivedFlag = resolveMetadataStatusFlag(metadata, ['archived'], false)
+  const existingAcceptingOrdersFlag = existingMarket
+    ? resolveStoredMetadataStatusFlag(existingMarket.metadata, ['acceptingOrders', 'accepting_orders'], true)
+    : true
+  const existingArchivedFlag = existingMarket
+    ? resolveStoredMetadataStatusFlag(existingMarket.metadata, ['archived'], false)
+    : false
 
   const marketAlreadyExists = Boolean(existingMarket)
   const eventIdForStatusUpdate = existingMarket?.event_id ?? eventId
@@ -1114,14 +1120,14 @@ async function processMarketData(
     || incomingUpdatedAtMs > existingUpdatedAtMs
     || existingMarket.event_id !== eventId
     || existingMarket.is_resolved !== market.resolved
-    || existingMarket.accepting_orders !== acceptingOrdersFlag
-    || existingMarket.archived !== archivedFlag
+    || existingAcceptingOrdersFlag !== acceptingOrdersFlag
+    || existingArchivedFlag !== archivedFlag
 
   const eventIdsForHiddenSync = new Set<string>()
   if (existingMarket) {
-    const archivedStateChanged = existingMarket.archived !== archivedFlag
+    const archivedStateChanged = existingArchivedFlag !== archivedFlag
     const eventChanged = existingMarket.event_id !== eventId
-    if (archivedStateChanged || (eventChanged && (existingMarket.archived || archivedFlag))) {
+    if (archivedStateChanged || (eventChanged && (existingArchivedFlag || archivedFlag))) {
       eventIdsForHiddenSync.add(existingMarket.event_id)
       eventIdsForHiddenSync.add(eventId)
     }
@@ -1226,8 +1232,6 @@ async function processMarketData(
     event_id: eventId,
     is_resolved: market.resolved,
     is_active: !market.resolved && !archivedFlag,
-    accepting_orders: acceptingOrdersFlag,
-    archived: archivedFlag,
     title: String(metadata.name),
     slug: String(metadata.slug),
     short_title: normalizeStringField(metadata.short_title),
@@ -2183,6 +2187,36 @@ function resolveMetadataStatusFlag(
   }
 
   return defaultValue
+}
+
+function parseStoredMarketMetadata(value: unknown): Record<string, any> | null {
+  if (!value) {
+    return null
+  }
+
+  if (typeof value === 'object') {
+    return value as Record<string, any>
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(value)
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, any> : null
+  }
+  catch {
+    return null
+  }
+}
+
+function resolveStoredMetadataStatusFlag(
+  value: unknown,
+  keys: string[],
+  defaultValue: boolean,
+): boolean {
+  return resolveMetadataStatusFlag(parseStoredMarketMetadata(value), keys, defaultValue)
 }
 
 function hashStringToHex(value: string) {

--- a/src/lib/db/migrations/2026_05_28_001_accepting_orders_status.sql
+++ b/src/lib/db/migrations/2026_05_28_001_accepting_orders_status.sql
@@ -1,4 +1,0 @@
--- Status flags are derived from markets.metadata at runtime.
--- Keeping this migration as a no-op avoids blocking Vercel/Supabase deploys
--- on large markets tables that cannot acquire ALTER TABLE locks quickly.
-SELECT 1;

--- a/src/lib/db/migrations/2026_05_28_001_accepting_orders_status.sql
+++ b/src/lib/db/migrations/2026_05_28_001_accepting_orders_status.sql
@@ -1,5 +1,4 @@
-ALTER TABLE markets
-  ADD COLUMN IF NOT EXISTS accepting_orders BOOLEAN NOT NULL DEFAULT TRUE;
-
-ALTER TABLE markets
-  ADD COLUMN IF NOT EXISTS archived BOOLEAN NOT NULL DEFAULT FALSE;
+-- Status flags are derived from markets.metadata at runtime.
+-- Keeping this migration as a no-op avoids blocking Vercel/Supabase deploys
+-- on large markets tables that cannot acquire ALTER TABLE locks quickly.
+SELECT 1;

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -92,6 +92,78 @@ function normalizeSportsMetadataText(value: string | null | undefined) {
     ?? ''
 }
 
+function parseMarketMetadata(value: unknown): Record<string, any> | null {
+  if (!value) {
+    return null
+  }
+
+  if (typeof value === 'object') {
+    return value as Record<string, any>
+  }
+
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(value)
+    return parsed && typeof parsed === 'object' ? parsed as Record<string, any> : null
+  }
+  catch {
+    return null
+  }
+}
+
+function normalizeOptionalBooleanField(value: unknown): boolean | null {
+  if (typeof value === 'boolean') {
+    return value
+  }
+
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value !== 0
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) {
+      return true
+    }
+    if (['false', '0', 'no', 'n', 'off'].includes(normalized)) {
+      return false
+    }
+  }
+
+  return null
+}
+
+function resolveMetadataStatusFlag(
+  metadata: Record<string, any> | null,
+  keys: string[],
+  defaultValue: boolean,
+): boolean {
+  const roots = [
+    metadata,
+    metadata?.sports?.market,
+    metadata?.event,
+    metadata?.sports?.event,
+  ]
+
+  for (const root of roots) {
+    if (!root || typeof root !== 'object') {
+      continue
+    }
+
+    for (const key of keys) {
+      const value = normalizeOptionalBooleanField((root as Record<string, unknown>)[key])
+      if (value !== null) {
+        return value
+      }
+    }
+  }
+
+  return defaultValue
+}
+
 function isMoneylineMarketForAdminList(input: {
   sports_market_type: string | null
   short_title: string | null
@@ -873,13 +945,18 @@ function eventResource(
     const probability = marketDisplayPrice * 100
     const normalizedCurrentVolume24h = Number(market.volume_24h || 0)
     const normalizedTotalVolume = Number(market.volume || 0)
+    const marketMetadata = parseMarketMetadata(market.metadata)
 
     return {
       ...market,
       neg_risk: Boolean(market.neg_risk),
       neg_risk_other: Boolean(market.neg_risk_other),
-      accepting_orders: market.accepting_orders !== false,
-      archived: Boolean(market.archived),
+      accepting_orders: resolveMetadataStatusFlag(
+        marketMetadata,
+        ['acceptingOrders', 'accepting_orders'],
+        true,
+      ),
+      archived: resolveMetadataStatusFlag(marketMetadata, ['archived'], false),
       sports_market_type: market.sports?.sports_market_type ?? null,
       sports_game_start_time: market.sports?.sports_game_start_time?.toISOString?.() ?? null,
       sports_start_time: market.sports?.sports_start_time?.toISOString?.() ?? null,

--- a/src/lib/db/schema/events/tables.ts
+++ b/src/lib/db/schema/events/tables.ts
@@ -269,8 +269,6 @@ export const markets = pgTable(
     icon_url: text(),
     is_active: boolean().default(true).notNull(),
     is_resolved: boolean().default(false).notNull(),
-    accepting_orders: boolean().default(true).notNull(),
-    archived: boolean().default(false).notNull(),
     metadata: text(),
     volume_24h: numeric({ precision: 20, scale: 6 }).default('0').notNull(),
     volume: numeric({ precision: 20, scale: 6 }).default('0').notNull(),

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -21,3 +21,40 @@ class MockResizeObserver {
 if (typeof globalThis.ResizeObserver === 'undefined') {
   globalThis.ResizeObserver = MockResizeObserver as typeof ResizeObserver
 }
+
+function createMemoryStorage(): Storage {
+  const store = new Map<string, string>()
+
+  return {
+    get length() {
+      return store.size
+    },
+    clear() {
+      store.clear()
+    },
+    getItem(key: string) {
+      return store.get(key) ?? null
+    },
+    key(index: number) {
+      return Array.from(store.keys())[index] ?? null
+    },
+    removeItem(key: string) {
+      store.delete(key)
+    },
+    setItem(key: string, value: string) {
+      store.set(key, String(value))
+    },
+  }
+}
+
+if (typeof window.localStorage?.clear !== 'function') {
+  const storage = createMemoryStorage()
+  Object.defineProperty(window, 'localStorage', {
+    configurable: true,
+    value: storage,
+  })
+  Object.defineProperty(globalThis, 'localStorage', {
+    configurable: true,
+    value: storage,
+  })
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Derives market status flags from `metadata` instead of DB columns to keep API responses stable and avoid DB migrations. Business impact: unblocks deploys and makes event visibility consistent with market metadata.

- **Behavior Changes**
  - `accepting_orders` and `archived` now come from `markets.metadata` (supports `acceptingOrders`/`accepting_orders` across nested paths; works with JSON or stringified JSON).
  - Event hidden state is derived from any related market with `archived: true` in metadata.
  - `is_active` is computed from resolved flags; the sync route no longer reads or writes status columns.
  - Removed uses of `markets.accepting_orders` and `markets.archived` in the schema; deleted the unused migration.
  - Affected APIs: event/market read endpoints still return `accepting_orders` and `archived` (now derived); the sync endpoint logic uses metadata for status.

- **Performance**
  - No ALTER TABLE operations; safer, faster deploys (migration removed).
  - Small read overhead from parsing metadata; fewer writes during sync reduce DB contention.

<sup>Written for commit 050e24d90beff2a2daf349c98fe4ece908964411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1076?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->

