### PR TITLE
fix: event activity community profile

### DIFF
--- a/src/app/api/event-activity/route.ts
+++ b/src/app/api/event-activity/route.ts
@@ -1,10 +1,6 @@
 import type { ActivityOrder } from '@/types'
 import { NextResponse } from 'next/server'
 import { filterActivitiesByMinAmount } from '@/lib/activity/filter'
-import {
-  COMMUNITY_PROFILE_LOOKUP_TIMEOUT_MS,
-  fetchCommunityProfileByAddress,
-} from '@/lib/community-profile'
 import { DEFAULT_ERROR_MESSAGE, MICRO_UNIT } from '@/lib/constants'
 import { EVENT_ACTIVITY_PAGE_SIZE } from '@/lib/data-api/trades'
 import { mapDataApiActivityToActivityOrder } from '@/lib/data-api/user'
@@ -13,7 +9,6 @@ import { getPublicAssetUrl } from '@/lib/storage'
 import { normalizeAddress } from '@/lib/wallet'
 
 const DATA_API_URL = process.env.DATA_URL!
-const COMMUNITY_API_URL = process.env.COMMUNITY_URL
 
 interface DataApiActivity {
   proxyWallet?: string
@@ -84,7 +79,6 @@ function storeHydratedProfile(
   profileLookup: Map<string, HydratedActivityProfile>,
   addresses: Array<string | null | undefined>,
   profile: HydratedActivityProfile,
-  preferExisting: boolean,
 ) {
   for (const address of addresses) {
     const normalized = normalizeAddress(address)?.toLowerCase()
@@ -93,59 +87,8 @@ function storeHydratedProfile(
     }
 
     const existing = profileLookup.get(normalized)
-    profileLookup.set(
-      normalized,
-      preferExisting ? mergeHydratedProfiles(existing ?? {}, profile) : mergeHydratedProfiles(profile, existing),
-    )
+    profileLookup.set(normalized, mergeHydratedProfiles(profile, existing))
   }
-}
-
-async function loadCommunityProfiles(addresses: string[]) {
-  if (!COMMUNITY_API_URL || addresses.length === 0) {
-    return new Map<string, HydratedActivityProfile>()
-  }
-
-  const results = await Promise.allSettled(
-    addresses.map(async (address) => {
-      const profile = await fetchCommunityProfileByAddress({
-        communityApiUrl: COMMUNITY_API_URL,
-        address,
-        signal: AbortSignal.timeout(COMMUNITY_PROFILE_LOOKUP_TIMEOUT_MS),
-      })
-
-      return { address, profile }
-    }),
-  )
-
-  const profileLookup = new Map<string, HydratedActivityProfile>()
-
-  results.forEach((result, index) => {
-    if (result.status === 'rejected') {
-      console.error('Failed to load activity community profile', {
-        address: addresses[index],
-        error: result.reason,
-      })
-      return
-    }
-
-    const profile = result.value.profile
-    if (!profile) {
-      return
-    }
-
-    storeHydratedProfile(
-      profileLookup,
-      [result.value.address, profile.address, profile.deposit_wallet_address],
-      {
-        username: profile.username?.trim() || undefined,
-        image: normalizeAvatarUrl(profile.avatar_url),
-        created_at: normalizeCreatedAt(profile.created_at),
-      },
-      false,
-    )
-  })
-
-  return profileLookup
 }
 
 export async function GET(request: Request) {
@@ -207,7 +150,7 @@ export async function GET(request: Request) {
       }
     })
 
-    const profileLookup = await loadCommunityProfiles(Array.from(addressSet))
+    const profileLookup = new Map<string, HydratedActivityProfile>()
 
     if (addressSet.size > 0) {
       const { data: profiles, error } = await UserRepository.getUsersByAddresses(Array.from(addressSet))
@@ -227,7 +170,6 @@ export async function GET(request: Request) {
           profileLookup,
           [normalizedAddress, normalizedDepositWallet],
           { username: profile.username, image: imageUrl, created_at: createdAt },
-          true,
         )
       }
     }
