### PR TITLE
fix: support social wallet whitelist signing

### DIFF
--- a/src/app/[locale]/admin/api/proposer-whitelists/route.ts
+++ b/src/app/[locale]/admin/api/proposer-whitelists/route.ts
@@ -10,6 +10,7 @@ import { loadEventCreationSignersFromEnv } from '@/lib/event-creation-signers'
 import {
   getServerCreatorProposerWhitelistRegistryAddress,
   normalizeProposerAddressList,
+  omitCreatorFromProposerAddressList,
   readCreatorProposerWhitelistStatus,
   readProposerWhitelistError,
   shortenProposerWhitelistAddress,
@@ -153,19 +154,29 @@ export async function POST(request: Request) {
     }
 
     const creator = getAddress(parsed.data.creator) as Address
-    let proposers: Address[]
+    let requestedProposers: Address[]
     try {
-      proposers = normalizeProposerAddressList(parsed.data.proposers)
+      requestedProposers = normalizeProposerAddressList(parsed.data.proposers)
     }
     catch (error) {
       return NextResponse.json({ error: readProposerWhitelistError(error) }, { status: 400 })
     }
 
-    if (parsed.data.action !== 'create' && proposers.length === 0) {
+    if (parsed.data.action !== 'create' && requestedProposers.length === 0) {
       return NextResponse.json({ error: 'At least one proposer wallet is required.' }, { status: 400 })
     }
 
     const registryAddress = getServerCreatorProposerWhitelistRegistryAddress()
+    const proposers = omitCreatorFromProposerAddressList(creator, requestedProposers)
+    if (parsed.data.action !== 'create' && proposers.length === 0) {
+      const currentStatus = await readCreatorProposerWhitelistStatus({
+        creator,
+        registryAddress,
+        hasServerSigner: buildSignerMap().has(creator.toLowerCase()),
+      })
+      return NextResponse.json({ status: currentStatus, txHashes: [] })
+    }
+
     const account = getServerSigner(creator)
     const publicClient = createPublicClient({
       chain: defaultViemNetwork,

--- a/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
@@ -251,9 +251,9 @@ export default function AdminProposersDialog({
     () => resolveProposerWhitelistAddress(appKitAddressRaw, user?.address, walletClient?.account?.address),
     [appKitAddressRaw, user?.address, walletClient?.account?.address],
   )
-  const connectedChainId = useMemo(
-    () => walletClient?.chain?.id ?? resolveChainId(appKitChainId),
-    [appKitChainId, walletClient?.chain?.id],
+  const appKitResolvedChainId = useMemo(
+    () => resolveChainId(appKitChainId),
+    [appKitChainId],
   )
   const [creators, setCreators] = useState<ProposerWhitelistCreatorOption[]>([])
   const [signers, setSigners] = useState<SignerOption[]>([])
@@ -292,6 +292,9 @@ export default function AdminProposersDialog({
     isRpcWalletProvider(walletProvider)
     || walletClientMatchesSelectedCreator,
   )
+  const connectedWalletTransportChainId = walletClientMatchesSelectedCreator
+    ? walletClient?.chain?.id ?? appKitResolvedChainId
+    : appKitResolvedChainId
   const canUseConnectedWallet = Boolean(
     selectedCreator
     && connectedWalletAddress
@@ -473,7 +476,7 @@ export default function AdminProposersDialog({
     if (!canUseConnectedWallet) {
       throw new Error(t('Use the selected creator EOA in your wallet to sign this action.'))
     }
-    if (connectedChainId && connectedChainId !== DEFAULT_CHAIN_ID) {
+    if (connectedWalletTransportChainId && connectedWalletTransportChainId !== DEFAULT_CHAIN_ID) {
       throw new Error(t('Switch wallet to {chain} before updating proposer whitelist.', { chain: defaultViemNetwork.name }))
     }
     const rpcProvider = isRpcWalletProvider(walletProvider)
@@ -490,6 +493,7 @@ export default function AdminProposersDialog({
       rpcProvider,
       walletClient,
       walletClientMatchesCreator,
+      chainId: connectedWalletTransportChainId ?? DEFAULT_CHAIN_ID,
     }
   }
 
@@ -581,7 +585,7 @@ export default function AdminProposersDialog({
     }
 
     return sendWithEstimatedFeeRetry({
-      chainId: connectedChainId ?? DEFAULT_CHAIN_ID,
+      chainId: connection.chainId,
       client: publicClient,
       send: sendWithRpcFallback,
     })

--- a/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
@@ -3,7 +3,7 @@
 import type { Address, Hash, Hex } from 'viem'
 import type { SignerOption } from './admin-create-event-form-types'
 import type { ProposerWhitelistCreatorOption, ProposerWhitelistMutationResponse, ProposerWhitelistStatus, ProposerWhitelistStatusResponse } from '@/lib/proposer-whitelist'
-import { useAppKitAccount } from '@reown/appkit/react'
+import { useAppKitAccount, useAppKitNetworkCore, useAppKitProvider } from '@reown/appkit/react'
 import { CheckCircle2Icon, CircleIcon, Loader2Icon, PlusIcon, UserCheckIcon, XIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useCallback, useEffect, useEffectEvent, useMemo, useState } from 'react'
@@ -32,6 +32,7 @@ import { DEFAULT_CHAIN_ID } from '@/lib/network'
 import {
   isProposerWhitelistStatusResponse,
   normalizeProposerAddressList,
+  omitCreatorFromProposerAddressList,
   readProposerWhitelistError,
   resolveProposerWhitelistAddress,
   shortenProposerWhitelistAddress,
@@ -57,6 +58,31 @@ interface AdminProposersDialogProps {
 
 interface EventCreationSignersResponse {
   data?: SignerOption[]
+}
+
+interface RpcWalletProvider {
+  request: (args: { method: string, params?: unknown[] }) => Promise<unknown>
+}
+
+function isRpcWalletProvider(value: unknown): value is RpcWalletProvider {
+  return Boolean(value)
+    && typeof value === 'object'
+    && typeof (value as { request?: unknown }).request === 'function'
+}
+
+function resolveChainId(value: number | string | undefined) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value
+  }
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value)
+    return Number.isFinite(parsed) ? parsed : null
+  }
+  return null
+}
+
+function isSameAddress(first?: string | null, second?: string | null) {
+  return Boolean(first && second && first.toLowerCase() === second.toLowerCase())
 }
 
 function readApiError(payload: unknown) {
@@ -210,18 +236,24 @@ export default function AdminProposersDialog({
   onStatusChange,
 }: AdminProposersDialogProps) {
   const t = useExtracted()
-  const { address: appKitAddressRaw } = useAppKitAccount()
+  const { address: appKitAddressRaw } = useAppKitAccount({ namespace: 'eip155' })
+  const { walletProvider } = useAppKitProvider<RpcWalletProvider>('eip155')
+  const { chainId: appKitChainId } = useAppKitNetworkCore()
   const { data: walletClient } = useWalletClient()
   const publicClient = usePublicClient()
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
   const user = useUser()
   const connectedWalletAddress = useMemo(
-    () => resolveProposerWhitelistAddress(appKitAddressRaw, walletClient?.account?.address),
-    [appKitAddressRaw, walletClient?.account?.address],
+    () => resolveProposerWhitelistAddress(appKitAddressRaw, user?.address, walletClient?.account?.address),
+    [appKitAddressRaw, user?.address, walletClient?.account?.address],
   )
   const knownCreatorAddress = useMemo(
     () => resolveProposerWhitelistAddress(appKitAddressRaw, user?.address, walletClient?.account?.address),
     [appKitAddressRaw, user?.address, walletClient?.account?.address],
+  )
+  const connectedChainId = useMemo(
+    () => walletClient?.chain?.id ?? resolveChainId(appKitChainId),
+    [appKitChainId, walletClient?.chain?.id],
   )
   const [creators, setCreators] = useState<ProposerWhitelistCreatorOption[]>([])
   const [signers, setSigners] = useState<SignerOption[]>([])
@@ -251,10 +283,16 @@ export default function AdminProposersDialog({
     })
   }, [creators, initialCreatorAddress, knownCreatorAddress, lockCreatorSelection, signers, t])
   const selectedOption = creatorOptions.find(item => selectedCreator && item.address.toLowerCase() === selectedCreator.toLowerCase()) ?? null
+  const hasConnectedWalletTransport = Boolean(
+    isRpcWalletProvider(walletProvider)
+    || isRpcWalletProvider(walletClient)
+    || (selectedCreator && walletClient && isSameAddress(walletClient.account?.address, selectedCreator)),
+  )
   const canUseConnectedWallet = Boolean(
     selectedCreator
     && connectedWalletAddress
-    && selectedCreator.toLowerCase() === connectedWalletAddress.toLowerCase(),
+    && isSameAddress(selectedCreator, connectedWalletAddress)
+    && hasConnectedWalletTransport,
   )
   const canUseServerSigner = Boolean(status?.hasServerSigner || selectedOption?.hasServerSigner)
   const isSwitchingCreator = Boolean(
@@ -424,17 +462,34 @@ export default function AdminProposersDialog({
     return receipt
   }
 
-  function getConnectedWalletClient() {
+  function getConnectedWalletConnection() {
     if (!selectedCreator) {
       throw new Error(t('Select a creator wallet first.'))
     }
-    if (!canUseConnectedWallet || !walletClient) {
+    if (!canUseConnectedWallet) {
       throw new Error(t('Use the selected creator EOA in your wallet to sign this action.'))
     }
-    if (walletClient.chain?.id && walletClient.chain.id !== DEFAULT_CHAIN_ID) {
+    if (connectedChainId && connectedChainId !== DEFAULT_CHAIN_ID) {
       throw new Error(t('Switch wallet to {chain} before updating proposer whitelist.', { chain: defaultViemNetwork.name }))
     }
-    return walletClient
+    const rpcProvider = isRpcWalletProvider(walletProvider)
+      ? walletProvider
+      : isRpcWalletProvider(walletClient)
+        ? walletClient
+        : null
+    const walletClientMatchesCreator = Boolean(
+      walletClient
+      && isSameAddress(walletClient.account?.address, selectedCreator),
+    )
+    if (!walletClientMatchesCreator && !rpcProvider) {
+      throw new Error(t('Wallet connection is not ready. Please try again.'))
+    }
+
+    return {
+      rpcProvider,
+      walletClient,
+      walletClientMatchesCreator,
+    }
   }
 
   async function sendWalletTransaction(input: {
@@ -445,15 +500,19 @@ export default function AdminProposersDialog({
     to?: Address
     value?: bigint
   }) {
-    const client = getConnectedWalletClient()
+    const connection = getConnectedWalletConnection()
 
-    function send(overrides?: {
+    function sendWithWalletClient(overrides?: {
       maxFeePerGas?: bigint
       maxPriorityFeePerGas?: bigint
     }) {
-      return client.sendTransaction({
+      if (!connection.walletClient) {
+        throw new Error(t('Wallet connection is not ready. Please try again.'))
+      }
+
+      return connection.walletClient.sendTransaction({
         account: input.account,
-        chain: client.chain,
+        chain: connection.walletClient.chain,
         to: input.to,
         data: input.data,
         value: input.value ?? 0n,
@@ -461,12 +520,47 @@ export default function AdminProposersDialog({
       })
     }
 
+    async function sendRpc(overrides?: {
+      maxFeePerGas?: bigint
+      maxPriorityFeePerGas?: bigint
+    }) {
+      if (!connection.rpcProvider) {
+        throw new Error(t('Wallet connection is not ready. Please try again.'))
+      }
+
+      const txRequest = buildRpcWalletTransactionRequest({
+        from: input.account,
+        to: input.to,
+        data: input.data,
+        value: input.value ?? 0n,
+        ...(overrides ?? {}),
+      })
+      const rpcHash = await runWithSignaturePrompt(
+        () => connection.rpcProvider!.request({
+          method: 'eth_sendTransaction',
+          params: [txRequest],
+        }),
+        {
+          title: input.title,
+          description: input.description,
+        },
+      )
+      if (typeof rpcHash !== 'string' || !rpcHash.startsWith('0x')) {
+        throw new Error(t('Wallet provider returned an invalid transaction hash.'))
+      }
+      return rpcHash as Hash
+    }
+
     async function sendWithRpcFallback(overrides?: {
       maxFeePerGas?: bigint
       maxPriorityFeePerGas?: bigint
     }) {
+      if (!connection.walletClientMatchesCreator) {
+        return await sendRpc(overrides)
+      }
+
       try {
-        return await runWithSignaturePrompt(() => send(overrides), {
+        return await runWithSignaturePrompt(() => sendWithWalletClient(overrides), {
           title: input.title,
           description: input.description,
         })
@@ -477,27 +571,7 @@ export default function AdminProposersDialog({
           throw sendError
         }
 
-        const txRequest = buildRpcWalletTransactionRequest({
-          from: input.account,
-          to: input.to,
-          data: input.data,
-          value: input.value ?? 0n,
-          ...(overrides ?? {}),
-        })
-        const rpcHash = await runWithSignaturePrompt(
-          () => client.request({
-            method: 'eth_sendTransaction',
-            params: [txRequest],
-          }) as Promise<unknown>,
-          {
-            title: input.title,
-            description: input.description,
-          },
-        )
-        if (typeof rpcHash !== 'string' || !rpcHash.startsWith('0x')) {
-          throw new Error(t('Wallet provider returned an invalid transaction hash.'))
-        }
-        return rpcHash as Hash
+        return await sendRpc(overrides)
       }
     }
 
@@ -506,7 +580,7 @@ export default function AdminProposersDialog({
     }
 
     return sendWithEstimatedFeeRetry({
-      chainId: client.chain?.id ?? DEFAULT_CHAIN_ID,
+      chainId: connectedChainId ?? DEFAULT_CHAIN_ID,
       client: publicClient,
       send: sendWithRpcFallback,
     })
@@ -572,17 +646,26 @@ export default function AdminProposersDialog({
       return
     }
 
-    let proposers: Address[] = []
+    let requestedProposers: Address[] = []
     try {
-      proposers = normalizeProposerAddressList(rawProposers)
+      requestedProposers = normalizeProposerAddressList(rawProposers)
     }
     catch (error) {
       toast.error(error instanceof Error ? error.message : t('Invalid wallet address.'))
       return
     }
 
-    if (proposers.length === 0 && action !== 'create') {
+    if (requestedProposers.length === 0 && action !== 'create') {
       toast.error(t('Add at least one wallet.'))
+      return
+    }
+
+    const proposers = omitCreatorFromProposerAddressList(selectedCreator, requestedProposers)
+
+    if (proposers.length === 0 && action !== 'create') {
+      setWalletInput('')
+      setAddOpen(false)
+      toast.success(t('Proposer whitelist updated.'))
       return
     }
 

--- a/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
+++ b/src/app/[locale]/admin/events/calendar/_components/AdminProposersDialog.tsx
@@ -283,10 +283,14 @@ export default function AdminProposersDialog({
     })
   }, [creators, initialCreatorAddress, knownCreatorAddress, lockCreatorSelection, signers, t])
   const selectedOption = creatorOptions.find(item => selectedCreator && item.address.toLowerCase() === selectedCreator.toLowerCase()) ?? null
+  const walletClientMatchesSelectedCreator = Boolean(
+    selectedCreator
+    && walletClient
+    && isSameAddress(walletClient.account?.address, selectedCreator),
+  )
   const hasConnectedWalletTransport = Boolean(
     isRpcWalletProvider(walletProvider)
-    || isRpcWalletProvider(walletClient)
-    || (selectedCreator && walletClient && isSameAddress(walletClient.account?.address, selectedCreator)),
+    || walletClientMatchesSelectedCreator,
   )
   const canUseConnectedWallet = Boolean(
     selectedCreator
@@ -474,13 +478,10 @@ export default function AdminProposersDialog({
     }
     const rpcProvider = isRpcWalletProvider(walletProvider)
       ? walletProvider
-      : isRpcWalletProvider(walletClient)
+      : walletClientMatchesSelectedCreator && isRpcWalletProvider(walletClient)
         ? walletClient
         : null
-    const walletClientMatchesCreator = Boolean(
-      walletClient
-      && isSameAddress(walletClient.account?.address, selectedCreator),
-    )
+    const walletClientMatchesCreator = walletClientMatchesSelectedCreator
     if (!walletClientMatchesCreator && !rpcProvider) {
       throw new Error(t('Wallet connection is not ready. Please try again.'))
     }

--- a/src/lib/proposer-whitelist.ts
+++ b/src/lib/proposer-whitelist.ts
@@ -85,6 +85,11 @@ export function normalizeProposerAddressList(value: string | string[]) {
   return [...deduped.values()]
 }
 
+export function omitCreatorFromProposerAddressList(creator: Address, proposers: Address[]) {
+  const creatorKey = creator.toLowerCase()
+  return proposers.filter(proposer => proposer.toLowerCase() !== creatorKey)
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
 }

--- a/tests/unit/AdminProposersDialog.test.tsx
+++ b/tests/unit/AdminProposersDialog.test.tsx
@@ -12,6 +12,8 @@ const PROPOSER = getAddress('0x00000000000000000000000000000000000000ee')
 
 const mocks = vi.hoisted(() => ({
   useAppKitAccount: vi.fn(),
+  useAppKitNetworkCore: vi.fn(),
+  useAppKitProvider: vi.fn(),
   useWalletClient: vi.fn(),
   usePublicClient: vi.fn(),
   useUser: vi.fn(),
@@ -32,6 +34,8 @@ vi.mock('next-intl', () => ({
 
 vi.mock('@reown/appkit/react', () => ({
   useAppKitAccount: () => mocks.useAppKitAccount(),
+  useAppKitNetworkCore: () => mocks.useAppKitNetworkCore(),
+  useAppKitProvider: () => mocks.useAppKitProvider(),
 }))
 
 vi.mock('wagmi', () => ({
@@ -87,6 +91,8 @@ vi.mock('@/components/ui/textarea', () => ({
 describe('adminProposersDialog', () => {
   beforeEach(() => {
     mocks.useAppKitAccount.mockReturnValue({ address: CREATOR })
+    mocks.useAppKitNetworkCore.mockReturnValue({ chainId: 80002 })
+    mocks.useAppKitProvider.mockReturnValue({ walletProvider: { request: mocks.walletRequest } })
     mocks.useUser.mockReturnValue({ address: null })
     mocks.sendTransaction.mockReset()
     mocks.walletRequest.mockReset()
@@ -116,6 +122,9 @@ describe('adminProposersDialog', () => {
     })
     mocks.getGasPrice.mockResolvedValue(100n)
     mocks.sendTransaction
+      .mockResolvedValueOnce('0xdeploy')
+      .mockResolvedValueOnce('0xregister')
+    mocks.walletRequest
       .mockResolvedValueOnce('0xdeploy')
       .mockResolvedValueOnce('0xregister')
     mocks.waitForTransactionReceipt
@@ -162,8 +171,10 @@ describe('adminProposersDialog', () => {
     vi.stubGlobal('fetch', mocks.fetch)
   })
 
-  it('uses the resolved AppKit EOA for whitelist creation even when walletClient account differs', async () => {
+  it('uses the Better Auth EOA through the AppKit RPC provider when walletClient account differs', async () => {
     const user = userEvent.setup()
+    mocks.useAppKitAccount.mockReturnValue({ address: null })
+    mocks.useUser.mockReturnValue({ address: CREATOR })
 
     render(
       <AdminProposersDialog
@@ -180,19 +191,26 @@ describe('adminProposersDialog', () => {
     await user.click(screen.getByRole('button', { name: 'Create whitelist' }))
 
     await waitFor(() => {
-      expect(mocks.sendTransaction).toHaveBeenCalledTimes(2)
+      expect(mocks.walletRequest).toHaveBeenCalledTimes(2)
     })
 
-    expect(mocks.sendTransaction).toHaveBeenNthCalledWith(1, expect.objectContaining({
-      account: CREATOR,
-      data: expect.stringMatching(/^0x/i),
-      value: 0n,
+    expect(mocks.sendTransaction).not.toHaveBeenCalled()
+    expect(mocks.walletRequest).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      method: 'eth_sendTransaction',
+      params: [expect.objectContaining({
+        from: CREATOR,
+        data: expect.stringMatching(/^0x/i),
+        value: '0x0',
+      })],
     }))
-    expect(mocks.sendTransaction).toHaveBeenNthCalledWith(2, expect.objectContaining({
-      account: CREATOR,
-      to: REGISTRY,
-      data: expect.stringMatching(/^0x/i),
-      value: 0n,
+    expect(mocks.walletRequest).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      method: 'eth_sendTransaction',
+      params: [expect.objectContaining({
+        from: CREATOR,
+        to: REGISTRY,
+        data: expect.stringMatching(/^0x/i),
+        value: '0x0',
+      })],
     }))
     expect(mocks.toastError).not.toHaveBeenCalledWith('Use the selected creator EOA in your wallet to sign this action.')
     expect(mocks.toastSuccess).toHaveBeenCalledWith('Proposer whitelist updated.')
@@ -202,6 +220,7 @@ describe('adminProposersDialog', () => {
     const user = userEvent.setup()
 
     mocks.useAppKitAccount.mockReturnValue({ address: null })
+    mocks.useAppKitProvider.mockReturnValue({ walletProvider: null })
     mocks.useUser.mockReturnValue({ address: CREATOR })
     mocks.useWalletClient.mockReturnValue(null)
     mocks.usePublicClient.mockReturnValue(null)

--- a/tests/unit/AdminProposersDialog.test.tsx
+++ b/tests/unit/AdminProposersDialog.test.tsx
@@ -216,6 +216,41 @@ describe('adminProposersDialog', () => {
     expect(mocks.toastSuccess).toHaveBeenCalledWith('Proposer whitelist updated.')
   })
 
+  it('validates the AppKit provider network when social-wallet transport is used', async () => {
+    const user = userEvent.setup()
+    mocks.useAppKitAccount.mockReturnValue({ address: null })
+    mocks.useAppKitNetworkCore.mockReturnValue({ chainId: 80002 })
+    mocks.useUser.mockReturnValue({ address: CREATOR })
+    mocks.useWalletClient.mockReturnValue({
+      account: { address: EMBEDDED_ACCOUNT },
+      chain: { id: 1, name: 'Ethereum' },
+      sendTransaction: mocks.sendTransaction,
+      request: mocks.walletRequest,
+    })
+
+    render(
+      <AdminProposersDialog
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Create whitelist' })).toBeEnabled()
+    })
+
+    await user.type(screen.getByRole('textbox'), PROPOSER)
+    await user.click(screen.getByRole('button', { name: 'Create whitelist' }))
+
+    await waitFor(() => {
+      expect(mocks.walletRequest).toHaveBeenCalledTimes(2)
+    })
+
+    expect(mocks.sendTransaction).not.toHaveBeenCalled()
+    expect(mocks.toastError).not.toHaveBeenCalledWith('Switch wallet to Polygon Amoy before updating proposer whitelist.')
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Proposer whitelist updated.')
+  })
+
   it('keeps server-signer fallback available when only the stored user address matches the selected creator', async () => {
     const user = userEvent.setup()
 

--- a/tests/unit/AdminProposersDialog.test.tsx
+++ b/tests/unit/AdminProposersDialog.test.tsx
@@ -301,4 +301,89 @@ describe('adminProposersDialog', () => {
     expect(mocks.sendTransaction).not.toHaveBeenCalled()
     expect(mocks.toastSuccess).toHaveBeenCalledWith('Proposer whitelist updated.')
   })
+
+  it('does not treat a mismatched walletClient request method as creator wallet transport', async () => {
+    const user = userEvent.setup()
+
+    mocks.useAppKitAccount.mockReturnValue({ address: null })
+    mocks.useAppKitProvider.mockReturnValue({ walletProvider: null })
+    mocks.useUser.mockReturnValue({ address: CREATOR })
+    mocks.fetch.mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input)
+      if (url.includes('/admin/api/event-creations/signers')) {
+        return {
+          ok: true,
+          json: async () => ({
+            data: [{
+              address: CREATOR,
+              displayName: 'Server signer',
+              shortAddress: '0x0000...00AA',
+            }],
+          }),
+        }
+      }
+      if (url.includes('/admin/api/proposer-whitelists?creator=')) {
+        return {
+          ok: true,
+          json: async () => ({
+            registryAddress: REGISTRY,
+            creators: [{
+              address: CREATOR,
+              displayName: 'Server signer',
+              shortAddress: '0x0000...00AA',
+              hasServerSigner: true,
+            }],
+            status: {
+              creator: CREATOR,
+              registryAddress: REGISTRY,
+              whitelistAddress: null,
+              proposers: [],
+              hasServerSigner: true,
+            },
+          }),
+        }
+      }
+      if (url.endsWith('/admin/api/proposer-whitelists') && init?.method === 'POST') {
+        return {
+          ok: true,
+          json: async () => ({
+            status: {
+              creator: CREATOR,
+              registryAddress: REGISTRY,
+              whitelistAddress: WHITELIST,
+              proposers: [PROPOSER],
+              hasServerSigner: true,
+            },
+            txHashes: ['0xserver'],
+          }),
+        }
+      }
+
+      throw new Error(`Unexpected fetch: ${url}`)
+    })
+
+    render(
+      <AdminProposersDialog
+        open
+        onOpenChange={vi.fn()}
+      />,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Create whitelist' })).toBeEnabled()
+    })
+
+    await user.type(screen.getByRole('textbox'), PROPOSER)
+    await user.click(screen.getByRole('button', { name: 'Create whitelist' }))
+
+    await waitFor(() => {
+      expect(mocks.fetch).toHaveBeenCalledWith('/admin/api/proposer-whitelists', expect.objectContaining({
+        method: 'POST',
+      }))
+    })
+
+    expect(mocks.walletRequest).not.toHaveBeenCalled()
+    expect(mocks.sendTransaction).not.toHaveBeenCalled()
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Proposer whitelist updated.')
+  })
 })

--- a/tests/unit/proposerWhitelist.test.ts
+++ b/tests/unit/proposerWhitelist.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { readProposerWhitelistError, resolveProposerWhitelistAddress } from '@/lib/proposer-whitelist'
+import {
+  omitCreatorFromProposerAddressList,
+  readProposerWhitelistError,
+  resolveProposerWhitelistAddress,
+} from '@/lib/proposer-whitelist'
 
 describe('readProposerWhitelistError', () => {
   it('maps underpriced gas errors to a compact user-facing message', () => {
@@ -27,5 +31,17 @@ describe('resolveProposerWhitelistAddress', () => {
 
   it('returns null when no valid address is provided', () => {
     expect(resolveProposerWhitelistAddress(undefined, null, 'invalid')).toBeNull()
+  })
+})
+
+describe('omitCreatorFromProposerAddressList', () => {
+  it('removes the creator EOA while preserving other proposer wallets', () => {
+    const creator = '0x00000000000000000000000000000000000000AA'
+    const proposer = '0x00000000000000000000000000000000000000BB'
+
+    expect(omitCreatorFromProposerAddressList(creator, [
+      '0x00000000000000000000000000000000000000aa',
+      proposer,
+    ])).toEqual([proposer])
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable social/custodial wallet signing for proposer whitelists, with provider network checks. We now require the signer transport to match the selected creator and route mismatched sessions through the `@reown/appkit` RPC provider.

- **Bug Fixes**
  - Fallback to RPC `eth_sendTransaction` via `useAppKitProvider('eip155')` when the wallet client account doesn’t match the creator; do not treat a mismatched `walletClient` as a valid transport.
  - Validate and enforce chain on the active transport using `useAppKitNetworkCore`; block wrong-network txs for social wallets and EOAs.
  - Omit the creator from proposer addresses; if the list is empty, return current status with no txs (API) and show success (UI).

<sup>Written for commit b1c516073cb1916f0c5687c8eb2ad47f92b1bc76. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1107?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

