### PR TITLE
docs: remove updaetdAt from data/orders and data/order payloads

### DIFF
--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -3142,8 +3142,7 @@
           "sizeMatched",
           "assetId",
           "type",
-          "createdAt",
-          "updatedAt"
+          "createdAt"
         ],
         "properties": {
           "associateTrades": {
@@ -3214,10 +3213,6 @@
             "description": "Time-in-force policy recorded for the order."
           },
           "createdAt": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "updatedAt": {
             "type": "string",
             "format": "date-time"
           }

--- a/src/app/api/open-orders/route.ts
+++ b/src/app/api/open-orders/route.ts
@@ -35,7 +35,6 @@ interface ClobOpenOrder {
   asset_id: string
   expiration?: string
   created_at: string
-  updated_at: string
 }
 
 export async function GET(request: Request) {

--- a/tests/unit/openOrdersRoute.test.ts
+++ b/tests/unit/openOrdersRoute.test.ts
@@ -135,7 +135,6 @@ describe('open orders routes', () => {
           expiration: '0',
           order_type: 'GTD',
           created_at: '2026-05-23T00:00:00.000Z',
-          updated_at: '2026-05-23T00:01:00.000Z',
         },
       ]),
     })
@@ -236,7 +235,6 @@ describe('open orders routes', () => {
           expiration: '0',
           order_type: 'GTD',
           created_at: '2026-05-23T00:00:00.000Z',
-          updated_at: '2026-05-23T00:01:00.000Z',
         },
       ]),
     })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed `updatedAt`/`updated_at` from open orders payloads in the docs, route types, and tests to match the actual API responses. Clients should no longer rely on this field; use `createdAt`/`created_at` if needed for ordering.

<sup>Written for commit 225bc44280190652b599c0f9991757fab2ba1a97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

