### PR TITLE
fix: og image ssrf

### DIFF
--- a/src/app/[locale]/(platform)/settings/_actions/update-profile.ts
+++ b/src/app/[locale]/(platform)/settings/_actions/update-profile.ts
@@ -6,6 +6,7 @@ import sharp from 'sharp'
 import { z } from 'zod'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { UserRepository } from '@/lib/db/queries/user'
+import { validateOutboundImageUrl } from '@/lib/og-image-security'
 import { uploadPublicAsset } from '@/lib/storage'
 
 const MAX_FILE_SIZE = 5 * 1024 * 1024
@@ -94,6 +95,14 @@ export async function updateUserAction(formData: FormData): Promise<ActionState>
       })
 
       return { errors }
+    }
+
+    if (validated.data.avatar_url && !(await validateOutboundImageUrl(validated.data.avatar_url))) {
+      return {
+        errors: {
+          avatar_url: 'Avatar URL must point to a public HTTP(S) image host.',
+        },
+      }
     }
 
     const updateData: Record<string, unknown> = {

--- a/src/app/api/og/event/route.tsx
+++ b/src/app/api/og/event/route.tsx
@@ -1,6 +1,5 @@
 import type { SupportedLocale } from '@/i18n/locales'
 import type { Event } from '@/types'
-import { Buffer } from 'node:buffer'
 import { ImageResponse } from 'next/og'
 import OgImage from '@/app/api/og/_components/OgImage'
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/i18n/locales'
@@ -8,8 +7,8 @@ import { oklchToRenderableColor } from '@/lib/color'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { EventRepository } from '@/lib/db/queries/event'
 import { formatCentsLabel, formatCompactCurrency, formatPercent } from '@/lib/formatters'
+import { fetchSafeOgImageDataUrl } from '@/lib/og-image-security'
 import { resolveOutcomeButtonTheme } from '@/lib/outcome-theme'
-import { readResponseBodyWithLimit } from '@/lib/read-response-body-with-limit'
 import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -18,18 +17,7 @@ const IMAGE_HEIGHT = 630
 const CHART_WIDTH = 598
 const CHART_HEIGHT = 120
 const MAX_CHART_POINTS = 28
-// Keep the OG inline image budget aligned with the current public asset size limit.
-const MAX_OG_REMOTE_IMAGE_BYTES = 2 * 1024 * 1024
-const SOCIAL_IMAGE_FETCH_TIMEOUT_MS = 1200
 const SOCIAL_HISTORY_FETCH_TIMEOUT_MS = 1500
-const IMAGE_DATA_URI_CONTENT_TYPES = new Set([
-  'image/gif',
-  'image/jpeg',
-  'image/jpg',
-  'image/png',
-  'image/svg+xml',
-  'image/webp',
-])
 const THEME_PRESET_PRIMARY_COLOR = {
   amber: 'oklch(0.881 0.168 94.237)',
   default: 'oklch(0.55 0.2 255)',
@@ -95,58 +83,6 @@ function resolveLocale(value: string | null): SupportedLocale {
     : DEFAULT_LOCALE
 }
 
-function sanitizeImageUrl(rawUrl: string | null | undefined, siteUrl: string) {
-  const trimmed = rawUrl?.trim()
-  if (!trimmed) {
-    return ''
-  }
-
-  try {
-    const parsed = new URL(trimmed, `${siteUrl}/`)
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      return ''
-    }
-    return parsed.toString()
-  }
-  catch {
-    return ''
-  }
-}
-
-async function fetchImageDataUrl(url: string) {
-  try {
-    const response = await fetch(url, {
-      headers: {
-        Accept: 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
-      },
-      next: {
-        revalidate: 900,
-      },
-      signal: AbortSignal.timeout(SOCIAL_IMAGE_FETCH_TIMEOUT_MS),
-    })
-
-    if (!response.ok) {
-      return ''
-    }
-
-    const contentType = response.headers.get('content-type')?.split(';')[0]?.trim().toLowerCase() ?? ''
-    if (!IMAGE_DATA_URI_CONTENT_TYPES.has(contentType)) {
-      return ''
-    }
-
-    const imageBytes = await readResponseBodyWithLimit(response, MAX_OG_REMOTE_IMAGE_BYTES)
-    if (!imageBytes || imageBytes.byteLength === 0) {
-      return ''
-    }
-
-    const base64 = Buffer.from(imageBytes).toString('base64')
-    return `data:${contentType};base64,${base64}`
-  }
-  catch {
-    return ''
-  }
-}
-
 function resolveFocusedMarket(event: Event, marketSlug: string) {
   const normalizedMarketSlug = marketSlug.trim().toLowerCase()
   if (normalizedMarketSlug) {
@@ -168,19 +104,20 @@ function resolveFocusedMarket(event: Event, marketSlug: string) {
 }
 
 async function resolveEventImage(event: Event, focusedMarket: EventMarket | null, siteUrl: string) {
-  const imageCandidate = [
+  const imageCandidates = [
     focusedMarket?.icon_url,
     event.icon_url,
     event.sports_team_logo_urls?.[0],
   ]
-    .map(candidate => sanitizeImageUrl(candidate, siteUrl))
-    .find(Boolean)
 
-  if (!imageCandidate) {
-    return ''
+  for (const imageCandidate of imageCandidates) {
+    const imageDataUrl = await fetchSafeOgImageDataUrl(imageCandidate, { siteUrl })
+    if (imageDataUrl) {
+      return imageDataUrl
+    }
   }
 
-  return fetchImageDataUrl(imageCandidate)
+  return ''
 }
 
 function resolveBinaryOutcome(market: EventMarket, outcomeIndex: number, fallbackIndex: number) {

--- a/src/app/api/og/leaderboard/route.tsx
+++ b/src/app/api/og/leaderboard/route.tsx
@@ -15,7 +15,7 @@ import {
 import OgImage from '@/app/api/og/_components/OgImage'
 import { oklchToRenderableColor } from '@/lib/color'
 import { truncateAddress } from '@/lib/formatters'
-import { fetchSafeOgImageDataUrl } from '@/lib/og-image-security'
+import { resolveTrustedOgImageSource } from '@/lib/og-image-security'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 const OG_IMAGE_WIDTH = 1200
@@ -267,7 +267,7 @@ export async function GET(request: Request) {
       fetchLeaderboardRows({ category, period, order }),
     ])
     const siteName = normalizeText(runtimeTheme.site.name, 24) ?? 'Prediction Market'
-    const siteLogoSrc = await fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl)
+    const siteLogoSrc = await resolveTrustedOgImageSource(runtimeTheme.site.logoUrl)
     const primaryColor = resolveThemePrimaryColor(
       runtimeTheme.theme.light.primary ?? runtimeTheme.theme.dark.primary ?? null,
       runtimeTheme.theme.presetId,

--- a/src/app/api/og/leaderboard/route.tsx
+++ b/src/app/api/og/leaderboard/route.tsx
@@ -15,6 +15,7 @@ import {
 import OgImage from '@/app/api/og/_components/OgImage'
 import { oklchToRenderableColor } from '@/lib/color'
 import { truncateAddress } from '@/lib/formatters'
+import { fetchSafeOgImageDataUrl } from '@/lib/og-image-security'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 const OG_IMAGE_WIDTH = 1200
@@ -266,7 +267,7 @@ export async function GET(request: Request) {
       fetchLeaderboardRows({ category, period, order }),
     ])
     const siteName = normalizeText(runtimeTheme.site.name, 24) ?? 'Prediction Market'
-    const siteLogoSrc = runtimeTheme.site.logoUrl?.trim() ?? ''
+    const siteLogoSrc = await fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl)
     const primaryColor = resolveThemePrimaryColor(
       runtimeTheme.theme.light.primary ?? runtimeTheme.theme.dark.primary ?? null,
       runtimeTheme.theme.presetId,

--- a/src/app/api/og/position/route.tsx
+++ b/src/app/api/og/position/route.tsx
@@ -1,6 +1,6 @@
 import { ImageResponse } from 'next/og'
 import OgImage from '@/app/api/og/_components/OgImage'
-import { fetchSafeOgImageDataUrl, normalizeOutboundImageUrl } from '@/lib/og-image-security'
+import { fetchSafeOgImageDataUrl, normalizeOutboundImageUrl, resolveTrustedOgImageSource } from '@/lib/og-image-security'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 interface ShareCardPayload {
@@ -131,7 +131,7 @@ export async function GET(request: Request) {
   const outcomeLabel = payload.outcome || (variant === 'no' ? 'No' : 'Yes')
   const runtimeTheme = await loadRuntimeThemeState()
   const [siteLogoSrc, positionImageSrc, userImageSrc] = await Promise.all([
-    fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl),
+    resolveTrustedOgImageSource(runtimeTheme.site.logoUrl),
     fetchSafeOgImageDataUrl(payload.imageUrl),
     fetchSafeOgImageDataUrl(payload.userImage),
   ])

--- a/src/app/api/og/position/route.tsx
+++ b/src/app/api/og/position/route.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from 'next/og'
 import OgImage from '@/app/api/og/_components/OgImage'
+import { fetchSafeOgImageDataUrl, normalizeOutboundImageUrl } from '@/lib/og-image-security'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 interface ShareCardPayload {
@@ -37,99 +38,6 @@ function normalizeOptionalText(value: unknown, maxLength = 120) {
     return ''
   }
   return trimmed.length > maxLength ? `${trimmed.slice(0, maxLength - 3)}...` : trimmed
-}
-
-function normalizeHostname(hostname: string) {
-  return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '')
-}
-
-function isPrivateIpv4Hostname(hostname: string) {
-  if (!/^\d{1,3}(?:\.\d{1,3}){3}$/.test(hostname)) {
-    return false
-  }
-
-  const octets = hostname.split('.').map(part => Number(part))
-  if (octets.some(octet => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
-    return false
-  }
-
-  const [first, second] = octets
-  return first === 0
-    || first === 10
-    || first === 127
-    || (first === 100 && second >= 64 && second <= 127)
-    || (first === 169 && second === 254)
-    || (first === 172 && second >= 16 && second <= 31)
-    || (first === 192 && second === 168)
-    || (first === 198 && (second === 18 || second === 19))
-}
-
-function isPrivateIpv6Hostname(hostname: string) {
-  if (!hostname.includes(':')) {
-    return false
-  }
-
-  const normalized = hostname.toLowerCase()
-  if (normalized === '::' || normalized === '::1') {
-    return true
-  }
-
-  if (normalized.startsWith('::ffff:')) {
-    return isPrivateIpv4Hostname(normalized.slice(7))
-  }
-
-  const firstHextet = (() => {
-    const [head] = normalized.split('::', 2)
-    if (!head) {
-      return '0'
-    }
-
-    return head.split(':')[0] || '0'
-  })()
-
-  return /^fc/i.test(firstHextet)
-    || /^fd/i.test(firstHextet)
-    || /^fe[89ab]/i.test(firstHextet)
-}
-
-function isDisallowedImageHostname(hostname: string) {
-  const normalized = normalizeHostname(hostname)
-  if (!normalized) {
-    return true
-  }
-
-  if (normalized === 'localhost' || normalized.endsWith('.localhost')) {
-    return true
-  }
-
-  if (!normalized.includes('.') && !normalized.includes(':')) {
-    return true
-  }
-
-  return isPrivateIpv4Hostname(normalized) || isPrivateIpv6Hostname(normalized)
-}
-
-function sanitizeImageUrl(rawUrl: string) {
-  const trimmed = rawUrl.trim()
-  if (!trimmed || trimmed.length > 2048) {
-    return ''
-  }
-  try {
-    const parsed = new URL(trimmed)
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      return ''
-    }
-    if (parsed.username || parsed.password) {
-      return ''
-    }
-    if (isDisallowedImageHostname(parsed.hostname)) {
-      return ''
-    }
-    return parsed.toString()
-  }
-  catch {
-    return ''
-  }
 }
 
 function parsePayload(rawPayload: string | null): ShareCardPayload | null {
@@ -194,8 +102,8 @@ function normalizeSharePayload(parsed: Partial<ShareCardPayload>): ShareCardPayl
 
   const rawImageUrl = typeof parsed.imageUrl === 'string' ? parsed.imageUrl : ''
   const rawUserImage = typeof parsed.userImage === 'string' ? parsed.userImage : ''
-  const safeImageUrl = sanitizeImageUrl(rawImageUrl)
-  const safeUserImage = sanitizeImageUrl(rawUserImage)
+  const safeImageUrl = normalizeOutboundImageUrl(rawImageUrl)
+  const safeUserImage = normalizeOutboundImageUrl(rawUserImage)
   return {
     title,
     outcome,
@@ -222,9 +130,13 @@ export async function GET(request: Request) {
   const accent = variant === 'no' ? '#ef4444' : '#22c55e'
   const outcomeLabel = payload.outcome || (variant === 'no' ? 'No' : 'Yes')
   const runtimeTheme = await loadRuntimeThemeState()
-  const siteLogoSrc = runtimeTheme.site.logoUrl
+  const [siteLogoSrc, positionImageSrc, userImageSrc] = await Promise.all([
+    fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl),
+    fetchSafeOgImageDataUrl(payload.imageUrl),
+    fetchSafeOgImageDataUrl(payload.userImage),
+  ])
   const siteName = runtimeTheme.site.name
-  const hasUserBadge = Boolean(payload.userName || payload.userImage)
+  const hasUserBadge = Boolean(payload.userName || userImageSrc)
   const dividerDots = Array.from({ length: 32 })
   const horizontalDots = Array.from({ length: 40 })
 
@@ -255,9 +167,9 @@ export async function GET(request: Request) {
               color: '#e2e8f0',
             }}
           >
-            {payload.userImage && (
+            {userImageSrc && (
               <OgImage
-                src={payload.userImage}
+                src={userImageSrc}
                 alt=""
                 width={40}
                 height={40}
@@ -342,10 +254,10 @@ export async function GET(request: Request) {
                   border: '2px solid #e2e8f0',
                 }}
               >
-                {payload.imageUrl
+                {positionImageSrc
                   ? (
                       <OgImage
-                        src={payload.imageUrl}
+                        src={positionImageSrc}
                         alt=""
                         width={160}
                         height={160}

--- a/src/app/api/og/predictions/route.tsx
+++ b/src/app/api/og/predictions/route.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from 'next/og'
 import OgImage from '@/app/api/og/_components/OgImage'
 import { oklchToRenderableColor } from '@/lib/color'
+import { fetchSafeOgImageDataUrl } from '@/lib/og-image-security'
 import { humanizePredictionSearchSlug } from '@/lib/prediction-search'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -91,7 +92,7 @@ export async function GET(request: Request) {
     runtimeTheme.theme.presetId,
   )
   const siteName = normalizeText(runtimeTheme.site.name, 30) ?? 'Prediction Markets'
-  const siteLogoSrc = runtimeTheme.site.logoUrl?.trim() ?? ''
+  const siteLogoSrc = await fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl)
   const cards = [
     { left: 34, top: 18, width: 360, height: 238, opacity: 0.88 },
     { left: 416, top: 18, width: 240, height: 238, opacity: 0.76 },

--- a/src/app/api/og/predictions/route.tsx
+++ b/src/app/api/og/predictions/route.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og'
 import OgImage from '@/app/api/og/_components/OgImage'
 import { oklchToRenderableColor } from '@/lib/color'
-import { fetchSafeOgImageDataUrl } from '@/lib/og-image-security'
+import { resolveTrustedOgImageSource } from '@/lib/og-image-security'
 import { humanizePredictionSearchSlug } from '@/lib/prediction-search'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -92,7 +92,7 @@ export async function GET(request: Request) {
     runtimeTheme.theme.presetId,
   )
   const siteName = normalizeText(runtimeTheme.site.name, 30) ?? 'Prediction Markets'
-  const siteLogoSrc = await fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl)
+  const siteLogoSrc = await resolveTrustedOgImageSource(runtimeTheme.site.logoUrl)
   const cards = [
     { left: 34, top: 18, width: 360, height: 238, opacity: 0.88 },
     { left: 416, top: 18, width: 240, height: 238, opacity: 0.76 },

--- a/src/app/api/og/profile/route.tsx
+++ b/src/app/api/og/profile/route.tsx
@@ -7,6 +7,7 @@ import {
 } from '@/lib/community-profile'
 import { UserRepository } from '@/lib/db/queries/user'
 import { truncateAddress } from '@/lib/formatters'
+import { fetchSafeOgImageDataUrl, normalizeOutboundImageUrl } from '@/lib/og-image-security'
 import { normalizePublicProfileSlug } from '@/lib/platform-routing'
 import { fetchPortfolioSnapshot } from '@/lib/portfolio'
 import resolveSiteUrl from '@/lib/site-url'
@@ -109,14 +110,14 @@ function resolvePositionIconUrl(rawIcon: unknown, siteUrl: string) {
   }
 
   if (icon.startsWith('/')) {
-    return new URL(icon, siteUrl).toString()
+    return normalizeOutboundImageUrl(icon, { siteUrl })
   }
 
   if (icon.startsWith('http://') || icon.startsWith('https://')) {
-    return icon
+    return normalizeOutboundImageUrl(icon)
   }
 
-  return `https://gateway.irys.xyz/${icon}`
+  return normalizeOutboundImageUrl(`https://gateway.irys.xyz/${icon}`)
 }
 
 function resolveProfileAvatarUrl(rawAvatar: unknown, siteUrl: string) {
@@ -126,11 +127,11 @@ function resolveProfileAvatarUrl(rawAvatar: unknown, siteUrl: string) {
   }
 
   if (avatar.startsWith('/')) {
-    return new URL(avatar, siteUrl).toString()
+    return normalizeOutboundImageUrl(avatar, { siteUrl })
   }
 
   if (avatar.startsWith('http://') || avatar.startsWith('https://')) {
-    return avatar
+    return normalizeOutboundImageUrl(avatar)
   }
 
   return ''
@@ -282,7 +283,7 @@ async function fetchProfilePositions(userAddress: string, siteUrl: string): Prom
       return []
     }
 
-    return payload
+    const positions = payload
       .map((entry) => {
         const raw = (entry ?? {}) as Record<string, unknown>
         const title = normalizeText(typeof raw.title === 'string' ? raw.title : 'Untitled market', 52) ?? 'Untitled market'
@@ -311,6 +312,11 @@ async function fetchProfilePositions(userAddress: string, siteUrl: string): Prom
       .filter(position => position.currentValue > 0 || position.tradeValue > 0)
       .sort((left, right) => right.currentValue - left.currentValue)
       .slice(0, 8)
+
+    return await Promise.all(positions.map(async position => ({
+      ...position,
+      iconUrl: await fetchSafeOgImageDataUrl(position.iconUrl),
+    })))
   }
   catch {
     return []
@@ -339,11 +345,13 @@ export async function GET(request: Request) {
     const displayName = profileUsername
       ?? (normalized.type === 'username' ? normalized.value : truncateAddress(normalized.value))
     const siteUrl = resolveSiteUrl(process.env)
-    const avatarUrl = resolveProfileAvatarUrl(profile?.image, siteUrl)
+    const avatarCandidate = resolveProfileAvatarUrl(profile?.image, siteUrl)
     const resolvedAddress = profile?.deposit_wallet_address
       ?? (normalized.type === 'address' ? normalized.value : null)
 
-    const [snapshot, positions] = await Promise.all([
+    const [siteLogoSrc, avatarUrl, snapshot, positions] = await Promise.all([
+      fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl),
+      fetchSafeOgImageDataUrl(avatarCandidate),
       fetchPortfolioSnapshot(resolvedAddress),
       resolvedAddress ? fetchProfilePositions(resolvedAddress, siteUrl) : Promise.resolve([]),
     ])
@@ -392,10 +400,10 @@ export async function GET(request: Request) {
                 gap: '10px',
               }}
             >
-              {runtimeTheme.site.logoUrl
+              {siteLogoSrc
                 ? (
                     <OgImage
-                      src={runtimeTheme.site.logoUrl}
+                      src={siteLogoSrc}
                       alt=""
                       width={36}
                       height={36}

--- a/src/app/api/og/profile/route.tsx
+++ b/src/app/api/og/profile/route.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/lib/community-profile'
 import { UserRepository } from '@/lib/db/queries/user'
 import { truncateAddress } from '@/lib/formatters'
-import { fetchSafeOgImageDataUrl, normalizeOutboundImageUrl } from '@/lib/og-image-security'
+import { fetchSafeOgImageDataUrl, normalizeOutboundImageUrl, resolveTrustedOgImageSource } from '@/lib/og-image-security'
 import { normalizePublicProfileSlug } from '@/lib/platform-routing'
 import { fetchPortfolioSnapshot } from '@/lib/portfolio'
 import resolveSiteUrl from '@/lib/site-url'
@@ -350,7 +350,7 @@ export async function GET(request: Request) {
       ?? (normalized.type === 'address' ? normalized.value : null)
 
     const [siteLogoSrc, avatarUrl, snapshot, positions] = await Promise.all([
-      fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl),
+      resolveTrustedOgImageSource(runtimeTheme.site.logoUrl),
       fetchSafeOgImageDataUrl(avatarCandidate),
       fetchPortfolioSnapshot(resolvedAddress),
       resolvedAddress ? fetchProfilePositions(resolvedAddress, siteUrl) : Promise.resolve([]),

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from 'next/og'
 import OgImage from '@/app/api/og/_components/OgImage'
 import { oklchToRenderableColor } from '@/lib/color'
+import { fetchSafeOgImageDataUrl } from '@/lib/og-image-security'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 const OG_IMAGE_WIDTH = 1200
@@ -60,7 +61,7 @@ export async function GET() {
   const runtimeTheme = await loadRuntimeThemeState()
   const siteName = normalizeText(runtimeTheme.site.name, 24) ?? 'Prediction Market'
   const siteDescription = normalizeText(runtimeTheme.site.description, 74) ?? 'Trade live prediction markets in real time.'
-  const siteLogoSrc = runtimeTheme.site.logoUrl?.trim() ?? ''
+  const siteLogoSrc = await fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl)
   const primaryColor = resolveThemePrimaryColor(
     runtimeTheme.theme.light.primary ?? runtimeTheme.theme.dark.primary ?? null,
     runtimeTheme.theme.presetId,

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og'
 import OgImage from '@/app/api/og/_components/OgImage'
 import { oklchToRenderableColor } from '@/lib/color'
-import { fetchSafeOgImageDataUrl } from '@/lib/og-image-security'
+import { resolveTrustedOgImageSource } from '@/lib/og-image-security'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 const OG_IMAGE_WIDTH = 1200
@@ -61,7 +61,7 @@ export async function GET() {
   const runtimeTheme = await loadRuntimeThemeState()
   const siteName = normalizeText(runtimeTheme.site.name, 24) ?? 'Prediction Market'
   const siteDescription = normalizeText(runtimeTheme.site.description, 74) ?? 'Trade live prediction markets in real time.'
-  const siteLogoSrc = await fetchSafeOgImageDataUrl(runtimeTheme.site.logoUrl)
+  const siteLogoSrc = await resolveTrustedOgImageSource(runtimeTheme.site.logoUrl)
   const primaryColor = resolveThemePrimaryColor(
     runtimeTheme.theme.light.primary ?? runtimeTheme.theme.dark.primary ?? null,
     runtimeTheme.theme.presetId,

--- a/src/lib/og-image-security.ts
+++ b/src/lib/og-image-security.ts
@@ -1,9 +1,9 @@
-import type { ClientRequest, IncomingMessage, RequestOptions } from 'node:http'
+import type { ClientRequest, RequestOptions as HttpRequestOptions, IncomingMessage } from 'node:http'
 import type { RequestOptions as HttpsRequestOptions } from 'node:https'
 import { Buffer } from 'node:buffer'
 import { lookup } from 'node:dns/promises'
-import http from 'node:http'
-import https from 'node:https'
+import * as http from 'node:http'
+import * as https from 'node:https'
 import { isIP } from 'node:net'
 import 'server-only'
 
@@ -44,7 +44,7 @@ function normalizeHostname(hostname: string) {
   return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '')
 }
 
-function parseIpv4Address(address: string) {
+function parseIpv4Address(address: string): [number, number, number, number] | null {
   const octets = address.split('.')
   if (octets.length !== 4) {
     return null
@@ -61,7 +61,7 @@ function parseIpv4Address(address: string) {
     return null
   }
 
-  return parsed
+  return [parsed[0]!, parsed[1]!, parsed[2]!, parsed[3]!]
 }
 
 function isPublicIpv4Address(address: string) {
@@ -127,9 +127,10 @@ function parseIpv6Address(address: string) {
     return null
   }
 
+  const compressedGroups = Array.from({ length: hasCompression ? missingGroups : 0 }).fill('0') as string[]
   const groups = [
     ...left,
-    ...Array.from({ length: hasCompression ? missingGroups : 0 }).fill('0'),
+    ...compressedGroups,
     ...right,
   ]
   if (groups.length !== 8) {
@@ -263,7 +264,15 @@ async function resolvePublicAddress(url: URL): Promise<ResolvedAddress | null> {
     return null
   }
 
-  return addresses[0] as ResolvedAddress
+  const firstAddress = addresses[0]
+  if (!firstAddress || (firstAddress.family !== 4 && firstAddress.family !== 6)) {
+    return null
+  }
+
+  return {
+    address: firstAddress.address,
+    family: firstAddress.family,
+  }
 }
 
 export async function validateOutboundImageUrl(rawUrl: string | null | undefined, options: Pick<SafeImageOptions, 'siteUrl'> = {}) {
@@ -356,7 +365,6 @@ function readIncomingMessageWithLimit(response: IncomingMessage, maxBytes: numbe
 }
 
 function requestImage(url: URL, address: string, timeoutMs: number, maxBytes: number) {
-  const transport = url.protocol === 'https:' ? https : http
   const port = url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80)
 
   return new Promise<ImageResponsePayload>((resolve, reject) => {
@@ -384,7 +392,7 @@ function requestImage(url: URL, address: string, timeoutMs: number, maxBytes: nu
       reject(error)
     }
 
-    const requestOptions: RequestOptions & HttpsRequestOptions = {
+    const requestOptions: HttpRequestOptions = {
       hostname: address,
       port,
       method: 'GET',
@@ -396,11 +404,7 @@ function requestImage(url: URL, address: string, timeoutMs: number, maxBytes: nu
       },
     }
 
-    if (url.protocol === 'https:') {
-      requestOptions.servername = url.hostname
-    }
-
-    request = transport.request(requestOptions, (response) => {
+    function handleResponse(response: IncomingMessage) {
       const statusCode = response.statusCode ?? 0
       const location = getHeaderValue(response.headers.location)
       const contentType = getHeaderValue(response.headers['content-type']).split(';')[0]?.trim().toLowerCase() ?? ''
@@ -414,7 +418,22 @@ function requestImage(url: URL, address: string, timeoutMs: number, maxBytes: nu
       readIncomingMessageWithLimit(response, maxBytes)
         .then(body => settleWithPayload({ body, contentType, location, statusCode }))
         .catch(fail)
-    })
+    }
+
+    if (url.protocol === 'https:') {
+      request = https.request({
+        ...requestOptions,
+        servername: url.hostname,
+      } satisfies HttpsRequestOptions, handleResponse)
+    }
+    else {
+      request = http.request(requestOptions, handleResponse)
+    }
+
+    if (!request) {
+      fail(new Error('Failed to create image request.'))
+      return
+    }
 
     request.on('error', fail)
     request.end()

--- a/src/lib/og-image-security.ts
+++ b/src/lib/og-image-security.ts
@@ -1,0 +1,469 @@
+import type { ClientRequest, IncomingMessage, RequestOptions } from 'node:http'
+import type { RequestOptions as HttpsRequestOptions } from 'node:https'
+import { Buffer } from 'node:buffer'
+import { lookup } from 'node:dns/promises'
+import http from 'node:http'
+import https from 'node:https'
+import { isIP } from 'node:net'
+import 'server-only'
+
+const DEFAULT_MAX_IMAGE_BYTES = 2 * 1024 * 1024
+const DEFAULT_TIMEOUT_MS = 1200
+const DEFAULT_MAX_REDIRECTS = 3
+const MAX_URL_LENGTH = 2048
+
+const IMAGE_DATA_URI_CONTENT_TYPES = new Set([
+  'image/gif',
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/svg+xml',
+  'image/webp',
+])
+
+interface SafeImageOptions {
+  siteUrl?: string
+  timeoutMs?: number
+  maxBytes?: number
+  maxRedirects?: number
+}
+
+interface ResolvedAddress {
+  address: string
+  family: 4 | 6
+}
+
+interface ImageResponsePayload {
+  body: Uint8Array | null
+  contentType: string
+  location: string
+  statusCode: number
+}
+
+function normalizeHostname(hostname: string) {
+  return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '')
+}
+
+function parseIpv4Address(address: string) {
+  const octets = address.split('.')
+  if (octets.length !== 4) {
+    return null
+  }
+
+  const parsed = octets.map((part) => {
+    if (!/^\d{1,3}$/.test(part)) {
+      return Number.NaN
+    }
+    return Number(part)
+  })
+
+  if (parsed.some(octet => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return null
+  }
+
+  return parsed
+}
+
+function isPublicIpv4Address(address: string) {
+  const octets = parseIpv4Address(address)
+  if (!octets) {
+    return false
+  }
+
+  const [first, second, third] = octets
+  return !(first === 0
+    || first === 10
+    || first === 127
+    || (first === 100 && second >= 64 && second <= 127)
+    || (first === 169 && second === 254)
+    || (first === 172 && second >= 16 && second <= 31)
+    || (first === 192 && second === 0 && third === 0)
+    || (first === 192 && second === 0 && third === 2)
+    || (first === 192 && second === 88 && third === 99)
+    || (first === 192 && second === 168)
+    || (first === 198 && (second === 18 || second === 19))
+    || (first === 198 && second === 51 && third === 100)
+    || (first === 203 && second === 0 && third === 113)
+    || first >= 224)
+}
+
+function parseIpv6Address(address: string) {
+  let normalized = normalizeHostname(address)
+  const zoneIndex = normalized.indexOf('%')
+  if (zoneIndex !== -1) {
+    normalized = normalized.slice(0, zoneIndex)
+  }
+
+  if (normalized.includes('.')) {
+    const lastColon = normalized.lastIndexOf(':')
+    if (lastColon === -1) {
+      return null
+    }
+
+    const ipv4 = parseIpv4Address(normalized.slice(lastColon + 1))
+    if (!ipv4) {
+      return null
+    }
+
+    const high = ((ipv4[0] << 8) | ipv4[1]).toString(16)
+    const low = ((ipv4[2] << 8) | ipv4[3]).toString(16)
+    normalized = `${normalized.slice(0, lastColon)}:${high}:${low}`
+  }
+
+  const compressedParts = normalized.split('::')
+  if (compressedParts.length > 2) {
+    return null
+  }
+
+  const left = compressedParts[0] ? compressedParts[0].split(':') : []
+  const right = compressedParts[1] ? compressedParts[1].split(':') : []
+  if ([...left, ...right].some(part => !/^[0-9a-f]{1,4}$/i.test(part))) {
+    return null
+  }
+
+  const hasCompression = compressedParts.length === 2
+  const missingGroups = 8 - left.length - right.length
+  if ((!hasCompression && missingGroups !== 0) || (hasCompression && missingGroups < 1)) {
+    return null
+  }
+
+  const groups = [
+    ...left,
+    ...Array.from({ length: hasCompression ? missingGroups : 0 }).fill('0'),
+    ...right,
+  ]
+  if (groups.length !== 8) {
+    return null
+  }
+
+  return groups.reduce((value, group) => (value << 16n) + BigInt(Number.parseInt(group, 16)), 0n)
+}
+
+function isIpv6InRange(address: bigint, baseAddress: string, prefixLength: number) {
+  const base = parseIpv6Address(baseAddress)
+  if (base == null) {
+    return false
+  }
+
+  const shift = 128n - BigInt(prefixLength)
+  return (address >> shift) === (base >> shift)
+}
+
+function isPublicIpv6Address(address: string) {
+  const parsed = parseIpv6Address(address)
+  if (parsed == null) {
+    return false
+  }
+
+  if (parsed <= 1n) {
+    return false
+  }
+
+  if ((parsed >> 32n) === 0xFFFFn) {
+    const ipv4Number = Number(parsed & 0xFFFFFFFFn)
+    const ipv4Address = [
+      (ipv4Number >>> 24) & 255,
+      (ipv4Number >>> 16) & 255,
+      (ipv4Number >>> 8) & 255,
+      ipv4Number & 255,
+    ].join('.')
+    return isPublicIpv4Address(ipv4Address)
+  }
+
+  if (parsed <= 0xFFFFFFFFn) {
+    return false
+  }
+
+  return !(
+    isIpv6InRange(parsed, '64:ff9b:1::', 48)
+    || isIpv6InRange(parsed, '100::', 64)
+    || isIpv6InRange(parsed, '2001::', 23)
+    || isIpv6InRange(parsed, '2001:db8::', 32)
+    || isIpv6InRange(parsed, '2002::', 16)
+    || isIpv6InRange(parsed, 'fc00::', 7)
+    || isIpv6InRange(parsed, 'fe80::', 10)
+    || isIpv6InRange(parsed, 'ff00::', 8)
+  )
+}
+
+export function isPublicIpAddress(address: string) {
+  const normalized = normalizeHostname(address)
+  const family = isIP(normalized)
+  if (family === 4) {
+    return isPublicIpv4Address(normalized)
+  }
+  if (family === 6) {
+    return isPublicIpv6Address(normalized)
+  }
+  return false
+}
+
+function isDisallowedHostname(hostname: string) {
+  const normalized = normalizeHostname(hostname)
+  if (!normalized) {
+    return true
+  }
+
+  if (normalized === 'localhost' || normalized.endsWith('.localhost')) {
+    return true
+  }
+
+  const family = isIP(normalized)
+  if (family) {
+    return !isPublicIpAddress(normalized)
+  }
+
+  return !normalized.includes('.')
+}
+
+export function normalizeOutboundImageUrl(rawUrl: string | null | undefined, options: Pick<SafeImageOptions, 'siteUrl'> = {}) {
+  const trimmed = rawUrl?.trim()
+  if (!trimmed || trimmed.length > MAX_URL_LENGTH) {
+    return ''
+  }
+
+  try {
+    const baseUrl = options.siteUrl ? `${options.siteUrl.replace(/\/+$/, '')}/` : undefined
+    const parsed = baseUrl ? new URL(trimmed, baseUrl) : new URL(trimmed)
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return ''
+    }
+    if (parsed.username || parsed.password) {
+      return ''
+    }
+    if (isDisallowedHostname(parsed.hostname)) {
+      return ''
+    }
+    return parsed.toString()
+  }
+  catch {
+    return ''
+  }
+}
+
+async function resolvePublicAddress(url: URL): Promise<ResolvedAddress | null> {
+  const hostname = normalizeHostname(url.hostname)
+  if (isDisallowedHostname(hostname)) {
+    return null
+  }
+
+  const family = isIP(hostname)
+  if (family) {
+    return isPublicIpAddress(hostname)
+      ? { address: hostname, family: family as 4 | 6 }
+      : null
+  }
+
+  const addresses = await lookup(hostname, { all: true, verbatim: false })
+  if (addresses.length === 0) {
+    return null
+  }
+
+  if (addresses.some(address => !isPublicIpAddress(address.address))) {
+    return null
+  }
+
+  return addresses[0] as ResolvedAddress
+}
+
+export async function validateOutboundImageUrl(rawUrl: string | null | undefined, options: Pick<SafeImageOptions, 'siteUrl'> = {}) {
+  const normalized = normalizeOutboundImageUrl(rawUrl, options)
+  if (!normalized) {
+    return false
+  }
+
+  try {
+    const parsed = new URL(normalized)
+    return Boolean(await resolvePublicAddress(parsed))
+  }
+  catch {
+    return false
+  }
+}
+
+function isRedirectStatus(statusCode: number) {
+  return statusCode === 301
+    || statusCode === 302
+    || statusCode === 303
+    || statusCode === 307
+    || statusCode === 308
+}
+
+function getHeaderValue(header: string | string[] | undefined) {
+  return Array.isArray(header) ? header[0] ?? '' : header ?? ''
+}
+
+function readIncomingMessageWithLimit(response: IncomingMessage, maxBytes: number) {
+  const contentLengthHeader = getHeaderValue(response.headers['content-length'])
+  const contentLength = contentLengthHeader ? Number.parseInt(contentLengthHeader, 10) : Number.NaN
+  if (Number.isFinite(contentLength) && (contentLength < 0 || contentLength > maxBytes)) {
+    response.resume()
+    return Promise.resolve(null)
+  }
+
+  return new Promise<Uint8Array | null>((resolve, reject) => {
+    const chunks: Buffer[] = []
+    let totalBytes = 0
+    let settled = false
+
+    function cleanup() {
+      response.off('data', handleData)
+      response.off('end', handleEnd)
+      response.off('error', handleError)
+    }
+
+    function settle(value: Uint8Array | null) {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      resolve(value)
+    }
+
+    function fail(error: Error) {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      reject(error)
+    }
+
+    function handleData(chunk: Buffer | Uint8Array) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk)
+      totalBytes += buffer.byteLength
+      if (totalBytes > maxBytes) {
+        response.destroy()
+        settle(null)
+        return
+      }
+      chunks.push(buffer)
+    }
+
+    function handleEnd() {
+      settle(Buffer.concat(chunks, totalBytes))
+    }
+
+    function handleError(error: Error) {
+      fail(error)
+    }
+
+    response.on('data', handleData)
+    response.on('end', handleEnd)
+    response.on('error', handleError)
+  })
+}
+
+function requestImage(url: URL, address: string, timeoutMs: number, maxBytes: number) {
+  const transport = url.protocol === 'https:' ? https : http
+  const port = url.port ? Number(url.port) : (url.protocol === 'https:' ? 443 : 80)
+
+  return new Promise<ImageResponsePayload>((resolve, reject) => {
+    let settled = false
+    let request: ClientRequest | null = null
+    const timeout = setTimeout(() => {
+      request?.destroy(new Error('Image request timed out.'))
+    }, timeoutMs)
+
+    function settleWithPayload(payload: ImageResponsePayload) {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      resolve(payload)
+    }
+
+    function fail(error: Error) {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timeout)
+      reject(error)
+    }
+
+    const requestOptions: RequestOptions & HttpsRequestOptions = {
+      hostname: address,
+      port,
+      method: 'GET',
+      path: `${url.pathname}${url.search}`,
+      headers: {
+        'Accept': 'image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8',
+        'Host': url.host,
+        'User-Agent': 'kuest-og-image-fetcher',
+      },
+    }
+
+    if (url.protocol === 'https:') {
+      requestOptions.servername = url.hostname
+    }
+
+    request = transport.request(requestOptions, (response) => {
+      const statusCode = response.statusCode ?? 0
+      const location = getHeaderValue(response.headers.location)
+      const contentType = getHeaderValue(response.headers['content-type']).split(';')[0]?.trim().toLowerCase() ?? ''
+
+      if (isRedirectStatus(statusCode) || statusCode < 200 || statusCode >= 300 || !IMAGE_DATA_URI_CONTENT_TYPES.has(contentType)) {
+        response.resume()
+        settleWithPayload({ body: null, contentType, location, statusCode })
+        return
+      }
+
+      readIncomingMessageWithLimit(response, maxBytes)
+        .then(body => settleWithPayload({ body, contentType, location, statusCode }))
+        .catch(fail)
+    })
+
+    request.on('error', fail)
+    request.end()
+  })
+}
+
+async function fetchValidatedImageDataUrl(url: URL, options: Required<Omit<SafeImageOptions, 'siteUrl'>>, redirectCount = 0): Promise<string> {
+  if (redirectCount > options.maxRedirects) {
+    return ''
+  }
+
+  const resolved = await resolvePublicAddress(url)
+  if (!resolved) {
+    return ''
+  }
+
+  const response = await requestImage(url, resolved.address, options.timeoutMs, options.maxBytes)
+  if (isRedirectStatus(response.statusCode)) {
+    if (!response.location) {
+      return ''
+    }
+
+    const redirectUrl = normalizeOutboundImageUrl(new URL(response.location, url).toString())
+    return redirectUrl
+      ? fetchValidatedImageDataUrl(new URL(redirectUrl), options, redirectCount + 1)
+      : ''
+  }
+
+  if (!response.body || response.body.byteLength === 0 || !IMAGE_DATA_URI_CONTENT_TYPES.has(response.contentType)) {
+    return ''
+  }
+
+  return `data:${response.contentType};base64,${Buffer.from(response.body).toString('base64')}`
+}
+
+export async function fetchSafeOgImageDataUrl(rawUrl: string | null | undefined, options: SafeImageOptions = {}) {
+  const normalized = normalizeOutboundImageUrl(rawUrl, options)
+  if (!normalized) {
+    return ''
+  }
+
+  try {
+    return await fetchValidatedImageDataUrl(new URL(normalized), {
+      maxBytes: options.maxBytes ?? DEFAULT_MAX_IMAGE_BYTES,
+      maxRedirects: options.maxRedirects ?? DEFAULT_MAX_REDIRECTS,
+      timeoutMs: options.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    })
+  }
+  catch {
+    return ''
+  }
+}

--- a/src/lib/og-image-security.ts
+++ b/src/lib/og-image-security.ts
@@ -11,6 +11,7 @@ const DEFAULT_MAX_IMAGE_BYTES = 2 * 1024 * 1024
 const DEFAULT_TIMEOUT_MS = 1200
 const DEFAULT_MAX_REDIRECTS = 3
 const MAX_URL_LENGTH = 2048
+const MAX_TRUSTED_DATA_URI_LENGTH = DEFAULT_MAX_IMAGE_BYTES * 2
 
 const IMAGE_DATA_URI_CONTENT_TYPES = new Set([
   'image/gif',
@@ -42,6 +43,21 @@ interface ImageResponsePayload {
 
 function normalizeHostname(hostname: string) {
   return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '')
+}
+
+function isTrustedImageDataUri(rawUrl: string) {
+  if (rawUrl.length > MAX_TRUSTED_DATA_URI_LENGTH) {
+    return false
+  }
+
+  const commaIndex = rawUrl.indexOf(',')
+  if (commaIndex === -1 || !rawUrl.toLowerCase().startsWith('data:')) {
+    return false
+  }
+
+  const metadata = rawUrl.slice('data:'.length, commaIndex).toLowerCase()
+  const contentType = metadata.split(';')[0]?.trim() ?? ''
+  return IMAGE_DATA_URI_CONTENT_TYPES.has(contentType)
 }
 
 function parseIpv4Address(address: string): [number, number, number, number] | null {
@@ -183,6 +199,7 @@ function isPublicIpv6Address(address: string) {
     || isIpv6InRange(parsed, '2002::', 16)
     || isIpv6InRange(parsed, 'fc00::', 7)
     || isIpv6InRange(parsed, 'fe80::', 10)
+    || isIpv6InRange(parsed, 'fec0::', 10)
     || isIpv6InRange(parsed, 'ff00::', 8)
   )
 }
@@ -485,4 +502,17 @@ export async function fetchSafeOgImageDataUrl(rawUrl: string | null | undefined,
   catch {
     return ''
   }
+}
+
+export async function resolveTrustedOgImageSource(rawUrl: string | null | undefined, options: SafeImageOptions = {}) {
+  const trimmed = rawUrl?.trim()
+  if (!trimmed) {
+    return ''
+  }
+
+  if (isTrustedImageDataUri(trimmed)) {
+    return trimmed
+  }
+
+  return fetchSafeOgImageDataUrl(trimmed, options)
 }

--- a/tests/unit/ogImageSecurity.test.ts
+++ b/tests/unit/ogImageSecurity.test.ts
@@ -1,0 +1,73 @@
+import { lookup } from 'node:dns/promises'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  isPublicIpAddress,
+  normalizeOutboundImageUrl,
+  validateOutboundImageUrl,
+} from '@/lib/og-image-security'
+
+const dnsMocks = vi.hoisted(() => ({
+  lookup: vi.fn(),
+}))
+
+vi.mock('node:dns/promises', () => ({
+  default: {
+    lookup: dnsMocks.lookup,
+  },
+  lookup: dnsMocks.lookup,
+}))
+
+const lookupMock = vi.mocked(lookup)
+
+describe('OG image security helpers', () => {
+  beforeEach(() => {
+    lookupMock.mockReset()
+  })
+
+  it('normalizes public HTTP(S) image URLs', () => {
+    expect(normalizeOutboundImageUrl(' https://cdn.example.com/avatar.png ')).toBe('https://cdn.example.com/avatar.png')
+    expect(normalizeOutboundImageUrl('/avatar.png', { siteUrl: 'https://kuest.example' })).toBe('https://kuest.example/avatar.png')
+  })
+
+  it('rejects local, private, single-label, credentialed, and unsupported URLs', () => {
+    expect(normalizeOutboundImageUrl('http://localhost:3000/avatar.png')).toBe('')
+    expect(normalizeOutboundImageUrl('http://127.0.0.1/avatar.png')).toBe('')
+    expect(normalizeOutboundImageUrl('http://2130706433/avatar.png')).toBe('')
+    expect(normalizeOutboundImageUrl('http://10.0.0.12/avatar.png')).toBe('')
+    expect(normalizeOutboundImageUrl('http://169.254.169.254/latest/meta-data')).toBe('')
+    expect(normalizeOutboundImageUrl('http://metadata/avatar.png')).toBe('')
+    expect(normalizeOutboundImageUrl('https://user:pass@example.com/avatar.png')).toBe('')
+    expect(normalizeOutboundImageUrl('file:///etc/passwd')).toBe('')
+  })
+
+  it('classifies public and non-public IP ranges', () => {
+    expect(isPublicIpAddress('8.8.8.8')).toBe(true)
+    expect(isPublicIpAddress('2606:4700:4700::1111')).toBe(true)
+    expect(isPublicIpAddress('0.0.0.0')).toBe(false)
+    expect(isPublicIpAddress('127.0.0.1')).toBe(false)
+    expect(isPublicIpAddress('192.168.1.10')).toBe(false)
+    expect(isPublicIpAddress('::1')).toBe(false)
+    expect(isPublicIpAddress('fc00::1')).toBe(false)
+    expect(isPublicIpAddress('fe80::1')).toBe(false)
+    expect(isPublicIpAddress('::ffff:127.0.0.1')).toBe(false)
+    expect(isPublicIpAddress('::ffff:7f00:1')).toBe(false)
+  })
+
+  it('rejects hostnames that resolve to a private address', async () => {
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '10.0.0.5', family: 4 },
+    ])
+
+    await expect(validateOutboundImageUrl('https://cdn.example.com/avatar.png')).resolves.toBe(false)
+  })
+
+  it('allows hostnames only when every resolved address is public', async () => {
+    lookupMock.mockResolvedValue([
+      { address: '93.184.216.34', family: 4 },
+      { address: '2606:4700:4700::1111', family: 6 },
+    ])
+
+    await expect(validateOutboundImageUrl('https://cdn.example.com/avatar.png')).resolves.toBe(true)
+  })
+})

--- a/tests/unit/ogImageSecurity.test.ts
+++ b/tests/unit/ogImageSecurity.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   isPublicIpAddress,
   normalizeOutboundImageUrl,
+  resolveTrustedOgImageSource,
   validateOutboundImageUrl,
 } from '@/lib/og-image-security'
 
@@ -49,8 +50,16 @@ describe('OG image security helpers', () => {
     expect(isPublicIpAddress('::1')).toBe(false)
     expect(isPublicIpAddress('fc00::1')).toBe(false)
     expect(isPublicIpAddress('fe80::1')).toBe(false)
+    expect(isPublicIpAddress('fec0::1')).toBe(false)
     expect(isPublicIpAddress('::ffff:127.0.0.1')).toBe(false)
     expect(isPublicIpAddress('::ffff:7f00:1')).toBe(false)
+  })
+
+  it('preserves trusted data image sources without outbound resolution', async () => {
+    const logo = 'data:image/svg+xml;utf8,%3Csvg%20viewBox%3D%220%200%201%201%22%2F%3E'
+
+    await expect(resolveTrustedOgImageSource(logo)).resolves.toBe(logo)
+    expect(lookupMock).not.toHaveBeenCalled()
   })
 
   it('rejects hostnames that resolve to a private address', async () => {


### PR DESCRIPTION
Thanks to @endscene665

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened OG image fetching to prevent SSRF by validating URLs, requiring DNS to resolve only to public IPs, and pinning requests to the resolved address. Applied across all OG routes and avatar updates with strict timeouts, size limits, allowed image types, and safe data:image logo support.

- **Bug Fixes**
  - Added `src/lib/og-image-security.ts` with `normalizeOutboundImageUrl`, `validateOutboundImageUrl`, `fetchSafeOgImageDataUrl`, and `resolveTrustedOgImageSource`:
    - HTTP/HTTPS only, no credentials; blocks localhost/private/single‑label hosts.
    - DNS must return only public IPv4/IPv6; requests are pinned to the resolved IP; redirects limited to 3.
    - Enforces 2MB max, 1200ms timeout; allows only image content types; preserves trusted data:image URIs.
  - Replaced ad‑hoc image fetching across all OG routes (`/og`, `/og/event`, `/og/position`, `/og/leaderboard`, `/og/predictions`, `/og/profile`) with the safe helpers; site logos now use `resolveTrustedOgImageSource`.
  - Validates `avatar_url` in profile update and rejects non‑public image hosts with a clear error.
  - Expanded unit tests to cover trusted data URIs and the “all addresses must be public” DNS policy.

- **Migration**
  - Avatar URLs must be public HTTP(S) image hosts; private/local addresses and single‑label hosts are blocked.

<sup>Written for commit 3b24fc1ebdc51da785ddb2bcdb634c648083b6f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1089?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

