### PR TITLE
fix: show resolved sports order panel in right rail

### DIFF
--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -62,6 +62,7 @@ import {
   resolveButtonOverlayStyle,
   resolveButtonStyle,
   resolveSelectedButton,
+  resolveSelectedMarket,
   SportsGameDetailsPanel,
   SportsGameGraph,
   SportsOrderPanelMarketInfo,
@@ -310,7 +311,47 @@ export default function SportsEventCenter({
     orderMarketConditionId,
     orderOutcomeIndex,
   })
-  const pageAboutMarket = activeTradeHeaderContext?.market ?? activeTradeContext?.market ?? null
+  const pageAboutMarket = useMemo(() => {
+    if (activeTradeHeaderContext?.market) {
+      return activeTradeHeaderContext.market
+    }
+
+    if (activeTradeContext?.market) {
+      return activeTradeContext.market
+    }
+
+    const candidateKeys = [
+      openSectionKey ? selectedButtonBySection[openSectionKey] : null,
+      openAuxiliaryConditionId ? selectedAuxiliaryButtonByConditionId[openAuxiliaryConditionId] : null,
+      marketSlugToButtonKey,
+      selectedButtonBySection.moneyline,
+      selectedButtonBySection.spread,
+      selectedButtonBySection.total,
+      selectedButtonBySection.btts,
+      moneylineButtonKey,
+      null,
+    ]
+
+    for (const buttonKey of candidateKeys) {
+      const market = resolveSelectedMarket(activeCard, buttonKey)
+      if (market) {
+        return market
+      }
+    }
+
+    return null
+  }, [
+    activeCard,
+    activeTradeContext?.market,
+    activeTradeHeaderContext?.market,
+    marketSlugToButtonKey,
+    moneylineButtonKey,
+    openAuxiliaryConditionId,
+    openSectionKey,
+    selectedAuxiliaryButtonByConditionId,
+    selectedButtonBySection,
+  ])
+  const pageAboutOutcome = pageAboutMarket?.outcomes[0] ?? null
 
   const activeTradeContextButtonKey = activeTradeContext?.button.key ?? null
 
@@ -1614,11 +1655,32 @@ export default function SportsEventCenter({
                   />
                 </div>
               )
-            : (
-                <div className="rounded-xl border bg-card p-4 text-sm text-muted-foreground">
-                  Select a market to trade.
-                </div>
-              )}
+            : pageAboutMarket
+              ? (
+                  <div className="grid gap-6">
+                    <EventOrderPanelForm
+                      isMobile={false}
+                      event={activeCard.event}
+                      className="bg-card"
+                      oddsFormat={oddsFormat}
+                      initialMarket={pageAboutMarket}
+                      initialOutcome={pageAboutOutcome}
+                    />
+                    <EventOrderPanelTermsDisclaimer />
+                    <SportsEventRelatedGames
+                      cards={relatedCards}
+                      sportSlug={sportSlug}
+                      sportLabel={sportLabel}
+                      locale={locale}
+                      vertical={vertical}
+                    />
+                  </div>
+                )
+              : (
+                  <div className="rounded-xl border bg-card p-4 text-sm text-muted-foreground">
+                    Select a market to trade.
+                  </div>
+                )}
         </aside>
       </div>
 

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -1663,6 +1663,7 @@ export default function SportsEventCenter({
                       event={activeCard.event}
                       className="bg-card"
                       oddsFormat={oddsFormat}
+                      optimisticallyClaimedConditionIds={claimedConditionIds}
                       initialMarket={pageAboutMarket}
                       initialOutcome={pageAboutOutcome}
                     />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show the sports order panel in the right rail when a market can be inferred, replacing the empty state. Fixes deep links and selection flows where a market is selected but the panel wasn’t shown.

- **Bug Fixes**
  - Resolve the active market via `resolveSelectedMarket` using header/trade context, section/aux selections (incl. moneyline/spread/total/btts), slug, and moneyline keys.
  - When found, render `EventOrderPanelForm` with `initialMarket` and its first outcome; otherwise show “Select a market.” Pass `optimisticallyClaimedConditionIds` to preserve claimed state.
  - Memoize the resolved market to reduce unnecessary re-renders.

<sup>Written for commit 9098f0a2d745f03e38766d22575ab66da3963dcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1127?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