@@ -237,8 +179,8 @@ export async function GET(request: Request) {
       const matchedProfile = normalized ? profileLookup.get(normalized) : null
       const fallbackAddress = activity.user.address || activity.user.id
 
-      const username = matchedProfile?.username || activity.user.username || fallbackAddress || 'trader'
-      const image = normalizeAvatarUrl(matchedProfile?.image || activity.user.image)
+      const username = activity.user.username || matchedProfile?.username || fallbackAddress || 'trader'
+      const image = normalizeAvatarUrl(activity.user.image || matchedProfile?.image)
 
       return {
         ...activity,

--- a/src/app/api/event-activity/route.ts
+++ b/src/app/api/event-activity/route.ts
@@ -1,6 +1,10 @@
 import type { ActivityOrder } from '@/types'
 import { NextResponse } from 'next/server'
 import { filterActivitiesByMinAmount } from '@/lib/activity/filter'
+import {
+  COMMUNITY_PROFILE_LOOKUP_TIMEOUT_MS,
+  fetchCommunityProfileByAddress,
+} from '@/lib/community-profile'
 import { DEFAULT_ERROR_MESSAGE, MICRO_UNIT } from '@/lib/constants'
 import { EVENT_ACTIVITY_PAGE_SIZE } from '@/lib/data-api/trades'
 import { mapDataApiActivityToActivityOrder } from '@/lib/data-api/user'
@@ -9,6 +13,7 @@ import { getPublicAssetUrl } from '@/lib/storage'
 import { normalizeAddress } from '@/lib/wallet'
 
 const DATA_API_URL = process.env.DATA_URL!
+const COMMUNITY_API_URL = process.env.COMMUNITY_URL
 
 interface DataApiActivity {
   proxyWallet?: string
@@ -33,6 +38,12 @@ interface DataApiActivity {
   profileImageOptimized?: string
 }
 
+interface HydratedActivityProfile {
+  username?: string | null
+  image?: string | null
+  created_at?: string
+}
+
 function normalizeAvatarUrl(image: string | null | undefined) {
   if (!image) {
     return ''
@@ -43,6 +54,98 @@ function normalizeAvatarUrl(image: string | null | undefined) {
   }
 
   return getPublicAssetUrl(image)
+}
+
+function normalizeCreatedAt(value: string | Date | null | undefined) {
+  if (!value) {
+    return undefined
+  }
+
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) {
+    return undefined
+  }
+
+  return date.toISOString()
+}
+
+function mergeHydratedProfiles(
+  preferred: HydratedActivityProfile,
+  fallback?: HydratedActivityProfile | null,
+): HydratedActivityProfile {
+  return {
+    username: preferred.username || fallback?.username,
+    image: preferred.image || fallback?.image,
+    created_at: preferred.created_at || fallback?.created_at,
+  }
+}
+
+function storeHydratedProfile(
+  profileLookup: Map<string, HydratedActivityProfile>,
+  addresses: Array<string | null | undefined>,
+  profile: HydratedActivityProfile,
+  preferExisting: boolean,
+) {
+  for (const address of addresses) {
+    const normalized = normalizeAddress(address)?.toLowerCase()
+    if (!normalized) {
+      continue
+    }
+
+    const existing = profileLookup.get(normalized)
+    profileLookup.set(
+      normalized,
+      preferExisting ? mergeHydratedProfiles(existing ?? {}, profile) : mergeHydratedProfiles(profile, existing),
+    )
+  }
+}
+
+async function loadCommunityProfiles(addresses: string[]) {
+  if (!COMMUNITY_API_URL || addresses.length === 0) {
+    return new Map<string, HydratedActivityProfile>()
+  }
+
+  const results = await Promise.allSettled(
+    addresses.map(async (address) => {
+      const profile = await fetchCommunityProfileByAddress({
+        communityApiUrl: COMMUNITY_API_URL,
+        address,
+        signal: AbortSignal.timeout(COMMUNITY_PROFILE_LOOKUP_TIMEOUT_MS),
+      })
+
+      return { address, profile }
+    }),
+  )
+
+  const profileLookup = new Map<string, HydratedActivityProfile>()
+
+  results.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      console.error('Failed to load activity community profile', {
+        address: addresses[index],
+        error: result.reason,
+      })
+      return
+    }
+
+    const profile = result.value.profile
+    if (!profile) {
+      return
+    }
+
+    storeHydratedProfile(
+      profileLookup,
+      [result.value.address, profile.address, profile.deposit_wallet_address],
+      {
+        username: profile.username?.trim() || undefined,
+        image: normalizeAvatarUrl(profile.avatar_url),
+        created_at: normalizeCreatedAt(profile.created_at),
+      },
+      false,
+    )
+  })
+
+  return profileLookup
 }
 
 export async function GET(request: Request) {
@@ -104,7 +207,7 @@ export async function GET(request: Request) {
       }
     })
 
