### PR TITLE
refactor: runtime env only deployments

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -33,7 +33,7 @@ DISABLE_IMAGE_OPTIMIZATION=false
 
 # Force public shell prerendering on/off at build time.
 # Leave empty to infer from SITE_URL/VERCEL_PROJECT_PRODUCTION_URL + POSTGRES_URL + REOWN_APPKIT_PROJECT_ID.
-KUEST_PRERENDER_PUBLIC_SHELL=""
+BUILD_PRERENDER_PUBLIC_SHELL=""
 
 # PostgreSQL runtime connection (required outside Vercel/Supabase integration flow)
 POSTGRES_URL=""

--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,9 @@ KUEST_PASSPHRASE=""
 # Admin wallets (comma-separated, EVM 0x... addresses on Polygon)
 ADMIN_WALLETS=""
 
+# Public site URL, used for canonical links, wallet metadata, embeds, and callbacks
+SITE_URL=""
+
 # Your REOWN APPKIT project id http://dashboard.reown.com/
 REOWN_APPKIT_PROJECT_ID=""
 
@@ -27,6 +30,10 @@ CRON_SECRET=""
 
 # Disable Next.js image optimization
 DISABLE_IMAGE_OPTIMIZATION=false
+
+# Force public shell prerendering on/off at build time.
+# Leave empty to infer from SITE_URL/VERCEL_PROJECT_PRODUCTION_URL + POSTGRES_URL + REOWN_APPKIT_PROJECT_ID.
+KUEST_PRERENDER_PUBLIC_SHELL=""
 
 # PostgreSQL runtime connection (required outside Vercel/Supabase integration flow)
 POSTGRES_URL=""

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,13 +22,13 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
+      - uses: docker/build-push-action@f9f3042c3f8d1a6e1a6e8d0d7370e8f6c1d9c8c5 # v7.2.0
         with:
           context: .
           file: infra/docker/Dockerfile
@@ -38,14 +38,3 @@ jobs:
             ghcr.io/kuestcom/prediction-market:${{ github.sha }}
           build-args: |
             COMMIT_SHA=${{ github.sha }}
-
-      - name: Trigger deploy
-        env:
-          DEPLOY_WEBHOOK_URL: ${{ secrets.DEPLOY_WEBHOOK_URL }}
-        run: |
-          set -euo pipefail
-          if [ -z "$DEPLOY_WEBHOOK_URL" ]; then
-            echo "DEPLOY_WEBHOOK_URL secret is not set." >&2
-            exit 1
-          fi
-          curl --fail --silent --show-error --output /dev/null --request POST "$DEPLOY_WEBHOOK_URL"

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -38,8 +38,6 @@ jobs:
             ghcr.io/kuestcom/prediction-market:${{ github.sha }}
           build-args: |
             COMMIT_SHA=${{ github.sha }}
-            SITE_URL=${{ vars.SITE_URL }}
-            REOWN_APPKIT_PROJECT_ID=${{ vars.REOWN_APPKIT_PROJECT_ID }}
 
       - name: Trigger deploy
         env:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -28,7 +28,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: docker/build-push-action@f9f3042c3f8d1a6e1a6e8d0d7370e8f6c1d9c8c5 # v7.2.0
+      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: infra/docker/Dockerfile

--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -6,12 +6,8 @@ ENV PNPM_HOME=/pnpm
 ENV PATH=$PNPM_HOME:$PATH
 
 ARG COMMIT_SHA=unknown
-ARG SITE_URL=http://localhost:3000
-ARG REOWN_APPKIT_PROJECT_ID=""
 
 ENV COMMIT_SHA=$COMMIT_SHA
-ENV SITE_URL=$SITE_URL
-ENV REOWN_APPKIT_PROJECT_ID=$REOWN_APPKIT_PROJECT_ID
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends python3 make g++ \

