### PR TITLE
fix: stop sending successful deposit wallet submits to Sentry

### DIFF
--- a/src/app/[locale]/(platform)/_actions/approve-tokens.ts
+++ b/src/app/[locale]/(platform)/_actions/approve-tokens.ts
@@ -408,15 +408,6 @@ export async function submitDepositWalletTransactionAction(
       autoRedeem = await markAutoRedeemApprovalCompleted(user.id)
     }
 
-    captureDepositWalletEvent('Deposit Wallet submit accepted', {
-      operation: 'wallet_submit',
-      userAddress: user.address,
-      depositWallet: user.deposit_wallet_address,
-      txHash,
-      durationMs: Date.now() - startedAt,
-      metadata: request.metadata,
-    })
-
     return { error: null, approvals, autoRedeem, txHash }
   }
   catch (error) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop sending successful deposit wallet submit events to Sentry to reduce noise and avoid false positives. Removed the success capture in submitDepositWalletTransactionAction; error reporting remains unchanged.

<sup>Written for commit 1dc3a7f9a4bba01fe1b2755691f84e171abddcd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