-    const profileLookup = new Map<string, { username?: string | null, image?: string | null, created_at?: string }>()
+    const profileLookup = await loadCommunityProfiles(Array.from(addressSet))
 
     if (addressSet.size > 0) {
       const { data: profiles, error } = await UserRepository.getUsersByAddresses(Array.from(addressSet))
@@ -118,16 +221,14 @@ export async function GET(request: Request) {
         const normalizedDepositWallet = normalizeAddress(profile.deposit_wallet_address)?.toLowerCase()
         const imageUrl = normalizeAvatarUrl(profile.image)
 
-        const createdAt = profile.created_at
-          ? new Date(profile.created_at).toISOString()
-          : undefined
+        const createdAt = normalizeCreatedAt(profile.created_at)
 
-        if (normalizedAddress) {
-          profileLookup.set(normalizedAddress, { username: profile.username, image: imageUrl, created_at: createdAt })
-        }
-        if (normalizedDepositWallet) {
-          profileLookup.set(normalizedDepositWallet, { username: profile.username, image: imageUrl, created_at: createdAt })
-        }
+        storeHydratedProfile(
+          profileLookup,
+          [normalizedAddress, normalizedDepositWallet],
+          { username: profile.username, image: imageUrl, created_at: createdAt },
+          true,
+        )
       }
     }
 

--- a/src/app/api/holders/route.ts
+++ b/src/app/api/holders/route.ts
@@ -111,16 +111,14 @@ export async function GET(request: Request) {
           .map(key => profileLookup.get(key))
           .find(Boolean)
 
-        const hydratedImage = normalizeAvatarUrl(matchedProfile?.image ?? holder.user.image)
-
         return {
           ...holder,
           user: {
             ...holder.user,
             id: matchedProfile?.id ?? holder.user.id,
-            username: matchedProfile?.username || holder.user.username,
+            username: holder.user.username || matchedProfile?.username,
             deposit_wallet_address: matchedProfile?.deposit_wallet_address ?? holder.user.deposit_wallet_address,
-            image: hydratedImage,
+            image: normalizeAvatarUrl(holder.user.image || matchedProfile?.image),
             created_at: matchedProfile?.created_at ?? holder.user.created_at,
           },
         }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes event activity and holders profile hydration to prefer Data API user data and fall back to community profiles, ensuring correct usernames and avatars. Also normalizes dates and consistently maps profiles across wallet and deposit wallet addresses.

- **Bug Fixes**
  - Prefer `activity.user` and `holder.user` username/image; use hydrated community profile only as fallback.
  - Merge hydrated profiles for wallet and deposit wallet to prevent partial overwrites.
  - Safely convert `created_at` to ISO; ignore invalid dates.

<sup>Written for commit 1386b94ba2d1bec2fd3c4e4f22e65a0e35c4dbc4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

