### PR TITLE
ci: publish multi-arch Docker images with metadata tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,11 @@
-name: CD
+name: Publish Docker Image
 
 on:
   push:
     branches:
       - main
+    tags:
+      - 'v*'
 
 permissions:
   contents: read
@@ -22,19 +24,32 @@ jobs:
         with:
           persist-credentials: false
 
+      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/kuestcom/prediction-market
+          flavor: |
+            latest=auto
+          tags: |
+            type=sha,format=long,prefix=
+            type=ref,event=branch
+            type=ref,event=tag
+
       - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: infra/docker/Dockerfile
           push: true
-          tags: |
-            ghcr.io/kuestcom/prediction-market:main
-            ghcr.io/kuestcom/prediction-market:${{ github.sha }}
+          platforms: linux/amd64,linux/arm64
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             COMMIT_SHA=${{ github.sha }}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Publish multi-arch Docker images to `ghcr.io/kuestcom/prediction-market` with consistent metadata tags, triggered on `main` and version tags. Improves support for amd64 and arm64 and standardizes tagging.

- **New Features**
  - Build and push for linux/amd64 and linux/arm64 via `docker/setup-qemu-action` and `docker/setup-buildx-action`.
  - Tag and label images with `docker/metadata-action`: long SHA, branch, tag, and auto `latest`.
  - Trigger on pushes to `main` and tags matching `v*`; publish to GHCR.
  - Rename workflow to “Publish Docker Image”.

<sup>Written for commit 9d505434f300ada35bb75dd63853166d561218e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

