### PR TITLE
fix: align proposer whitelist wallet resolution

### DIFF
--- a/src/app/[locale]/admin/events/calendar/_components/AdminCreateEventForm.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/AdminCreateEventForm.tsx
@@ -121,6 +121,7 @@ import {
 import { AMOY_CHAIN_ID } from '@/lib/network'
 import {
   isProposerWhitelistStatusResponse,
+  resolveProposerWhitelistAddress,
 } from '@/lib/proposer-whitelist'
 import { cn } from '@/lib/utils'
 import { defaultViemNetwork, defaultViemRpcUrl } from '@/lib/viem-network'
@@ -272,13 +273,10 @@ function useAdminCreateEventForm({
   const initialRecurrenceInterval = initialDraftRecord?.recurrenceInterval
     ? String(initialDraftRecord.recurrenceInterval)
     : '1'
-  const eoaAddress = useMemo(() => {
-    const candidate = connectedAddress ?? user?.address ?? ''
-    if (!candidate || !isAddress(candidate)) {
-      return null
-    }
-    return getAddress(candidate)
-  }, [connectedAddress, user?.address])
+  const eoaAddress = useMemo(
+    () => resolveProposerWhitelistAddress(connectedAddress, user?.address),
+    [connectedAddress, user?.address],
+  )
   const eoaShortAddress = useMemo(
     () => (eoaAddress ? shortenAddress(eoaAddress) : ''),
     [eoaAddress],

--- a/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
@@ -32,8 +32,8 @@ import { DEFAULT_CHAIN_ID } from '@/lib/network'
 import {
   isProposerWhitelistStatusResponse,
   normalizeProposerAddressList,
-
   readProposerWhitelistError,
+  resolveProposerWhitelistAddress,
   shortenProposerWhitelistAddress,
 } from '@/lib/proposer-whitelist'
 import {
@@ -43,6 +43,7 @@ import {
 } from '@/lib/proposer-whitelist-contracts'
 import { cn } from '@/lib/utils'
 import { defaultViemNetwork } from '@/lib/viem-network'
+import { useUser } from '@/stores/useUser'
 
 interface AdminProposersDialogProps {
   open: boolean
@@ -171,14 +172,19 @@ export default function AdminProposersDialog({
   onStatusChange,
 }: AdminProposersDialogProps) {
   const t = useExtracted()
-  const { address: connectedAddressRaw } = useAppKitAccount()
-  const connectedAddress = useMemo(
-    () => connectedAddressRaw && isAddress(connectedAddressRaw) ? getAddress(connectedAddressRaw) as Address : null,
-    [connectedAddressRaw],
-  )
+  const { address: appKitAddressRaw } = useAppKitAccount()
   const { data: walletClient } = useWalletClient()
   const publicClient = usePublicClient()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
+  const user = useUser()
+  const connectedWalletAddress = useMemo(
+    () => resolveProposerWhitelistAddress(walletClient?.account?.address, appKitAddressRaw),
+    [appKitAddressRaw, walletClient?.account?.address],
+  )
+  const knownCreatorAddress = useMemo(
+    () => resolveProposerWhitelistAddress(walletClient?.account?.address, appKitAddressRaw, user?.address),
+    [appKitAddressRaw, user?.address, walletClient?.account?.address],
+  )
   const [creators, setCreators] = useState<ProposerWhitelistCreatorOption[]>([])
   const [signers, setSigners] = useState<SignerOption[]>([])
   const [selectedCreator, setSelectedCreator] = useState<Address | null>(null)
@@ -194,7 +200,7 @@ export default function AdminProposersDialog({
         creators,
         signers,
         initialCreatorAddress,
-        connectedAddress,
+        connectedAddress: knownCreatorAddress,
         connectedLabel: t('EOA wallet'),
       })
     }
@@ -202,15 +208,15 @@ export default function AdminProposersDialog({
     return mergeCreatorOptions({
       creators,
       signers,
-      connectedAddress,
+      connectedAddress: knownCreatorAddress,
       connectedLabel: t('EOA wallet'),
     })
-  }, [connectedAddress, creators, initialCreatorAddress, lockCreatorSelection, signers, t])
+  }, [creators, initialCreatorAddress, knownCreatorAddress, lockCreatorSelection, signers, t])
   const selectedOption = creatorOptions.find(item => selectedCreator && item.address.toLowerCase() === selectedCreator.toLowerCase()) ?? null
   const canUseConnectedWallet = Boolean(
     selectedCreator
-    && connectedAddress
-    && selectedCreator.toLowerCase() === connectedAddress.toLowerCase(),
+    && connectedWalletAddress
+    && selectedCreator.toLowerCase() === connectedWalletAddress.toLowerCase(),
   )
   const canUseServerSigner = Boolean(status?.hasServerSigner || selectedOption?.hasServerSigner)
   const isSwitchingCreator = Boolean(
@@ -295,13 +301,13 @@ export default function AdminProposersDialog({
       const availableCreators = mergeCreatorOptions({
         creators: nextPayload.creators,
         signers: nextSigners,
-        connectedAddress,
+        connectedAddress: knownCreatorAddress,
         connectedLabel: t('EOA wallet'),
       })
       const preferred = getPreferredCreator({
         initialCreatorAddress,
         selectedCreator: creator,
-        connectedAddress,
+        connectedAddress: knownCreatorAddress,
         creators: availableCreators,
       })
       setSelectedCreator(preferred)
@@ -314,18 +320,18 @@ export default function AdminProposersDialog({
     finally {
       setIsLoading(false)
     }
-  }, [connectedAddress, initialCreatorAddress, onStatusChange, signers, t])
+  }, [initialCreatorAddress, knownCreatorAddress, onStatusChange, signers, t])
 
   const bootstrapDialog = useEffectEvent(async () => {
     const nextSigners = await loadSigners()
     const preferred = getPreferredCreator({
       initialCreatorAddress,
       selectedCreator: null,
-      connectedAddress,
+      connectedAddress: knownCreatorAddress,
       creators: mergeCreatorOptions({
         creators: [],
         signers: nextSigners,
-        connectedAddress,
+        connectedAddress: knownCreatorAddress,
         connectedLabel: t('EOA wallet'),
       }),
     })
@@ -508,9 +514,9 @@ export default function AdminProposersDialog({
 
   const proposerRows = status?.proposers ?? []
   const connectedAddressAlreadyListed = Boolean(
-    connectedAddress && proposerRows.some(proposer => proposer.toLowerCase() === connectedAddress.toLowerCase()),
+    knownCreatorAddress && proposerRows.some(proposer => proposer.toLowerCase() === knownCreatorAddress.toLowerCase()),
   )
-  const showAddYourWallet = Boolean((!status?.whitelistAddress || addOpen) && connectedAddress && !connectedAddressAlreadyListed && !walletInput.trim())
+  const showAddYourWallet = Boolean((!status?.whitelistAddress || addOpen) && knownCreatorAddress && !connectedAddressAlreadyListed && !walletInput.trim())
   const actionDisabled = isLoading || isMutating || !selectedCreator || !status || (!canUseConnectedWallet && !canUseServerSigner)
 
   return (
@@ -644,7 +650,7 @@ export default function AdminProposersDialog({
                     <button
                       type="button"
                       className="w-fit text-xs font-medium text-primary hover:opacity-80"
-                      onClick={() => setWalletInput(connectedAddress ?? '')}
+                      onClick={() => setWalletInput(knownCreatorAddress ?? '')}
                     >
                       {t('add my own wallet')}
                     </button>

--- a/src/lib/proposer-whitelist.ts
+++ b/src/lib/proposer-whitelist.ts
@@ -53,6 +53,18 @@ export function shortenProposerWhitelistAddress(address: string) {
   return `${address.slice(0, 6)}...${address.slice(-4)}`
 }
 
+export function resolveProposerWhitelistAddress(...candidates: Array<string | null | undefined>): Address | null {
+  for (const candidate of candidates) {
+    if (!candidate || !isAddress(candidate)) {
+      continue
+    }
+
+    return getAddress(candidate) as Address
+  }
+
+  return null
+}
+
 export function normalizeProposerAddressList(value: string | string[]) {
   const values = Array.isArray(value)
     ? value

--- a/tests/unit/proposerWhitelist.test.ts
+++ b/tests/unit/proposerWhitelist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { readProposerWhitelistError } from '@/lib/proposer-whitelist'
+import { readProposerWhitelistError, resolveProposerWhitelistAddress } from '@/lib/proposer-whitelist'
 
 describe('readProposerWhitelistError', () => {
   it('maps underpriced gas errors to a compact user-facing message', () => {
@@ -12,5 +12,20 @@ describe('readProposerWhitelistError', () => {
   it('keeps mapping wallet signature rejection errors', () => {
     expect(readProposerWhitelistError('User rejected the request'))
       .toBe('Wallet signature was rejected.')
+  })
+})
+
+describe('resolveProposerWhitelistAddress', () => {
+  it('returns the first valid address candidate', () => {
+    expect(resolveProposerWhitelistAddress(
+      null,
+      'invalid',
+      '0x00000000000000000000000000000000000000aa',
+      '0x00000000000000000000000000000000000000bb',
+    )).toBe('0x00000000000000000000000000000000000000AA')
+  })
+
+  it('returns null when no valid address is provided', () => {
+    expect(resolveProposerWhitelistAddress(undefined, null, 'invalid')).toBeNull()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Aligned how we resolve the connected wallet address in proposer whitelist flows. Fixes incorrect creator selection and makes EOA detection consistent in the admin form and proposers dialog.

- **Bug Fixes**
  - Centralized address resolution with `resolveProposerWhitelistAddress`, checking `walletClient`, `AppKit`, and `user.address`.
  - Fixed creator selection, “add my own wallet”, and connected wallet checks in `AdminProposersDialog`.
  - Updated `AdminCreateEventForm` to use the resolver for EOA address.

- **Refactors**
  - Added `resolveProposerWhitelistAddress` helper and unit tests.

<sup>Written for commit 938d8e616b626080a5109e359e73e2267b8c1e2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1104?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

