### PR TITLE
fix: add error handling to sync-events script

### DIFF
--- a/scripts/sync-events.ts
+++ b/scripts/sync-events.ts
@@ -2,7 +2,8 @@ import { runCronRequest } from './cron-request.ts'
 
 try {
   await runCronRequest('/api/sync/events')
-} catch (error) {
+}
+catch (error) {
   console.error('Error syncing events:', error)
   process.exit(1)
 }

--- a/scripts/sync-events.ts
+++ b/scripts/sync-events.ts
@@ -1,3 +1,8 @@
 import { runCronRequest } from './cron-request.ts'
 
-await runCronRequest('/api/sync/events')
+try {
+  await runCronRequest('/api/sync/events')
+} catch (error) {
+  console.error('Error syncing events:', error)
+  process.exit(1)
+}


### PR DESCRIPTION
## 问题背景
The `sync-events.ts` script calls `await runCronRequest('/api/sync/events')` without any error handling. If the async function fails (e.g., due to network issues or API errors), it may cause an unhandled exception, leading to unexpected script termination without clear error information.

## 修改内容
Added a `try-catch` block to wrap the async call. In the `catch` block, the error is logged to the console, and the process exits with code 1 to indicate failure. This ensures that errors are properly captured and reported, improving script robustness.

## 验证方式
- Run the script under normal conditions to verify it works as expected.
- Simulate a failure (e.g., by interrupting network or providing invalid input) to confirm that the error is logged and the script exits with a non-zero code.
- Check the console output for the error message: `'Error syncing events:', error`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a try/catch around `runCronRequest('/api/sync/events')` in `scripts/sync-events.ts` to capture errors, log them, and exit with code 1; also formats the script for consistency. This prevents unhandled promise rejections and makes failures visible in CI and cron logs.

<sup>Written for commit c896367707abaebcb2811419040030c4b1376aef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

