### PR TITLE
fix: align whitelist modal wallet signing

### DIFF
--- a/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
@@ -215,6 +215,10 @@ export default function AdminProposersDialog({
   const publicClient = usePublicClient()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
   const user = useUser()
+  const connectedWalletAddress = useMemo(
+    () => resolveProposerWhitelistAddress(appKitAddressRaw, walletClient?.account?.address),
+    [appKitAddressRaw, walletClient?.account?.address],
+  )
   const knownCreatorAddress = useMemo(
     () => resolveProposerWhitelistAddress(appKitAddressRaw, user?.address, walletClient?.account?.address),
     [appKitAddressRaw, user?.address, walletClient?.account?.address],
@@ -249,8 +253,8 @@ export default function AdminProposersDialog({
   const selectedOption = creatorOptions.find(item => selectedCreator && item.address.toLowerCase() === selectedCreator.toLowerCase()) ?? null
   const canUseConnectedWallet = Boolean(
     selectedCreator
-    && knownCreatorAddress
-    && selectedCreator.toLowerCase() === knownCreatorAddress.toLowerCase(),
+    && connectedWalletAddress
+    && selectedCreator.toLowerCase() === connectedWalletAddress.toLowerCase(),
   )
   const canUseServerSigner = Boolean(status?.hasServerSigner || selectedOption?.hasServerSigner)
   const isSwitchingCreator = Boolean(

--- a/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import type { Address, Hash } from 'viem'
+import type { Address, Hash, Hex } from 'viem'
 import type { SignerOption } from './admin-create-event-form-types'
 import type { ProposerWhitelistCreatorOption, ProposerWhitelistMutationResponse, ProposerWhitelistStatus, ProposerWhitelistStatusResponse } from '@/lib/proposer-whitelist'
 import { useAppKitAccount } from '@reown/appkit/react'
@@ -8,7 +8,7 @@ import { CheckCircle2Icon, CircleIcon, Loader2Icon, PlusIcon, UserCheckIcon, XIc
 import { useExtracted } from 'next-intl'
 import { useCallback, useEffect, useEffectEvent, useMemo, useState } from 'react'
 import { toast } from 'sonner'
-import { getAddress, isAddress } from 'viem'
+import { encodeDeployData, encodeFunctionData, getAddress, isAddress, toHex } from 'viem'
 import { usePublicClient, useWalletClient } from 'wagmi'
 import { Button } from '@/components/ui/button'
 import {
@@ -41,9 +41,11 @@ import {
   CREATOR_PROPOSER_WHITELIST_BYTECODE,
   CREATOR_PROPOSER_WHITELIST_REGISTRY_ABI,
 } from '@/lib/proposer-whitelist-contracts'
+import { sendWithEstimatedFeeRetry } from '@/lib/transaction-fees'
 import { cn } from '@/lib/utils'
 import { defaultViemNetwork } from '@/lib/viem-network'
 import { useUser } from '@/stores/useUser'
+import { isBigIntSerializationError } from './admin-create-event-form-utils'
 
 interface AdminProposersDialogProps {
   open: boolean
@@ -164,6 +166,42 @@ function getPreferredCreator(input: {
   return input.creators[0]?.address ?? null
 }
 
+function buildRpcWalletTransactionRequest(params: {
+  from: `0x${string}`
+  data: `0x${string}`
+  to?: `0x${string}`
+  value?: bigint
+  maxFeePerGas?: bigint
+  maxPriorityFeePerGas?: bigint
+}) {
+  const request: {
+    from: `0x${string}`
+    data: `0x${string}`
+    to?: `0x${string}`
+    value: Hex
+    maxFeePerGas?: Hex
+    maxPriorityFeePerGas?: Hex
+  } = {
+    from: params.from,
+    data: params.data,
+    value: toHex(params.value ?? 0n),
+  }
+
+  if (params.to) {
+    request.to = params.to
+  }
+
+  if (typeof params.maxFeePerGas === 'bigint') {
+    request.maxFeePerGas = toHex(params.maxFeePerGas)
+  }
+
+  if (typeof params.maxPriorityFeePerGas === 'bigint') {
+    request.maxPriorityFeePerGas = toHex(params.maxPriorityFeePerGas)
+  }
+
+  return request
+}
+
 export default function AdminProposersDialog({
   open,
   onOpenChange,
@@ -177,12 +215,8 @@ export default function AdminProposersDialog({
   const publicClient = usePublicClient()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
   const user = useUser()
-  const connectedWalletAddress = useMemo(
-    () => resolveProposerWhitelistAddress(walletClient?.account?.address, appKitAddressRaw),
-    [appKitAddressRaw, walletClient?.account?.address],
-  )
   const knownCreatorAddress = useMemo(
-    () => resolveProposerWhitelistAddress(walletClient?.account?.address, appKitAddressRaw, user?.address),
+    () => resolveProposerWhitelistAddress(appKitAddressRaw, user?.address, walletClient?.account?.address),
     [appKitAddressRaw, user?.address, walletClient?.account?.address],
   )
   const [creators, setCreators] = useState<ProposerWhitelistCreatorOption[]>([])
@@ -215,8 +249,8 @@ export default function AdminProposersDialog({
   const selectedOption = creatorOptions.find(item => selectedCreator && item.address.toLowerCase() === selectedCreator.toLowerCase()) ?? null
   const canUseConnectedWallet = Boolean(
     selectedCreator
-    && connectedWalletAddress
-    && selectedCreator.toLowerCase() === connectedWalletAddress.toLowerCase(),
+    && knownCreatorAddress
+    && selectedCreator.toLowerCase() === knownCreatorAddress.toLowerCase(),
   )
   const canUseServerSigner = Boolean(status?.hasServerSigner || selectedOption?.hasServerSigner)
   const isSwitchingCreator = Boolean(
@@ -399,20 +433,94 @@ export default function AdminProposersDialog({
     return walletClient
   }
 
+  async function sendWalletTransaction(input: {
+    title: string
+    description: string
+    account: Address
+    data: Hex
+    to?: Address
+    value?: bigint
+  }) {
+    const client = getConnectedWalletClient()
+
+    function send(overrides?: {
+      maxFeePerGas?: bigint
+      maxPriorityFeePerGas?: bigint
+    }) {
+      return client.sendTransaction({
+        account: input.account,
+        chain: client.chain,
+        to: input.to,
+        data: input.data,
+        value: input.value ?? 0n,
+        ...(overrides ?? {}),
+      })
+    }
+
+    async function sendWithRpcFallback(overrides?: {
+      maxFeePerGas?: bigint
+      maxPriorityFeePerGas?: bigint
+    }) {
+      try {
+        return await runWithSignaturePrompt(() => send(overrides), {
+          title: input.title,
+          description: input.description,
+        })
+      }
+      catch (sendError) {
+        const message = sendError instanceof Error ? sendError.message : String(sendError)
+        if (!isBigIntSerializationError(message)) {
+          throw sendError
+        }
+
+        const txRequest = buildRpcWalletTransactionRequest({
+          from: input.account,
+          to: input.to,
+          data: input.data,
+          value: input.value ?? 0n,
+          ...(overrides ?? {}),
+        })
+        const rpcHash = await runWithSignaturePrompt(
+          () => client.request({
+            method: 'eth_sendTransaction',
+            params: [txRequest],
+          }) as Promise<unknown>,
+          {
+            title: input.title,
+            description: input.description,
+          },
+        )
+        if (typeof rpcHash !== 'string' || !rpcHash.startsWith('0x')) {
+          throw new Error(t('Wallet provider returned an invalid transaction hash.'))
+        }
+        return rpcHash as Hash
+      }
+    }
+
+    if (!publicClient) {
+      return sendWithRpcFallback()
+    }
+
+    return sendWithEstimatedFeeRetry({
+      chainId: client.chain?.id ?? DEFAULT_CHAIN_ID,
+      client: publicClient,
+      send: sendWithRpcFallback,
+    })
+  }
+
   async function runWalletCreate(proposers: Address[]) {
     if (!selectedCreator || !status) {
       throw new Error(t('Select a creator wallet first.'))
     }
-    const client = getConnectedWalletClient()
-    const deployHash = await runWithSignaturePrompt(() => client.deployContract({
-      account: selectedCreator,
-      chain: client.chain,
-      abi: CREATOR_PROPOSER_WHITELIST_ABI,
-      bytecode: CREATOR_PROPOSER_WHITELIST_BYTECODE,
-      args: [selectedCreator, proposers],
-    }), {
+    const deployHash = await sendWalletTransaction({
       title: t('Deploy proposer whitelist'),
       description: t('Transaction 1 of 2: deploy the whitelist contract for this creator.'),
+      account: selectedCreator,
+      data: encodeDeployData({
+        abi: CREATOR_PROPOSER_WHITELIST_ABI,
+        bytecode: CREATOR_PROPOSER_WHITELIST_BYTECODE,
+        args: [selectedCreator, proposers],
+      }),
     })
     const deployReceipt = await waitForWalletTx(deployHash)
     const whitelistAddress = deployReceipt?.contractAddress && isAddress(deployReceipt.contractAddress)
@@ -422,16 +530,16 @@ export default function AdminProposersDialog({
       throw new Error(t('Whitelist deployment did not return a contract address.'))
     }
 
-    const registerHash = await runWithSignaturePrompt(() => client.writeContract({
-      account: selectedCreator,
-      chain: client.chain,
-      address: status.registryAddress,
-      abi: CREATOR_PROPOSER_WHITELIST_REGISTRY_ABI,
-      functionName: 'registerWhitelist',
-      args: [whitelistAddress],
-    }), {
+    const registerHash = await sendWalletTransaction({
       title: t('Register proposer whitelist'),
       description: t('Transaction 2 of 2: register this whitelist in the registry.'),
+      account: selectedCreator,
+      to: status.registryAddress,
+      data: encodeFunctionData({
+        abi: CREATOR_PROPOSER_WHITELIST_REGISTRY_ABI,
+        functionName: 'registerWhitelist',
+        args: [whitelistAddress],
+      }),
     })
     await waitForWalletTx(registerHash)
   }
@@ -440,17 +548,16 @@ export default function AdminProposersDialog({
     if (!selectedCreator || !status?.whitelistAddress) {
       throw new Error(t('Creator whitelist is not registered yet.'))
     }
-    const client = getConnectedWalletClient()
-    const hash = await runWithSignaturePrompt(() => client.writeContract({
-      account: selectedCreator,
-      chain: client.chain,
-      address: status.whitelistAddress!,
-      abi: CREATOR_PROPOSER_WHITELIST_ABI,
-      functionName: action === 'add' ? 'addProposers' : 'removeProposers',
-      args: [proposers],
-    }), {
+    const hash = await sendWalletTransaction({
       title: action === 'add' ? t('Add proposers') : t('Remove proposer'),
       description: t('Open your wallet and approve the whitelist update.'),
+      account: selectedCreator,
+      to: status.whitelistAddress,
+      data: encodeFunctionData({
+        abi: CREATOR_PROPOSER_WHITELIST_ABI,
+        functionName: action === 'add' ? 'addProposers' : 'removeProposers',
+        args: [proposers],
+      }),
     })
     await waitForWalletTx(hash)
   }

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -959,6 +959,7 @@
   "CLn10+": "Transaktion fehlgeschlagen: {hash}",
   "UF9yoG": "Verwenden Sie die EOA des ausgewählten Creators in Ihrer Wallet, um diese Aktion zu signieren.",
   "S6VGoV": "Wechseln Sie die Wallet zu {chain}, bevor Sie die Proposer-Whitelist aktualisieren.",
+  "gRC0tc": "Der Wallet-Provider hat einen ungültigen Transaktions-Hash zurückgegeben.",
   "FDwiVN": "Proposer-Whitelist deployen",
   "bNFVri": "Transaktion 1 von 2: deployt den Whitelist-Vertrag für diesen Creator.",
   "RhNegi": "Der Whitelist-Deploy hat keine Vertragsadresse zurückgegeben.",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -959,6 +959,7 @@
   "CLn10+": "Transaction failed: {hash}",
   "UF9yoG": "Use the selected creator EOA in your wallet to sign this action.",
   "S6VGoV": "Switch wallet to {chain} before updating proposer whitelist.",
+  "gRC0tc": "Wallet provider returned an invalid transaction hash.",
   "FDwiVN": "Deploy proposer whitelist",
   "bNFVri": "Transaction 1 of 2: deploy the whitelist contract for this creator.",
   "RhNegi": "Whitelist deployment did not return a contract address.",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -959,6 +959,7 @@
   "CLn10+": "Transacción fallida: {hash}",
   "UF9yoG": "Usa la EOA del creator seleccionado en tu wallet para firmar esta acción.",
   "S6VGoV": "Cambia la wallet a {chain} antes de actualizar la whitelist de proposers.",
+  "gRC0tc": "El proveedor de la wallet devolvió un hash de transacción no válido.",
   "FDwiVN": "Deployar whitelist de proposers",
   "bNFVri": "Transacción 1 de 2: deploya el contrato de whitelist para este creator.",
   "RhNegi": "El deploy de la whitelist no devolvió una dirección de contrato.",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -959,6 +959,7 @@
   "CLn10+": "Transaction échouée : {hash}",
   "UF9yoG": "Utilisez l'EOA du creator sélectionné dans votre wallet pour signer cette action.",
   "S6VGoV": "Basculez la wallet sur {chain} avant de mettre à jour la whitelist des proposers.",
+  "gRC0tc": "Le fournisseur de la wallet a renvoyé un hash de transaction invalide.",
   "FDwiVN": "Déployer la whitelist des proposers",
   "bNFVri": "Transaction 1 sur 2 : déploie le contrat de whitelist pour ce creator.",
   "RhNegi": "Le déploiement de la whitelist n'a pas retourné d'adresse de contrat.",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -959,6 +959,7 @@
   "CLn10+": "Transação falhou: {hash}",
   "UF9yoG": "Use a EOA do creator selecionado na sua wallet para assinar esta ação.",
   "S6VGoV": "Troque a wallet para {chain} antes de atualizar a whitelist de proposers.",
+  "gRC0tc": "O provedor da wallet retornou um hash de transação inválido.",
   "FDwiVN": "Deployar whitelist de proposers",
   "bNFVri": "Transação 1 de 2: deploya o contrato de whitelist deste creator.",
   "RhNegi": "O deploy da whitelist não retornou um endereço de contrato.",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -959,6 +959,7 @@
   "CLn10+": "交易失败：{hash}",
   "UF9yoG": "请在钱包中使用所选 creator 的 EOA 签署此操作。",
   "S6VGoV": "更新 proposer whitelist 前，请将钱包切换到 {chain}。",
+  "gRC0tc": "钱包提供方返回了无效的交易哈希。",
   "FDwiVN": "Deploy proposer whitelist",
   "bNFVri": "第 1/2 笔交易：为此 creator 部署 whitelist 合约。",
   "RhNegi": "Whitelist 部署未返回合约地址。",

--- a/tests/unit/AdminProposersDialog.test.tsx
+++ b/tests/unit/AdminProposersDialog.test.tsx
@@ -23,6 +23,7 @@ const mocks = vi.hoisted(() => ({
   waitForTransactionReceipt: vi.fn(),
   estimateFeesPerGas: vi.fn(),
   getGasPrice: vi.fn(),
+  fetch: vi.fn(),
 }))
 
 vi.mock('next-intl', () => ({
@@ -95,6 +96,7 @@ describe('adminProposersDialog', () => {
     mocks.runWithSignaturePrompt.mockReset()
     mocks.toastSuccess.mockReset()
     mocks.toastError.mockReset()
+    mocks.fetch.mockReset()
 
     mocks.useWalletClient.mockReturnValue({
       account: { address: EMBEDDED_ACCOUNT },
@@ -125,7 +127,7 @@ describe('adminProposersDialog', () => {
         status: 'success',
       })
 
-    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+    mocks.fetch.mockImplementation(async (input: RequestInfo | URL) => {
       const url = String(input)
       if (url.includes('/admin/api/event-creations/signers')) {
         return {
@@ -156,7 +158,8 @@ describe('adminProposersDialog', () => {
       }
 
       throw new Error(`Unexpected fetch: ${url}`)
-    }))
+    })
+    vi.stubGlobal('fetch', mocks.fetch)
   })
 
   it('uses the resolved AppKit EOA for whitelist creation even when walletClient account differs', async () => {
@@ -192,6 +195,91 @@ describe('adminProposersDialog', () => {
       value: 0n,
     }))
     expect(mocks.toastError).not.toHaveBeenCalledWith('Use the selected creator EOA in your wallet to sign this action.')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Proposer whitelist updated.')
+  })
+
+  it('keeps server-signer fallback available when only the stored user address matches the selected creator', async () => {
+    const user = userEvent.setup()
+
+    mocks.useAppKitAccount.mockReturnValue({ address: null })
+    mocks.useUser.mockReturnValue({ address: CREATOR })
+    mocks.useWalletClient.mockReturnValue(null)
+    mocks.usePublicClient.mockReturnValue(null)
+    mocks.fetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/admin/api/event-creations/signers')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              address: CREATOR,
+              displayName: 'Server signer',
+              shortAddress: '0x0000...00AA',
+            }],
+          }),
+        }
+      }
+      if (url.includes('/admin/api/proposer-whitelists?creator=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            registryAddress: REGISTRY,
+            creators: [{
+              address: CREATOR,
+              displayName: 'Server signer',
+              shortAddress: '0x0000...00AA',
+              hasServerSigner: true,
+            }],
+            status: {
+              creator: CREATOR,
+              registryAddress: REGISTRY,
+              whitelistAddress: null,
+              proposers: [],
+              hasServerSigner: true,
+            },
+          }),
+        }
+      }
+      if (url.endsWith('/admin/api/proposer-whitelists') && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            status: {
+              creator: CREATOR,
+              registryAddress: REGISTRY,
+              whitelistAddress: WHITELIST,
+              proposers: [PROPOSER],
+              hasServerSigner: true,
+            },
+            txHashes: ['0xserver'],
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    render(
+      <AdminProposersDialog
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Create whitelist' })).toBeEnabled()
+    })
+
+    await user.type(screen.getByRole('textbox'), PROPOSER)
+    await user.click(screen.getByRole('button', { name: 'Create whitelist' }))
+
+    await waitFor(() => {
+      expect(mocks.fetch).toHaveBeenCalledWith('/admin/api/proposer-whitelists', expect.objectContaining({
+        method: 'POST',
+      }))
+    })
+
+    expect(mocks.sendTransaction).not.toHaveBeenCalled()
     expect(mocks.toastSuccess).toHaveBeenCalledWith('Proposer whitelist updated.')
   })
 })

--- a/tests/unit/AdminProposersDialog.test.tsx
+++ b/tests/unit/AdminProposersDialog.test.tsx
@@ -1,0 +1,197 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { getAddress } from 'viem'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import AdminProposersDialog from '@/app/[locale]/admin/events/calendar/_components/AdminProposersDialog'
+
+const CREATOR = getAddress('0x00000000000000000000000000000000000000aa')
+const EMBEDDED_ACCOUNT = getAddress('0x00000000000000000000000000000000000000bb')
+const REGISTRY = getAddress('0x00000000000000000000000000000000000000cc')
+const WHITELIST = getAddress('0x00000000000000000000000000000000000000dd')
+const PROPOSER = getAddress('0x00000000000000000000000000000000000000ee')
+
+const mocks = vi.hoisted(() => ({
+  useAppKitAccount: vi.fn(),
+  useWalletClient: vi.fn(),
+  usePublicClient: vi.fn(),
+  useUser: vi.fn(),
+  runWithSignaturePrompt: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastError: vi.fn(),
+  sendTransaction: vi.fn(),
+  walletRequest: vi.fn(),
+  waitForTransactionReceipt: vi.fn(),
+  estimateFeesPerGas: vi.fn(),
+  getGasPrice: vi.fn(),
+}))
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (value: string) => value,
+}))
+
+vi.mock('@reown/appkit/react', () => ({
+  useAppKitAccount: () => mocks.useAppKitAccount(),
+}))
+
+vi.mock('wagmi', () => ({
+  useWalletClient: () => ({ data: mocks.useWalletClient() }),
+  usePublicClient: () => mocks.usePublicClient(),
+}))
+
+vi.mock('@/stores/useUser', () => ({
+  useUser: () => mocks.useUser(),
+}))
+
+vi.mock('@/hooks/useSignaturePromptRunner', () => ({
+  useSignaturePromptRunner: () => ({
+    runWithSignaturePrompt: mocks.runWithSignaturePrompt,
+  }),
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: (...args: unknown[]) => mocks.toastSuccess(...args),
+    error: (...args: unknown[]) => mocks.toastError(...args),
+  },
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: any) => <button {...props}>{children}</button>,
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: any) => open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: any) => <div>{children}</div>,
+  DialogDescription: ({ children }: any) => <p>{children}</p>,
+  DialogHeader: ({ children }: any) => <div>{children}</div>,
+  DialogTitle: ({ children }: any) => <h2>{children}</h2>,
+}))
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: any) => <label {...props}>{children}</label>,
+}))
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children }: any) => <button type="button">{children}</button>,
+  SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+}))
+
+vi.mock('@/components/ui/textarea', () => ({
+  Textarea: ({ ...props }: any) => <textarea {...props} />,
+}))
+
+describe('adminProposersDialog', () => {
+  beforeEach(() => {
+    mocks.useAppKitAccount.mockReturnValue({ address: CREATOR })
+    mocks.useUser.mockReturnValue({ address: null })
+    mocks.sendTransaction.mockReset()
+    mocks.walletRequest.mockReset()
+    mocks.waitForTransactionReceipt.mockReset()
+    mocks.estimateFeesPerGas.mockReset()
+    mocks.getGasPrice.mockReset()
+    mocks.runWithSignaturePrompt.mockReset()
+    mocks.toastSuccess.mockReset()
+    mocks.toastError.mockReset()
+
+    mocks.useWalletClient.mockReturnValue({
+      account: { address: EMBEDDED_ACCOUNT },
+      chain: { id: 80002, name: 'Polygon Amoy' },
+      sendTransaction: mocks.sendTransaction,
+      request: mocks.walletRequest,
+    })
+    mocks.usePublicClient.mockReturnValue({
+      estimateFeesPerGas: mocks.estimateFeesPerGas,
+      getGasPrice: mocks.getGasPrice,
+      waitForTransactionReceipt: mocks.waitForTransactionReceipt,
+    })
+    mocks.runWithSignaturePrompt.mockImplementation(async (callback: () => Promise<unknown>) => callback())
+    mocks.estimateFeesPerGas.mockResolvedValue({
+      maxFeePerGas: 100n,
+      maxPriorityFeePerGas: 10n,
+    })
+    mocks.getGasPrice.mockResolvedValue(100n)
+    mocks.sendTransaction
+      .mockResolvedValueOnce('0xdeploy')
+      .mockResolvedValueOnce('0xregister')
+    mocks.waitForTransactionReceipt
+      .mockResolvedValueOnce({
+        status: 'success',
+        contractAddress: WHITELIST,
+      })
+      .mockResolvedValueOnce({
+        status: 'success',
+      })
+
+    vi.stubGlobal('fetch', vi.fn(async (input: RequestInfo | URL) => {
+      const url = String(input)
+      if (url.includes('/admin/api/event-creations/signers')) {
+        return {
+          ok: true,
+          json: async () => ({ data: [] }),
+        }
+      }
+      if (url.includes('/admin/api/proposer-whitelists')) {
+        return {
+          ok: true,
+          json: async () => ({
+            registryAddress: REGISTRY,
+            creators: [{
+              address: CREATOR,
+              displayName: 'EOA wallet',
+              shortAddress: '0x0000...00AA',
+              hasServerSigner: false,
+            }],
+            status: {
+              creator: CREATOR,
+              registryAddress: REGISTRY,
+              whitelistAddress: null,
+              proposers: [],
+              hasServerSigner: false,
+            },
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    }))
+  })
+
+  it('uses the resolved AppKit EOA for whitelist creation even when walletClient account differs', async () => {
+    const user = userEvent.setup()
+
+    render(
+      <AdminProposersDialog
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Create whitelist' })).toBeEnabled()
+    })
+
+    await user.type(screen.getByRole('textbox'), PROPOSER)
+    await user.click(screen.getByRole('button', { name: 'Create whitelist' }))
+
+    await waitFor(() => {
+      expect(mocks.sendTransaction).toHaveBeenCalledTimes(2)
+    })
+
+    expect(mocks.sendTransaction).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      account: CREATOR,
+      data: expect.stringMatching(/^0x/i),
+      value: 0n,
+    }))
+    expect(mocks.sendTransaction).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      account: CREATOR,
+      to: REGISTRY,
+      data: expect.stringMatching(/^0x/i),
+      value: 0n,
+    }))
+    expect(mocks.toastError).not.toHaveBeenCalledWith('Use the selected creator EOA in your wallet to sign this action.')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Proposer whitelist updated.')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the whitelist modal so transactions are signed by the selected creator EOA (AppKit/Google EOA), keeps a safer send flow with fee estimation and RPC fallback, and preserves the server-signer fallback when no wallet is available.

- **Bug Fixes**
  - Resolve the creator wallet using AppKit EOA and user address, not the `walletClient` account, so the signing prompt targets the selected creator.
  - Preserve server-signer fallback when only the stored user address matches the creator or no wallet is connected.
  - Handle BigInt serialization errors by falling back to `eth_sendTransaction` with hex-encoded fee fields, and show a localized error if the provider returns an invalid transaction hash.

- **Refactors**
  - Centralized tx sending via `sendWalletTransaction` and `buildRpcWalletTransactionRequest`, with `sendWithEstimatedFeeRetry` for fee estimates and retries.
  - Switched to `encodeDeployData`/`encodeFunctionData` from `viem` for deploy/write calls.
  - Simplified create/register/add/remove proposer flows and added unit tests for EOA routing and server-signer fallback.

<sup>Written for commit 7cdb92d7703ba5105d32328d33b038b8877801dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1106?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

