### PR TITLE
fix: restore test typecheck coverage

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,7 +5,6 @@ import reactYouMightNotNeedAnEffect from 'eslint-plugin-react-you-might-not-need
 export default antfu({
   react: true,
   nextjs: true,
-  ignores: ['tests'],
 }, {
   plugins: {
     'better-tailwindcss': eslintPluginBetterTailwindcss,

--- a/tests/unit/AdminAffiliateContentClient.test.tsx
+++ b/tests/unit/AdminAffiliateContentClient.test.tsx
@@ -10,7 +10,7 @@ vi.mock('next-intl', () => ({
 
 vi.mock('@/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm', () => ({
   __esModule: true,
-  default: ({ initialFeeRecipientWallet }: any) => {
+  default: function AdminAffiliateSettingsFormMock({ initialFeeRecipientWallet }: any) {
     const [draftWallet, setDraftWallet] = React.useState(initialFeeRecipientWallet)
 
     return React.createElement(
@@ -34,7 +34,7 @@ vi.mock('@/app/[locale]/admin/affiliate/_components/AdminAffiliateClaimableFeesC
   ),
 }))
 
-describe('AdminAffiliateContentClient', () => {
+describe('adminAffiliateContentClient', () => {
   it('keeps the claim card bound to the saved wallet until refresh', async () => {
     const user = userEvent.setup()
     const props = {

--- a/tests/unit/AdminAffiliateSettingsForm.test.tsx
+++ b/tests/unit/AdminAffiliateSettingsForm.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
-import * as React from 'react'
 import userEvent from '@testing-library/user-event'
+import * as React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import AdminAffiliateSettingsForm from '@/app/[locale]/admin/affiliate/_components/AdminAffiliateSettingsForm'
 
@@ -52,7 +52,7 @@ function renderForm(initialWallet = '') {
   )
 }
 
-describe('AdminAffiliateSettingsForm', () => {
+describe('adminAffiliateSettingsForm', () => {
   beforeEach(() => {
     mocks.refresh.mockReset()
     mocks.updateAction.mockReset()

--- a/tests/unit/CategorySidebar.test.tsx
+++ b/tests/unit/CategorySidebar.test.tsx
@@ -1,6 +1,6 @@
 import type { AnchorHTMLAttributes } from 'react'
-import { createElement } from 'react'
 import { render, screen } from '@testing-library/react'
+import { createElement } from 'react'
 import CategorySidebar from '@/app/[locale]/(platform)/(home)/_components/CategorySidebar'
 
 vi.mock('next-intl', () => ({

--- a/tests/unit/CopyVersion.test.tsx
+++ b/tests/unit/CopyVersion.test.tsx
@@ -1,5 +1,5 @@
-import { createElement } from 'react'
 import { render, screen } from '@testing-library/react'
+import { createElement } from 'react'
 
 const mocks = vi.hoisted(() => ({
   useQuery: vi.fn(),

--- a/tests/unit/EventBackToTopButton.test.tsx
+++ b/tests/unit/EventBackToTopButton.test.tsx
@@ -72,7 +72,7 @@ function flushAnimationFrame() {
   })
 }
 
-describe('EventBackToTopButton', () => {
+describe('eventBackToTopButton', () => {
   beforeEach(() => {
     mocks.pathname = '/event/first-event'
     document.body.innerHTML = ''

--- a/tests/unit/EventCard.test.tsx
+++ b/tests/unit/EventCard.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import EventCard from '@/app/[locale]/(platform)/(home)/_components/EventCard'
-import { describe, expect, it, vi, beforeEach } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   buildHomeSportsMoneylineModel: vi.fn(),

--- a/tests/unit/EventIconImage.test.tsx
+++ b/tests/unit/EventIconImage.test.tsx
@@ -1,5 +1,5 @@
-import { createElement } from 'react'
 import { render, screen } from '@testing-library/react'
+import { createElement } from 'react'
 import EventIconImage from '@/components/EventIconImage'
 
 vi.mock('next/image', () => ({

--- a/tests/unit/EventOrderStateSync.test.tsx
+++ b/tests/unit/EventOrderStateSync.test.tsx
@@ -95,7 +95,7 @@ function resetOrderState() {
   })
 }
 
-describe('EventOrderStateSync', () => {
+describe('eventOrderStateSync', () => {
   beforeEach(() => {
     resetOrderState()
     mocks.searchParams = new URLSearchParams('side=BUY&orderType=MARKET&outcomeIndex=0&shares=10')

--- a/tests/unit/EventRules.test.tsx
+++ b/tests/unit/EventRules.test.tsx
@@ -82,10 +82,15 @@ describe('eventRules', () => {
   })
 
   it('renders the additional context block above the rules text', () => {
-    render(<EventRules event={createEvent({
-      additional_context: 'Abelardo de la Espriella has been added as an option to this market.',
-      additional_context_updated_at: '2026-08-25T12:00:00.000Z',
-    })} mode="inline" />)
+    render(
+      <EventRules
+        event={createEvent({
+          additional_context: 'Abelardo de la Espriella has been added as an option to this market.',
+          additional_context_updated_at: '2026-08-25T12:00:00.000Z',
+        })}
+        mode="inline"
+      />,
+    )
 
     expect(screen.getByText('Additional context')).toBeInTheDocument()
     expect(screen.getByText('Updated Aug 25')).toBeInTheDocument()
@@ -93,11 +98,13 @@ describe('eventRules', () => {
   })
 
   it('starts expanded in accordion mode when additional context exists', () => {
-    render(<EventRules event={createEvent({
-      additional_context: 'Abelardo de la Espriella has been added as an option to this market.',
-      additional_context_updated_at: '2026-08-25T12:00:00.000Z',
-    })}
-    />)
+    render(
+      <EventRules event={createEvent({
+        additional_context: 'Abelardo de la Espriella has been added as an option to this market.',
+        additional_context_updated_at: '2026-08-25T12:00:00.000Z',
+      })}
+      />,
+    )
 
     expect(screen.getByRole('button', { name: 'Rules' })).toHaveAttribute('aria-expanded', 'true')
   })
@@ -107,13 +114,15 @@ describe('eventRules', () => {
 
     expect(screen.getByRole('button', { name: 'Rules' })).toHaveAttribute('aria-expanded', 'false')
 
-    rerender(<EventRules event={createEvent({
-      id: 'event-2',
-      slug: 'event-2',
-      additional_context: 'Abelardo de la Espriella has been added as an option to this market.',
-      additional_context_updated_at: '2026-08-25T12:00:00.000Z',
-    })}
-    />)
+    rerender(
+      <EventRules event={createEvent({
+        id: 'event-2',
+        slug: 'event-2',
+        additional_context: 'Abelardo de la Espriella has been added as an option to this market.',
+        additional_context_updated_at: '2026-08-25T12:00:00.000Z',
+      })}
+      />,
+    )
 
     expect(screen.getByRole('button', { name: 'Rules' })).toHaveAttribute('aria-expanded', 'true')
   })

--- a/tests/unit/EventShare.test.tsx
+++ b/tests/unit/EventShare.test.tsx
@@ -1,8 +1,8 @@
+import type { ReactNode } from 'react'
 import type { Event } from '@/types'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import type { ReactNode } from 'react'
 import EventShare from '@/app/[locale]/(platform)/event/[slug]/_components/EventShare'
 
 const mocks = vi.hoisted(() => ({

--- a/tests/unit/FilterSettingsRow.test.tsx
+++ b/tests/unit/FilterSettingsRow.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react'
-import FilterSettingsRow from '@/app/[locale]/(platform)/(home)/_components/FilterSettingsRow'
 import { createDefaultFilters } from '@/app/[locale]/(platform)/(home)/_components/filter-toolbar-settings'
+import FilterSettingsRow from '@/app/[locale]/(platform)/(home)/_components/FilterSettingsRow'
 
 vi.mock('next-intl', () => ({
   useExtracted: () => (message: string) => message,

--- a/tests/unit/PredictionChart.test.tsx
+++ b/tests/unit/PredictionChart.test.tsx
@@ -11,8 +11,12 @@ const series = [
 ]
 
 beforeAll(() => {
-  if (typeof SVGElement !== 'undefined' && typeof SVGElement.prototype.getComputedTextLength !== 'function') {
-    Object.defineProperty(SVGElement.prototype, 'getComputedTextLength', {
+  const svgElementPrototype = typeof SVGElement === 'undefined'
+    ? null
+    : SVGElement.prototype as SVGElement & { getComputedTextLength?: () => number }
+
+  if (svgElementPrototype && typeof svgElementPrototype.getComputedTextLength !== 'function') {
+    Object.defineProperty(svgElementPrototype, 'getComputedTextLength', {
       configurable: true,
       value() {
         return (this.textContent?.length ?? 0) * 8

--- a/tests/unit/SettingsDeleteAccountContent.test.tsx
+++ b/tests/unit/SettingsDeleteAccountContent.test.tsx
@@ -32,7 +32,7 @@ vi.mock('@/lib/logout', () => ({
   signOutAndRedirect: (args: { currentPathname: string }) => mocks.signOutAndRedirect(args),
 }))
 
-describe('SettingsDeleteAccountContent', () => {
+describe('settingsDeleteAccountContent', () => {
   beforeEach(() => {
     mocks.deleteAccountAction.mockReset()
     mocks.signOutAndRedirect.mockReset()
@@ -91,10 +91,12 @@ describe('SettingsDeleteAccountContent', () => {
 
   it('keeps dialog controls disabled while delete action is pending', async () => {
     const user = userEvent.setup()
-    let resolveDelete: ((value: {}) => void) | null = null
+    const pendingDelete: {
+      resolve?: (value: Record<string, never>) => void
+    } = {}
     mocks.deleteAccountAction.mockImplementationOnce(() => (
-      new Promise((resolve) => {
-        resolveDelete = resolve as (value: {}) => void
+      new Promise<Record<string, never>>((resolve) => {
+        pendingDelete.resolve = resolve
       })
     ))
 
@@ -109,7 +111,7 @@ describe('SettingsDeleteAccountContent', () => {
       expect(screen.getByRole('button', { name: 'Never mind' })).toBeDisabled()
     })
 
-    resolveDelete?.({})
+    pendingDelete.resolve?.({})
 
     await waitFor(() => {
       expect(mocks.signOutAndRedirect).toHaveBeenCalledWith({

--- a/tests/unit/SettingsProfileContent.test.tsx
+++ b/tests/unit/SettingsProfileContent.test.tsx
@@ -89,7 +89,7 @@ function createUser(overrides: Partial<User> = {}): User {
   }
 }
 
-describe('SettingsProfileContent', () => {
+describe('settingsProfileContent', () => {
   beforeEach(() => {
     mocks.clearCommunityAuth.mockReset()
     mocks.ensureCommunityToken.mockReset()

--- a/tests/unit/TradingOnboardingProvider.test.tsx
+++ b/tests/unit/TradingOnboardingProvider.test.tsx
@@ -95,7 +95,7 @@ function createUser(overrides: Partial<User> = {}): User {
   }
 }
 
-describe('TradingOnboardingProvider', () => {
+describe('tradingOnboardingProvider', () => {
   beforeEach(() => {
     useUser.setState(null)
     mocks.dialogProps = null

--- a/tests/unit/WalletSendForm.test.tsx
+++ b/tests/unit/WalletSendForm.test.tsx
@@ -34,7 +34,7 @@ function renderWalletSendForm(overrides: Partial<ComponentProps<typeof WalletSen
   )
 }
 
-describe('WalletSendForm', () => {
+describe('walletSendForm', () => {
   beforeEach(() => {
     mocks.useAppKitAccount.mockReturnValue({
       embeddedWalletInfo: undefined,

--- a/tests/unit/affiliateFeeSync.test.ts
+++ b/tests/unit/affiliateFeeSync.test.ts
@@ -8,11 +8,11 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('@/lib/hmac', () => ({
-  buildClobHmacSignature: (...args: any[]) => mocks.buildClobHmacSignature(...args),
+  buildClobHmacSignature: mocks.buildClobHmacSignature,
 }))
 
 vi.mock('@/lib/trading-auth/server', () => ({
-  getUserTradingAuthSecrets: (...args: any[]) => mocks.getUserTradingAuthSecrets(...args),
+  getUserTradingAuthSecrets: mocks.getUserTradingAuthSecrets,
 }))
 
 describe('syncBuilderFeesForAdmin', () => {

--- a/tests/unit/eventActivityUtils.test.ts
+++ b/tests/unit/eventActivityUtils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import { OUTCOME_INDEX } from '@/lib/constants'
 import { resolveEventActivityOutcomeColorClass } from '@/app/[locale]/(platform)/event/[slug]/_components/event-activity-utils'
+import { OUTCOME_INDEX } from '@/lib/constants'
 
 function createActivityOutcome(index: number, text: string) {
   return {

--- a/tests/unit/eventCardResolvedOutcome.test.ts
+++ b/tests/unit/eventCardResolvedOutcome.test.ts
@@ -162,8 +162,6 @@ describe('eventCardResolvedOutcome', () => {
         short_title: '340-359',
         title: '340-359',
         slug: 'lakers-spread-340-359',
-        resolution_source: null,
-        resolution_source_url: null,
       }],
     })).toBe(false)
   })

--- a/tests/unit/eventCreationHelpers.test.ts
+++ b/tests/unit/eventCreationHelpers.test.ts
@@ -60,6 +60,7 @@ function buildDraft(overrides: Partial<EventCreationDraftRecord> = {}): EventCre
     recurrenceInterval: 1,
     recurrenceUntil: buildLocalDateTimeValue(2026, 5, 30, 23, 59),
     walletAddress: '0x1111111111111111111111111111111111111111',
+    imageUrl: null,
     updatedAt: buildLocalDateTimeValue(2026, 2, 22, 10),
     endDate: buildLocalDateTimeValue(2026, 2, 22, 12),
     mainCategorySlug: 'crypto',

--- a/tests/unit/eventFaq.test.ts
+++ b/tests/unit/eventFaq.test.ts
@@ -1,9 +1,10 @@
+import type { EventFaqTranslatedMessages } from '@/lib/event-faq'
 import type { Event, Market, Outcome } from '@/types'
 import { describe, expect, it } from 'vitest'
 import {
   buildEventFaqItems,
   createEventFaqTranslator,
-  type EventFaqTranslatedMessages,
+
 } from '@/lib/event-faq'
 
 const TEST_FAQ_MESSAGES: EventFaqTranslatedMessages = {

--- a/tests/unit/eventOpenGraph.test.ts
+++ b/tests/unit/eventOpenGraph.test.ts
@@ -131,6 +131,7 @@ describe('event open graph helpers', () => {
         sports_league_slug: null,
         sports_event_slug: null,
         sports_section: null,
+        tags: [],
       },
     })
 

--- a/tests/unit/marketPricing.test.ts
+++ b/tests/unit/marketPricing.test.ts
@@ -54,6 +54,11 @@ describe('market pricing helpers', () => {
         question_id: 'question-1',
         outcome_slot_count: 2,
         resolved: false,
+        volume: 0,
+        open_interest: 0,
+        active_positions_count: 0,
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
       },
     }
   }

--- a/tests/unit/ogImageSecurity.test.ts
+++ b/tests/unit/ogImageSecurity.test.ts
@@ -20,7 +20,7 @@ vi.mock('node:dns/promises', () => ({
 
 const lookupMock = vi.mocked(lookup)
 
-describe('OG image security helpers', () => {
+describe('oG image security helpers', () => {
   beforeEach(() => {
     lookupMock.mockReset()
   })
@@ -63,7 +63,7 @@ describe('OG image security helpers', () => {
   })
 
   it('rejects hostnames that resolve to a private address', async () => {
-    lookupMock.mockResolvedValue([
+    dnsMocks.lookup.mockResolvedValue([
       { address: '93.184.216.34', family: 4 },
       { address: '10.0.0.5', family: 4 },
     ])
@@ -72,7 +72,7 @@ describe('OG image security helpers', () => {
   })
 
   it('allows hostnames only when every resolved address is public', async () => {
-    lookupMock.mockResolvedValue([
+    dnsMocks.lookup.mockResolvedValue([
       { address: '93.184.216.34', family: 4 },
       { address: '2606:4700:4700::1111', family: 6 },
     ])

--- a/tests/unit/openOrdersRoute.test.ts
+++ b/tests/unit/openOrdersRoute.test.ts
@@ -13,40 +13,40 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@/lib/db/queries/event', () => ({
   EventRepository: {
-    getEventMarketMetadata: (...args: any[]) => mocks.getEventMarketMetadata(...args),
+    getEventMarketMetadata: mocks.getEventMarketMetadata,
   },
 }))
 
 vi.mock('@/lib/db/queries/user', () => ({
   UserRepository: {
-    getCurrentUser: (...args: any[]) => mocks.getCurrentUser(...args),
+    getCurrentUser: mocks.getCurrentUser,
   },
 }))
 
 vi.mock('@/lib/db/utils/run-query', () => ({
-  runQuery: (...args: any[]) => mocks.runQuery(...args),
+  runQuery: mocks.runQuery,
 }))
 
 vi.mock('@/lib/drizzle', () => ({
   db: {
     query: {
       markets: {
-        findMany: (...args: any[]) => mocks.findMany(...args),
+        findMany: mocks.findMany,
       },
     },
   },
 }))
 
 vi.mock('@/lib/hmac', () => ({
-  buildClobHmacSignature: (...args: any[]) => mocks.buildClobHmacSignature(...args),
+  buildClobHmacSignature: mocks.buildClobHmacSignature,
 }))
 
 vi.mock('@/lib/storage', () => ({
-  getPublicAssetUrl: (...args: any[]) => mocks.getPublicAssetUrl(...args),
+  getPublicAssetUrl: mocks.getPublicAssetUrl,
 }))
 
 vi.mock('@/lib/trading-auth/server', () => ({
-  getUserTradingAuthSecrets: (...args: any[]) => mocks.getUserTradingAuthSecrets(...args),
+  getUserTradingAuthSecrets: mocks.getUserTradingAuthSecrets,
 }))
 
 function address(lastByte: string) {

--- a/tests/unit/ordersPayload.test.ts
+++ b/tests/unit/ordersPayload.test.ts
@@ -7,7 +7,7 @@ vi.mock('@/app/(platform)/event/[slug]/_actions/store-order', () => ({
 }))
 
 describe('buildOrderPayload money-safety defaults', () => {
-  const userAddress = '0x0000000000000000000000000000000000000001' as const
+  const makerAddress = '0x0000000000000000000000000000000000000001' as const
 
   afterEach(() => {
     vi.unstubAllEnvs()
@@ -15,7 +15,7 @@ describe('buildOrderPayload money-safety defaults', () => {
 
   it('keeps fee fields unsigned and normalizes expiration defensively', () => {
     const payload = buildOrderPayload({
-      userAddress,
+      makerAddress,
       outcome: { token_id: '1' } as any,
       side: ORDER_SIDE.BUY,
       orderType: ORDER_TYPE.MARKET,
@@ -29,7 +29,7 @@ describe('buildOrderPayload money-safety defaults', () => {
     expect(payload.expiration).toBe(0n)
 
     const payloadDefault = buildOrderPayload({
-      userAddress,
+      makerAddress,
       outcome: { token_id: '1' } as any,
       side: ORDER_SIDE.BUY,
       orderType: ORDER_TYPE.MARKET,
@@ -40,7 +40,7 @@ describe('buildOrderPayload money-safety defaults', () => {
     expect(payloadDefault.fee_rate_bps).toBe(0n)
 
     const payloadTrunc = buildOrderPayload({
-      userAddress,
+      makerAddress,
       outcome: { token_id: '1' } as any,
       side: ORDER_SIDE.BUY,
       orderType: ORDER_TYPE.MARKET,

--- a/tests/unit/publicShellEnv.test.ts
+++ b/tests/unit/publicShellEnv.test.ts
@@ -6,32 +6,35 @@ import {
 
 describe('public shell env detection', () => {
   it('enables prerendering when build-time public shell env is complete', () => {
-    const env = {
+    const env: NodeJS.ProcessEnv = {
+      NODE_ENV: 'test',
       POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
       REOWN_APPKIT_PROJECT_ID: 'project-id',
       SITE_URL: 'https://markets.example.com',
-    } as NodeJS.ProcessEnv
+    }
 
     expect(hasPublicShellPrerenderEnv(env)).toBe(true)
     expect(resolvePublicShellPrerenderMode(env)).toBe(true)
   })
 
   it('accepts VERCEL_PROJECT_PRODUCTION_URL instead of SITE_URL', () => {
-    const env = {
+    const env: NodeJS.ProcessEnv = {
+      NODE_ENV: 'test',
       POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
       REOWN_APPKIT_PROJECT_ID: 'project-id',
       VERCEL_PROJECT_PRODUCTION_URL: 'markets.example.com',
-    } as NodeJS.ProcessEnv
+    }
 
     expect(hasPublicShellPrerenderEnv(env)).toBe(true)
     expect(resolvePublicShellPrerenderMode(env)).toBe(true)
   })
 
   it('disables prerendering when the database is unavailable at build time', () => {
-    const env = {
+    const env: NodeJS.ProcessEnv = {
+      NODE_ENV: 'test',
       REOWN_APPKIT_PROJECT_ID: 'project-id',
       SITE_URL: 'https://markets.example.com',
-    } as NodeJS.ProcessEnv
+    }
 
     expect(hasPublicShellPrerenderEnv(env)).toBe(false)
     expect(resolvePublicShellPrerenderMode(env)).toBe(false)
@@ -39,14 +42,16 @@ describe('public shell env detection', () => {
 
   it('lets an explicit override force the build mode', () => {
     expect(resolvePublicShellPrerenderMode({
+      NODE_ENV: 'test',
       BUILD_PRERENDER_PUBLIC_SHELL: 'false',
       POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
       REOWN_APPKIT_PROJECT_ID: 'project-id',
       SITE_URL: 'https://markets.example.com',
-    } as NodeJS.ProcessEnv)).toBe(false)
+    })).toBe(false)
 
     expect(resolvePublicShellPrerenderMode({
+      NODE_ENV: 'test',
       BUILD_PRERENDER_PUBLIC_SHELL: 'true',
-    } as NodeJS.ProcessEnv)).toBe(true)
+    })).toBe(true)
   })
 })

--- a/tests/unit/sportsSidebarEntries.test.ts
+++ b/tests/unit/sportsSidebarEntries.test.ts
@@ -1,9 +1,20 @@
+import type { SportsMenuGroupEntry } from '@/lib/sports-menu-types'
 import type { SportsMenuSidebarRow } from '@/lib/sports-sidebar-entries'
 import { describe, expect, it } from 'vitest'
 import {
   buildSportsSidebarEntries,
-
 } from '@/lib/sports-sidebar-entries'
+
+function isSportsMenuGroupEntry(entry: ReturnType<typeof buildSportsSidebarEntries>[number]): entry is SportsMenuGroupEntry {
+  return entry.type === 'group'
+}
+
+function findSportsMenuGroup(
+  entries: ReturnType<typeof buildSportsSidebarEntries>,
+  menuSlug: string,
+) {
+  return entries.filter(isSportsMenuGroupEntry).find(entry => entry.menuSlug === menuSlug)
+}
 
 function buildLinkRow(params: {
   id: string
@@ -269,9 +280,7 @@ describe('sports sidebar entries', () => {
       }),
     ]
 
-    const soccerGroup = buildSportsSidebarEntries(rows, 'sports').find(
-      entry => entry.type === 'group' && entry.menuSlug === 'soccer',
-    )
+    const soccerGroup = findSportsMenuGroup(buildSportsSidebarEntries(rows, 'sports'), 'soccer')
 
     expect(soccerGroup).toMatchObject({
       type: 'group',
@@ -391,8 +400,8 @@ describe('sports sidebar entries', () => {
     ]
 
     const entries = buildSportsSidebarEntries(rows, 'sports')
-    const cricketGroup = entries.find(entry => entry.type === 'group' && entry.menuSlug === 'cricket')
-    const basketballGroup = entries.find(entry => entry.type === 'group' && entry.menuSlug === 'basketball')
+    const cricketGroup = findSportsMenuGroup(entries, 'cricket')
+    const basketballGroup = findSportsMenuGroup(entries, 'basketball')
 
     expect(cricketGroup).toMatchObject({
       type: 'group',

--- a/tests/unit/walletAllowances.test.ts
+++ b/tests/unit/walletAllowances.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   COLLATERAL_APPROVAL_REUSE_AMOUNT,
-  MAX_ALLOWANCE,
   hasSufficientCollateralAllowance,
+  MAX_ALLOWANCE,
 } from '@/lib/wallet/transactions'
 
 describe('collateral approval reuse threshold', () => {

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,25 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": [
+      "node",
+      "vitest/globals",
+      "@testing-library/jest-dom"
+    ]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts",
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "tests/**/*.ts",
+    "tests/**/*.tsx",
+    "vitest.config.ts",
+    "vitest.setup.ts",
+    "playwright.config.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restored TypeScript type checking across the test suite to catch type errors early and improve test reliability. Adds a dedicated test `tsconfig` and re-enables ESLint for `tests`, with small fixes in mocks and fixtures.

- **Refactors**
  - Added `tsconfig.test.json` with `types` for `node`, `vitest/globals`, and `@testing-library/jest-dom`; included test and config files.
  - Removed `tests` from ESLint `ignores` to restore lint/typecheck coverage.
  - Fixed test typings and mocks: removed `any` rest args, typed mock functions, aligned parameter names (e.g., `makerAddress`), added missing fixture fields, adjusted import order, and safely typed SVG prototype access.

<sup>Written for commit c341948afb5dca5c47db59ecf4b44ce651b363b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

