### PR TITLE
ci: build multi-arch images on native runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -20,6 +19,9 @@ jobs:
     name: Build ${{ matrix.platform }} image
     if: github.repository == 'kuestcom/prediction-market'
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
     strategy:
       fail-fast: false
       matrix:
@@ -68,8 +70,10 @@ jobs:
 
       - name: Export image digest
         shell: bash
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
         run: |
-          digest="${{ steps.build.outputs.digest }}"
+          digest="$DIGEST"
           if [ -z "$digest" ]; then
             echo "docker build did not return a digest" >&2
             exit 1
@@ -89,6 +93,9 @@ jobs:
     needs: build-image
     if: github.repository == 'kuestcom/prediction-market'
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Publish Docker Image
+name: Build and Publish Docker Image
 
 on:
   push:
@@ -16,16 +16,27 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  publish-image:
+  build-image:
+    name: Build ${{ matrix.platform }} image
     if: github.repository == 'kuestcom/prediction-market'
-    runs-on: ubuntu-24.04
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-24.04
+            artifact: docker-digest-amd64
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+            artifact: docker-digest-arm64
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
       - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           registry: ghcr.io
@@ -43,13 +54,87 @@ jobs:
             type=ref,event=branch
             type=ref,event=tag
 
-      - uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+      - id: build
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
         with:
           context: .
           file: infra/docker/Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ${{ steps.meta.outputs.tags }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,push-by-digest=true,name-canonical=true,push=true
+          tags: ghcr.io/kuestcom/prediction-market
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             COMMIT_SHA=${{ github.sha }}
+
+      - name: Export image digest
+        shell: bash
+        run: |
+          digest="${{ steps.build.outputs.digest }}"
+          if [ -z "$digest" ]; then
+            echo "docker build did not return a digest" >&2
+            exit 1
+          fi
+          mkdir -p /tmp/digests
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ matrix.artifact }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  publish-image:
+    name: Publish image manifest
+    needs: build-image
+    if: github.repository == 'kuestcom/prediction-market'
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          pattern: docker-digest-*
+          path: /tmp/digests
+          merge-multiple: true
+
+      - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: ghcr.io/kuestcom/prediction-market
+          flavor: |
+            latest=auto
+          tags: |
+            type=sha,format=long,prefix=
+            type=ref,event=branch
+            type=ref,event=tag
+
+      - name: Publish multi-platform manifest
+        shell: bash
+        env:
+          IMAGE_NAME: ghcr.io/kuestcom/prediction-market
+          TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          tag_args=()
+          while IFS= read -r tag; do
+            if [ -n "$tag" ]; then
+              tag_args+=("-t" "$tag")
+            fi
+          done <<< "$TAGS"
+
+          refs=()
+          for digest_file in /tmp/digests/*; do
+            refs+=("${IMAGE_NAME}@sha256:$(basename "$digest_file")")
+          done
+          if [ "${#refs[@]}" -ne 2 ]; then
+            echo "expected 2 image digests, found ${#refs[@]}" >&2
+            exit 1
+          fi
+
+          docker buildx imagetools create "${tag_args[@]}" "${refs[@]}"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -29,7 +29,7 @@ export default antfu({
   },
   settings: {
     'better-tailwindcss': {
-      tailwindConfig: './src/app/globals.css',
+      entryPoint: './src/app/globals.css',
     },
   },
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Build and publish multi-arch Docker images on native runners (amd64 and arm64) with stricter job permissions and digest validation, improving build speed and reliability. Produces a single multi-platform manifest on GHCR.

- **Refactors**
  - Split CI into per-arch build job and a final manifest publish job; run on `ubuntu-24.04` (amd64) and `ubuntu-24.04-arm` (arm64).
  - Use native runners; remove `docker/setup-qemu-action`.
  - Build with `docker/build-push-action` using push-by-digest; upload digests with `actions/upload-artifact`, validate digest count; publish the manifest with `docker buildx imagetools` using tags from `docker/metadata-action`. Set job-scoped `packages: write` permissions.

- **Bug Fixes**
  - Update `better-tailwindcss` config: replace `tailwindConfig` with `entryPoint` pointing to `./src/app/globals.css`.

<sup>Written for commit 07f7697911fee83f35eee5678ece424951010ce4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

