### PR TITLE
fix: avoid cached connection in subcategory route

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
@@ -5,56 +5,56 @@ import {
   getHomeInitialCurrentTimestamp,
   HOME_INITIAL_EVENTS_CACHE_LIFE,
 } from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+import { hasDatabaseEnv } from '@/lib/db/env'
 import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
 
 interface HomeInitialContentProps {
+  deferRuntimePrerender?: boolean
   initialMainTag?: string
   initialTag?: string
   locale: SupportedLocale
 }
 
-async function CachedHomeInitialContent({
+async function HomeInitialContentBody({
   initialMainTag,
   initialTag,
   locale,
 }: HomeInitialContentProps) {
+  const currentTimestamp = getHomeInitialCurrentTimestamp()
+
+  return (
+    <HomeContent
+      locale={locale}
+      currentTimestamp={currentTimestamp}
+      initialTag={initialTag}
+      initialMainTag={initialMainTag}
+    />
+  )
+}
+
+async function CachedHomeInitialContent(props: HomeInitialContentProps) {
   'use cache'
   cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
 
-  const currentTimestamp = getHomeInitialCurrentTimestamp()
-
-  return (
-    <HomeContent
-      locale={locale}
-      currentTimestamp={currentTimestamp}
-      initialTag={initialTag}
-      initialMainTag={initialMainTag}
-    />
-  )
+  return <HomeInitialContentBody {...props} />
 }
 
-async function RuntimeHomeInitialContent({
-  initialMainTag,
-  initialTag,
-  locale,
-}: HomeInitialContentProps) {
+async function RuntimeHomeInitialContent(props: HomeInitialContentProps) {
   await deferPublicShellPrerenderIfNeeded()
 
-  const currentTimestamp = getHomeInitialCurrentTimestamp()
-
-  return (
-    <HomeContent
-      locale={locale}
-      currentTimestamp={currentTimestamp}
-      initialTag={initialTag}
-      initialMainTag={initialMainTag}
-    />
-  )
+  return hasDatabaseEnv()
+    ? <CachedHomeInitialContent {...props} />
+    : <HomeInitialContentBody {...props} />
 }
 
-export default function HomeInitialContent(props: HomeInitialContentProps) {
-  if (shouldPrerenderPublicShell()) {
-    return <CachedHomeInitialContent {...props} />
+export default function HomeInitialContent({
+  deferRuntimePrerender = true,
+  ...props
+}: HomeInitialContentProps) {
+  if (shouldPrerenderPublicShell() || !deferRuntimePrerender) {
+    return hasDatabaseEnv()
+      ? <CachedHomeInitialContent {...props} />
+      : <HomeInitialContentBody {...props} />
   }
 
   return <RuntimeHomeInitialContent {...props} />

--- a/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
@@ -8,6 +8,7 @@ import {
   generateDynamicHomeSubcategoryStaticParams,
 } from '@/app/[locale]/(platform)/_lib/dynamic-home-category-page'
 import { isPlatformReservedRootSlug, normalizePublicProfileSlug } from '@/lib/platform-routing'
+import { shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
 import { shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export const generateStaticParams = generateDynamicHomeSubcategoryStaticParams
@@ -46,8 +47,6 @@ async function renderPlatformSubcategoryPage({
   slug: string
   subcategory: string
 }) {
-  'use cache'
-
   if (slug === STATIC_PARAMS_PLACEHOLDER || subcategory === STATIC_PARAMS_PLACEHOLDER) {
     if (shouldBypassPublicShellPlaceholder(slug, subcategory)) {
       return null
@@ -60,6 +59,24 @@ async function renderPlatformSubcategoryPage({
   }
 
   return <DynamicHomeSubcategoryPageContent locale={locale} slug={slug} subcategory={subcategory} />
+}
+
+async function renderCachedPlatformSubcategoryPage({
+  locale,
+  slug,
+  subcategory,
+}: {
+  locale: SupportedLocale
+  slug: string
+  subcategory: string
+}) {
+  'use cache'
+
+  return renderPlatformSubcategoryPage({
+    locale,
+    slug,
+    subcategory,
+  })
 }
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/[slug]/[subcategory]'>): Promise<Metadata> {
@@ -78,8 +95,11 @@ export default async function PlatformSubcategoryPage({ params }: PageProps<'/[l
   const { locale, slug, subcategory } = await params
   const resolvedLocale = locale as SupportedLocale
   setRequestLocale(resolvedLocale)
+  const renderPage = shouldPrerenderPublicShell()
+    ? renderCachedPlatformSubcategoryPage
+    : renderPlatformSubcategoryPage
 
-  return await renderPlatformSubcategoryPage({
+  return await renderPage({
     locale: resolvedLocale,
     slug,
     subcategory,

--- a/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/[subcategory]/page.tsx
@@ -7,8 +7,9 @@ import {
   DynamicHomeSubcategoryPageContent,
   generateDynamicHomeSubcategoryStaticParams,
 } from '@/app/[locale]/(platform)/_lib/dynamic-home-category-page'
+import { hasDatabaseEnv } from '@/lib/db/env'
 import { isPlatformReservedRootSlug, normalizePublicProfileSlug } from '@/lib/platform-routing'
-import { shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
+import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
 import { shouldBypassPublicShellPlaceholder, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
 export const generateStaticParams = generateDynamicHomeSubcategoryStaticParams
@@ -39,10 +40,12 @@ async function generatePlatformSubcategoryMetadata({
 }
 
 async function renderPlatformSubcategoryPage({
+  deferHomeRuntimePrerender,
   locale,
   slug,
   subcategory,
 }: {
+  deferHomeRuntimePrerender?: boolean
   locale: SupportedLocale
   slug: string
   subcategory: string
@@ -58,7 +61,14 @@ async function renderPlatformSubcategoryPage({
     notFound()
   }
 
-  return <DynamicHomeSubcategoryPageContent locale={locale} slug={slug} subcategory={subcategory} />
+  return (
+    <DynamicHomeSubcategoryPageContent
+      locale={locale}
+      slug={slug}
+      subcategory={subcategory}
+      deferHomeRuntimePrerender={deferHomeRuntimePrerender}
+    />
+  )
 }
 
 async function renderCachedPlatformSubcategoryPage({
@@ -73,6 +83,34 @@ async function renderCachedPlatformSubcategoryPage({
   'use cache'
 
   return renderPlatformSubcategoryPage({
+    deferHomeRuntimePrerender: false,
+    locale,
+    slug,
+    subcategory,
+  })
+}
+
+async function renderRuntimePlatformSubcategoryPage({
+  locale,
+  slug,
+  subcategory,
+}: {
+  locale: SupportedLocale
+  slug: string
+  subcategory: string
+}) {
+  await deferPublicShellPrerenderIfNeeded()
+
+  if (!hasDatabaseEnv()) {
+    return renderPlatformSubcategoryPage({
+      deferHomeRuntimePrerender: false,
+      locale,
+      slug,
+      subcategory,
+    })
+  }
+
+  return renderCachedPlatformSubcategoryPage({
     locale,
     slug,
     subcategory,
@@ -97,7 +135,7 @@ export default async function PlatformSubcategoryPage({ params }: PageProps<'/[l
   setRequestLocale(resolvedLocale)
   const renderPage = shouldPrerenderPublicShell()
     ? renderCachedPlatformSubcategoryPage
-    : renderPlatformSubcategoryPage
+    : renderRuntimePlatformSubcategoryPage
 
   return await renderPage({
     locale: resolvedLocale,

--- a/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
@@ -117,9 +117,11 @@ export async function buildDynamicHomeSubcategoryMetadata(
 }
 
 export async function DynamicHomeCategoryPageContent({
+  deferHomeRuntimePrerender,
   locale,
   slug,
 }: {
+  deferHomeRuntimePrerender?: boolean
   locale: SupportedLocale
   slug: string
 }) {
@@ -135,14 +137,22 @@ export async function DynamicHomeCategoryPageContent({
     notFound()
   }
 
-  return <HomeInitialContent locale={locale} initialTag={category.slug} />
+  return (
+    <HomeInitialContent
+      locale={locale}
+      initialTag={category.slug}
+      deferRuntimePrerender={deferHomeRuntimePrerender}
+    />
+  )
 }
 
 export async function DynamicHomeSubcategoryPageContent({
+  deferHomeRuntimePrerender,
   locale,
   slug,
   subcategory,
 }: {
+  deferHomeRuntimePrerender?: boolean
   locale: SupportedLocale
   slug: string
   subcategory: string
@@ -169,6 +179,7 @@ export async function DynamicHomeSubcategoryPageContent({
       locale={locale}
       initialTag={resolvedSubcategory.subcategory.slug}
       initialMainTag={resolvedSubcategory.category.slug}
+      deferRuntimePrerender={deferHomeRuntimePrerender}
     />
   )
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops caching request-scoped DB connections in subcategory pages by moving caching into dedicated wrappers and applying it only after the runtime request is deferred. Keeps prerender speed and enables safe runtime caching when a DB is available.

- **Bug Fixes**
  - Runtime subcategory path now defers the public shell and caches the result afterward to avoid sharing connections while speeding repeat renders.
  - Home content only caches when `hasDatabaseEnv()` and adds a `deferRuntimePrerender`/`deferHomeRuntimePrerender` flag to control deferral from category/subcategory pages.

<sup>Written for commit 6c6dee8686286f9c4643606e4365d65fd76cb0b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1093?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

