### PR TITLE
fix: keep enable trading in large modal

### DIFF
--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -753,6 +753,55 @@ function TradingOnboardingProviderContent({
     }
   }, [isEmailSubmitting, refreshSessionUserState, shouldContinueTradingAuthPrompt, status, isEventRoute])
 
+  const enableTradingAuthForCurrentUser = useCallback(async () => {
+    if (!user?.address) {
+      throw new Error(DEFAULT_ERROR_MESSAGE)
+    }
+
+    const timestamp = Math.floor(Date.now() / 1000).toString()
+    const message = buildTradingAuthMessage({
+      address: user.address as `0x${string}`,
+      timestamp,
+    })
+    const signature = await runWithSignaturePrompt(() => signTypedDataAsync({
+      domain: getTradingAuthDomain(),
+      types: TRADING_AUTH_TYPES,
+      primaryType: TRADING_AUTH_PRIMARY_TYPE,
+      message,
+    }))
+
+    const result = await enableTradingAuthAction({
+      signature,
+      timestamp,
+      nonce: message.nonce.toString(),
+    })
+
+    if (result.error || !result.data) {
+      throw new Error(result.error ?? DEFAULT_ERROR_MESSAGE)
+    }
+    const data = result.data
+
+    useUser.setState((previous) => {
+      if (!previous) {
+        return previous
+      }
+      return {
+        ...previous,
+        settings: mergeUserSettings(previous, {
+          tradingAuth: data.tradingAuth,
+        }),
+      }
+    })
+    void refreshSessionUserState()
+    setRequiresTradingAuthRefresh(false)
+    setDismissedModal(null)
+  }, [
+    refreshSessionUserState,
+    runWithSignaturePrompt,
+    signTypedDataAsync,
+    user?.address,
+  ])
+
   const handleCreateDepositWallet = useCallback(async () => {
     if (!user?.address || enableTradingStep === 'enabling') {
       return
@@ -761,18 +810,16 @@ function TradingOnboardingProviderContent({
 
     try {
       setEnableTradingStep('enabling')
-      const result = await createDepositWalletAction()
+      let result = await createDepositWalletAction()
+
+      if (result.error && isTradingAuthRequiredError(result.error)) {
+        await enableTradingAuthForCurrentUser()
+        setActiveModal('enable')
+        result = await createDepositWalletAction()
+      }
 
       if (result.error || !result.data) {
-        if (isTradingAuthRequiredError(result.error)) {
-          setRequiresTradingAuthRefresh(true)
-          setDismissedModal(null)
-          setActiveModal('enable-status')
-          setEnableTradingError(null)
-        }
-        else {
-          setEnableTradingError(result.error ?? DEFAULT_ERROR_MESSAGE)
-        }
+        setEnableTradingError(result.error ?? DEFAULT_ERROR_MESSAGE)
         setEnableTradingStep('idle')
         return
       }
@@ -799,7 +846,10 @@ function TradingOnboardingProviderContent({
       }
     }
     catch (error) {
-      if (error instanceof Error) {
+      if (error instanceof UserRejectedRequestError) {
+        setEnableTradingError(t('You rejected the signature request.'))
+      }
+      else if (error instanceof Error) {
         setEnableTradingError(error.message || DEFAULT_ERROR_MESSAGE)
       }
       else {
@@ -808,9 +858,11 @@ function TradingOnboardingProviderContent({
       setEnableTradingStep('idle')
     }
   }, [
+    enableTradingAuthForCurrentUser,
     enableTradingStep,
     refreshSessionUserState,
     status.hasTokenApprovals,
+    t,
     user?.address,
   ])
 
@@ -822,45 +874,7 @@ function TradingOnboardingProviderContent({
 
     try {
       setEnableTradingStep('enabling')
-      const timestamp = Math.floor(Date.now() / 1000).toString()
-      const message = buildTradingAuthMessage({
-        address: user.address as `0x${string}`,
-        timestamp,
-      })
-      const signature = await runWithSignaturePrompt(() => signTypedDataAsync({
-        domain: getTradingAuthDomain(),
-        types: TRADING_AUTH_TYPES,
-        primaryType: TRADING_AUTH_PRIMARY_TYPE,
-        message,
-      }))
-
-      const result = await enableTradingAuthAction({
-        signature,
-        timestamp,
-        nonce: message.nonce.toString(),
-      })
-
-      if (result.error || !result.data) {
-        setEnableTradingError(result.error ?? DEFAULT_ERROR_MESSAGE)
-        setEnableTradingStep('idle')
-        return
-      }
-      const data = result.data
-
-      useUser.setState((previous) => {
-        if (!previous) {
-          return previous
-        }
-        return {
-          ...previous,
-          settings: mergeUserSettings(previous, {
-            tradingAuth: data.tradingAuth,
-          }),
-        }
-      })
-      void refreshSessionUserState()
-      setRequiresTradingAuthRefresh(false)
-      setDismissedModal(null)
+      await enableTradingAuthForCurrentUser()
       if (status.hasDeployedDepositWallet) {
         setEnableTradingStep('completed')
         setActiveModal(status.hasTokenApprovals ? null : 'approve')
@@ -883,10 +897,8 @@ function TradingOnboardingProviderContent({
       setEnableTradingStep('idle')
     }
   }, [
+    enableTradingAuthForCurrentUser,
     enableTradingStep,
-    refreshSessionUserState,
-    runWithSignaturePrompt,
-    signTypedDataAsync,
     status.hasDeployedDepositWallet,
     status.hasTokenApprovals,
     t,

--- a/tests/unit/TradingOnboardingProvider.test.tsx
+++ b/tests/unit/TradingOnboardingProvider.test.tsx
@@ -1,13 +1,16 @@
 import type { User } from '@/types'
-import { render, screen, waitFor } from '@testing-library/react'
+import { act, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { useUser } from '@/stores/useUser'
 
 const mocks = vi.hoisted(() => ({
+  createDepositWalletAction: vi.fn(),
   dialogProps: null as any,
+  enableTradingAuthAction: vi.fn(),
   getSession: vi.fn().mockResolvedValue({ data: { user: null } }),
   openAppKit: vi.fn(),
+  signTypedDataAsync: vi.fn(),
   usePathname: vi.fn(() => '/'),
 }))
 
@@ -24,7 +27,7 @@ vi.mock('wagmi', () => ({
     signMessageAsync: vi.fn(),
   }),
   useSignTypedData: () => ({
-    signTypedDataAsync: vi.fn(),
+    signTypedDataAsync: mocks.signTypedDataAsync,
   }),
 }))
 
@@ -34,8 +37,8 @@ vi.mock('@/app/[locale]/(platform)/_actions/approve-tokens', () => ({
 
 vi.mock('@/app/[locale]/(platform)/_actions/deposit-wallet', () => ({
   checkUsernameAvailabilityAction: vi.fn(),
-  createDepositWalletAction: vi.fn(),
-  enableTradingAuthAction: vi.fn(),
+  createDepositWalletAction: mocks.createDepositWalletAction,
+  enableTradingAuthAction: mocks.enableTradingAuthAction,
   markAutoRedeemApprovalCompletedAction: vi.fn(),
   updateOnboardingEmailAction: vi.fn(),
   updateOnboardingUsernameAction: vi.fn(),
@@ -98,9 +101,12 @@ function createUser(overrides: Partial<User> = {}): User {
 describe('tradingOnboardingProvider', () => {
   beforeEach(() => {
     useUser.setState(null)
+    mocks.createDepositWalletAction.mockReset()
     mocks.dialogProps = null
+    mocks.enableTradingAuthAction.mockReset()
     mocks.getSession.mockClear()
     mocks.openAppKit.mockClear()
+    mocks.signTypedDataAsync.mockReset()
     mocks.usePathname.mockReturnValue('/')
   })
 
@@ -135,5 +141,56 @@ describe('tradingOnboardingProvider', () => {
       expect(screen.getByTestId('active-modal')).toHaveTextContent('username')
     })
     expect(mocks.dialogProps.usernameDefaultValue).toBe('')
+  })
+
+  it('keeps the initial enable trading flow inside the large modal when trading auth is missing', async () => {
+    const depositWalletAddress = '0xbc040c5a56d757986475005f8cde8e41fe3e2486'
+    mocks.signTypedDataAsync.mockResolvedValue('0xsignature')
+    mocks.enableTradingAuthAction.mockResolvedValue({
+      error: null,
+      data: {
+        tradingAuth: {
+          relayer: { enabled: true, updatedAt: '2026-06-06T12:00:00.000Z' },
+          clob: { enabled: true, updatedAt: '2026-06-06T12:00:00.000Z' },
+        },
+      },
+    })
+    mocks.createDepositWalletAction
+      .mockResolvedValueOnce({ error: 'Enable trading to continue.', data: null })
+      .mockResolvedValueOnce({
+        error: null,
+        data: {
+          deposit_wallet_address: depositWalletAddress,
+          deposit_wallet_signature: null,
+          deposit_wallet_signed_at: null,
+          deposit_wallet_status: 'deploying',
+          deposit_wallet_tx_hash: '0xtx',
+        },
+      })
+
+    useUser.setState(createUser({
+      email: 'user@example.com',
+      username: 'user',
+    }))
+
+    render(
+      <TradingOnboardingProvider>
+        <div />
+      </TradingOnboardingProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-modal')).toHaveTextContent('enable')
+    })
+
+    await act(async () => {
+      await mocks.dialogProps.onCreateDepositWallet()
+    })
+
+    expect(mocks.signTypedDataAsync).toHaveBeenCalledTimes(1)
+    expect(mocks.enableTradingAuthAction).toHaveBeenCalledTimes(1)
+    expect(mocks.createDepositWalletAction).toHaveBeenCalledTimes(2)
+    expect(screen.getByTestId('active-modal')).toHaveTextContent('enable')
+    expect(screen.getByTestId('active-modal')).not.toHaveTextContent('enable-status')
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the trading onboarding so the “Enable trading” flow stays in the large modal and doesn’t bounce to the status modal. If trading auth is missing, we prompt for signature, enable auth, and retry deposit wallet creation in place.

- **Bug Fixes**
  - Auto-handle “trading auth required” by collecting a signature, enabling trading, reopening the large “enable” modal, then retrying `createDepositWallet`.
  - Show a clear error when the signature is rejected by the user.
  - Added a unit test to ensure the large modal remains active and `createDepositWallet` is retried.

- **Refactors**
  - Extracted auth enablement into `enableTradingAuthForCurrentUser` and reused it across flows to remove duplicate logic.

<sup>Written for commit 0ceb301ce9309e070350f139409636c32ff6a171. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

