### PR TITLE
fix: event back to top button position

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventBackToTopButton.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventBackToTopButton.tsx
@@ -2,155 +2,61 @@
 
 import { ArrowUpIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
-import { usePathname } from 'next/navigation'
-import { useEffect, useMemo, useState, useSyncExternalStore } from 'react'
+import { useSyncExternalStore } from 'react'
 import { cn } from '@/lib/utils'
 
-const DEFAULT_WINDOW_VIEWPORT_SNAPSHOT = {
-  scrollY: 0,
-  viewportWidth: 0,
-}
-const DESKTOP_BACK_TO_TOP_BREAKPOINT = 1024
+const BACK_TO_TOP_SCROLL_THRESHOLD = 400
 
-let windowViewportSnapshot = DEFAULT_WINDOW_VIEWPORT_SNAPSHOT
-
-function subscribeWindowViewport(onStoreChange: () => void) {
+function subscribeScroll(onStoreChange: () => void) {
   if (typeof window === 'undefined') {
     return () => {}
   }
 
   window.addEventListener('scroll', onStoreChange, { passive: true })
-  window.addEventListener('resize', onStoreChange)
-  return () => {
+  return function unsubscribeScroll() {
     window.removeEventListener('scroll', onStoreChange)
-    window.removeEventListener('resize', onStoreChange)
   }
 }
 
-function getWindowViewportSnapshot() {
+function getScrollSnapshot() {
   if (typeof window === 'undefined') {
-    return DEFAULT_WINDOW_VIEWPORT_SNAPSHOT
+    return 0
   }
 
-  const scrollY = window.scrollY
-  const viewportWidth = window.innerWidth
-  if (windowViewportSnapshot.scrollY === scrollY && windowViewportSnapshot.viewportWidth === viewportWidth) {
-    return windowViewportSnapshot
-  }
-
-  windowViewportSnapshot = {
-    scrollY,
-    viewportWidth,
-  }
-  return windowViewportSnapshot
+  return window.scrollY
 }
 
-function useWindowViewport() {
-  return useSyncExternalStore(
-    subscribeWindowViewport,
-    getWindowViewportSnapshot,
-    () => DEFAULT_WINDOW_VIEWPORT_SNAPSHOT,
-  )
-}
-
-function useNavigationViewportReady() {
-  const pathname = usePathname()
-  const [settledPathname, setSettledPathname] = useState<string | null>(null)
-
-  useEffect(function markNavigationViewportReady() {
-    let firstFrameId = 0
-    let secondFrameId = 0
-
-    firstFrameId = window.requestAnimationFrame(function waitForNavigationScrollFrame() {
-      secondFrameId = window.requestAnimationFrame(function markNavigationViewportSettled() {
-        setSettledPathname(pathname)
-      })
-    })
-
-    return function cancelNavigationViewportReady() {
-      window.cancelAnimationFrame(firstFrameId)
-      window.cancelAnimationFrame(secondFrameId)
-    }
-  }, [pathname])
-
-  return settledPathname === pathname
-}
-
-function useBackToTopBounds({
-  enabled,
-  scrollY,
-  viewportWidth,
-}: {
-  enabled: boolean
-  scrollY: number
-  viewportWidth: number
-}) {
-  return useMemo(() => {
-    if (!enabled || typeof document === 'undefined' || viewportWidth < DESKTOP_BACK_TO_TOP_BREAKPOINT) {
-      return null
-    }
-
-    const content = document.getElementById('event-content-main')
-    const eventMarkets = document.getElementById('event-markets')
-    if (!content || !eventMarkets) {
-      return null
-    }
-
-    const eventMarketsTop = eventMarkets.getBoundingClientRect().top + scrollY
-    if (scrollY < eventMarketsTop - 80) {
-      return null
-    }
-
-    const rect = content.getBoundingClientRect()
-    const boundedWidth = viewportWidth > 0 ? Math.min(rect.width, viewportWidth) : rect.width
-    return {
-      left: rect.left,
-      width: boundedWidth,
-    }
-  }, [enabled, scrollY, viewportWidth])
+function useWindowScrollY() {
+  return useSyncExternalStore(subscribeScroll, getScrollSnapshot, () => 0)
 }
 
 export default function EventBackToTopButton() {
   const t = useExtracted()
-  const isNavigationViewportReady = useNavigationViewportReady()
-  const { scrollY, viewportWidth } = useWindowViewport()
-  const bounds = useBackToTopBounds({
-    enabled: isNavigationViewportReady,
-    scrollY,
-    viewportWidth,
-  })
+  const scrollY = useWindowScrollY()
+
+  if (scrollY < BACK_TO_TOP_SCROLL_THRESHOLD) {
+    return null
+  }
 
   function handleBackToTop() {
     window.scrollTo({ top: 0, behavior: 'smooth' })
   }
 
-  if (!bounds) {
-    return null
-  }
-
   return (
-    <div
-      className="pointer-events-none fixed bottom-6 hidden md:flex"
-      style={{ left: `${bounds.left}px`, width: `${bounds.width}px` }}
-    >
-      <div className="grid w-full grid-cols-3 items-center px-4">
-        <div />
-        <button
-          type="button"
-          onClick={handleBackToTop}
-          className={cn(`
-            pointer-events-auto justify-self-center rounded-full border bg-background/90 px-4 py-2 text-sm font-medium
-            text-foreground shadow-lg backdrop-blur-sm transition-colors
-            hover:text-muted-foreground
-          `)}
-          aria-label={t('Back to top')}
-        >
-          <span className="inline-flex items-center gap-2">
-            {t('Back to top')}
-            <ArrowUpIcon className="size-4" />
-          </span>
-        </button>
-      </div>
+    <div className="pointer-events-none fixed inset-x-0 bottom-6 z-30 hidden justify-center md:flex">
+      <button
+        type="button"
+        onClick={handleBackToTop}
+        className={cn(`
+          pointer-events-auto inline-flex items-center gap-2 rounded-full border bg-background/90 px-4 py-2 text-sm
+          font-medium text-foreground shadow-lg backdrop-blur-sm transition-colors
+          hover:text-muted-foreground
+        `)}
+        aria-label={t('Back to top')}
+      >
+        {t('Back to top')}
+        <ArrowUpIcon className="size-4" />
+      </button>
     </div>
   )
 }

--- a/tests/unit/EventBackToTopButton.test.tsx
+++ b/tests/unit/EventBackToTopButton.test.tsx
@@ -1,126 +1,60 @@
-import { act, render, screen } from '@testing-library/react'
+import { act, fireEvent, render, screen } from '@testing-library/react'
 import EventBackToTopButton from '@/app/[locale]/(platform)/event/[slug]/_components/EventBackToTopButton'
-
-const mocks = vi.hoisted(() => ({
-  pathname: '/event/first-event',
-}))
-
-vi.mock('next/navigation', () => ({
-  usePathname: () => mocks.pathname,
-}))
 
 vi.mock('next-intl', () => ({
   useExtracted: () => (message: string) => message,
 }))
 
-let animationFrameId = 0
-let animationFrameCallbacks = new Map<number, FrameRequestCallback>()
-
-function setWindowViewport({ scrollY, width }: { scrollY: number, width: number }) {
+function setWindowScrollY(scrollY: number) {
   Object.defineProperty(window, 'scrollY', {
     configurable: true,
     value: scrollY,
-  })
-
-  Object.defineProperty(window, 'innerWidth', {
-    configurable: true,
-    value: width,
-  })
-}
-
-function createDomRect({
-  left = 0,
-  top = 0,
-  width = 0,
-  height = 0,
-}: Partial<DOMRect> = {}) {
-  return {
-    bottom: top + height,
-    height,
-    left,
-    right: left + width,
-    top,
-    width,
-    x: left,
-    y: top,
-    toJSON() {
-      return {}
-    },
-  } as DOMRect
-}
-
-function createEventPageAnchors() {
-  const content = document.createElement('div')
-  content.id = 'event-content-main'
-  content.getBoundingClientRect = () => createDomRect({ left: 24, width: 960 })
-
-  const eventMarkets = document.createElement('div')
-  eventMarkets.id = 'event-markets'
-  eventMarkets.getBoundingClientRect = () => createDomRect({ top: 400 - window.scrollY, width: 960 })
-
-  document.body.append(content, eventMarkets)
-}
-
-function flushAnimationFrame() {
-  const callbacks = [...animationFrameCallbacks.values()]
-  animationFrameCallbacks = new Map()
-
-  act(() => {
-    for (const callback of callbacks) {
-      callback(performance.now())
-    }
   })
 }
 
 describe('eventBackToTopButton', () => {
   beforeEach(() => {
-    mocks.pathname = '/event/first-event'
     document.body.innerHTML = ''
-    setWindowViewport({ scrollY: 0, width: 1280 })
-    animationFrameId = 0
-    animationFrameCallbacks = new Map()
-
-    window.requestAnimationFrame = vi.fn((callback: FrameRequestCallback) => {
-      animationFrameId += 1
-      animationFrameCallbacks.set(animationFrameId, callback)
-      return animationFrameId
-    })
-
-    window.cancelAnimationFrame = vi.fn((id: number) => {
-      animationFrameCallbacks.delete(id)
-    })
+    setWindowScrollY(0)
+    vi.spyOn(window, 'scrollTo').mockImplementation(() => {})
   })
 
-  it('does not render from a stale home scroll position before navigation scroll settles', () => {
-    createEventPageAnchors()
-    setWindowViewport({ scrollY: 900, width: 1280 })
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
 
+  it('does not render before the page has been scrolled far enough', () => {
     render(<EventBackToTopButton />)
 
     expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument()
   })
 
-  it('stays hidden when the event page scrolls to top after navigation', () => {
-    createEventPageAnchors()
-    setWindowViewport({ scrollY: 900, width: 1280 })
+  it('renders after the page is scrolled past the threshold', () => {
+    setWindowScrollY(401)
 
     render(<EventBackToTopButton />)
 
-    setWindowViewport({ scrollY: 0, width: 1280 })
-    flushAnimationFrame()
-    flushAnimationFrame()
-
-    expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Back to top' })).toBeInTheDocument()
   })
 
-  it('renders after navigation settles when the event page is actually scrolled past markets', () => {
-    createEventPageAnchors()
-    setWindowViewport({ scrollY: 900, width: 1280 })
+  it('scrolls to the top when clicked', () => {
+    setWindowScrollY(401)
 
     render(<EventBackToTopButton />)
 
-    flushAnimationFrame()
-    flushAnimationFrame()
+    fireEvent.click(screen.getByRole('button', { name: 'Back to top' }))
+
+    expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' })
+  })
+
+  it('updates visibility when scroll position changes', () => {
+    render(<EventBackToTopButton />)
+    expect(screen.queryByRole('button', { name: 'Back to top' })).not.toBeInTheDocument()
+
+    act(() => {
+      setWindowScrollY(401)
+      window.dispatchEvent(new Event('scroll'))
+    })
 
     expect(screen.getByRole('button', { name: 'Back to top' })).toBeInTheDocument()
   })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Back to top button position on event pages. The button is now centered at the bottom on desktop and appears only after scrolling past 400px.

- **Bug Fixes**
  - Centered the button using a fixed, inset-x container; visible on `md` and up.
  - Visibility now depends only on window scroll (400px threshold) via a simple scroll subscription; removed resize/pathname/DOM-bound logic.
  - Updated unit tests to cover visibility changes on scroll and smooth scroll-to-top behavior.

<sup>Written for commit beaffe7f0df42bf90f329046300ea6615ea6b88a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

