### PR TITLE
chore: add sync scripts

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -51,7 +51,7 @@ COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
 COPY --from=build --chown=nextjs:nodejs /tmp/runtime-node_modules/postgres ./node_modules/postgres
 COPY --from=build --chown=nextjs:nodejs /app/package.json ./package.json
-COPY --from=build --chown=nextjs:nodejs /app/scripts/migrate.ts ./scripts/migrate.ts
+COPY --from=build --chown=nextjs:nodejs /app/scripts ./scripts
 COPY --from=build --chown=nextjs:nodejs /app/src/lib/site-url.ts ./src/lib/site-url.ts
 COPY --from=build --chown=nextjs:nodejs /app/src/lib/db/migrations ./src/lib/db/migrations
 

--- a/knip.config.ts
+++ b/knip.config.ts
@@ -4,6 +4,7 @@ const config: KnipConfig = {
   ignore: [
     'docs.config.ts',
     'public/**/*',
+    'scripts/**',
     'src/components/ui/**',
   ],
   treatConfigHintsAsErrors: false,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "kuest-prediction-market",
+  "type": "module",
   "private": true,
   "packageManager": "pnpm@11.5.0",
   "description": "Launch Your Own Decentralized Prediction Market in Minutes.",

--- a/scripts/cron-request.ts
+++ b/scripts/cron-request.ts
@@ -1,0 +1,26 @@
+export async function runCronRequest(endpointPath: string, options: any = {}) {
+  const siteUrl = process.env.SITE_URL?.trim()
+  if (!siteUrl) {
+    throw new Error('SITE_URL is not set')
+  }
+
+  const timeoutMilliseconds = options.timeoutMilliseconds ?? 30000
+  const response = await fetch(new URL(endpointPath, siteUrl), {
+    headers: {
+      Authorization: `Bearer ${process.env.CRON_SECRET ?? ''}`,
+    },
+    signal: AbortSignal.timeout(timeoutMilliseconds),
+  })
+
+  const body = await response.text()
+
+  console.log(response.status, response.statusText)
+
+  if (body) {
+    console.log(body)
+  }
+
+  if (!response.ok) {
+    process.exit(1)
+  }
+}

--- a/scripts/sync-event-creations-enqueue.ts
+++ b/scripts/sync-event-creations-enqueue.ts
@@ -1,0 +1,5 @@
+import { runCronRequest } from './cron-request'
+
+await runCronRequest('/api/sync/event-creations/enqueue', {
+  timeoutMilliseconds: 10000,
+})

--- a/scripts/sync-event-creations.ts
+++ b/scripts/sync-event-creations.ts
@@ -1,0 +1,3 @@
+import { runCronRequest } from './cron-request'
+
+await runCronRequest('/api/sync/event-creations')

--- a/scripts/sync-events.ts
+++ b/scripts/sync-events.ts
@@ -1,0 +1,3 @@
+import { runCronRequest } from './cron-request'
+
+await runCronRequest('/api/sync/events')

--- a/scripts/sync-resolution.ts
+++ b/scripts/sync-resolution.ts
@@ -1,0 +1,3 @@
+import { runCronRequest } from './cron-request'
+
+await runCronRequest('/api/sync/resolution')

--- a/scripts/sync-translations-enqueue.ts
+++ b/scripts/sync-translations-enqueue.ts
@@ -1,0 +1,5 @@
+import { runCronRequest } from './cron-request'
+
+await runCronRequest('/api/sync/translations/enqueue', {
+  timeoutMilliseconds: 20000,
+})

--- a/scripts/sync-translations.ts
+++ b/scripts/sync-translations.ts
@@ -1,0 +1,3 @@
+import { runCronRequest } from './cron-request'
+
+await runCronRequest('/api/sync/translations')

--- a/scripts/sync-volume-enqueue.ts
+++ b/scripts/sync-volume-enqueue.ts
@@ -1,0 +1,5 @@
+import { runCronRequest } from './cron-request'
+
+await runCronRequest('/api/sync/volume/enqueue', {
+  timeoutMilliseconds: 10000,
+})

--- a/scripts/sync-volume.ts
+++ b/scripts/sync-volume.ts
@@ -1,0 +1,3 @@
+import { runCronRequest } from './cron-request'
+
+await runCronRequest('/api/sync/volume')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add sync scripts that trigger our API cron endpoints so we can run syncs via cron or locally. Docker now includes the scripts, and the scripts run as ESM.

- **New Features**
  - Added `scripts/cron-request.ts` helper that calls endpoints with `SITE_URL` and `CRON_SECRET` and a 30s default timeout.
  - Added sync scripts for events, event creations, resolution, translations, and volume, plus enqueue variants with shorter timeouts.
  - Docker now copies the whole `scripts/` folder; `knip` ignores `scripts/**`; set `"type": "module"` in `package.json`.

<sup>Written for commit fc951561085cb9a33b48817a84dcee917eeb015b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1091?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

