### PR TITLE
fix: missing action for cancel open order on /portfolio

### DIFF
--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersList.tsx
@@ -9,6 +9,7 @@ import { useExtracted } from 'next-intl'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { useTradingOnboarding } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
+import { cancelOrderAction } from '@/app/[locale]/(platform)/event/[slug]/_actions/cancel-order'
 import { cancelAllOrdersAction } from '@/app/[locale]/(platform)/portfolio/_actions/cancel-all-orders'
 import { usePortfolioOpenOrdersQuery } from '@/app/[locale]/(platform)/portfolio/_hooks/usePortfolioOpenOrdersQuery'
 import { matchesOpenOrdersSearchQuery, resolveOpenOrdersSearchParams, sortOpenOrders } from '@/app/[locale]/(platform)/portfolio/_utils/PortfolioOpenOrdersUtils'
@@ -30,6 +31,30 @@ interface LoadMoreStateValue {
   key: string
   infiniteScrollError: string | null
   isLoadingMore: boolean
+}
+
+function useRemoveOpenOrdersFromCache({
+  queryClient,
+  openOrdersQueryKey,
+}: {
+  queryClient: QueryClient
+  openOrdersQueryKey: (string | undefined)[]
+}) {
+  return useCallback(function removeOrdersFromCache(orderIds: string[]) {
+    if (!orderIds.length) {
+      return
+    }
+
+    queryClient.setQueryData<InfiniteData<{ data: PortfolioUserOpenOrder[], next_cursor: string }>>(openOrdersQueryKey, current =>
+      removeOpenOrdersFromInfiniteData(current, orderIds))
+
+    updateQueryDataWhere<InfiniteData<{ data: UserOpenOrder[], next_cursor: string }>>(
+      queryClient,
+      ['user-open-orders'],
+      () => true,
+      current => removeOpenOrdersFromInfiniteData(current, orderIds),
+    )
+  }, [openOrdersQueryKey, queryClient])
 }
 
 function useOpenOrdersFilterState(userAddress: string) {
@@ -102,33 +127,17 @@ function useCancelAllOpenOrders({
   userAddress,
   orders,
   queryClient,
-  openOrdersQueryKey,
+  removeOrdersFromCache,
   openTradeRequirements,
 }: {
   userAddress: string
   orders: PortfolioUserOpenOrder[]
   queryClient: QueryClient
-  openOrdersQueryKey: (string | undefined)[]
+  removeOrdersFromCache: (orderIds: string[]) => void
   openTradeRequirements: OpenTradeRequirements
 }) {
   const t = useExtracted()
   const [isCancellingAll, setIsCancellingAll] = useState(false)
-
-  const removeOrdersFromCache = useCallback((orderIds: string[]) => {
-    if (!orderIds.length) {
-      return
-    }
-
-    queryClient.setQueryData<InfiniteData<{ data: PortfolioUserOpenOrder[], next_cursor: string }>>(openOrdersQueryKey, current =>
-      removeOpenOrdersFromInfiniteData(current, orderIds))
-
-    updateQueryDataWhere<InfiniteData<{ data: UserOpenOrder[], next_cursor: string }>>(
-      queryClient,
-      ['user-open-orders'],
-      () => true,
-      current => removeOpenOrdersFromInfiniteData(current, orderIds),
-    )
-  }, [openOrdersQueryKey, queryClient])
 
   const handleCancelAll = useCallback(async () => {
     if (isCancellingAll || !orders.length) {
@@ -177,6 +186,66 @@ function useCancelAllOpenOrders({
   }, [isCancellingAll, openTradeRequirements, orders.length, queryClient, removeOrdersFromCache, t, userAddress])
 
   return { isCancellingAll, handleCancelAll }
+}
+
+function useCancelOpenOrder({
+  userAddress,
+  queryClient,
+  removeOrdersFromCache,
+  openTradeRequirements,
+}: {
+  userAddress: string
+  queryClient: QueryClient
+  removeOrdersFromCache: (orderIds: string[]) => void
+  openTradeRequirements: OpenTradeRequirements
+}) {
+  const t = useExtracted()
+  const [pendingCancelIds, setPendingCancelIds] = useState<Set<string>>(() => new Set())
+
+  const handleCancelOrder = useCallback(async function handleCancelOrder(order: PortfolioUserOpenOrder) {
+    if (pendingCancelIds.has(order.id)) {
+      return
+    }
+
+    setPendingCancelIds((current) => {
+      const next = new Set(current)
+      next.add(order.id)
+      return next
+    })
+
+    try {
+      const response = await cancelOrderAction(order.id)
+      if (response?.error) {
+        throw new Error(response.error)
+      }
+
+      toast.success(t('Order cancelled'))
+
+      removeOrdersFromCache([order.id])
+      await queryClient.invalidateQueries({ queryKey: ['public-open-orders', userAddress] })
+      void queryClient.invalidateQueries({ queryKey: ['orderbook-summary'] })
+    }
+    catch (error: any) {
+      const message = typeof error?.message === 'string'
+        ? error.message
+        : t('Failed to cancel order.')
+      if (isTradingAuthRequiredError(message)) {
+        openTradeRequirements({ forceTradingAuth: true })
+      }
+      else {
+        toast.error(message)
+      }
+    }
+    finally {
+      setPendingCancelIds((current) => {
+        const next = new Set(current)
+        next.delete(order.id)
+        return next
+      })
+    }
+  }, [openTradeRequirements, pendingCancelIds, queryClient, removeOrdersFromCache, t, userAddress])
+
+  return { pendingCancelIds, handleCancelOrder }
 }
 
 function useLoadMoreOpenOrders({
@@ -323,12 +392,22 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
     && userAddress
     && user.deposit_wallet_address.toLowerCase() === userAddress.toLowerCase(),
   )
+  const removeOrdersFromCache = useRemoveOpenOrdersFromCache({
+    queryClient,
+    openOrdersQueryKey,
+  })
+  const { pendingCancelIds, handleCancelOrder } = useCancelOpenOrder({
+    userAddress,
+    queryClient,
+    removeOrdersFromCache,
+    openTradeRequirements,
+  })
 
   const { isCancellingAll, handleCancelAll } = useCancelAllOpenOrders({
     userAddress,
     orders,
     queryClient,
-    openOrdersQueryKey,
+    removeOrdersFromCache,
     openTradeRequirements,
   })
 
@@ -384,6 +463,8 @@ export default function PortfolioOpenOrdersList({ userAddress }: PortfolioOpenOr
         isLoadingMore={isLoadingMore}
         loadMoreRef={loadMoreRef}
         onRetryLoadMore={loadMoreOpenOrders}
+        onCancelOrder={handleCancelOrder}
+        pendingCancelIds={pendingCancelIds}
       />
     </div>
   )

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersRow.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersRow.tsx
@@ -19,9 +19,11 @@ import { cn } from '@/lib/utils'
 
 interface PortfolioOpenOrdersRowProps {
   order: PortfolioUserOpenOrder
+  onCancel: (order: PortfolioUserOpenOrder) => void
+  isCancelling: boolean
 }
 
-export default function PortfolioOpenOrdersRow({ order }: PortfolioOpenOrdersRowProps) {
+export default function PortfolioOpenOrdersRow({ order, onCancel, isCancelling }: PortfolioOpenOrdersRowProps) {
   const t = useExtracted()
   const normalizeOutcomeLabel = useOutcomeLabel()
   const totalShares = getOrderTotalShares(order)
@@ -114,7 +116,12 @@ export default function PortfolioOpenOrdersRow({ order }: PortfolioOpenOrdersRow
                 type="button"
                 variant="outline"
                 size="sm"
-                aria-label={t('Cancel')}
+                aria-label={t('Cancel {side} order for {outcome}', {
+                  side: order.side === 'buy' ? t('Buy') : t('Sell'),
+                  outcome: outcomeText,
+                })}
+                disabled={isCancelling}
+                onClick={() => onCancel(order)}
               >
                 <XIcon className="size-4" />
               </Button>

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersTable.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersTable.tsx
@@ -14,6 +14,8 @@ interface PortfolioOpenOrdersTableProps {
   isLoadingMore: boolean
   loadMoreRef: RefObject<HTMLDivElement | null>
   onRetryLoadMore: () => void
+  onCancelOrder: (order: PortfolioUserOpenOrder) => void
+  pendingCancelIds: Set<string>
 }
 
 export default function PortfolioOpenOrdersTable({
@@ -25,6 +27,8 @@ export default function PortfolioOpenOrdersTable({
   isLoadingMore,
   loadMoreRef,
   onRetryLoadMore,
+  onCancelOrder,
+  pendingCancelIds,
 }: PortfolioOpenOrdersTableProps) {
   const t = useExtracted()
   const hasOrders = orders.length > 0
@@ -57,7 +61,12 @@ export default function PortfolioOpenOrdersTable({
     body = (
       <>
         {orders.map(order => (
-          <PortfolioOpenOrdersRow key={order.id} order={order} />
+          <PortfolioOpenOrdersRow
+            key={order.id}
+            order={order}
+            onCancel={onCancelOrder}
+            isCancelling={pendingCancelIds.has(order.id)}
+          />
         ))}
         {(isFetchingNextPage || isLoadingMore) && (
           <tr>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Hooked up the missing cancel action on the Portfolio open orders list. Users can now cancel individual open orders with proper loading, cache updates, and error handling.

- **Bug Fixes**
  - Connected cancelOrderAction via a new useCancelOpenOrder hook; passed onCancel and pending states to table/row, disabled the button while cancelling, and improved aria-labels.
  - Extracted cache removal into useRemoveOpenOrdersFromCache; shared by single-cancel and cancel-all.
  - Removed cancelled orders from local caches and invalidated related queries (public-open-orders, orderbook-summary).
  - Handled auth-required errors by triggering openTradeRequirements and added success/error toasts.

<sup>Written for commit cc81f1e7dc2fb4ee2ba1e5067d0a1fc17f3d9835. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1078?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

