### PR TITLE
fix: show zero-volume home outcomes and sort by chance

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCard.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCard.tsx
@@ -12,6 +12,10 @@ import {
   resolveEventCardResolvedOutcomeIndex,
   shouldUseResolvedXTracker,
 } from '@/app/[locale]/(platform)/(home)/_utils/eventCardResolvedOutcome'
+import {
+  hasHomeCardMarketChance,
+  resolveHomeCardBinaryOutcome,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay'
 import { useXTrackerTweetCount } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useXTrackerTweetCount'
 import { Card, CardContent } from '@/components/ui/card'
 import { OUTCOME_INDEX } from '@/lib/constants'
@@ -30,16 +34,6 @@ const EventCardSportsMoneyline = dynamic<EventCardSportsMoneylineProps>(
 
 function isMarketResolved(market: Market) {
   return Boolean(market.is_resolved || market.condition?.resolved)
-}
-
-function resolveBinaryOutcome(market: Market | undefined, outcomeIndex: typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO) {
-  if (!market) {
-    return null
-  }
-
-  return market.outcomes.find(outcome => outcome.outcome_index === outcomeIndex)
-    ?? market.outcomes[outcomeIndex]
-    ?? null
 }
 
 function useCanUseXTrackerResolvedOutcomes(event: EventCardProps['event']) {
@@ -109,8 +103,8 @@ export default function EventCard({
   const cardTitle = shouldUsePrimaryMarketTitle
     ? (primaryMarket?.question || primaryMarket?.short_title || primaryMarket?.title || event.title)
     : event.title
-  const yesOutcome = resolveBinaryOutcome(primaryMarket, OUTCOME_INDEX.YES)
-  const noOutcome = resolveBinaryOutcome(primaryMarket, OUTCOME_INDEX.NO)
+  const yesOutcome = primaryMarket ? resolveHomeCardBinaryOutcome(primaryMarket, OUTCOME_INDEX.YES) : null
+  const noOutcome = primaryMarket ? resolveHomeCardBinaryOutcome(primaryMarket, OUTCOME_INDEX.NO) : null
   const shouldShowNewBadge = shouldShowEventNewBadge(event, currentTimestamp)
   const shouldShowLiveBadge = !isResolvedEvent && Boolean(event.has_live_chart)
   const chanceByMarket = buildChanceByMarket(event.markets, priceOverridesByMarket)
@@ -128,8 +122,12 @@ export default function EventCard({
     return chanceByMarket[marketId] ?? 0
   }
 
-  const primaryDisplayChance = primaryMarket ? getDisplayChance(primaryMarket.condition_id) : 0
-  const roundedPrimaryDisplayChance = Math.round(primaryDisplayChance)
+  const primaryDisplayChance = primaryMarket && hasHomeCardMarketChance(primaryMarket)
+    ? getDisplayChance(primaryMarket.condition_id)
+    : null
+  const roundedPrimaryDisplayChance = primaryDisplayChance == null
+    ? null
+    : Math.round(primaryDisplayChance)
   const endedLabel = !isResolvedEvent || !isSingleMarket || !event.resolved_at
     ? null
     : (() => {

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardHeader.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardHeader.tsx
@@ -1,5 +1,9 @@
 import type { Event, Market } from '@/types'
 import { useExtracted } from 'next-intl'
+import {
+  formatHomeCardChanceLabel,
+  resolveHomeCardBinaryOutcome,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay'
 import AppLink from '@/components/AppLink'
 import EventIconImage from '@/components/EventIconImage'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
@@ -17,7 +21,7 @@ interface EventCardHeaderProps {
   title: string
   isSingleMarket: boolean
   primaryMarket?: Market
-  roundedPrimaryDisplayChance: number
+  roundedPrimaryDisplayChance: number | null
 }
 
 export default function EventCardHeader({
@@ -30,20 +34,22 @@ export default function EventCardHeader({
   const t = useExtracted()
   const normalizeOutcomeLabel = useOutcomeLabel()
   const isResolvedEvent = isEventResolvedLike(event)
-  const yesOutcome = primaryMarket?.outcomes.find(outcome => outcome.outcome_index === OUTCOME_INDEX.YES) ?? primaryMarket?.outcomes[0]
-  const noOutcome = primaryMarket?.outcomes.find(outcome => outcome.outcome_index === OUTCOME_INDEX.NO) ?? primaryMarket?.outcomes[1]
+  const yesOutcome = primaryMarket ? resolveHomeCardBinaryOutcome(primaryMarket, OUTCOME_INDEX.YES) : null
+  const noOutcome = primaryMarket ? resolveHomeCardBinaryOutcome(primaryMarket, OUTCOME_INDEX.NO) : null
   const outcomeLabels = new Set([
     normalizeOutcomeText(yesOutcome?.outcome_text),
     normalizeOutcomeText(noOutcome?.outcome_text),
   ])
   const hasStandardYesNoOutcomes = outcomeLabels.has('yes') && outcomeLabels.has('no')
+  const hasPrimaryDisplayChance = roundedPrimaryDisplayChance != null
   const isTiedChance = roundedPrimaryDisplayChance === 50
-  const leadingOutcomeLabel = roundedPrimaryDisplayChance > 50
+  const leadingOutcomeLabel = hasPrimaryDisplayChance && roundedPrimaryDisplayChance > 50
     ? yesOutcome?.outcome_text
     : noOutcome?.outcome_text
-  const chanceFooterLabel = !hasStandardYesNoOutcomes && !isTiedChance
+  const chanceFooterLabel = hasPrimaryDisplayChance && !hasStandardYesNoOutcomes && !isTiedChance
     ? (normalizeOutcomeLabel(leadingOutcomeLabel) || t('chance'))
     : t('chance')
+  const primaryChanceLabel = formatHomeCardChanceLabel(roundedPrimaryDisplayChance)
   const eventHref = resolveEventPagePath(event)
   const isSportsEvent = Boolean(event.sports_event_id || event.sports_sport_slug || event.sports_event_slug)
 
@@ -99,23 +105,25 @@ export default function EventCardHeader({
                 strokeWidth="5"
                 strokeLinecap="round"
                 className={
-                  cn(`transition-all duration-300 ${
-                    roundedPrimaryDisplayChance < 40
-                      ? 'text-no'
-                      : roundedPrimaryDisplayChance === 50
-                        ? 'text-slate-400'
-                        : 'text-yes'
-                  }`)
+                  cn(
+                    'transition-all duration-300',
+                    hasPrimaryDisplayChance
+                      ? roundedPrimaryDisplayChance < 40
+                        ? 'text-no'
+                        : roundedPrimaryDisplayChance === 50
+                          ? 'text-slate-400'
+                          : 'text-yes'
+                      : 'text-slate-400',
+                  )
                 }
-                strokeDasharray={`${(roundedPrimaryDisplayChance / 100) * 94.25} 94.25`}
+                strokeDasharray={`${((roundedPrimaryDisplayChance ?? 0) / 100) * 94.25} 94.25`}
                 strokeDashoffset="0"
               />
             </svg>
 
             <div className="absolute inset-0 flex items-center justify-center pt-4">
               <span className="text-sm font-bold text-slate-900 dark:text-slate-100">
-                {roundedPrimaryDisplayChance}
-                %
+                {primaryChanceLabel}
               </span>
             </div>
           </div>

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
@@ -1,6 +1,11 @@
 import type { Event, Market } from '@/types'
 import { CheckIcon, XIcon } from 'lucide-react'
 import { resolveBinaryOutcomeByIndex } from '@/app/[locale]/(platform)/(home)/_utils/eventCardResolvedOutcome'
+import {
+  formatHomeCardChanceLabel,
+  hasHomeCardMarketChance,
+  resolveHomeCardBinaryOutcome,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay'
 import AppLink from '@/components/AppLink'
 import { Button } from '@/components/ui/button'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
@@ -43,6 +48,15 @@ export default function EventCardMarketsList({
         .sort((a, b) => (a.rank - b.rank) || (a.index - b.index))
         .map(item => item.market)
     : markets
+        .map((market, index) => ({
+          market,
+          index,
+          displayChance: hasHomeCardMarketChance(market)
+            ? getDisplayChance(market.condition_id)
+            : 0,
+        }))
+        .sort((a, b) => (b.displayChance - a.displayChance) || (a.index - b.index))
+        .map(item => item.market)
 
   return (
     <div
@@ -58,68 +72,69 @@ export default function EventCardMarketsList({
         const resolvedOutcome = isResolvedEvent
           ? resolveBinaryOutcomeByIndex(market, resolvedOutcomeIndex)
           : null
-        const yesOutcome = market.outcomes.find(outcome => outcome.outcome_index === OUTCOME_INDEX.YES) ?? market.outcomes[0]
-        const noOutcome = market.outcomes.find(outcome => outcome.outcome_index === OUTCOME_INDEX.NO) ?? market.outcomes[1]
+        const yesOutcome = resolveHomeCardBinaryOutcome(market, OUTCOME_INDEX.YES)
+        const noOutcome = resolveHomeCardBinaryOutcome(market, OUTCOME_INDEX.NO)
         const resolvedLabel = resolvedOutcome?.outcome_text
         const isYesOutcome = resolvedOutcomeIndex === OUTCOME_INDEX.YES
         const displayResolvedLabel = normalizeOutcomeLabel(resolvedLabel) ?? resolvedLabel
-        const displayChance = Math.round(getDisplayChance(market.condition_id))
-        const oppositeChance = Math.max(0, Math.min(100, 100 - displayChance))
-        const unresolvedMarketContent = !yesOutcome || !noOutcome
+        const displayChance = hasHomeCardMarketChance(market)
+          ? Math.round(getDisplayChance(market.condition_id))
+          : null
+        const oppositeChance = displayChance == null
           ? null
-          : (
-              <>
-                <span className="text-base font-semibold text-foreground">
-                  {displayChance}
-                  %
-                </span>
-                <div className="flex gap-1">
-                  <Button
-                    asChild
-                    variant="yes"
-                    className="group/yes h-7 w-10 px-2 py-1 text-xs"
-                  >
-                    <AppLink
-                      intentPrefetch
-                      href={resolveEventOutcomePath(event, {
-                        marketSlug: market.slug,
-                        outcomeIndex: yesOutcome.outcome_index,
-                      })}
-                    >
-                      <span className="truncate group-hover/yes:hidden">
-                        {normalizeOutcomeLabel(yesOutcome.outcome_text) ?? yesOutcome.outcome_text}
-                      </span>
-                      <span className="hidden group-hover/yes:inline">
-                        {displayChance}
-                        %
-                      </span>
-                    </AppLink>
-                  </Button>
-                  <Button
-                    asChild
-                    variant="no"
-                    size="sm"
-                    className="group/no h-auto w-11 px-2 py-1 text-xs"
-                  >
-                    <AppLink
-                      intentPrefetch
-                      href={resolveEventOutcomePath(event, {
-                        marketSlug: market.slug,
-                        outcomeIndex: noOutcome.outcome_index,
-                      })}
-                    >
-                      <span className="truncate group-hover/no:hidden">
-                        {normalizeOutcomeLabel(noOutcome.outcome_text) ?? noOutcome.outcome_text}
-                      </span>
-                      <span className="hidden group-hover/no:inline">
-                        {oppositeChance}
-                        %
-                      </span>
-                    </AppLink>
-                  </Button>
-                </div>
-              </>
-            )
+          : Math.max(0, Math.min(100, 100 - displayChance))
+        const displayChanceLabel = formatHomeCardChanceLabel(displayChance)
+        const oppositeChanceLabel = formatHomeCardChanceLabel(oppositeChance)
+        const unresolvedMarketContent = (
+          <>
+            <span className="text-base font-semibold text-foreground">
+              {displayChanceLabel}
+            </span>
+            <div className="flex gap-1">
+              <Button
+                asChild
+                variant="yes"
+                className="group/yes h-7 w-10 px-2 py-1 text-xs"
+              >
+                <AppLink
+                  intentPrefetch
+                  href={resolveEventOutcomePath(event, {
+                    marketSlug: market.slug,
+                    outcomeIndex: yesOutcome.outcome_index,
+                  })}
+                >
+                  <span className="truncate group-hover/yes:hidden">
+                    {normalizeOutcomeLabel(yesOutcome.outcome_text) ?? yesOutcome.outcome_text}
+                  </span>
+                  <span className="hidden group-hover/yes:inline">
+                    {displayChanceLabel}
+                  </span>
+                </AppLink>
+              </Button>
+              <Button
+                asChild
+                variant="no"
+                size="sm"
+                className="group/no h-auto w-11 px-2 py-1 text-xs"
+              >
+                <AppLink
+                  intentPrefetch
+                  href={resolveEventOutcomePath(event, {
+                    marketSlug: market.slug,
+                    outcomeIndex: noOutcome.outcome_index,
+                  })}
+                >
+                  <span className="truncate group-hover/no:hidden">
+                    {normalizeOutcomeLabel(noOutcome.outcome_text) ?? noOutcome.outcome_text}
+                  </span>
+                  <span className="hidden group-hover/no:inline">
+                    {oppositeChanceLabel}
+                  </span>
+                </AppLink>
+              </Button>
+            </div>
+          </>
+        )
 
         return (
           <div

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
@@ -88,7 +88,7 @@ export default function EventCardSingleMarketActions({
         <AppLink
           intentPrefetch
           href={resolveEventOutcomePath(event, {
-            outcomeIndex: OUTCOME_INDEX.YES,
+            outcomeIndex: yesOutcome.outcome_index,
           })}
         >
           <span className="truncate">{normalizeOutcomeLabel(yesOutcome.outcome_text) ?? yesOutcome.outcome_text}</span>
@@ -102,7 +102,7 @@ export default function EventCardSingleMarketActions({
         <AppLink
           intentPrefetch
           href={resolveEventOutcomePath(event, {
-            outcomeIndex: OUTCOME_INDEX.NO,
+            outcomeIndex: noOutcome.outcome_index,
           })}
         >
           <span className="truncate">{normalizeOutcomeLabel(noOutcome.outcome_text) ?? noOutcome.outcome_text}</span>

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions.tsx
@@ -1,4 +1,5 @@
-import type { Market, Outcome } from '@/types'
+import type { HomeCardBinaryOutcome } from '@/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay'
+import type { Market } from '@/types'
 import { CheckIcon, XIcon } from 'lucide-react'
 import { resolveBinaryOutcomeByIndex } from '@/app/[locale]/(platform)/(home)/_utils/eventCardResolvedOutcome'
 import AppLink from '@/components/AppLink'
@@ -15,8 +16,8 @@ interface EventCardSingleMarketActionsProps {
     sports_league_slug?: string | null
     sports_event_slug?: string | null
   }
-  yesOutcome: Outcome
-  noOutcome: Outcome
+  yesOutcome: HomeCardBinaryOutcome
+  noOutcome: HomeCardBinaryOutcome
   primaryMarket: Market | undefined
   isResolvedEvent: boolean
   resolvedOutcomeIndexByConditionId: Partial<Record<string, typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO>>

--- a/src/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay.ts
+++ b/src/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay.ts
@@ -33,13 +33,23 @@ export function resolveHomeCardBinaryOutcome(
   outcomeIndex: typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO,
 ): HomeCardBinaryOutcome {
   const matchingOutcome = market.outcomes.find(outcome => outcome.outcome_index === outcomeIndex)
+  if (matchingOutcome) {
+    return {
+      outcome_index: matchingOutcome.outcome_index,
+      outcome_text: matchingOutcome.outcome_text?.trim() || FALLBACK_BINARY_OUTCOME_LABELS[outcomeIndex],
+    }
+  }
+
   const positionalOutcome = market.outcomes[outcomeIndex]
-  const outcomeText = matchingOutcome?.outcome_text?.trim()
-    || positionalOutcome?.outcome_text?.trim()
-    || FALLBACK_BINARY_OUTCOME_LABELS[outcomeIndex]
+  if (positionalOutcome) {
+    return {
+      outcome_index: positionalOutcome.outcome_index,
+      outcome_text: positionalOutcome.outcome_text?.trim() || FALLBACK_BINARY_OUTCOME_LABELS[outcomeIndex],
+    }
+  }
 
   return {
     outcome_index: outcomeIndex,
-    outcome_text: outcomeText,
+    outcome_text: FALLBACK_BINARY_OUTCOME_LABELS[outcomeIndex],
   }
 }

--- a/src/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay.ts
+++ b/src/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay.ts
@@ -1,0 +1,45 @@
+import type { Market, Outcome } from '@/types'
+import { OUTCOME_INDEX } from '@/lib/constants'
+
+export type HomeCardBinaryOutcome = Pick<Outcome, 'outcome_index' | 'outcome_text'>
+
+const HOME_CARD_UNAVAILABLE_CHANCE_LABEL = '—'
+
+const FALLBACK_BINARY_OUTCOME_LABELS = {
+  [OUTCOME_INDEX.YES]: 'Yes',
+  [OUTCOME_INDEX.NO]: 'No',
+} as const
+
+function hasPositiveNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+export function hasHomeCardMarketChance(market: Pick<Market, 'volume' | 'volume_24h' | 'condition'> | null | undefined) {
+  return hasPositiveNumber(market?.volume)
+    || hasPositiveNumber(market?.volume_24h)
+    || hasPositiveNumber(market?.condition?.volume)
+}
+
+export function formatHomeCardChanceLabel(value: number | null | undefined) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return HOME_CARD_UNAVAILABLE_CHANCE_LABEL
+  }
+
+  return `${Math.round(value)}%`
+}
+
+export function resolveHomeCardBinaryOutcome(
+  market: Pick<Market, 'outcomes'>,
+  outcomeIndex: typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO,
+): HomeCardBinaryOutcome {
+  const matchingOutcome = market.outcomes.find(outcome => outcome.outcome_index === outcomeIndex)
+  const positionalOutcome = market.outcomes[outcomeIndex]
+  const outcomeText = matchingOutcome?.outcome_text?.trim()
+    || positionalOutcome?.outcome_text?.trim()
+    || FALLBACK_BINARY_OUTCOME_LABELS[outcomeIndex]
+
+  return {
+    outcome_index: outcomeIndex,
+    outcome_text: outcomeText,
+  }
+}

--- a/tests/unit/EventCard.test.tsx
+++ b/tests/unit/EventCard.test.tsx
@@ -5,6 +5,7 @@ import EventCard from '@/app/[locale]/(platform)/(home)/_components/EventCard'
 const mocks = vi.hoisted(() => ({
   buildHomeSportsMoneylineModel: vi.fn(),
   dynamicSportsCard: vi.fn(),
+  singleMarketActions: vi.fn(),
   useXTrackerTweetCount: vi.fn(),
 }))
 
@@ -29,7 +30,10 @@ vi.mock('@/app/[locale]/(platform)/(home)/_components/EventCardMarketsList', () 
 }))
 
 vi.mock('@/app/[locale]/(platform)/(home)/_components/EventCardSingleMarketActions', () => ({
-  default: () => <div data-testid="event-card-single-market-actions" />,
+  default: (props: any) => {
+    mocks.singleMarketActions(props)
+    return <div data-testid="event-card-single-market-actions" />
+  },
 }))
 
 vi.mock('@/app/[locale]/(platform)/(home)/_utils/eventCardResolvedOutcome', () => ({
@@ -88,6 +92,7 @@ describe('eventCard', () => {
   beforeEach(() => {
     mocks.buildHomeSportsMoneylineModel.mockReset()
     mocks.dynamicSportsCard.mockReset()
+    mocks.singleMarketActions.mockReset()
     mocks.useXTrackerTweetCount.mockReset()
     mocks.useXTrackerTweetCount.mockReturnValue({ data: null })
   })
@@ -102,6 +107,43 @@ describe('eventCard', () => {
     expect(screen.getByTestId('event-card-single-market-actions')).toBeInTheDocument()
     expect(screen.queryByTestId('sports-moneyline-card')).not.toBeInTheDocument()
     expect(mocks.dynamicSportsCard).not.toHaveBeenCalled()
+  })
+
+  it('uses standard Yes and No action labels when a binary market has no outcome rows', () => {
+    mocks.buildHomeSportsMoneylineModel.mockReturnValue(null)
+
+    render(
+      <EventCard
+        event={{
+          ...EVENT,
+          volume: 0,
+          markets: [
+            {
+              ...EVENT.markets[0],
+              volume: 0,
+              volume_24h: 0,
+              outcomes: [],
+              condition: {
+                resolved: false,
+                volume: 0,
+              },
+            },
+          ],
+        } as any}
+      />,
+    )
+
+    expect(screen.getByTestId('event-card-single-market-actions')).toBeInTheDocument()
+    expect(mocks.singleMarketActions).toHaveBeenCalledWith(expect.objectContaining({
+      yesOutcome: expect.objectContaining({
+        outcome_index: 0,
+        outcome_text: 'Yes',
+      }),
+      noOutcome: expect.objectContaining({
+        outcome_index: 1,
+        outcome_text: 'No',
+      }),
+    }))
   })
 
   it('renders the sports moneyline branch through the dynamic component boundary', () => {

--- a/tests/unit/EventCardHeader.test.tsx
+++ b/tests/unit/EventCardHeader.test.tsx
@@ -1,0 +1,72 @@
+import type { AnchorHTMLAttributes } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import EventCardHeader from '@/app/[locale]/(platform)/(home)/_components/EventCardHeader'
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (message: string) => message,
+}))
+
+vi.mock('@/components/AppLink', () => ({
+  default: function MockAppLink({
+    children,
+    href,
+    intentPrefetch: _intentPrefetch,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string, intentPrefetch?: boolean }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    )
+  },
+}))
+
+vi.mock('@/components/EventIconImage', () => ({
+  default: () => <span data-testid="event-icon" />,
+}))
+
+const EVENT = {
+  id: 'event-1',
+  slug: 'highest-temperature-sao-paulo',
+  title: 'Highest temperature in Sao Paulo on June 9?',
+  creator: 'Kuest',
+  icon_url: null,
+  status: 'active',
+  markets: [
+    {
+      condition_id: 'market-1',
+      is_resolved: false,
+      condition: {
+        resolved: false,
+      },
+    },
+  ],
+  tags: [],
+} as any
+
+describe('eventCardHeader', () => {
+  it('shows an unavailable chance label for single-market cards without displayable volume', () => {
+    render(
+      <EventCardHeader
+        event={EVENT}
+        title={EVENT.title}
+        isSingleMarket
+        primaryMarket={{
+          ...EVENT.markets[0],
+          volume: 0,
+          volume_24h: 0,
+          outcomes: [],
+          condition: {
+            resolved: false,
+            volume: 0,
+          },
+        } as any}
+        roundedPrimaryDisplayChance={null}
+      />,
+    )
+
+    expect(screen.getByText('—')).toBeInTheDocument()
+    expect(screen.getByText('chance')).toBeInTheDocument()
+  })
+})

--- a/tests/unit/EventCardMarketsList.test.tsx
+++ b/tests/unit/EventCardMarketsList.test.tsx
@@ -1,0 +1,117 @@
+import type { AnchorHTMLAttributes } from 'react'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+import EventCardMarketsList from '@/app/[locale]/(platform)/(home)/_components/EventCardMarketsList'
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (message: string) => message,
+}))
+
+vi.mock('@/components/AppLink', () => ({
+  default: function MockAppLink({
+    children,
+    href,
+    intentPrefetch: _intentPrefetch,
+    ...props
+  }: AnchorHTMLAttributes<HTMLAnchorElement> & { href: string, intentPrefetch?: boolean }) {
+    return (
+      <a href={href} {...props}>
+        {children}
+      </a>
+    )
+  },
+}))
+
+const EVENT = {
+  id: 'event-1',
+  slug: 'highest-temperature-sao-paulo',
+  title: 'Highest temperature in Sao Paulo on June 9?',
+  sports_sport_slug: null,
+  sports_league_slug: null,
+  sports_event_slug: null,
+  tags: [],
+} as any
+
+describe('eventCardMarketsList', () => {
+  it('sorts active markets by descending display chance like the event page', () => {
+    render(
+      <EventCardMarketsList
+        event={EVENT}
+        markets={[
+          {
+            condition_id: 'low-market',
+            slug: 'low-market',
+            title: 'Lower chance market',
+            short_title: 'Lower chance',
+            volume: 100,
+            volume_24h: 0,
+            outcomes: [],
+            condition: {
+              volume: 100,
+              resolved: false,
+            },
+          },
+          {
+            condition_id: 'high-market',
+            slug: 'high-market',
+            title: 'Higher chance market',
+            short_title: 'Higher chance',
+            volume: 100,
+            volume_24h: 0,
+            outcomes: [],
+            condition: {
+              volume: 100,
+              resolved: false,
+            },
+          },
+        ] as any}
+        isResolvedEvent={false}
+        getDisplayChance={marketId => marketId === 'high-market' ? 72 : 18}
+        resolvedOutcomeIndexByConditionId={{}}
+      />,
+    )
+
+    const marketLinks = screen.getAllByRole('link').filter(link =>
+      link.textContent === 'Higher chance' || link.textContent === 'Lower chance',
+    )
+    expect(marketLinks.map(link => link.textContent)).toEqual([
+      'Higher chance',
+      'Lower chance',
+    ])
+  })
+
+  it('keeps zero-volume market outcomes visible with an unavailable chance label', () => {
+    render(
+      <EventCardMarketsList
+        event={EVENT}
+        markets={[
+          {
+            condition_id: 'market-1',
+            slug: 'highest-temperature-in-sao-paulo-on-june-9',
+            title: 'Highest temperature in Sao Paulo on June 9?',
+            short_title: 'Sao Paulo temperature',
+            volume: 0,
+            volume_24h: 0,
+            outcomes: [],
+            condition: {
+              volume: 0,
+              resolved: false,
+            },
+          },
+        ] as any}
+        isResolvedEvent={false}
+        getDisplayChance={() => 50}
+        resolvedOutcomeIndexByConditionId={{}}
+      />,
+    )
+
+    expect(screen.getByText('Sao Paulo temperature')).toBeInTheDocument()
+    expect(screen.getByText('Yes')).toBeInTheDocument()
+    expect(screen.getByText('No')).toBeInTheDocument()
+    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+    expect(screen.getAllByRole('link').map(link => link.getAttribute('href'))).toEqual(expect.arrayContaining([
+      '/event/highest-temperature-sao-paulo/highest-temperature-in-sao-paulo-on-june-9?outcomeIndex=0',
+      '/event/highest-temperature-sao-paulo/highest-temperature-in-sao-paulo-on-june-9?outcomeIndex=1',
+    ]))
+  })
+})

--- a/tests/unit/EventCardMarketsList.test.tsx
+++ b/tests/unit/EventCardMarketsList.test.tsx
@@ -114,4 +114,46 @@ describe('eventCardMarketsList', () => {
       '/event/highest-temperature-sao-paulo/highest-temperature-in-sao-paulo-on-june-9?outcomeIndex=1',
     ]))
   })
+
+  it('preserves positional outcome indices when falling back to existing outcome rows', () => {
+    render(
+      <EventCardMarketsList
+        event={EVENT}
+        markets={[
+          {
+            condition_id: 'market-1',
+            slug: 'indexed-outcomes',
+            title: 'Indexed outcomes',
+            short_title: 'Indexed outcomes',
+            volume: 10,
+            volume_24h: 0,
+            outcomes: [
+              {
+                outcome_index: 4,
+                outcome_text: 'Hotter',
+              },
+              {
+                outcome_index: 7,
+                outcome_text: 'Cooler',
+              },
+            ],
+            condition: {
+              volume: 10,
+              resolved: false,
+            },
+          },
+        ] as any}
+        isResolvedEvent={false}
+        getDisplayChance={() => 64}
+        resolvedOutcomeIndexByConditionId={{}}
+      />,
+    )
+
+    expect(screen.getByText('Hotter')).toBeInTheDocument()
+    expect(screen.getByText('Cooler')).toBeInTheDocument()
+    expect(screen.getAllByRole('link').map(link => link.getAttribute('href'))).toEqual(expect.arrayContaining([
+      '/event/highest-temperature-sao-paulo/indexed-outcomes?outcomeIndex=4',
+      '/event/highest-temperature-sao-paulo/indexed-outcomes?outcomeIndex=7',
+    ]))
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show zero-volume markets on home EventCards and sort active markets by chance to match the event page. Adds clear fallback labels, an unavailable chance indicator, and preserves outcome indices in links.

- **Bug Fixes**
  - Keep zero-volume markets and their Yes/No actions visible; show '—' when chance is unavailable.
  - Sort active markets by descending display chance when not resolved.
  - Fallback to "Yes"/"No" labels when markets have no outcome rows, and preserve existing outcome indices in links.
  - Unify binary outcome/chance handling across header and markets list for consistent colors and labels.

<sup>Written for commit 4da92df4a55cbd98a3d98c999daed90ea12ce276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

