### PR TITLE
ci: add a cd.yml workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,55 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-image:
+    if: github.repository == 'kuestcom/prediction-market'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+        with:
+          context: .
+          file: infra/docker/Dockerfile
+          push: true
+          tags: |
+            ghcr.io/kuestcom/prediction-market:main
+            ghcr.io/kuestcom/prediction-market:${{ github.sha }}
+          build-args: |
+            COMMIT_SHA=${{ github.sha }}
+            SITE_URL=${{ vars.SITE_URL }}
+            REOWN_APPKIT_PROJECT_ID=${{ vars.REOWN_APPKIT_PROJECT_ID }}
+
+      - name: Trigger deploy
+        env:
+          DEPLOY_WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
+        run: |
+          set -euo pipefail
+          if [ -z "$DEPLOY_WEBHOOK_URL" ]; then
+            echo "DEPLOY_WEBHOOK_URL secret is not set." >&2
+            exit 1
+          fi
+          curl --fail --silent --show-error --output /dev/null --request POST "$DEPLOY_WEBHOOK_URL"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
 
 permissions:
   contents: read

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -5,6 +5,14 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 
+ARG COMMIT_SHA=unknown
+ARG SITE_URL=http://localhost:3000
+ARG REOWN_APPKIT_PROJECT_ID=""
+
+ENV COMMIT_SHA=$COMMIT_SHA
+ENV SITE_URL=$SITE_URL
+ENV REOWN_APPKIT_PROJECT_ID=$REOWN_APPKIT_PROJECT_ID
+
 RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ \
   && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a CD workflow that builds and pushes our Docker image to GHCR on `main`, then triggers a deploy webhook. Dockerfile accepts `COMMIT_SHA`, `SITE_URL`, and `REOWN_APPKIT_PROJECT_ID` as build args and exposes them as env vars.

- **New Features**
  - Builds from `infra/docker/Dockerfile` and pushes `ghcr.io/kuestcom/prediction-market:main` and `:<sha>`.
  - Runs only on pushes to `main` for `kuestcom/prediction-market`, uses concurrency, and logs in to GHCR with `GITHUB_TOKEN`.
  - Triggers deploy via webhook; fails if `DEPLOY_WEBHOOK_URL` is missing.

- **Migration**
  - Add the `DEPLOY_WEBHOOK_URL` repo secret.
  - Set repo variables `SITE_URL` and `REOWN_APPKIT_PROJECT_ID` if you need non-default values.

<sup>Written for commit 96b03f932d61a2b7b83ca4b47d86f8efe05cac45. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

