### PR TITLE
fix: ignore expected Next.js notFound errors in Sentry

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,7 +1,15 @@
 import * as Sentry from '@sentry/nextjs'
+import { isNextNotFoundError } from './src/lib/next-http-fallback'
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 0.1,
   enableLogs: true,
+  beforeSend(event, hint) {
+    if (isNextNotFoundError(hint.originalException)) {
+      return null
+    }
+
+    return event
+  },
 })

--- a/src/app/global-error.tsx
+++ b/src/app/global-error.tsx
@@ -3,9 +3,14 @@
 import * as Sentry from '@sentry/nextjs'
 import NextError from 'next/error'
 import { useEffect } from 'react'
+import { isNextNotFoundError } from '@/lib/next-http-fallback'
 
 function useSentryCapture(error: Error & { digest?: string }) {
   useEffect(function captureExceptionEffect() {
+    if (isNextNotFoundError(error)) {
+      return
+    }
+
     Sentry.captureException(error)
   }, [error])
 }

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,9 +1,17 @@
 import * as Sentry from '@sentry/nextjs'
+import { isNextNotFoundError } from '@/lib/next-http-fallback'
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,
   tracesSampleRate: 0.1,
   enableLogs: true,
+  beforeSend(event, hint) {
+    if (isNextNotFoundError(hint.originalException)) {
+      return null
+    }
+
+    return event
+  },
 })
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,7 +1,19 @@
+import type { Instrumentation } from 'next'
 import * as Sentry from '@sentry/nextjs'
+import { isNextNotFoundError } from '@/lib/next-http-fallback'
 
 export async function register() {
   await import('../sentry.server.config')
 }
 
-export const onRequestError = Sentry.captureRequestError
+export function onRequestError(
+  error: Parameters<Instrumentation.onRequestError>[0],
+  request: Parameters<Instrumentation.onRequestError>[1],
+  context: Parameters<Instrumentation.onRequestError>[2],
+) {
+  if (isNextNotFoundError(error)) {
+    return
+  }
+
+  Sentry.captureRequestError(error, request, context)
+}

--- a/src/lib/next-http-fallback.ts
+++ b/src/lib/next-http-fallback.ts
@@ -1,0 +1,24 @@
+const NEXT_HTTP_ERROR_FALLBACK_PREFIX = 'NEXT_HTTP_ERROR_FALLBACK;'
+
+function getErrorDigest(error: unknown) {
+  if (!error || typeof error !== 'object') {
+    return null
+  }
+
+  const record = error as { digest?: unknown }
+  return typeof record.digest === 'string' ? record.digest : null
+}
+
+export function getNextHttpFallbackStatus(error: unknown) {
+  const digest = getErrorDigest(error)
+  if (!digest || !digest.startsWith(NEXT_HTTP_ERROR_FALLBACK_PREFIX)) {
+    return null
+  }
+
+  const status = Number.parseInt(digest.slice(NEXT_HTTP_ERROR_FALLBACK_PREFIX.length), 10)
+  return Number.isFinite(status) ? status : null
+}
+
+export function isNextNotFoundError(error: unknown) {
+  return getNextHttpFallbackStatus(error) === 404
+}

--- a/tests/unit/nextHttpFallback.test.ts
+++ b/tests/unit/nextHttpFallback.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { getNextHttpFallbackStatus, isNextNotFoundError } from '@/lib/next-http-fallback'
+
+describe('nextHttpFallback', () => {
+  it('returns the status from a Next.js http fallback digest', () => {
+    expect(getNextHttpFallbackStatus({
+      digest: 'NEXT_HTTP_ERROR_FALLBACK;404',
+    })).toBe(404)
+  })
+
+  it('identifies Next.js not found fallback errors', () => {
+    expect(isNextNotFoundError({
+      digest: 'NEXT_HTTP_ERROR_FALLBACK;404',
+    })).toBe(true)
+  })
+
+  it('ignores non fallback errors', () => {
+    expect(getNextHttpFallbackStatus({
+      digest: 'some-other-error',
+    })).toBeNull()
+    expect(isNextNotFoundError(new Error('boom'))).toBe(false)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ignore expected Next.js notFound (404) errors in Sentry to reduce noise and keep alerts meaningful. We detect the NEXT_HTTP_ERROR_FALLBACK;404 digest and drop those events.

- **Bug Fixes**
  - Added `beforeSend` filters in `@sentry/nextjs` client and server init to skip 404 fallbacks.
  - Prevented capture in the global error boundary and `onRequestError`.
  - Introduced `getNextHttpFallbackStatus` and `isNextNotFoundError` utilities.
  - Added unit tests for the new helpers.

<sup>Written for commit 38746284aaf9a9ec6bc75d42badd47e5dd5bc199. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