--- a/next.config.ts
+++ b/next.config.ts
@@ -84,7 +84,7 @@ const config: NextConfig = {
   env: {
     COMMIT_SHA: commitSha,
     IS_VERCEL: process.env.VERCEL_ENV ? 'true' : 'false',
-    KUEST_BUILD_PRERENDER_PUBLIC_SHELL: shouldPrerenderPublicShell ? 'true' : 'false',
+    BUILD_PRERENDER_PUBLIC_SHELL: shouldPrerenderPublicShell ? 'true' : 'false',
     SENTRY_DSN: process.env.SENTRY_DSN,
     CREATE_MARKET_URL: process.env.CREATE_MARKET_URL ?? 'https://create-market.kuest.com',
     GAMMA_URL: process.env.GAMMA_URL ?? 'https://gamma-api.kuest.com',

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,11 +4,11 @@ import { createMDX } from 'fumadocs-mdx/next'
 import createNextIntlPlugin from 'next-intl/plugin'
 import { resolveCommitSha } from '@/lib/git'
 import { getOptimizedImageHostPatterns } from '@/lib/image/image-optimization'
-import resolveSiteUrl from './src/lib/site-url'
+import { resolvePublicShellPrerenderMode } from '@/lib/public-shell-env'
 
-const siteUrl = resolveSiteUrl(process.env)
 const optimizedImageHostPatterns = getOptimizedImageHostPatterns(process.env)
 const commitSha = resolveCommitSha()
+const shouldPrerenderPublicShell = resolvePublicShellPrerenderMode(process.env)
 
 const config: NextConfig = {
   output: process.env.VERCEL_ENV ? undefined : 'standalone',
@@ -84,9 +84,8 @@ const config: NextConfig = {
   env: {
     COMMIT_SHA: commitSha,
     IS_VERCEL: process.env.VERCEL_ENV ? 'true' : 'false',
-    SITE_URL: siteUrl,
+    KUEST_BUILD_PRERENDER_PUBLIC_SHELL: shouldPrerenderPublicShell ? 'true' : 'false',
     SENTRY_DSN: process.env.SENTRY_DSN,
-    REOWN_APPKIT_PROJECT_ID: process.env.REOWN_APPKIT_PROJECT_ID,
     CREATE_MARKET_URL: process.env.CREATE_MARKET_URL ?? 'https://create-market.kuest.com',
     GAMMA_URL: process.env.GAMMA_URL ?? 'https://gamma-api.kuest.com',
     GEOBLOCK_URL: process.env.GEOBLOCK_URL ?? 'https://geoblock.kuest.com',

--- a/next.config.ts
+++ b/next.config.ts
@@ -120,4 +120,5 @@ const withNextIntl = createNextIntlPlugin({
 
 export default withSentryConfig(withNextIntl(withMDX(config)), {
   telemetry: false,
+  silent: true,
 })

--- a/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
@@ -1,0 +1,61 @@
+import type { SupportedLocale } from '@/i18n/locales'
+import { cacheLife } from 'next/cache'
+import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
+import {
+  getHomeInitialCurrentTimestamp,
+  HOME_INITIAL_EVENTS_CACHE_LIFE,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
+
+interface HomeInitialContentProps {
+  initialMainTag?: string
+  initialTag?: string
+  locale: SupportedLocale
+}
+
+async function CachedHomeInitialContent({
+  initialMainTag,
+  initialTag,
+  locale,
+}: HomeInitialContentProps) {
+  'use cache'
+  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
+
+  const currentTimestamp = getHomeInitialCurrentTimestamp()
+
+  return (
+    <HomeContent
+      locale={locale}
+      currentTimestamp={currentTimestamp}
+      initialTag={initialTag}
+      initialMainTag={initialMainTag}
+    />
+  )
+}
+
+async function RuntimeHomeInitialContent({
+  initialMainTag,
+  initialTag,
+  locale,
+}: HomeInitialContentProps) {
+  await deferPublicShellPrerenderIfNeeded()
+
+  const currentTimestamp = getHomeInitialCurrentTimestamp()
+
+  return (
+    <HomeContent
+      locale={locale}
+      currentTimestamp={currentTimestamp}
+      initialTag={initialTag}
+      initialMainTag={initialMainTag}
+    />
+  )
+}
+
+export default function HomeInitialContent(props: HomeInitialContentProps) {
+  if (shouldPrerenderPublicShell()) {
+    return <CachedHomeInitialContent {...props} />
+  }
+
+  return <RuntimeHomeInitialContent {...props} />
+}

--- a/src/app/[locale]/(platform)/(home)/new/page.tsx
+++ b/src/app/[locale]/(platform)/(home)/new/page.tsx
@@ -1,13 +1,7 @@
-'use cache'
-
 import type { Metadata } from 'next'
+import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
-import { cacheLife } from 'next/cache'
-import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
-import {
-  getHomeInitialCurrentTimestamp,
-  HOME_INITIAL_EVENTS_CACHE_LIFE,
-} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+import HomeInitialContent from '@/app/[locale]/(platform)/(home)/_components/HomeInitialContent'
 import { getNewPageSeoTitle } from '@/lib/platform-routing'
 
 const MAIN_TAG_SLUG = 'new' as const
@@ -17,11 +11,9 @@ export const metadata: Metadata = {
 }
 
 export default async function NewPage({ params }: PageProps<'/[locale]/new'>) {
-  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
-
   const { locale } = await params
-  setRequestLocale(locale)
-  const currentTimestamp = getHomeInitialCurrentTimestamp()
+  const resolvedLocale = locale as SupportedLocale
+  setRequestLocale(resolvedLocale)
 
-  return <HomeContent locale={locale} currentTimestamp={currentTimestamp} initialTag={MAIN_TAG_SLUG} />
+  return <HomeInitialContent locale={resolvedLocale} initialTag={MAIN_TAG_SLUG} />
 }

--- a/src/app/[locale]/(platform)/(home)/page.tsx
+++ b/src/app/[locale]/(platform)/(home)/page.tsx
@@ -1,28 +1,11 @@
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
-import { cacheLife } from 'next/cache'
-import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
-import {
-  getHomeInitialCurrentTimestamp,
-  HOME_INITIAL_EVENTS_CACHE_LIFE,
-} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
-
-async function CachedHomePageContent({
-  locale,
-}: {
-  locale: SupportedLocale
-}) {
-  'use cache'
-  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
-
-  const currentTimestamp = getHomeInitialCurrentTimestamp()
-  return <HomeContent locale={locale} currentTimestamp={currentTimestamp} />
-}
+import HomeInitialContent from '@/app/[locale]/(platform)/(home)/_components/HomeInitialContent'
 
 export default async function HomePage({ params }: PageProps<'/[locale]'>) {
   const { locale } = await params
   setRequestLocale(locale)
   const resolvedLocale = locale as SupportedLocale
 
-  return <CachedHomePageContent locale={resolvedLocale} />
+  return <HomeInitialContent locale={resolvedLocale} />
 }

--- a/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
@@ -8,7 +8,7 @@ import {
   generateDynamicHomeSubcategoryStaticParams,
 } from '@/app/[locale]/(platform)/_lib/dynamic-home-category-page'
 import { isPlatformReservedRootSlug, normalizePublicProfileSlug } from '@/lib/platform-routing'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export const generateStaticParams = generateDynamicHomeSubcategoryStaticParams
 
@@ -24,6 +24,9 @@ async function generatePlatformSubcategoryMetadata({
   'use cache'
 
   if (slug === STATIC_PARAMS_PLACEHOLDER || subcategory === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug, subcategory)) {
+      return {}
+    }
     notFound()
   }
 
@@ -46,6 +49,9 @@ async function renderPlatformSubcategoryPage({
   'use cache'
 
   if (slug === STATIC_PARAMS_PLACEHOLDER || subcategory === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug, subcategory)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/page.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/app/[locale]/(platform)/_lib/dynamic-home-category-page'
 import { buildPublicProfileMetadata, PublicProfilePageContent } from '@/app/[locale]/(platform)/_lib/public-profile-page'
 import { isPlatformReservedRootSlug, normalizePublicProfileSlug } from '@/lib/platform-routing'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export const generateStaticParams = generateDynamicHomeCategoryStaticParams
 
@@ -21,6 +21,9 @@ async function generatePlatformSlugMetadata({
   slug: string
 }): Promise<Metadata> {
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return {}
+    }
     notFound()
   }
 
@@ -47,6 +50,9 @@ async function renderPlatformSlugPage({
   slug: string
 }) {
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
@@ -18,7 +18,7 @@ import {
   getMainTagSeoTitle,
 } from '@/lib/platform-routing'
 import resolveSiteUrl from '@/lib/site-url'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 async function getMainTags(locale: SupportedLocale) {
   const { data: mainTags } = await loadPlatformMainTags(locale)
@@ -49,15 +49,18 @@ async function CachedDynamicHomeContent({
 }
 
 export async function generateDynamicHomeCategoryStaticParams() {
-  return [{ slug: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ slug: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export async function generateDynamicHomeSubcategoryStaticParams() {
-  return [{ slug: STATIC_PARAMS_PLACEHOLDER, subcategory: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ slug: STATIC_PARAMS_PLACEHOLDER, subcategory: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export async function buildDynamicHomeCategoryMetadata(locale: SupportedLocale, slug: string): Promise<Metadata> {
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return {}
+    }
     notFound()
   }
 
@@ -101,6 +104,9 @@ export async function buildDynamicHomeSubcategoryMetadata(
   subcategory: string,
 ): Promise<Metadata> {
   if (slug === STATIC_PARAMS_PLACEHOLDER || subcategory === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug, subcategory)) {
+      return {}
+    }
     notFound()
   }
 
@@ -146,6 +152,9 @@ export async function DynamicHomeCategoryPageContent({
   slug: string
 }) {
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return null
+    }
     notFound()
   }
 
@@ -167,6 +176,9 @@ export async function DynamicHomeSubcategoryPageContent({
   subcategory: string
 }) {
   if (slug === STATIC_PARAMS_PLACEHOLDER || subcategory === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug, subcategory)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
@@ -1,12 +1,7 @@
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
-import { cacheLife } from 'next/cache'
 import { notFound } from 'next/navigation'
-import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
-import {
-  getHomeInitialCurrentTimestamp,
-  HOME_INITIAL_EVENTS_CACHE_LIFE,
-} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+import HomeInitialContent from '@/app/[locale]/(platform)/(home)/_components/HomeInitialContent'
 import {
   buildLocalizedPagePath,
   buildPredictionResultsOgImageUrl,
@@ -23,29 +18,6 @@ import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_
 async function getMainTags(locale: SupportedLocale) {
   const { data: mainTags } = await loadPlatformMainTags(locale)
   return mainTags ?? []
-}
-
-async function CachedDynamicHomeContent({
-  initialMainTag,
-  initialTag,
-  locale,
-}: {
-  initialMainTag?: string
-  initialTag: string
-  locale: SupportedLocale
-}) {
-  'use cache'
-  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
-
-  const currentTimestamp = getHomeInitialCurrentTimestamp()
-  return (
-    <HomeContent
-      locale={locale}
-      currentTimestamp={currentTimestamp}
-      initialTag={initialTag}
-      initialMainTag={initialMainTag}
-    />
-  )
 }
 
 export async function generateDynamicHomeCategoryStaticParams() {
@@ -163,7 +135,7 @@ export async function DynamicHomeCategoryPageContent({
     notFound()
   }
 
-  return <CachedDynamicHomeContent locale={locale} initialTag={category.slug} />
+  return <HomeInitialContent locale={locale} initialTag={category.slug} />
 }
 
 export async function DynamicHomeSubcategoryPageContent({
@@ -193,7 +165,7 @@ export async function DynamicHomeSubcategoryPageContent({
   }
 
   return (
-    <CachedDynamicHomeContent
+    <HomeInitialContent
       locale={locale}
       initialTag={resolvedSubcategory.subcategory.slug}
       initialMainTag={resolvedSubcategory.category.slug}

--- a/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/layout.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/layout.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from 'react'
 import { setRequestLocale } from 'next-intl/server'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER, slugParts: [STATIC_PARAMS_PLACEHOLDER] }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER, slugParts: [STATIC_PARAMS_PLACEHOLDER] })
 }
 
 export default async function EsportsSlugPartsLayout({

--- a/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/page.tsx
@@ -9,10 +9,10 @@ import {
   renderSportsVerticalEventPage,
 } from '@/app/[locale]/(platform)/sports/_utils/sports-event-page'
 import { resolveCanonicalEventSlugFromSportsPath } from '@/lib/event-page-data'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER, slugParts: [STATIC_PARAMS_PLACEHOLDER] }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER, slugParts: [STATIC_PARAMS_PLACEHOLDER] })
 }
 
 async function resolveLeagueEventPath(
@@ -42,6 +42,9 @@ export async function generateMetadata({
   const { locale, sport, slugParts } = await params
 
   if (sport === STATIC_PARAMS_PLACEHOLDER || slugParts.includes(STATIC_PARAMS_PLACEHOLDER)) {
+    if (shouldBypassPublicShellPlaceholder(sport, slugParts)) {
+      return {}
+    }
     notFound()
   }
 
@@ -91,6 +94,9 @@ export default async function EsportsSlugPartsPage({
   const { locale, sport, slugParts } = await params
 
   if (sport === STATIC_PARAMS_PLACEHOLDER || slugParts.includes(STATIC_PARAMS_PLACEHOLDER)) {
+    if (shouldBypassPublicShellPlaceholder(sport, slugParts)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/esports/[sport]/games/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/games/page.tsx
@@ -9,11 +9,11 @@ import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/s
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
 import { EventRepository } from '@/lib/db/queries/event'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER })
 }
 
 async function resolveEsportsSportContext(sport: string) {
@@ -45,6 +45,9 @@ export async function generateMetadata({
   setRequestLocale(locale)
 
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return {}
+    }
     notFound()
   }
 
@@ -72,6 +75,9 @@ export default async function EsportsGamesBySportPage({
   const { locale, sport } = await params
   setRequestLocale(locale)
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/esports/[sport]/games/week/[week]/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/games/week/[week]/page.tsx
@@ -9,14 +9,14 @@ import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/s
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
 import { EventRepository } from '@/lib/db/queries/event'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateStaticParams() {
-  return [{
+  return getPublicShellStaticParams({
     sport: STATIC_PARAMS_PLACEHOLDER,
     week: STATIC_PARAMS_PLACEHOLDER,
-  }]
+  })
 }
 
 async function resolveEsportsSportContext(sport: string) {
@@ -57,6 +57,9 @@ export async function generateMetadata({
   setRequestLocale(locale)
 
   if (sport === STATIC_PARAMS_PLACEHOLDER || week === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport, week)) {
+      return {}
+    }
     notFound()
   }
 
@@ -92,6 +95,9 @@ export default async function EsportsGamesBySportWeekPage({
   setRequestLocale(locale)
 
   if (sport === STATIC_PARAMS_PLACEHOLDER || week === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport, week)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/esports/[sport]/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/page.tsx
@@ -4,16 +4,19 @@ import { notFound } from 'next/navigation'
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
 import { redirect } from '@/i18n/navigation'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export default async function EsportsBySportRedirectPage({ params }: PageProps<'/[locale]/esports/[sport]'>) {
   const { locale, sport } = await params
   setRequestLocale(locale)
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/esports/[sport]/props/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/props/page.tsx
@@ -6,11 +6,11 @@ import { notFound } from 'next/navigation'
 import SportsContent from '@/app/[locale]/(platform)/sports/_components/SportsContent'
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER })
 }
 
 async function resolveEsportsSportContext(sport: string) {
@@ -42,6 +42,9 @@ export async function generateMetadata({
   setRequestLocale(locale)
 
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return {}
+    }
     notFound()
   }
 
@@ -68,6 +71,9 @@ export default async function EsportsPropsBySportPage({
   const { locale, sport } = await params
   setRequestLocale(locale)
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/[market]/page.tsx
@@ -9,11 +9,11 @@ import { buildTranslatedEventFaqItems } from '@/lib/event-faq-server'
 import { buildEventPageMetadata } from '@/lib/event-open-graph'
 import { getEventRouteBySlug, loadEventPagePublicContentData } from '@/lib/event-page-data'
 import { resolveEventMarketPath } from '@/lib/events-routing'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateStaticParams() {
-  return [{ market: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ market: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/event/[slug]/[market]'>): Promise<Metadata> {
@@ -21,6 +21,9 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/event/[s
   setRequestLocale(locale)
   const resolvedLocale = locale as SupportedLocale
   if (slug === STATIC_PARAMS_PLACEHOLDER || market === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug, market)) {
+      return {}
+    }
     notFound()
   }
   return await buildEventPageMetadata({
@@ -97,6 +100,9 @@ export default async function EventMarketPage({ params }: PageProps<'/[locale]/e
   setRequestLocale(locale)
   const resolvedLocale = locale as SupportedLocale
   if (slug === STATIC_PARAMS_PLACEHOLDER || market === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug, market)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartEmbedDialog.tsx
@@ -13,6 +13,7 @@ import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
 import { useIsMobile } from '@/hooks/useIsMobile'
+import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import { fetchAffiliateSettingsFromAPI } from '@/lib/affiliate-data'
 import { maybeShowAffiliateToast } from '@/lib/affiliate-toast'
@@ -33,7 +34,6 @@ import {
   buildWebComponentCode,
   EMBED_SCRIPT_URL,
   normalizeEmbedBaseUrl,
-  requireEmbedValue,
 } from '@/lib/embed-widget'
 import { slugifySiteName } from '@/lib/slug'
 import { cn } from '@/lib/utils'
@@ -63,7 +63,6 @@ interface AffiliateSettingsState {
 
 type EmbedType = 'iframe' | 'web-component'
 
-const SITE_URL = normalizeEmbedBaseUrl(requireEmbedValue(process.env.SITE_URL, 'SITE_URL'))
 const IFRAME_HEIGHT_WITH_CHART = 400
 const IFRAME_HEIGHT_WITH_FILTERS = 440
 const IFRAME_HEIGHT_NO_CHART = 180
@@ -250,6 +249,7 @@ function EventChartEmbedDialogEditor({
 }: Pick<EventChartEmbedDialogProps, 'markets' | 'initialMarketId'>) {
   const t = useExtracted()
   const site = useSiteIdentity()
+  const { siteUrl } = usePublicRuntimeConfig()
   const user = useUser()
   const [editorState, setEditorState] = useState(() => createInitialEditorState(markets, initialMarketId))
   const affiliateCode = user?.affiliate_code?.trim() ?? ''
@@ -274,7 +274,7 @@ function EventChartEmbedDialogEditor({
       return 'market'
     }
   }, [site.name])
-  const embedBaseUrl = SITE_URL
+  const embedBaseUrl = useMemo(() => normalizeEmbedBaseUrl(siteUrl), [siteUrl])
   const embedElementName = `${siteSlug}-market-embed`
   const embedIframeTitle = `${siteSlug}-market-iframe`
 

--- a/src/app/[locale]/(platform)/event/[slug]/layout.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/layout.tsx
@@ -1,8 +1,8 @@
 import { setRequestLocale } from 'next-intl/server'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ slug: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ slug: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export default async function EventLayout({ params, children }: LayoutProps<'/[locale]/event/[slug]'>) {

--- a/src/app/[locale]/(platform)/event/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/page.tsx
@@ -9,11 +9,11 @@ import { buildTranslatedEventFaqItems } from '@/lib/event-faq-server'
 import { buildEventPageMetadata } from '@/lib/event-open-graph'
 import { getEventRouteBySlug, loadEventPagePublicContentData } from '@/lib/event-page-data'
 import { resolveEventBasePath, resolveEventPagePath } from '@/lib/events-routing'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateStaticParams() {
-  return [{ slug: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ slug: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/event/[slug]'>): Promise<Metadata> {
@@ -21,6 +21,9 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/event/[s
   setRequestLocale(locale)
   const resolvedLocale = locale as SupportedLocale
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return {}
+    }
     notFound()
   }
   return await buildEventPageMetadata({
@@ -91,6 +94,9 @@ export default async function EventPage({ params }: PageProps<'/[locale]/event/[
   setRequestLocale(locale)
   const resolvedLocale = locale as SupportedLocale
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/layout.tsx
+++ b/src/app/[locale]/(platform)/layout.tsx
@@ -10,9 +10,12 @@ import PlatformNavigationProvider from '@/app/[locale]/(platform)/_providers/Pla
 import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { loadPlatformMainTags } from '@/lib/platform-main-tags'
 import { buildChildParentMap, buildPlatformNavigationTags } from '@/lib/platform-navigation'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 import AppKitProvider from '@/providers/AppKitProvider'
 
 export default async function PlatformLayout({ params, children }: LayoutProps<'/[locale]'>) {
+  await deferPublicShellPrerenderIfNeeded()
+
   const { locale } = await params
   const resolvedLocale = locale as SupportedLocale
   setRequestLocale(resolvedLocale)

--- a/src/app/[locale]/(platform)/predictions/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/predictions/[slug]/page.tsx
@@ -10,16 +10,20 @@ import {
   DEFAULT_PREDICTION_RESULTS_SORT,
   DEFAULT_PREDICTION_RESULTS_STATUS,
 } from '@/lib/prediction-results-filters'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ slug: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ slug: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/predictions/[slug]'>): Promise<Metadata> {
   const { locale, slug } = await params
   const resolvedLocale = locale as SupportedLocale
   setRequestLocale(resolvedLocale)
+
+  if (shouldBypassPublicShellPlaceholder(slug)) {
+    return {}
+  }
 
   return generatePredictionResultsMetadata({
     locale: resolvedLocale,
@@ -35,6 +39,9 @@ export default async function PredictionResultsPage({
   setRequestLocale(resolvedLocale)
 
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/predictions/[slug]/route-filters/[status]/[sort]/page.tsx
+++ b/src/app/[locale]/(platform)/predictions/[slug]/route-filters/[status]/[sort]/page.tsx
@@ -12,14 +12,14 @@ import {
   parsePredictionResultsSort,
   parsePredictionResultsStatus,
 } from '@/lib/prediction-results-filters'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{
+  return getPublicShellStaticParams({
     slug: STATIC_PARAMS_PLACEHOLDER,
     sort: DEFAULT_PREDICTION_RESULTS_SORT,
     status: DEFAULT_PREDICTION_RESULTS_STATUS,
-  }]
+  })
 }
 
 interface PredictionResultsFilteredPageParams {
@@ -38,6 +38,10 @@ export async function generateMetadata({
   const resolvedLocale = locale as SupportedLocale
   setRequestLocale(resolvedLocale)
 
+  if (shouldBypassPublicShellPlaceholder(slug)) {
+    return {}
+  }
+
   return generatePredictionResultsMetadata({
     locale: resolvedLocale,
     slug,
@@ -54,6 +58,9 @@ export default async function PredictionResultsFilteredPage({
   setRequestLocale(resolvedLocale)
 
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/profile/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/profile/[slug]/page.tsx
@@ -3,11 +3,11 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
 import { buildPublicProfileMetadata, PublicProfilePageContent } from '@/app/[locale]/(platform)/_lib/public-profile-page'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { normalizeAddress } from '@/lib/wallet'
 
 export async function generateStaticParams() {
-  return [{ slug: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ slug: STATIC_PARAMS_PLACEHOLDER })
 }
 
 function resolveProfileNamespaceSlug(slug: string) {
@@ -24,6 +24,9 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/profile/
   setRequestLocale(resolvedLocale)
 
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return {}
+    }
     notFound()
   }
 
@@ -37,6 +40,9 @@ export default async function ProfileSlugPage({ params }: PageProps<'/[locale]/p
   const { locale, slug } = await params
   setRequestLocale(locale)
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/series/[slug]/page.tsx
+++ b/src/app/[locale]/(platform)/series/[slug]/page.tsx
@@ -5,10 +5,10 @@ import { notFound } from 'next/navigation'
 import { redirect } from '@/i18n/navigation'
 import { EventRepository } from '@/lib/db/queries/event'
 import { resolveEventPagePath } from '@/lib/events-routing'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ slug: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ slug: STATIC_PARAMS_PLACEHOLDER })
 }
 
 const LIVE_TRADING_WINDOW_MS = 24 * 60 * 60 * 1000
@@ -81,6 +81,9 @@ export default async function SeriesPage({ params }: SeriesPageProps) {
   setRequestLocale(locale)
 
   if (slug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(slug)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/AffiliateWidgetDialog.tsx
@@ -12,6 +12,7 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { Label } from '@/components/ui/label'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'
 import { Switch } from '@/components/ui/switch'
+import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import { fetchAffiliateSettingsFromAPI } from '@/lib/affiliate-data'
 import { maybeShowAffiliateToast } from '@/lib/affiliate-toast'
@@ -30,7 +31,6 @@ import {
   buildWebComponentCode,
   EMBED_SCRIPT_URL,
   normalizeEmbedBaseUrl,
-  requireEmbedValue,
 } from '@/lib/embed-widget'
 import { slugifySiteName } from '@/lib/slug'
 import { cn } from '@/lib/utils'
@@ -143,7 +143,6 @@ async function fetchCategoryMarkets(tag: string, locale: string, signal: AbortSi
     .slice(0, 80)
 }
 
-const SITE_URL = normalizeEmbedBaseUrl(requireEmbedValue(process.env.SITE_URL, 'SITE_URL'))
 const IFRAME_HEIGHT_WITH_CHART = 400
 const IFRAME_HEIGHT_WITH_FILTERS = 440
 const IFRAME_HEIGHT_NO_CHART = 180
@@ -256,6 +255,7 @@ function useCategoryMarkets({
 }
 
 function useEmbedCode({
+  embedBaseUrl,
   selectedCategory,
   locale,
   theme,
@@ -267,6 +267,7 @@ function useEmbedCode({
   embedIframeTitle,
   selectedMarketSlug,
 }: {
+  embedBaseUrl: string
   selectedCategory: string
   locale: string
   theme: EmbedTheme
@@ -288,14 +289,14 @@ function useEmbedCode({
   const iframeSrc = useMemo(
     () =>
       buildAffiliateIframeSrc(
-        SITE_URL,
+        embedBaseUrl,
         selectedCategory,
         locale,
         theme,
         features,
         affiliateCode,
       ),
-    [selectedCategory, locale, theme, features, affiliateCode],
+    [embedBaseUrl, selectedCategory, locale, theme, features, affiliateCode],
   )
   const previewSrc = useMemo(
     () =>
@@ -386,6 +387,7 @@ export default function AffiliateWidgetDialog({
   const t = useExtracted()
   const locale = useLocale()
   const site = useSiteIdentity()
+  const { siteUrl } = usePublicRuntimeConfig()
   const user = useUser()
   const affiliateCode = user?.affiliate_code?.trim() ?? ''
   const {
@@ -403,6 +405,7 @@ export default function AffiliateWidgetDialog({
   const { copied, setCopied } = useCopyFlashState()
   const { selectedCategory, setSelectedCategoryState } = useEmbedCategorySelection(categories)
   const siteSlug = useSiteSlug(site.name)
+  const embedBaseUrl = useMemo(() => normalizeEmbedBaseUrl(siteUrl), [siteUrl])
   const { affiliateSharePercent, builderTakerFeePercent } = useAffiliateFeeSettings(affiliateCode)
   const {
     data: currentMarkets = [],
@@ -433,6 +436,7 @@ export default function AffiliateWidgetDialog({
     iframeLines,
     webComponentLines,
   } = useEmbedCode({
+    embedBaseUrl,
     selectedCategory,
     locale,
     theme,

--- a/src/app/[locale]/(platform)/settings/affiliate/page.tsx
+++ b/src/app/[locale]/(platform)/settings/affiliate/page.tsx
@@ -9,6 +9,7 @@ import { AffiliateRepository } from '@/lib/db/queries/affiliate'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { TagRepository } from '@/lib/db/queries/tag'
 import { UserRepository } from '@/lib/db/queries/user'
+import resolveSiteUrl from '@/lib/site-url'
 import { getPublicAssetUrl } from '@/lib/storage'
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/settings/affiliate'>): Promise<Metadata> {
@@ -71,9 +72,7 @@ export default async function AffiliateSettingsPage({ params }: PageProps<'/[loc
   const commissionPercent = Number(affiliateFeeSettings.builderTakerFeeBps * affiliateFeeSettings.affiliateShareBps) / 1000000
 
   function resolveBaseUrl() {
-    const raw = process.env.SITE_URL!
-
-    return raw.startsWith('http') ? raw : `https://${raw}`
+    return resolveSiteUrl(process.env)
   }
 
   const affiliateData = affiliateCode

--- a/src/app/[locale]/(platform)/sports/[sport]/[event]/[market]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/[event]/[market]/page.tsx
@@ -21,11 +21,11 @@ import { buildEventPageMetadata } from '@/lib/event-open-graph'
 import { getEventRouteBySlug, resolveCanonicalEventSlugFromSportsPath } from '@/lib/event-page-data'
 import { resolveEventBasePath, resolveEventMarketPath } from '@/lib/events-routing'
 import { resolveSportsEventMarketViewKey } from '@/lib/sports-event-slugs'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateStaticParams() {
-  return [{ market: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ market: STATIC_PARAMS_PLACEHOLDER })
 }
 
 function isSameSportsGame(
@@ -53,6 +53,9 @@ export async function generateMetadata({
     || event === STATIC_PARAMS_PLACEHOLDER
     || market === STATIC_PARAMS_PLACEHOLDER
   ) {
+    if (shouldBypassPublicShellPlaceholder(sport, event, market)) {
+      return {}
+    }
     notFound()
   }
   const canonicalEventSlug = await resolveCanonicalEventSlugFromSportsPath(sport, event)
@@ -77,6 +80,9 @@ export default async function SportsEventMarketPage({
     || event === STATIC_PARAMS_PLACEHOLDER
     || market === STATIC_PARAMS_PLACEHOLDER
   ) {
+    if (shouldBypassPublicShellPlaceholder(sport, event, market)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/sports/[sport]/[event]/layout.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/[event]/layout.tsx
@@ -2,10 +2,10 @@
 
 import type { ReactNode } from 'react'
 import { setRequestLocale } from 'next-intl/server'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER, event: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER, event: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export default async function SportsEventLayout({

--- a/src/app/[locale]/(platform)/sports/[sport]/[event]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/[event]/page.tsx
@@ -5,10 +5,10 @@ import {
   generateSportsVerticalEventMetadata,
   renderSportsVerticalEventPage,
 } from '@/app/[locale]/(platform)/sports/_utils/sports-event-page'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER, event: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER, event: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export async function generateMetadata({

--- a/src/app/[locale]/(platform)/sports/[sport]/games/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/games/page.tsx
@@ -9,11 +9,11 @@ import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/s
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
 import { EventRepository } from '@/lib/db/queries/event'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER })
 }
 
 async function resolveSportsSportContext(sport: string) {
@@ -45,6 +45,9 @@ export async function generateMetadata({
   setRequestLocale(locale)
 
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return {}
+    }
     notFound()
   }
 
@@ -71,6 +74,9 @@ export default async function SportsGamesBySportPage({
   const { locale, sport } = await params
   setRequestLocale(locale)
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/sports/[sport]/games/week/[week]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/games/week/[week]/page.tsx
@@ -9,14 +9,14 @@ import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/s
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
 import { EventRepository } from '@/lib/db/queries/event'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateStaticParams() {
-  return [{
+  return getPublicShellStaticParams({
     sport: STATIC_PARAMS_PLACEHOLDER,
     week: STATIC_PARAMS_PLACEHOLDER,
-  }]
+  })
 }
 
 async function resolveSportsSportContext(sport: string) {
@@ -57,6 +57,9 @@ export async function generateMetadata({
   setRequestLocale(locale)
 
   if (sport === STATIC_PARAMS_PLACEHOLDER || week === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport, week)) {
+      return {}
+    }
     notFound()
   }
 
@@ -92,6 +95,9 @@ export default async function SportsGamesBySportWeekPage({
   setRequestLocale(locale)
 
   if (sport === STATIC_PARAMS_PLACEHOLDER || week === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport, week)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/sports/[sport]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/page.tsx
@@ -4,10 +4,10 @@ import { notFound } from 'next/navigation'
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
 import { redirect } from '@/i18n/navigation'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export default async function SportsBySportRedirectPage({
@@ -16,6 +16,9 @@ export default async function SportsBySportRedirectPage({
   const { locale, sport } = await params
   setRequestLocale(locale)
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/sports/[sport]/props/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/props/page.tsx
@@ -6,11 +6,11 @@ import { notFound } from 'next/navigation'
 import SportsContent from '@/app/[locale]/(platform)/sports/_components/SportsContent'
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateStaticParams() {
-  return [{ sport: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER })
 }
 
 async function resolveSportsSportContext(sport: string) {
@@ -42,6 +42,9 @@ export async function generateMetadata({
   setRequestLocale(locale)
 
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return {}
+    }
     notFound()
   }
 
@@ -68,6 +71,9 @@ export default async function SportsPropsBySportPage({
   const { locale, sport } = await params
   setRequestLocale(locale)
   if (sport === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sport)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/sports/_utils/sports-event-page.tsx
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-event-page.tsx
@@ -21,7 +21,7 @@ import { getEventRouteBySlug, resolveCanonicalEventSlugFromSportsPath } from '@/
 import { resolveEventBasePath, resolveEventMarketPath, resolveEventPagePath } from '@/lib/events-routing'
 import { resolveSportsEventMarketViewKey } from '@/lib/sports-event-slugs'
 import { getSportsVerticalConfig } from '@/lib/sports-vertical'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export interface SportsVerticalEventPageParams {
@@ -94,6 +94,10 @@ export async function generateSportsVerticalEventMetadata({
 }: SportsVerticalEventPageParams): Promise<Metadata> {
   setRequestLocale(locale)
 
+  if (shouldBypassPublicShellPlaceholder(sport, league, event)) {
+    return {}
+  }
+
   return await buildEventPageMetadata({
     eventSlug: await resolveCanonicalSportsEventSlug({ sport, league, event }),
     locale: locale as SupportedLocale,
@@ -108,6 +112,10 @@ export async function renderSportsVerticalEventPage({
   vertical,
 }: RenderSportsVerticalEventPageParams) {
   const resolvedLocale = locale as SupportedLocale
+  if (shouldBypassPublicShellPlaceholder(sport, league, event)) {
+    return null
+  }
+
   const canonicalEventSlug = await resolveCanonicalSportsEventSlug({ sport, league, event })
   const eventRoute = await getEventRouteBySlug(canonicalEventSlug)
   if (!eventRoute) {
@@ -190,6 +198,10 @@ export async function generateSportsVerticalEventMarketMetadata({
 }: SportsVerticalEventMarketPageParams): Promise<Metadata> {
   setRequestLocale(locale)
 
+  if (shouldBypassPublicShellPlaceholder(sport, league, event, market)) {
+    return {}
+  }
+
   return await buildEventPageMetadata({
     eventSlug: await resolveCanonicalSportsEventSlug({ sport, league, event }),
     locale: locale as SupportedLocale,
@@ -206,6 +218,10 @@ export async function renderSportsVerticalEventMarketPage({
   vertical,
 }: RenderSportsVerticalEventMarketPageParams) {
   const resolvedLocale = locale as SupportedLocale
+  if (shouldBypassPublicShellPlaceholder(sport, league, event, market)) {
+    return null
+  }
+
   const canonicalEventSlug = await resolveCanonicalSportsEventSlug({ sport, league, event })
   const eventRoute = await getEventRouteBySlug(canonicalEventSlug)
   if (!eventRoute) {

--- a/src/app/[locale]/(platform)/sports/futures/[sportSlug]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/futures/[sportSlug]/page.tsx
@@ -6,10 +6,10 @@ import { notFound } from 'next/navigation'
 import SportsContent from '@/app/[locale]/(platform)/sports/_components/SportsContent'
 import { findSportsHrefBySlug } from '@/app/[locale]/(platform)/sports/_utils/sports-menu-routing'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
-import { STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
+import { getPublicShellStaticParams, shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export async function generateStaticParams() {
-  return [{ sportSlug: STATIC_PARAMS_PLACEHOLDER }]
+  return getPublicShellStaticParams({ sportSlug: STATIC_PARAMS_PLACEHOLDER })
 }
 
 export const metadata: Metadata = {
@@ -22,6 +22,9 @@ export default async function SportsFuturesBySportPage({
   const { locale, sportSlug } = await params
   setRequestLocale(locale)
   if (sportSlug === STATIC_PARAMS_PLACEHOLDER) {
+    if (shouldBypassPublicShellPlaceholder(sportSlug)) {
+      return null
+    }
     notFound()
   }
 

--- a/src/app/[locale]/(platform)/tos/page.tsx
+++ b/src/app/[locale]/(platform)/tos/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
 import { SettingsRepository } from '@/lib/db/queries/settings'
+import resolveSiteUrl from '@/lib/site-url'
 import { getTermsOfServicePdfUrl } from '@/lib/terms-of-service'
 import { getThemeSiteSettingsFormState, loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -27,7 +28,7 @@ export default async function TermsOfUsePage({ params }: PageProps<'/[locale]/to
   const siteSettings = getThemeSiteSettingsFormState(allSettings ?? undefined)
   const siteName = siteSettings.siteName
   const siteNameUpper = siteName.toUpperCase()
-  const siteUrl = (process.env.SITE_URL?.trim()?.replace(/\/$/, '') ?? '') || undefined
+  const siteUrl = resolveSiteUrl(process.env)
   const termsOfServicePdfUrl = getTermsOfServicePdfUrl(allSettings ?? undefined)
 
   if (termsOfServicePdfUrl) {

--- a/src/app/[locale]/admin/_components/CopyVersion.tsx
+++ b/src/app/[locale]/admin/_components/CopyVersion.tsx
@@ -8,10 +8,10 @@ import { useState } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 
 const COMMIT_SHA = process.env.COMMIT_SHA?.trim() || 'unknown'
 const NORMALIZED_COMMIT_SHA = COMMIT_SHA.toLowerCase()
-const SITE_URL = process.env.SITE_URL ?? 'unknown'
 const IS_VERCEL = process.env.IS_VERCEL ?? 'false'
 const UPSTREAM_COMMITS_URL = 'https://api.github.com/repos/kuestcom/prediction-market/commits?per_page=1'
 const GITHUB_SYNC_IMAGE_SRC = '/images/sync/github-sync.jpg'
@@ -188,6 +188,7 @@ function ForkSyncWarning({ forkRepositoryUrl, upstreamCommitSha }: ForkSyncWarni
 export default function CopyVersion({ forkRepositoryUrl }: CopyVersionProps) {
   const [copied, setCopied] = useState(false)
   const t = useExtracted()
+  const { siteUrl } = usePublicRuntimeConfig()
   const latestUpstreamCommitQuery = useQuery({
     queryKey: ['github-upstream-commit-sha', UPSTREAM_COMMITS_URL],
     queryFn: fetchLatestUpstreamCommit,
@@ -202,7 +203,7 @@ export default function CopyVersion({ forkRepositoryUrl }: CopyVersionProps) {
   async function copyVersionPayload() {
     const payload = `{${[
       COMMIT_SHA,
-      SITE_URL,
+      siteUrl,
       IS_VERCEL,
       new Date().toISOString(),
     ].join(';')}}`

--- a/src/app/[locale]/admin/api/users/route.ts
+++ b/src/app/[locale]/admin/api/users/route.ts
@@ -4,6 +4,7 @@ import { isAdminWallet } from '@/lib/admin'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { UserRepository } from '@/lib/db/queries/user'
 import { buildPublicProfilePath, buildUsernameProfilePath } from '@/lib/platform-routing'
+import resolveSiteUrl from '@/lib/site-url'
 import { getPublicAssetUrl } from '@/lib/storage'
 
 export async function GET(request: NextRequest) {
@@ -57,10 +58,7 @@ export async function GET(request: NextRequest) {
       }]),
     )
 
-    const baseProfileUrl = (() => {
-      const raw = process.env.SITE_URL!
-      return raw.startsWith('http') ? raw : `https://${raw}`
-    })()
+    const baseProfileUrl = resolveSiteUrl(process.env)
 
     const transformedUsers = (data ?? []).map((user) => {
       const created = new Date(user.created_at)

--- a/src/app/[locale]/docs/_components/GammaAPIPage.client.tsx
+++ b/src/app/[locale]/docs/_components/GammaAPIPage.client.tsx
@@ -2,9 +2,10 @@
 
 import { Custom } from 'fumadocs-openapi/playground/client'
 import { defineClientConfig } from 'fumadocs-openapi/ui/client'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 import { OpenAPIPlaygroundResult } from '@/app/[locale]/docs/_components/OpenAPIPlaygroundResult'
 import { Input } from '@/components/ui/input'
+import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 
 function resolveCreatorHostname(siteUrl: string | undefined): string {
   const raw = siteUrl?.trim()
@@ -20,10 +21,9 @@ function resolveCreatorHostname(siteUrl: string | undefined): string {
   }
 }
 
-const creatorHostname = resolveCreatorHostname(process.env.SITE_URL)
-
 function syncCreatorControllerValue(
   paramName: string,
+  creatorHostname: string,
   controller: ReturnType<typeof Custom.useController>,
 ) {
   if (paramName !== 'creator') {
@@ -36,14 +36,16 @@ function syncCreatorControllerValue(
 }
 
 function GammaParameterField({ fieldName, param }: { fieldName: (string | number)[], param: any }) {
+  const { siteUrl } = usePublicRuntimeConfig()
+  const creatorHostname = useMemo(() => resolveCreatorHostname(siteUrl), [siteUrl])
   const schema = param.schema ?? {}
   const controller = Custom.useController(fieldName, {
     defaultValue: param.name === 'creator' ? creatorHostname : schema.default,
   })
 
   useEffect(function syncFixedCreatorParameter() {
-    syncCreatorControllerValue(param.name, controller)
-  }, [controller, param.name])
+    syncCreatorControllerValue(param.name, creatorHostname, controller)
+  }, [controller, creatorHostname, param.name])
 
   const label = (
     <div className="flex items-center gap-1 text-xs font-medium">

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -1,7 +1,11 @@
 import type { Metadata, Viewport } from 'next'
+import type { ReactNode } from 'react'
+import type { SupportedLocale } from '@/i18n/locales'
+import type { RuntimeThemeState } from '@/lib/theme-settings'
 import { hasLocale, NextIntlClientProvider } from 'next-intl'
 import { setRequestLocale } from 'next-intl/server'
 import { notFound } from 'next/navigation'
+import { Suspense } from 'react'
 import CustomJavascriptCode from '@/components/CustomJavascriptCode'
 import GlobalAnnouncementBanner from '@/components/GlobalAnnouncementBanner'
 import PwaInstallStateSync from '@/components/PwaInstallStateSync'
@@ -13,14 +17,19 @@ import { routing } from '@/i18n/routing'
 import { openSauceOne } from '@/lib/fonts'
 import { loadGlobalAnnouncementSettings } from '@/lib/global-announcement-settings'
 import { IS_TEST_MODE } from '@/lib/network'
+import { getPublicRuntimeConfig } from '@/lib/public-runtime-config'
+import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
 import { resolvePwaThemeColors } from '@/lib/pwa-colors'
 import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 import { AppProviders } from '@/providers/AppProviders'
+import PublicRuntimeConfigProvider from '@/providers/PublicRuntimeConfigProvider'
 import SiteIdentityProvider from '@/providers/SiteIdentityProvider'
 import '../globals.css'
 
 export async function generateViewport(): Promise<Viewport> {
+  await deferPublicShellPrerenderIfNeeded()
+
   const runtimeTheme = await loadRuntimeThemeState()
   const { lightSurface, darkSurface } = resolvePwaThemeColors(runtimeTheme.theme)
 
@@ -33,6 +42,8 @@ export async function generateViewport(): Promise<Viewport> {
 }
 
 export async function generateMetadata(): Promise<Metadata> {
+  await deferPublicShellPrerenderIfNeeded()
+
   const runtimeTheme = await loadRuntimeThemeState()
   const site = runtimeTheme.site
   const siteUrl = resolveSiteUrl(process.env)
@@ -88,12 +99,20 @@ export async function generateStaticParams() {
   return [{ locale: 'en' }]
 }
 
-export default async function LocaleLayout({ params, children }: LayoutProps<'/[locale]'>) {
-  const { locale } = await params
+interface LocaleDocumentProps {
+  children: ReactNode
+  locale: SupportedLocale
+}
 
-  if (!hasLocale(routing.locales, locale)) {
-    notFound()
-  }
+interface LocaleRuntimeData {
+  globalAnnouncement: Awaited<ReturnType<typeof loadGlobalAnnouncementSettings>>
+  hasGlobalAnnouncement: boolean
+  publicRuntimeConfig: ReturnType<typeof getPublicRuntimeConfig>
+  runtimeTheme: RuntimeThemeState
+}
+
+async function loadLocaleRuntimeData(locale: SupportedLocale): Promise<LocaleRuntimeData> {
+  await deferPublicShellPrerenderIfNeeded()
 
   const enabledLocales = await loadEnabledLocales()
   if (!enabledLocales.includes(locale)) {
@@ -101,22 +120,52 @@ export default async function LocaleLayout({ params, children }: LayoutProps<'/[
   }
 
   const runtimeTheme = await loadRuntimeThemeState()
+  const publicRuntimeConfig = getPublicRuntimeConfig()
   const globalAnnouncement = await loadGlobalAnnouncementSettings()
   const hasGlobalAnnouncement = globalAnnouncement.message.trim().length > 0
 
   setRequestLocale(locale)
 
+  return {
+    globalAnnouncement,
+    hasGlobalAnnouncement,
+    publicRuntimeConfig,
+    runtimeTheme,
+  }
+}
+
+function ThemeDocumentState({
+  runtimeTheme,
+  syncRootPreset,
+}: {
+  runtimeTheme: RuntimeThemeState
+  syncRootPreset: boolean
+}) {
+  const setPresetScript = `document.documentElement.setAttribute('data-theme-preset',${JSON.stringify(runtimeTheme.theme.presetId)});`
+
   return (
-    <html
-      lang={locale}
-      className={openSauceOne.variable}
-      data-theme-preset={runtimeTheme.theme.presetId}
-      suppressHydrationWarning
-    >
-      <body className="flex min-h-screen flex-col font-sans">
-        <SiteStructuredData locale={locale} site={runtimeTheme.site} />
-        <PwaServiceWorker />
-        {runtimeTheme.theme.cssText && <style id="theme-vars" dangerouslySetInnerHTML={{ __html: runtimeTheme.theme.cssText }} />}
+    <>
+      {syncRootPreset && <script id="theme-preset-sync" dangerouslySetInnerHTML={{ __html: setPresetScript }} />}
+      {runtimeTheme.theme.cssText && <style id="theme-vars" dangerouslySetInnerHTML={{ __html: runtimeTheme.theme.cssText }} />}
+    </>
+  )
+}
+
+function LocaleBody({
+  children,
+  globalAnnouncement,
+  hasGlobalAnnouncement,
+  locale,
+  publicRuntimeConfig,
+  runtimeTheme,
+  syncRootPreset,
+}: LocaleDocumentProps & LocaleRuntimeData & { syncRootPreset: boolean }) {
+  return (
+    <body className="flex min-h-screen flex-col font-sans">
+      <ThemeDocumentState runtimeTheme={runtimeTheme} syncRootPreset={syncRootPreset} />
+      <SiteStructuredData locale={locale} site={runtimeTheme.site} />
+      <PwaServiceWorker />
+      <PublicRuntimeConfigProvider config={publicRuntimeConfig}>
         <SiteIdentityProvider site={runtimeTheme.site}>
           <NextIntlClientProvider locale={locale}>
             <AppProviders>
@@ -137,7 +186,72 @@ export default async function LocaleLayout({ params, children }: LayoutProps<'/[
             </AppProviders>
           </NextIntlClientProvider>
         </SiteIdentityProvider>
-      </body>
+      </PublicRuntimeConfigProvider>
+    </body>
+  )
+}
+
+async function PrerenderedLocaleDocument({ locale, children }: LocaleDocumentProps) {
+  const runtimeData = await loadLocaleRuntimeData(locale)
+
+  return (
+    <html
+      lang={locale}
+      className={openSauceOne.variable}
+      data-theme-preset={runtimeData.runtimeTheme.theme.presetId}
+      suppressHydrationWarning
+    >
+      <LocaleBody
+        {...runtimeData}
+        locale={locale}
+        syncRootPreset={false}
+      >
+        {children}
+      </LocaleBody>
     </html>
   )
+}
+
+async function RuntimeLocaleBody({ locale, children }: LocaleDocumentProps) {
+  const runtimeData = await loadLocaleRuntimeData(locale)
+
+  return (
+    <LocaleBody
+      {...runtimeData}
+      locale={locale}
+      syncRootPreset
+    >
+      {children}
+    </LocaleBody>
+  )
+}
+
+function RuntimeLocaleDocument({ locale, children }: LocaleDocumentProps) {
+  return (
+    <html
+      lang={locale}
+      className={openSauceOne.variable}
+      suppressHydrationWarning
+    >
+      <Suspense fallback={null}>
+        <RuntimeLocaleBody locale={locale}>
+          {children}
+        </RuntimeLocaleBody>
+      </Suspense>
+    </html>
+  )
+}
+
+export default async function LocaleLayout({ params, children }: LayoutProps<'/[locale]'>) {
+  const { locale } = await params
+
+  if (!hasLocale(routing.locales, locale)) {
+    notFound()
+  }
+
+  setRequestLocale(locale)
+
+  return shouldPrerenderPublicShell()
+    ? <PrerenderedLocaleDocument locale={locale}>{children}</PrerenderedLocaleDocument>
+    : <RuntimeLocaleDocument locale={locale}>{children}</RuntimeLocaleDocument>
 }

--- a/src/app/api/affiliate-info/route.ts
+++ b/src/app/api/affiliate-info/route.ts
@@ -4,6 +4,7 @@ import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { ZERO_ADDRESS } from '@/lib/contracts'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { UserRepository } from '@/lib/db/queries/user'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 const GENERAL_SETTINGS_GROUP = 'general'
 const FEE_RECIPIENT_WALLET_KEY = 'fee_recipient_wallet'
@@ -17,6 +18,8 @@ function getFeeRecipientAddress(settings?: Record<string, Record<string, { value
 
 export async function GET() {
   try {
+    await deferPublicShellPrerenderIfNeeded()
+
     const { data: settings } = await SettingsRepository.getSettings()
     const referrerAddress = getFeeRecipientAddress(settings ?? undefined)
     const affiliateSettings = settings?.affiliate

--- a/src/app/api/affiliate-info/route.ts
+++ b/src/app/api/affiliate-info/route.ts
@@ -1,3 +1,4 @@
+import { unstable_rethrow } from 'next/navigation'
 import { NextResponse } from 'next/server'
 import { AFFILIATE_SHARE_BPS_KEY, getAffiliateFeeSettings } from '@/lib/affiliate-fee-settings'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
@@ -67,6 +68,7 @@ export async function GET() {
     })
   }
   catch (error) {
+    unstable_rethrow(error)
     console.error('Failed to load affiliate info', error)
     return NextResponse.json({ error: DEFAULT_ERROR_MESSAGE }, { status: 500 })
   }

--- a/src/app/api/affiliate-settings/route.ts
+++ b/src/app/api/affiliate-settings/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { bpsToPercent, getAffiliateFeeSettings, getAffiliateFeeSettingsUpdatedAt } from '@/lib/affiliate-fee-settings'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { SettingsRepository } from '@/lib/db/queries/settings'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 interface AffiliateSettingsResponse {
   builderTakerFeePercent: number
@@ -12,6 +13,8 @@ interface AffiliateSettingsResponse {
 
 export async function GET() {
   try {
+    await deferPublicShellPrerenderIfNeeded()
+
     const { data: settings, error } = await SettingsRepository.getSettings()
 
     if (error || !settings) {

--- a/src/app/api/affiliate-settings/route.ts
+++ b/src/app/api/affiliate-settings/route.ts
@@ -1,3 +1,4 @@
+import { unstable_rethrow } from 'next/navigation'
 import { NextResponse } from 'next/server'
 import { bpsToPercent, getAffiliateFeeSettings, getAffiliateFeeSettingsUpdatedAt } from '@/lib/affiliate-fee-settings'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
@@ -51,6 +52,7 @@ export async function GET() {
     })
   }
   catch (error) {
+    unstable_rethrow(error)
     console.error('API Error:', error)
     return NextResponse.json({ error: DEFAULT_ERROR_MESSAGE }, { status: 500 })
   }

--- a/src/app/api/geoblock/route.ts
+++ b/src/app/api/geoblock/route.ts
@@ -1,7 +1,10 @@
 import { NextResponse } from 'next/server'
 import { loadBlockedCountries } from '@/lib/geoblock-settings'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 export async function GET() {
+  await deferPublicShellPrerenderIfNeeded()
+
   const blockedCountries = await loadBlockedCountries()
 
   return NextResponse.json(

--- a/src/app/api/lifi/chains/route.ts
+++ b/src/app/api/lifi/chains/route.ts
@@ -1,8 +1,11 @@
 import { getChains } from '@lifi/sdk'
 import { NextResponse } from 'next/server'
 import { ensureLiFiServerConfig } from '@/lib/lifi'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 export async function GET() {
+  await deferPublicShellPrerenderIfNeeded()
+
   await ensureLiFiServerConfig()
 
   try {

--- a/src/app/api/locales/route.ts
+++ b/src/app/api/locales/route.ts
@@ -1,3 +1,4 @@
+import { unstable_rethrow } from 'next/navigation'
 import { NextResponse } from 'next/server'
 import { loadEnabledLocales } from '@/i18n/locale-settings'
 import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
@@ -10,6 +11,7 @@ export async function GET() {
     return NextResponse.json({ locales })
   }
   catch (error) {
+    unstable_rethrow(error)
     console.error('Failed to load locales', error)
     return NextResponse.json({ locales: [] }, { status: 500 })
   }

--- a/src/app/api/locales/route.ts
+++ b/src/app/api/locales/route.ts
@@ -1,8 +1,11 @@
 import { NextResponse } from 'next/server'
 import { loadEnabledLocales } from '@/i18n/locale-settings'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 
 export async function GET() {
   try {
+    await deferPublicShellPrerenderIfNeeded()
+
     const locales = await loadEnabledLocales()
     return NextResponse.json({ locales })
   }

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -2,6 +2,7 @@ import { ImageResponse } from 'next/og'
 import OgImage from '@/app/api/og/_components/OgImage'
 import { oklchToRenderableColor } from '@/lib/color'
 import { resolveTrustedOgImageSource } from '@/lib/og-image-security'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 const OG_IMAGE_WIDTH = 1200
@@ -58,6 +59,8 @@ function resolveDescriptionFontSize(description: string) {
 }
 
 export async function GET() {
+  await deferPublicShellPrerenderIfNeeded()
+
   const runtimeTheme = await loadRuntimeThemeState()
   const siteName = normalizeText(runtimeTheme.site.name, 24) ?? 'Prediction Market'
   const siteDescription = normalizeText(runtimeTheme.site.description, 74) ?? 'Trade live prediction markets in real time.'

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/i18n/locales'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 import { source } from '@/lib/source'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -220,6 +221,8 @@ function formatEndpoint({
 }
 
 export async function GET() {
+  await deferPublicShellPrerenderIfNeeded()
+
   const runtimeTheme = await loadRuntimeThemeState()
   const site = runtimeTheme.site
   const siteDescription = normalizeDescription(site.description) ?? 'Decentralized prediction markets.'

--- a/src/app/manifest.ts
+++ b/src/app/manifest.ts
@@ -1,9 +1,12 @@
 import type { MetadataRoute } from 'next'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 import { resolvePwaThemeColors } from '@/lib/pwa-colors'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export default async function manifest(): Promise<MetadataRoute.Manifest> {
+  await deferPublicShellPrerenderIfNeeded()
+
   const runtimeTheme = await loadRuntimeThemeState()
   const site = runtimeTheme.site
   const { lightSurface } = resolvePwaThemeColors(runtimeTheme.theme)

--- a/src/app/market.html/route.ts
+++ b/src/app/market.html/route.ts
@@ -3,6 +3,7 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/i18n/locales'
 import { EventRepository } from '@/lib/db/queries/event'
 import { EMBED_SCRIPT_URL, normalizeEmbedBaseUrl, requireEmbedValue } from '@/lib/embed-widget'
+import resolveSiteUrl from '@/lib/site-url'
 import { slugifySiteName } from '@/lib/slug'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -64,7 +65,7 @@ export async function GET(request: NextRequest) {
   const showFilters = showChart && features.has('filters')
   const navArrowColor = theme === 'dark' ? 'rgba(255, 255, 255, 0.9)' : 'rgba(17, 24, 39, 0.9)'
 
-  const siteUrl = normalizeEmbedBaseUrl(requireEmbedValue(process.env.SITE_URL, 'SITE_URL'))
+  const siteUrl = normalizeEmbedBaseUrl(resolveSiteUrl(process.env))
   const scriptUrl = EMBED_SCRIPT_URL
   const runtimeTheme = await loadRuntimeThemeState()
   const siteName = requireEmbedValue(runtimeTheme.site.name, 'theme.site_name')

--- a/src/app/sitemaps/sitemap.ts
+++ b/src/app/sitemaps/sitemap.ts
@@ -2,6 +2,7 @@ import type { MetadataRoute } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { loadEnabledLocales } from '@/i18n/locale-settings'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
+import { hasDatabaseEnv } from '@/lib/db/env'
 import { withLocalePrefix } from '@/lib/locale-path'
 import resolveSiteUrl from '@/lib/site-url'
 import {
@@ -39,7 +40,7 @@ export default async function sitemap({ id }: Props): Promise<MetadataRoute.Site
   const sitemapId = await id
   const siteUrl = resolveSiteUrl(process.env)
   const fallbackLastModified = formatDateForSitemap(new Date())
-  const enabledLocales = await loadEnabledLocales()
+  const enabledLocales = hasDatabaseEnv() ? await loadEnabledLocales() : [DEFAULT_LOCALE]
 
   return buildSitemapEntries(sitemapId, siteUrl, fallbackLastModified, enabledLocales)
 }

--- a/src/hooks/usePublicRuntimeConfig.ts
+++ b/src/hooks/usePublicRuntimeConfig.ts
@@ -1,0 +1,15 @@
+'use client'
+
+import type { PublicRuntimeConfig } from '@/lib/public-runtime-config'
+import { createContext, use } from 'react'
+
+const defaultPublicRuntimeConfig: PublicRuntimeConfig = {
+  reownAppKitProjectId: '',
+  siteUrl: 'http://localhost:3000',
+}
+
+export const PublicRuntimeConfigContext = createContext<PublicRuntimeConfig>(defaultPublicRuntimeConfig)
+
+export function usePublicRuntimeConfig() {
+  return use(PublicRuntimeConfigContext)
+}

--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -1,3 +1,4 @@
+import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeSiteName } from '@/lib/theme-settings'
 
 export interface OpenRouterMessage {
@@ -45,8 +46,8 @@ async function buildOpenRouterHeaders(apiKey: string) {
     'Authorization': `Bearer ${apiKey}`,
   }
 
-  if (process.env.SITE_URL) {
-    headers['HTTP-Referer'] = process.env.SITE_URL
+  if (process.env.SITE_URL?.trim() || process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim()) {
+    headers['HTTP-Referer'] = resolveSiteUrl(process.env)
   }
 
   const siteName = await loadRuntimeThemeSiteName()

--- a/src/lib/appkit.ts
+++ b/src/lib/appkit.ts
@@ -3,9 +3,6 @@ import type { DefaultNetworkKey } from '@/lib/network'
 import { WagmiAdapter } from '@reown/appkit-adapter-wagmi'
 import { polygon, polygonAmoy } from '@reown/appkit/networks'
 import { DEFAULT_NETWORK_KEY } from '@/lib/network'
-import { reownProjectId } from '@/lib/reown-project-id'
-
-const projectId = reownProjectId
 
 const APPKIT_NETWORKS_BY_KEY = {
   amoy: polygonAmoy,
@@ -15,10 +12,10 @@ const APPKIT_NETWORKS_BY_KEY = {
 export const defaultNetwork = APPKIT_NETWORKS_BY_KEY[DEFAULT_NETWORK_KEY]
 export const networks = [defaultNetwork] as [AppKitNetwork, ...AppKitNetwork[]]
 
-export const wagmiAdapter = new WagmiAdapter({
-  ssr: false,
-  projectId,
-  networks,
-})
-
-export const wagmiConfig = wagmiAdapter.wagmiConfig
+export function createAppKitWagmiAdapter(projectId: string) {
+  return new WagmiAdapter({
+    ssr: false,
+    projectId,
+    networks,
+  })
+}

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,6 +30,19 @@ const SITE_URL = resolveSiteUrl(process.env)
 const siteUrlObject = new URL(SITE_URL)
 const SIWE_DOMAIN = siteUrlObject.host
 const SIWE_EMAIL_DOMAIN = siteUrlObject.hostname || 'kuest.com'
+const BUILD_ONLY_BETTER_AUTH_SECRET = 'runtime-env-only-build-placeholder-secret-32-chars-minimum'
+
+function resolveBetterAuthSecret() {
+  if (process.env.BETTER_AUTH_SECRET?.trim()) {
+    return process.env.BETTER_AUTH_SECRET
+  }
+
+  if (!process.env.POSTGRES_URL?.trim()) {
+    return BUILD_ONLY_BETTER_AUTH_SECRET
+  }
+
+  return undefined
+}
 
 function parseTimestampMs(value: unknown): number | null {
   if (value === null || value === undefined) {
@@ -155,7 +168,7 @@ export const auth = betterAuth({
   }),
   experimental: { joins: true },
   appName: DEFAULT_THEME_SITE_NAME,
-  secret: process.env.BETTER_AUTH_SECRET,
+  secret: resolveBetterAuthSecret(),
   baseURL: SITE_URL,
   advanced: {
     database: {

--- a/src/lib/db/env.ts
+++ b/src/lib/db/env.ts
@@ -1,0 +1,3 @@
+export function hasDatabaseEnv(env: NodeJS.ProcessEnv = process.env) {
+  return typeof env.POSTGRES_URL === 'string' && env.POSTGRES_URL.trim().length > 0
+}

--- a/src/lib/db/queries/settings.ts
+++ b/src/lib/db/queries/settings.ts
@@ -2,40 +2,51 @@ import type { QueryResult } from '@/types'
 import { and, eq, sql } from 'drizzle-orm'
 import { cacheTag, updateTag } from 'next/cache'
 import { cacheTags } from '@/lib/cache-tags'
+import { hasDatabaseEnv } from '@/lib/db/env'
 import { settings } from '@/lib/db/schema/settings/tables'
 import { runQuery } from '@/lib/db/utils/run-query'
 import { db } from '@/lib/drizzle'
 
-export const SettingsRepository = {
-  async getSettings(): Promise<QueryResult<Record<string, Record<string, { value: string, updated_at: string }>>>> {
-    'use cache'
-    cacheTag(cacheTags.settings)
+type SettingsMap = Record<string, Record<string, { value: string, updated_at: string }>>
 
-    return runQuery(async () => {
-      try {
-        const data = await db.select({
-          group: settings.group,
-          key: settings.key,
-          value: settings.value,
-          updated_at: settings.updated_at,
-        }).from(settings)
+async function getCachedSettings(): Promise<QueryResult<SettingsMap>> {
+  'use cache'
+  cacheTag(cacheTags.settings)
 
-        const settingsByGroup: Record<string, Record<string, { value: string, updated_at: string }>> = {}
+  return runQuery(async () => {
+    try {
+      const data = await db.select({
+        group: settings.group,
+        key: settings.key,
+        value: settings.value,
+        updated_at: settings.updated_at,
+      }).from(settings)
 
-        for (const setting of data) {
-          settingsByGroup[setting.group] ??= {}
-          settingsByGroup[setting.group][setting.key] = {
-            value: setting.value,
-            updated_at: setting.updated_at.toISOString(),
-          }
+      const settingsByGroup: SettingsMap = {}
+
+      for (const setting of data) {
+        settingsByGroup[setting.group] ??= {}
+        settingsByGroup[setting.group][setting.key] = {
+          value: setting.value,
+          updated_at: setting.updated_at.toISOString(),
         }
+      }
 
-        return { data: settingsByGroup, error: null }
-      }
-      catch {
-        return { data: null, error: 'Failed to fetch settings.' }
-      }
-    })
+      return { data: settingsByGroup, error: null }
+    }
+    catch {
+      return { data: null, error: 'Failed to fetch settings.' }
+    }
+  })
+}
+
+export const SettingsRepository = {
+  async getSettings(): Promise<QueryResult<SettingsMap>> {
+    if (!hasDatabaseEnv()) {
+      return { data: null, error: 'Database env vars are not configured.' }
+    }
+
+    return getCachedSettings()
   },
 
   async updateSettings(settingsArray: Array<{ group: string, key: string, value: string }>): Promise<QueryResult<Array<typeof settings.$inferSelect>>> {

--- a/src/lib/db/queries/sports-menu.ts
+++ b/src/lib/db/queries/sports-menu.ts
@@ -6,6 +6,7 @@ import type { QueryResult } from '@/types'
 import { and, asc, eq, gt, or, sql } from 'drizzle-orm'
 import { cacheTag, unstable_cache } from 'next/cache'
 import { cacheTags } from '@/lib/cache-tags'
+import { hasDatabaseEnv } from '@/lib/db/env'
 import {
   event_sports,
   events,
@@ -307,94 +308,144 @@ function findDefaultFuturesHref(menuEntries: SportsMenuEntry[]) {
   return null
 }
 
-export async function getSportsSlugResolverFromDb() {
+function buildEmptySportsMenuLayoutData(): SportsMenuLayoutData {
+  return {
+    menuEntries: [],
+    countsBySlug: {},
+    canonicalSlugByAliasKey: {},
+    h1TitleBySlug: {},
+    sectionsBySlug: {},
+  }
+}
+
+function buildQueryResult<T>(data: T): QueryResult<T> {
+  return {
+    data,
+    error: null,
+  }
+}
+
+async function getCachedSportsSlugResolverFromDb() {
   const rows = await getCachedSportsMenuRows()
   const mappingEntries = toMappingEntries(rows)
   return buildSportsSlugResolver(mappingEntries)
 }
 
+export async function getSportsSlugResolverFromDb() {
+  if (!hasDatabaseEnv()) {
+    return buildSportsSlugResolver([])
+  }
+
+  return getCachedSportsSlugResolverFromDb()
+}
+
+async function getCachedMenuEntries(vertical: SportsVertical): Promise<QueryResult<SportsMenuEntry[]>> {
+  'use cache'
+  cacheTag(cacheTags.sportsMenu)
+
+  return runQuery(async () => {
+    const rows = await getCachedSportsMenuRows()
+
+    return buildQueryResult(buildSportsSidebarEntries(rows, vertical))
+  })
+}
+
+async function getCachedLayoutData(vertical: SportsVertical): Promise<QueryResult<SportsMenuLayoutData>> {
+  'use cache'
+  cacheTag(cacheTags.sportsMenu)
+
+  return runQuery(async () => {
+    const [rows, activeCountRows] = await Promise.all([
+      getCachedSportsMenuRows(),
+      getCachedActiveSportsCountRows(),
+    ])
+    const resolver = buildSportsSlugResolver(toMappingEntries(rows))
+    const menuEntries = buildSportsSidebarEntries(rows, vertical)
+    const countsBySlug = buildSportsMenuCountsBySlug(resolver, activeCountRows, menuEntries)
+
+    return buildQueryResult({
+      menuEntries,
+      countsBySlug,
+      canonicalSlugByAliasKey: Object.fromEntries(resolver.canonicalByAliasKey),
+      h1TitleBySlug: Object.fromEntries(resolver.h1TitleBySlug),
+      sectionsBySlug: Object.fromEntries(resolver.sectionsBySlug),
+    })
+  })
+}
+
+async function getCachedCanonicalSlugByAlias(alias: string): Promise<QueryResult<string | null>> {
+  'use cache'
+  cacheTag(cacheTags.sportsMenu)
+
+  return runQuery(async () => {
+    const resolver = await getCachedSportsSlugResolverFromDb()
+
+    return buildQueryResult(resolveCanonicalSportsSlugAlias(resolver, alias))
+  })
+}
+
+async function getCachedLandingHref(vertical: SportsVertical): Promise<QueryResult<string | null>> {
+  'use cache'
+  cacheTag(cacheTags.sportsMenu)
+
+  return runQuery(async () => {
+    const rows = await getCachedSportsMenuRows()
+    const menuEntries = buildSportsSidebarEntries(rows, vertical)
+
+    return buildQueryResult(findDefaultLandingHref(menuEntries))
+  })
+}
+
+async function getCachedFuturesHref(vertical: SportsVertical): Promise<QueryResult<string | null>> {
+  'use cache'
+  cacheTag(cacheTags.sportsMenu)
+
+  return runQuery(async () => {
+    const rows = await getCachedSportsMenuRows()
+    const menuEntries = buildSportsSidebarEntries(rows, vertical)
+
+    return buildQueryResult(findDefaultFuturesHref(menuEntries))
+  })
+}
+
 export const SportsMenuRepository = {
   async getMenuEntries(vertical: SportsVertical = 'sports'): Promise<QueryResult<SportsMenuEntry[]>> {
-    'use cache'
-    cacheTag(cacheTags.sportsMenu)
+    if (!hasDatabaseEnv()) {
+      return buildQueryResult([])
+    }
 
-    return runQuery(async () => {
-      const rows = await getCachedSportsMenuRows()
-
-      return {
-        data: buildSportsSidebarEntries(rows, vertical),
-        error: null,
-      }
-    })
+    return getCachedMenuEntries(vertical)
   },
 
   async getLayoutData(vertical: SportsVertical = 'sports'): Promise<QueryResult<SportsMenuLayoutData>> {
-    'use cache'
-    cacheTag(cacheTags.sportsMenu)
+    if (!hasDatabaseEnv()) {
+      return buildQueryResult(buildEmptySportsMenuLayoutData())
+    }
 
-    return runQuery(async () => {
-      const [rows, activeCountRows] = await Promise.all([
-        getCachedSportsMenuRows(),
-        getCachedActiveSportsCountRows(),
-      ])
-      const resolver = buildSportsSlugResolver(toMappingEntries(rows))
-      const menuEntries = buildSportsSidebarEntries(rows, vertical)
-      const countsBySlug = buildSportsMenuCountsBySlug(resolver, activeCountRows, menuEntries)
-
-      return {
-        data: {
-          menuEntries,
-          countsBySlug,
-          canonicalSlugByAliasKey: Object.fromEntries(resolver.canonicalByAliasKey),
-          h1TitleBySlug: Object.fromEntries(resolver.h1TitleBySlug),
-          sectionsBySlug: Object.fromEntries(resolver.sectionsBySlug),
-        },
-        error: null,
-      }
-    })
+    return getCachedLayoutData(vertical)
   },
 
   async resolveCanonicalSlugByAlias(alias: string): Promise<QueryResult<string | null>> {
-    'use cache'
-    cacheTag(cacheTags.sportsMenu)
+    if (!hasDatabaseEnv()) {
+      return buildQueryResult(null)
+    }
 
-    return runQuery(async () => {
-      const resolver = await getSportsSlugResolverFromDb()
-
-      return {
-        data: resolveCanonicalSportsSlugAlias(resolver, alias),
-        error: null,
-      }
-    })
+    return getCachedCanonicalSlugByAlias(alias)
   },
 
   async getLandingHref(vertical: SportsVertical = 'sports'): Promise<QueryResult<string | null>> {
-    'use cache'
-    cacheTag(cacheTags.sportsMenu)
+    if (!hasDatabaseEnv()) {
+      return buildQueryResult(null)
+    }
 
-    return runQuery(async () => {
-      const rows = await getCachedSportsMenuRows()
-      const menuEntries = buildSportsSidebarEntries(rows, vertical)
-
-      return {
-        data: findDefaultLandingHref(menuEntries),
-        error: null,
-      }
-    })
+    return getCachedLandingHref(vertical)
   },
 
   async getFuturesHref(vertical: SportsVertical = 'sports'): Promise<QueryResult<string | null>> {
-    'use cache'
-    cacheTag(cacheTags.sportsMenu)
+    if (!hasDatabaseEnv()) {
+      return buildQueryResult(null)
+    }
 
-    return runQuery(async () => {
-      const rows = await getCachedSportsMenuRows()
-      const menuEntries = buildSportsSidebarEntries(rows, vertical)
-
-      return {
-        data: findDefaultFuturesHref(menuEntries),
-        error: null,
-      }
-    })
+    return getCachedFuturesHref(vertical)
   },
 }

--- a/src/lib/openapi-proxy.ts
+++ b/src/lib/openapi-proxy.ts
@@ -1,4 +1,5 @@
 import { OPENAPI_SERVER_URLS } from '@/lib/openapi-servers'
+import resolveSiteUrl from '@/lib/site-url'
 
 function toUrlOrigin(url: string): string | null {
   try {
@@ -22,6 +23,14 @@ function resolveCreatorHostname(siteUrl: string | undefined): string | null {
   catch {
     return null
   }
+}
+
+function resolveCreatorHostnameFromEnv(): string | null {
+  if (!process.env.SITE_URL?.trim() && !process.env.VERCEL_PROJECT_PRODUCTION_URL?.trim()) {
+    return null
+  }
+
+  return resolveCreatorHostname(resolveSiteUrl(process.env))
 }
 
 const allowedOrigins = new Set(
@@ -58,9 +67,9 @@ async function proxy(request: Request): Promise<Response> {
 
   const gammaOrigin = toUrlOrigin(OPENAPI_SERVER_URLS.gamma ?? '')
   if (gammaOrigin && parsedUrl.origin === gammaOrigin) {
-    const creatorHostname = resolveCreatorHostname(process.env.SITE_URL)
+    const creatorHostname = resolveCreatorHostnameFromEnv()
     if (!creatorHostname) {
-      return toProxyError('[Proxy] SITE_URL environment variable is not configured.', 500)
+      return toProxyError('[Proxy] SITE_URL or VERCEL_PROJECT_PRODUCTION_URL environment variable is not configured.', 500)
     }
 
     // Force the creator scope for docs playground requests (immutable).

--- a/src/lib/public-runtime-config.ts
+++ b/src/lib/public-runtime-config.ts
@@ -1,0 +1,18 @@
+import resolveSiteUrl from '@/lib/site-url'
+
+export interface PublicRuntimeConfig {
+  reownAppKitProjectId: string
+  siteUrl: string
+}
+
+function normalizePublicEnvValue(value: string | undefined) {
+  const normalized = value?.trim()
+  return normalized && normalized.length > 0 ? normalized : ''
+}
+
+export function getPublicRuntimeConfig(env: NodeJS.ProcessEnv = process.env): PublicRuntimeConfig {
+  return {
+    reownAppKitProjectId: normalizePublicEnvValue(env.REOWN_APPKIT_PROJECT_ID),
+    siteUrl: resolveSiteUrl(env),
+  }
+}

--- a/src/lib/public-shell-env.ts
+++ b/src/lib/public-shell-env.ts
@@ -31,6 +31,6 @@ export function hasPublicShellPrerenderEnv(env: NodeJS.ProcessEnv) {
 }
 
 export function resolvePublicShellPrerenderMode(env: NodeJS.ProcessEnv) {
-  const explicitMode = parseBooleanEnv(env.KUEST_PRERENDER_PUBLIC_SHELL)
+  const explicitMode = parseBooleanEnv(env.BUILD_PRERENDER_PUBLIC_SHELL)
   return explicitMode ?? hasPublicShellPrerenderEnv(env)
 }

--- a/src/lib/public-shell-env.ts
+++ b/src/lib/public-shell-env.ts
@@ -1,0 +1,36 @@
+function hasNonEmptyEnvValue(value: string | undefined) {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function parseBooleanEnv(value: string | undefined) {
+  const normalized = value?.trim().toLowerCase()
+  if (!normalized) {
+    return null
+  }
+
+  if (['1', 'true', 'yes', 'on'].includes(normalized)) {
+    return true
+  }
+
+  if (['0', 'false', 'no', 'off'].includes(normalized)) {
+    return false
+  }
+
+  return null
+}
+
+function hasBuildSiteUrlEnv(env: NodeJS.ProcessEnv) {
+  return hasNonEmptyEnvValue(env.SITE_URL)
+    || hasNonEmptyEnvValue(env.VERCEL_PROJECT_PRODUCTION_URL)
+}
+
+export function hasPublicShellPrerenderEnv(env: NodeJS.ProcessEnv) {
+  return hasBuildSiteUrlEnv(env)
+    && hasNonEmptyEnvValue(env.POSTGRES_URL)
+    && hasNonEmptyEnvValue(env.REOWN_APPKIT_PROJECT_ID)
+}
+
+export function resolvePublicShellPrerenderMode(env: NodeJS.ProcessEnv) {
+  const explicitMode = parseBooleanEnv(env.KUEST_PRERENDER_PUBLIC_SHELL)
+  return explicitMode ?? hasPublicShellPrerenderEnv(env)
+}

--- a/src/lib/public-shell-rendering.ts
+++ b/src/lib/public-shell-rendering.ts
@@ -1,0 +1,15 @@
+import { connection } from 'next/server'
+
+const SHOULD_PRERENDER_PUBLIC_SHELL = process.env.KUEST_BUILD_PRERENDER_PUBLIC_SHELL === 'true'
+
+export function shouldPrerenderPublicShell() {
+  return SHOULD_PRERENDER_PUBLIC_SHELL
+}
+
+export async function deferPublicShellPrerenderIfNeeded() {
+  if (SHOULD_PRERENDER_PUBLIC_SHELL) {
+    return
+  }
+
+  await connection()
+}

--- a/src/lib/public-shell-rendering.ts
+++ b/src/lib/public-shell-rendering.ts
@@ -1,6 +1,6 @@
 import { connection } from 'next/server'
 
-const SHOULD_PRERENDER_PUBLIC_SHELL = process.env.KUEST_BUILD_PRERENDER_PUBLIC_SHELL === 'true'
+const SHOULD_PRERENDER_PUBLIC_SHELL = process.env.BUILD_PRERENDER_PUBLIC_SHELL === 'true'
 
 export function shouldPrerenderPublicShell() {
   return SHOULD_PRERENDER_PUBLIC_SHELL

--- a/src/lib/sitemap.ts
+++ b/src/lib/sitemap.ts
@@ -3,6 +3,7 @@ import { cacheTag } from 'next/cache'
 import { loadEnabledLocales } from '@/i18n/locale-settings'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
 import { cacheTags } from '@/lib/cache-tags'
+import { hasDatabaseEnv } from '@/lib/db/env'
 import { getSportsSlugResolverFromDb } from '@/lib/db/queries/sports-menu'
 import { TagRepository } from '@/lib/db/queries/tag'
 import { event_sports, event_tags, events, markets, tags } from '@/lib/db/schema/events/tables'
@@ -246,6 +247,9 @@ async function getCategorySitemapEntries(): Promise<SitemapRouteEntry[]> {
 
   cacheTag(cacheTags.mainTags(DEFAULT_LOCALE))
   const fallbackDate = formatDateForSitemap(new Date())
+  if (!hasDatabaseEnv()) {
+    return []
+  }
 
   try {
     const { data: mainTags } = await TagRepository.getMainTags(DEFAULT_LOCALE)
@@ -274,6 +278,9 @@ async function getPredictionSitemapEntries(): Promise<SitemapRouteEntry[]> {
   'use cache'
 
   cacheTag(cacheTags.sitemap)
+  if (!hasDatabaseEnv()) {
+    return []
+  }
 
   try {
     const sportsSlugResolver = await getSportsSlugResolverFromDb()
@@ -347,6 +354,12 @@ async function getDynamicEventSitemaps(): Promise<DynamicEventSitemaps> {
   'use cache'
 
   cacheTag(cacheTags.sitemap)
+  if (!hasDatabaseEnv()) {
+    return {
+      active: [],
+      closedByMonth: {},
+    }
+  }
 
   try {
     const sportsSlugResolver = await getSportsSlugResolverFromDb()
@@ -550,6 +563,10 @@ function chunkSitemapEntries(entries: SitemapRouteEntry[], chunkSize: number): S
 }
 
 async function resolveLocalizedSitemapChunkSize(): Promise<number> {
+  if (!hasDatabaseEnv()) {
+    return SITEMAP_URL_LIMIT
+  }
+
   const enabledLocales = await loadEnabledLocales()
   const localeCount = Math.max(enabledLocales.length, 1)
 

--- a/src/lib/static-params.ts
+++ b/src/lib/static-params.ts
@@ -1,1 +1,20 @@
+import { shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
+
 export const STATIC_PARAMS_PLACEHOLDER = '__placeholder__'
+
+export function getPublicShellStaticParams<T extends Record<string, unknown>>(params: T): T[] {
+  return [params]
+}
+
+type StaticParamValue = string | string[] | null | undefined
+
+function isStaticParamsPlaceholder(...values: StaticParamValue[]) {
+  return values.some(value =>
+    value === STATIC_PARAMS_PLACEHOLDER
+    || (Array.isArray(value) && value.includes(STATIC_PARAMS_PLACEHOLDER)),
+  )
+}
+
+export function shouldBypassPublicShellPlaceholder(...values: StaticParamValue[]) {
+  return !shouldPrerenderPublicShell() && isStaticParamsPlaceholder(...values)
+}

--- a/src/lib/theme-settings.ts
+++ b/src/lib/theme-settings.ts
@@ -5,6 +5,7 @@ import { cacheTag } from 'next/cache'
 import { cacheTags } from '@/lib/cache-tags'
 import { DEFAULT_FEE_RECEIVER_WALLET_ADDRESS, ZERO_ADDRESS } from '@/lib/contracts'
 import { validateCustomJavascriptCodesJson } from '@/lib/custom-javascript-code'
+import { hasDatabaseEnv } from '@/lib/db/env'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { getPublicAssetUrl } from '@/lib/storage'
 import {
@@ -799,7 +800,7 @@ export function validateThemeSiteSettingsInput(params: {
   })
 }
 
-export async function loadRuntimeThemeState(): Promise<RuntimeThemeState> {
+async function loadCachedRuntimeThemeState(): Promise<RuntimeThemeState> {
   'use cache'
   cacheTag(cacheTags.settings)
 
@@ -888,6 +889,14 @@ export async function loadRuntimeThemeState(): Promise<RuntimeThemeState> {
     site,
     source: normalizedTheme?.data || normalizedSite?.data ? 'settings' : 'default',
   }
+}
+
+export async function loadRuntimeThemeState(): Promise<RuntimeThemeState> {
+  if (!hasDatabaseEnv()) {
+    return buildDefaultThemeState()
+  }
+
+  return loadCachedRuntimeThemeState()
 }
 
 export async function loadRuntimeThemeSiteName() {

--- a/src/providers/AppKitProvider.tsx
+++ b/src/providers/AppKitProvider.tsx
@@ -15,11 +15,11 @@ import { WagmiProvider } from 'wagmi'
 import { SignaturePromptHost } from '@/components/SignaturePromptHost'
 import { AppKitContext, defaultAppKitValue } from '@/hooks/useAppKit'
 import { useHasHydrated } from '@/hooks/useHasHydrated'
+import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
-import { defaultNetwork, networks, wagmiAdapter, wagmiConfig } from '@/lib/appkit'
+import { createAppKitWagmiAdapter, defaultNetwork, networks } from '@/lib/appkit'
 import { authClient } from '@/lib/auth-client'
 import { IS_BROWSER } from '@/lib/constants'
-import { reownProjectId } from '@/lib/reown-project-id'
 import { clearBrowserStorage, clearNonHttpOnlyCookies } from '@/lib/utils'
 import { mergeSessionUserState, useUser } from '@/stores/useUser'
 
@@ -57,21 +57,23 @@ function getAppKitInstanceSnapshot() {
 function initializeAppKitSingleton(
   themeMode: 'light' | 'dark',
   site: { name: string, description: string, logoUrl: string },
+  runtimeConfig: { projectId: string, siteUrl: string },
+  wagmiAdapter: ReturnType<typeof createAppKitWagmiAdapter>,
 ) {
-  if (hasInitializedAppKit || !IS_BROWSER) {
+  if (hasInitializedAppKit || !IS_BROWSER || !runtimeConfig.projectId) {
     return appKitInstance
   }
 
   try {
     appKitInstance = createAppKit({
-      projectId: reownProjectId,
+      projectId: runtimeConfig.projectId,
       adapters: [wagmiAdapter],
       themeMode,
       defaultAccountTypes: { eip155: 'eoa' },
       metadata: {
         name: site.name,
         description: site.description,
-        url: process.env.SITE_URL!,
+        url: runtimeConfig.siteUrl,
         icons: [site.logoUrl],
       },
       themeVariables: {
@@ -94,7 +96,7 @@ function initializeAppKitSingleton(
       siweConfig: createSIWEConfig({
         signOutOnAccountChange: true,
         getMessageParams: async () => ({
-          domain: new URL(process.env.SITE_URL!).host,
+          domain: new URL(runtimeConfig.siteUrl).host,
           uri: typeof window !== 'undefined' ? window.location.origin : '',
           chains: [defaultNetwork.id],
           statement: 'Please sign with your account',
@@ -244,14 +246,20 @@ function createAppKitContextValue({
 
 function useAppKitInstance({
   appKitThemeMode,
+  projectId,
   siteName,
   siteDescription,
   siteLogoUrl,
+  siteUrl,
+  wagmiAdapter,
 }: {
   appKitThemeMode: 'light' | 'dark'
+  projectId: string
   siteName: string
   siteDescription: string
   siteLogoUrl: string
+  siteUrl: string
+  wagmiAdapter: ReturnType<typeof createAppKitWagmiAdapter>
 }) {
   const [appKitInitRetryToken, setAppKitInitRetryToken] = useState(0)
   const instance = useSyncExternalStore(
@@ -261,7 +269,7 @@ function useAppKitInstance({
   )
 
   useEffect(function initializeAppKitWithRetry() {
-    if (instance) {
+    if (instance || !projectId) {
       return
     }
 
@@ -269,7 +277,10 @@ function useAppKitInstance({
       name: siteName,
       description: siteDescription,
       logoUrl: siteLogoUrl,
-    })
+    }, {
+      projectId,
+      siteUrl,
+    }, wagmiAdapter)
     if (initializedInstance) {
       return
     }
@@ -280,7 +291,7 @@ function useAppKitInstance({
     return function cancelAppKitInitRetry() {
       window.clearTimeout(retryTimeout)
     }
-  }, [appKitThemeMode, appKitInitRetryToken, instance, siteDescription, siteLogoUrl, siteName])
+  }, [appKitThemeMode, appKitInitRetryToken, instance, projectId, siteDescription, siteLogoUrl, siteName, siteUrl, wagmiAdapter])
 
   return instance
 }
@@ -304,15 +315,24 @@ function useAppKitContextValue({
 export default function AppKitProvider({ children }: { children: ReactNode }) {
   const t = useExtracted()
   const site = useSiteIdentity()
+  const { reownAppKitProjectId, siteUrl } = usePublicRuntimeConfig()
   const hasHydrated = useHasHydrated()
   const currentUser = useUser()
   const resolvedTheme = useResolvedThemeMode()
   const appKitThemeMode: 'light' | 'dark' = resolvedTheme === 'dark' ? 'dark' : 'light'
+  const wagmiAdapter = useMemo(
+    () => createAppKitWagmiAdapter(reownAppKitProjectId),
+    [reownAppKitProjectId],
+  )
+  const wagmiConfig = wagmiAdapter.wagmiConfig
   const instance = useAppKitInstance({
     appKitThemeMode,
+    projectId: reownAppKitProjectId,
     siteName: site.name,
     siteDescription: site.description,
     siteLogoUrl: site.logoUrl,
+    siteUrl,
+    wagmiAdapter,
   })
   const appKitValue = useAppKitContextValue({
     instance,

--- a/src/providers/PublicRuntimeConfigProvider.tsx
+++ b/src/providers/PublicRuntimeConfigProvider.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import type { ReactNode } from 'react'
+import type { PublicRuntimeConfig } from '@/lib/public-runtime-config'
+import { PublicRuntimeConfigContext } from '@/hooks/usePublicRuntimeConfig'
+
+export default function PublicRuntimeConfigProvider({
+  config,
+  children,
+}: {
+  config: PublicRuntimeConfig
+  children: ReactNode
+}) {
+  return <PublicRuntimeConfigContext value={config}>{children}</PublicRuntimeConfigContext>
+}

--- a/tests/unit/AppKitProvider.test.ts
+++ b/tests/unit/AppKitProvider.test.ts
@@ -21,11 +21,16 @@ vi.mock('@reown/appkit/react', () => ({
 
 vi.mock('@/lib/appkit', () => ({
   __esModule: true,
-  projectId: 'test-project',
+  createAppKitWagmiAdapter: vi.fn(() => ({ wagmiConfig: {} })),
   defaultNetwork: { id: 1 },
   networks: [{ id: 1 }],
-  wagmiAdapter: {},
-  wagmiConfig: {},
+}))
+
+vi.mock('@/hooks/usePublicRuntimeConfig', () => ({
+  usePublicRuntimeConfig: () => ({
+    reownAppKitProjectId: 'test-project',
+    siteUrl: 'https://markets.test',
+  }),
 }))
 
 vi.mock('wagmi', () => ({

--- a/tests/unit/publicShellEnv.test.ts
+++ b/tests/unit/publicShellEnv.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import {
+  hasPublicShellPrerenderEnv,
+  resolvePublicShellPrerenderMode,
+} from '@/lib/public-shell-env'
+
+describe('public shell env detection', () => {
+  it('enables prerendering when build-time public shell env is complete', () => {
+    const env = {
+      POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
+      REOWN_APPKIT_PROJECT_ID: 'project-id',
+      SITE_URL: 'https://markets.example.com',
+    } as NodeJS.ProcessEnv
+
+    expect(hasPublicShellPrerenderEnv(env)).toBe(true)
+    expect(resolvePublicShellPrerenderMode(env)).toBe(true)
+  })
+
+  it('accepts VERCEL_PROJECT_PRODUCTION_URL instead of SITE_URL', () => {
+    const env = {
+      POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
+      REOWN_APPKIT_PROJECT_ID: 'project-id',
+      VERCEL_PROJECT_PRODUCTION_URL: 'markets.example.com',
+    } as NodeJS.ProcessEnv
+
+    expect(hasPublicShellPrerenderEnv(env)).toBe(true)
+    expect(resolvePublicShellPrerenderMode(env)).toBe(true)
+  })
+
+  it('disables prerendering when the database is unavailable at build time', () => {
+    const env = {
+      REOWN_APPKIT_PROJECT_ID: 'project-id',
+      SITE_URL: 'https://markets.example.com',
+    } as NodeJS.ProcessEnv
+
+    expect(hasPublicShellPrerenderEnv(env)).toBe(false)
+    expect(resolvePublicShellPrerenderMode(env)).toBe(false)
+  })
+
+  it('lets an explicit override force the build mode', () => {
+    expect(resolvePublicShellPrerenderMode({
+      KUEST_PRERENDER_PUBLIC_SHELL: 'false',
+      POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
+      REOWN_APPKIT_PROJECT_ID: 'project-id',
+      SITE_URL: 'https://markets.example.com',
+    } as NodeJS.ProcessEnv)).toBe(false)
+
+    expect(resolvePublicShellPrerenderMode({
+      KUEST_PRERENDER_PUBLIC_SHELL: 'true',
+    } as NodeJS.ProcessEnv)).toBe(true)
+  })
+})

--- a/tests/unit/publicShellEnv.test.ts
+++ b/tests/unit/publicShellEnv.test.ts
@@ -39,14 +39,14 @@ describe('public shell env detection', () => {
 
   it('lets an explicit override force the build mode', () => {
     expect(resolvePublicShellPrerenderMode({
-      KUEST_PRERENDER_PUBLIC_SHELL: 'false',
+      BUILD_PRERENDER_PUBLIC_SHELL: 'false',
       POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
       REOWN_APPKIT_PROJECT_ID: 'project-id',
       SITE_URL: 'https://markets.example.com',
     } as NodeJS.ProcessEnv)).toBe(false)
 
     expect(resolvePublicShellPrerenderMode({
-      KUEST_PRERENDER_PUBLIC_SHELL: 'true',
+      BUILD_PRERENDER_PUBLIC_SHELL: 'true',
     } as NodeJS.ProcessEnv)).toBe(true)
   })
 })

--- a/tests/unit/staticParams.test.ts
+++ b/tests/unit/staticParams.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('static params helpers', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.unstubAllEnvs()
+  })
+
+  it('returns placeholder params when public shell prerendering is enabled', async () => {
+    vi.stubEnv('KUEST_BUILD_PRERENDER_PUBLIC_SHELL', 'true')
+    const { getPublicShellStaticParams } = await import('@/lib/static-params')
+
+    expect(getPublicShellStaticParams({ slug: '__placeholder__' })).toEqual([
+      { slug: '__placeholder__' },
+    ])
+  })
+
+  it('still returns placeholder params when public shell prerendering is disabled', async () => {
+    vi.stubEnv('KUEST_BUILD_PRERENDER_PUBLIC_SHELL', 'false')
+    const { getPublicShellStaticParams } = await import('@/lib/static-params')
+
+    expect(getPublicShellStaticParams({ slug: '__placeholder__' })).toEqual([
+      { slug: '__placeholder__' },
+    ])
+  })
+
+  it('bypasses placeholder renders only in runtime-env builds', async () => {
+    vi.stubEnv('KUEST_BUILD_PRERENDER_PUBLIC_SHELL', 'false')
+    const { shouldBypassPublicShellPlaceholder } = await import('@/lib/static-params')
+
+    expect(shouldBypassPublicShellPlaceholder('__placeholder__')).toBe(true)
+    expect(shouldBypassPublicShellPlaceholder(['sports', '__placeholder__'])).toBe(true)
+    expect(shouldBypassPublicShellPlaceholder('sports')).toBe(false)
+  })
+
+  it('keeps placeholder renders active in prerender builds', async () => {
+    vi.stubEnv('KUEST_BUILD_PRERENDER_PUBLIC_SHELL', 'true')
+    const { shouldBypassPublicShellPlaceholder } = await import('@/lib/static-params')
+
+    expect(shouldBypassPublicShellPlaceholder('__placeholder__')).toBe(false)
+  })
+})

--- a/tests/unit/staticParams.test.ts
+++ b/tests/unit/staticParams.test.ts
@@ -7,7 +7,7 @@ describe('static params helpers', () => {
   })
 
   it('returns placeholder params when public shell prerendering is enabled', async () => {
-    vi.stubEnv('KUEST_BUILD_PRERENDER_PUBLIC_SHELL', 'true')
+    vi.stubEnv('BUILD_PRERENDER_PUBLIC_SHELL', 'true')
     const { getPublicShellStaticParams } = await import('@/lib/static-params')
 
     expect(getPublicShellStaticParams({ slug: '__placeholder__' })).toEqual([
@@ -16,7 +16,7 @@ describe('static params helpers', () => {
   })
 
   it('still returns placeholder params when public shell prerendering is disabled', async () => {
-    vi.stubEnv('KUEST_BUILD_PRERENDER_PUBLIC_SHELL', 'false')
+    vi.stubEnv('BUILD_PRERENDER_PUBLIC_SHELL', 'false')
     const { getPublicShellStaticParams } = await import('@/lib/static-params')
 
     expect(getPublicShellStaticParams({ slug: '__placeholder__' })).toEqual([
@@ -25,7 +25,7 @@ describe('static params helpers', () => {
   })
 
   it('bypasses placeholder renders only in runtime-env builds', async () => {
-    vi.stubEnv('KUEST_BUILD_PRERENDER_PUBLIC_SHELL', 'false')
+    vi.stubEnv('BUILD_PRERENDER_PUBLIC_SHELL', 'false')
     const { shouldBypassPublicShellPlaceholder } = await import('@/lib/static-params')
 
     expect(shouldBypassPublicShellPlaceholder('__placeholder__')).toBe(true)
@@ -34,7 +34,7 @@ describe('static params helpers', () => {
   })
 
   it('keeps placeholder renders active in prerender builds', async () => {
-    vi.stubEnv('KUEST_BUILD_PRERENDER_PUBLIC_SHELL', 'true')
+    vi.stubEnv('BUILD_PRERENDER_PUBLIC_SHELL', 'true')
     const { shouldBypassPublicShellPlaceholder } = await import('@/lib/static-params')
 
     expect(shouldBypassPublicShellPlaceholder('__placeholder__')).toBe(false)

--- a/tests/unit/themeSettings.test.ts
+++ b/tests/unit/themeSettings.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   cacheTag: vi.fn(),
@@ -13,11 +13,23 @@ vi.mock('@/lib/db/queries/settings', () => ({
   SettingsRepository: { getSettings: (...args: any[]) => mocks.getSettings(...args) },
 }))
 
+const originalPostgresUrl = process.env.POSTGRES_URL
+
 describe('theme settings runtime resolver', () => {
   beforeEach(() => {
     vi.resetModules()
     mocks.cacheTag.mockReset()
     mocks.getSettings.mockReset()
+    process.env.POSTGRES_URL = 'postgres://theme-settings-test'
+  })
+
+  afterEach(() => {
+    if (originalPostgresUrl == null) {
+      delete process.env.POSTGRES_URL
+      return
+    }
+
+    process.env.POSTGRES_URL = originalPostgresUrl
   })
 
   it('uses default fallback when DB read fails', async () => {
@@ -32,6 +44,16 @@ describe('theme settings runtime resolver', () => {
     expect(state.site.name).toBeTruthy()
     expect(state.site.description).toBeTruthy()
     expect(state.site.logoSvg).toContain('<svg')
+  })
+
+  it('uses uncached default fallback when database env is missing', async () => {
+    delete process.env.POSTGRES_URL
+
+    const { loadRuntimeThemeState } = await import('@/lib/theme-settings')
+    const state = await loadRuntimeThemeState()
+
+    expect(state.source).toBe('default')
+    expect(mocks.getSettings).not.toHaveBeenCalled()
   })
 
   it('uses settings theme when DB values are valid', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enables runtime-env-only deployments by adding a public shell rendering mode controlled at build time and moving `SITE_URL`/`REOWN_APPKIT_PROJECT_ID` to runtime. Dynamic routes, APIs, sitemaps, and `@reown/appkit` now initialize with runtime values, with quiet builds and safe fallbacks when the database isn’t available.

- **New Features**
  - Public shell rendering with build-time switch `BUILD_PRERENDER_PUBLIC_SHELL`; helpers `shouldPrerenderPublicShell` and `deferPublicShellPrerenderIfNeeded` (auto-enabled if `SITE_URL` or `VERCEL_PROJECT_PRODUCTION_URL` + `POSTGRES_URL` + `REOWN_APPKIT_PROJECT_ID` are set).
  - `PublicRuntimeConfigProvider`/`usePublicRuntimeConfig` provide `siteUrl` and `reownAppKitProjectId` at runtime; `@reown/appkit` is initialized via a new `createAppKitWagmiAdapter`.
  - `HomeInitialContent` streams/SSRs initial home events in runtime-env builds.
  - Static params utilities for dynamic routes: `getPublicShellStaticParams`, `shouldBypassPublicShellPlaceholder`.
  - Database-optional behavior (`hasDatabaseEnv`) across settings, sports menu, and sitemaps to avoid build-time errors.
  - APIs, manifest, og images, and locale endpoints defer rendering in runtime mode for consistent behavior.
  - `SITE_URL` resolution accepts `VERCEL_PROJECT_PRODUCTION_URL` when unset; used in embeds, OpenAPI proxy, and OpenRouter referrer.

- **Migration**
  - Provide `SITE_URL` and `REOWN_APPKIT_PROJECT_ID` at runtime; set `POSTGRES_URL` to enable prerender; override with `BUILD_PRERENDER_PUBLIC_SHELL`. `VERCEL_PROJECT_PRODUCTION_URL` is accepted when `SITE_URL` isn’t set.
  - Stop passing `SITE_URL` and `REOWN_APPKIT_PROJECT_ID` as Docker build args or in CI. CD workflow updated (docker/login-action v4.1.0, docker/build-push-action v7.2.0, removed deploy webhook).
  - Update `.env`: add `SITE_URL` and optional `BUILD_PRERENDER_PUBLIC_SHELL`.

<sup>Written for commit aa3d85d1f62b1892ae5428c3798e034404728552. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1092?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

