### PR TITLE
fix: search performance

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventTradeToast.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventTradeToast.tsx
@@ -16,7 +16,7 @@ export default function EventTradeToast({ title, marketImage, marketTitle, child
           src={marketImage}
           alt={marketTitle || title}
           sizes="40px"
-          containerClassName="size-10 rounded-sm"
+          containerClassName="size-10 rounded-sm shrink-0"
         />
       )}
       <div>

--- a/src/app/api/events/route.ts
+++ b/src/app/api/events/route.ts
@@ -13,6 +13,7 @@ export async function GET(request: Request) {
   const mainTag = searchParams.get('mainTag') || ''
   const search = searchParams.get('search') || ''
   const bookmarked = searchParams.get('bookmarked') === 'true'
+  const includeBookmarkState = searchParams.get('includeBookmarkState') !== 'false'
   const frequency = searchParams.get('frequency') || 'all'
   const hideSports = searchParams.get('hideSports') === 'true'
   const hideCrypto = searchParams.get('hideCrypto') === 'true'
@@ -52,7 +53,10 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Invalid sports section filter.' }, { status: 400 })
   }
 
-  const user = await UserRepository.getCurrentUser({ minimal: true })
+  const shouldResolveCurrentUser = bookmarked || includeBookmarkState
+  const user = shouldResolveCurrentUser
+    ? await UserRepository.getCurrentUser({ minimal: true })
+    : null
   const userId = user?.id
 
   try {

--- a/src/app/api/users/route.ts
+++ b/src/app/api/users/route.ts
@@ -14,12 +14,9 @@ export async function GET(request: Request) {
   }
 
   try {
-    const { data, error } = await UserRepository.listUsers({
+    const { data, error } = await UserRepository.searchPublicProfiles({
       search: query,
       limit: 10,
-      sortBy: 'username',
-      sortOrder: 'asc',
-      searchByUsernameOnly: true,
     })
 
     if (error) {

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -5,6 +5,10 @@ import { isSportsAuxiliaryEventSlug } from '@/lib/sports-event-slugs'
 
 const SEARCH_EVENTS_LIMIT = 5
 
+function isAbortError(error: unknown) {
+  return error instanceof Error && error.name === 'AbortError'
+}
+
 interface UseSearch {
   query: string
   results: SearchResultItems
@@ -32,7 +36,7 @@ export function useSearch(): UseSearch {
   const [manualActiveTab, setManualActiveTab] = useState<'events' | 'profiles' | null>(null)
   const requestIdRef = useRef(0)
 
-  const searchEvents = useCallback(async (searchQuery: string, requestId: number) => {
+  const searchEvents = useCallback(async (searchQuery: string, requestId: number, signal: AbortSignal) => {
     if (searchQuery.length < 2) {
       if (requestId === requestIdRef.current) {
         setResults(prev => ({ ...prev, events: [] }))
@@ -50,14 +54,14 @@ export function useSearch(): UseSearch {
         status: 'all',
         limit: SEARCH_EVENTS_LIMIT.toString(),
       })
-      const response = await fetch(`/api/events?${params.toString()}`)
+      const response = await fetch(`/api/events?${params.toString()}`, { signal })
       if (response.ok) {
         const data = await response.json()
         const filteredEvents = Array.isArray(data)
           ? data.filter(event => !isSportsAuxiliaryEventSlug(event?.slug))
           : []
 
-        if (requestId !== requestIdRef.current) {
+        if (signal.aborted || requestId !== requestIdRef.current) {
           return
         }
 
@@ -71,6 +75,10 @@ export function useSearch(): UseSearch {
       }
     }
     catch (error) {
+      if (signal.aborted || isAbortError(error)) {
+        return
+      }
+
       console.error('Events search error:', error)
 
       if (requestId !== requestIdRef.current) {
@@ -80,13 +88,13 @@ export function useSearch(): UseSearch {
       setResults(prev => ({ ...prev, events: [] }))
     }
     finally {
-      if (requestId === requestIdRef.current) {
+      if (!signal.aborted && requestId === requestIdRef.current) {
         setIsLoading(prev => ({ ...prev, events: false }))
       }
     }
   }, [])
 
-  const searchProfiles = useCallback(async (searchQuery: string, requestId: number) => {
+  const searchProfiles = useCallback(async (searchQuery: string, requestId: number, signal: AbortSignal) => {
     if (searchQuery.length < 2) {
       if (requestId === requestIdRef.current) {
         setResults(prev => ({ ...prev, profiles: [] }))
@@ -99,11 +107,11 @@ export function useSearch(): UseSearch {
     }
 
     try {
-      const response = await fetch(`/api/users?search=${encodeURIComponent(searchQuery)}`)
+      const response = await fetch(`/api/users?search=${encodeURIComponent(searchQuery)}`, { signal })
       if (response.ok) {
         const data = await response.json()
 
-        if (requestId !== requestIdRef.current) {
+        if (signal.aborted || requestId !== requestIdRef.current) {
           return
         }
 
@@ -117,6 +125,10 @@ export function useSearch(): UseSearch {
       }
     }
     catch (error) {
+      if (signal.aborted || isAbortError(error)) {
+        return
+      }
+
       console.error('Profiles search error:', error)
 
       if (requestId !== requestIdRef.current) {
@@ -126,13 +138,13 @@ export function useSearch(): UseSearch {
       setResults(prev => ({ ...prev, profiles: [] }))
     }
     finally {
-      if (requestId === requestIdRef.current) {
+      if (!signal.aborted && requestId === requestIdRef.current) {
         setIsLoading(prev => ({ ...prev, profiles: false }))
       }
     }
   }, [])
 
-  const search = useCallback(async (searchQuery: string) => {
+  const search = useCallback(async (searchQuery: string, signal: AbortSignal) => {
     const normalizedQuery = searchQuery.trim()
     const requestId = requestIdRef.current + 1
 
@@ -146,22 +158,25 @@ export function useSearch(): UseSearch {
     }
 
     await Promise.all([
-      searchEvents(normalizedQuery, requestId),
-      searchProfiles(normalizedQuery, requestId),
+      searchEvents(normalizedQuery, requestId, signal),
+      searchProfiles(normalizedQuery, requestId, signal),
     ])
 
-    if (requestId === requestIdRef.current) {
+    if (!signal.aborted && requestId === requestIdRef.current) {
       setShowResults(true)
     }
   }, [searchEvents, searchProfiles])
 
-  // Debounce search
-  useEffect(() => {
+  useEffect(function debounceSearch() {
+    const controller = new AbortController()
     const timer = setTimeout(() => {
-      search(query)
+      search(query, controller.signal)
     }, 300)
 
-    return () => clearTimeout(timer)
+    return function cancelDebouncedSearch() {
+      controller.abort()
+      clearTimeout(timer)
+    }
   }, [query, search])
 
   const hasEvents = results.events.length > 0 || isLoading.events

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -53,6 +53,7 @@ export function useSearch(): UseSearch {
         search: searchQuery,
         status: 'all',
         limit: SEARCH_EVENTS_LIMIT.toString(),
+        includeBookmarkState: 'false',
       })
       const response = await fetch(`/api/events?${params.toString()}`, { signal })
       if (response.ok) {

--- a/src/hooks/useSearch.ts
+++ b/src/hooks/useSearch.ts
@@ -3,6 +3,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { sortSearchResultEvents } from '@/lib/event-search-results'
 import { isSportsAuxiliaryEventSlug } from '@/lib/sports-event-slugs'
 
+const SEARCH_EVENTS_LIMIT = 5
+
 interface UseSearch {
   query: string
   results: SearchResultItems
@@ -46,6 +48,7 @@ export function useSearch(): UseSearch {
       const params = new URLSearchParams({
         search: searchQuery,
         status: 'all',
+        limit: SEARCH_EVENTS_LIMIT.toString(),
       })
       const response = await fetch(`/api/events?${params.toString()}`)
       if (response.ok) {

--- a/src/lib/db/migrations/2026_06_09_001_users_username_search_index.sql
+++ b/src/lib/db/migrations/2026_06_09_001_users_username_search_index.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS idx_users_username_lower_gin_trgm
+  ON users USING GIN (LOWER(username) gin_trgm_ops);

--- a/src/lib/db/queries/user.ts
+++ b/src/lib/db/queries/user.ts
@@ -13,6 +13,15 @@ import { db } from '@/lib/drizzle'
 import { getPublicAssetUrl } from '@/lib/storage'
 import { normalizeAddress } from '@/lib/wallet'
 
+function sanitizeUserSearchTerm(search: string) {
+  return search
+    .trim()
+    .replace(/[,()]/g, ' ')
+    .replace(/['"]/g, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
 export const UserRepository = {
   async getProfileByUsernameOrDepositWalletAddress(username: string) {
     return await runQuery(async () => {
@@ -257,12 +266,7 @@ export const UserRepository = {
 
       let whereCondition
       if (search && search.trim()) {
-        const searchTerm = search.trim()
-        const sanitizedSearchTerm = searchTerm
-          .replace(/[,()]/g, ' ')
-          .replace(/['"]/g, '')
-          .replace(/\s+/g, ' ')
-          .trim()
+        const sanitizedSearchTerm = sanitizeUserSearchTerm(search)
 
         if (sanitizedSearchTerm) {
           const usernameCondition = ilike(users.username, `%${sanitizedSearchTerm}%`)
@@ -336,6 +340,44 @@ export const UserRepository = {
     }
 
     return { data: data.users, error: null, count: data.count }
+  },
+
+  async searchPublicProfiles(params: {
+    limit?: number
+    search: string
+  }) {
+    'use cache'
+
+    const { data, error } = await runQuery(async () => {
+      const sanitizedSearchTerm = sanitizeUserSearchTerm(params.search)
+
+      if (!sanitizedSearchTerm) {
+        return { data: [], error: null }
+      }
+
+      const limit = Math.min(Math.max(params.limit ?? 10, 1), 100)
+      const rows = await db
+        .select({
+          id: users.id,
+          username: users.username,
+          address: users.address,
+          deposit_wallet_address: users.deposit_wallet_address,
+          created_at: users.created_at,
+          image: users.image,
+        })
+        .from(users)
+        .where(ilike(users.username, `%${sanitizedSearchTerm}%`))
+        .orderBy(asc(users.username), asc(users.address))
+        .limit(limit)
+
+      return { data: rows, error: null }
+    })
+
+    if (!data || error) {
+      return { data: null, error: error || DEFAULT_ERROR_MESSAGE }
+    }
+
+    return { data, error: null }
   },
 
   async getUsersByIds(ids: string[]) {

--- a/src/lib/db/queries/user.ts
+++ b/src/lib/db/queries/user.ts
@@ -22,6 +22,11 @@ function sanitizeUserSearchTerm(search: string) {
     .trim()
 }
 
+function buildUsernameSearchCondition(searchTerm: string) {
+  const loweredUsername = sql<string>`LOWER(${users.username})`
+  return ilike(loweredUsername, `%${searchTerm.toLowerCase()}%`)
+}
+
 export const UserRepository = {
   async getProfileByUsernameOrDepositWalletAddress(username: string) {
     return await runQuery(async () => {
@@ -269,7 +274,7 @@ export const UserRepository = {
         const sanitizedSearchTerm = sanitizeUserSearchTerm(search)
 
         if (sanitizedSearchTerm) {
-          const usernameCondition = ilike(users.username, `%${sanitizedSearchTerm}%`)
+          const usernameCondition = buildUsernameSearchCondition(sanitizedSearchTerm)
           whereCondition = searchByUsernameOnly
             ? usernameCondition
             : or(
@@ -366,7 +371,7 @@ export const UserRepository = {
           image: users.image,
         })
         .from(users)
-        .where(ilike(users.username, `%${sanitizedSearchTerm}%`))
+        .where(buildUsernameSearchCondition(sanitizedSearchTerm))
         .orderBy(asc(users.username), asc(users.address))
         .limit(limit)
 

--- a/src/lib/db/schema/auth/tables.ts
+++ b/src/lib/db/schema/auth/tables.ts
@@ -1,6 +1,7 @@
 import { sql } from 'drizzle-orm'
 import {
   boolean,
+  index,
   integer,
   jsonb,
   pgTable,
@@ -42,6 +43,7 @@ export const users = pgTable(
   },
   table => ({
     usernameLowerUniqueIdx: uniqueIndex('idx_users_username').on(sql`LOWER(${table.username})`),
+    usernameSearchIdx: index('idx_users_username_lower_gin_trgm').using('gin', sql`LOWER(${table.username}) gin_trgm_ops`),
   }),
 )
 

--- a/tests/unit/eventsRoute.test.ts
+++ b/tests/unit/eventsRoute.test.ts
@@ -42,6 +42,20 @@ describe('events route', () => {
     expect(mocks.listHomeEventsPage).not.toHaveBeenCalled()
   })
 
+  it('skips current user lookup when bookmark state is explicitly excluded', async () => {
+    mocks.listEvents.mockResolvedValueOnce({ data: [], error: null })
+
+    const response = await GET(new Request('https://example.com/api/events?search=brazil&status=all&includeBookmarkState=false&locale=en'))
+
+    expect(response.status).toBe(200)
+    expect(mocks.getCurrentUser).not.toHaveBeenCalled()
+    expect(mocks.listEvents).toHaveBeenCalledWith(expect.objectContaining({
+      search: 'brazil',
+      status: 'all',
+      userId: undefined,
+    }))
+  })
+
   it('forwards mainTag to the events repository', async () => {
     mocks.getCurrentUser.mockResolvedValueOnce({ id: 'user-1' })
     mocks.listEvents.mockResolvedValueOnce({ data: [], error: null })

--- a/tests/unit/useSearch.test.ts
+++ b/tests/unit/useSearch.test.ts
@@ -2,7 +2,7 @@ import { act, renderHook } from '@testing-library/react'
 import { useSearch } from '@/hooks/useSearch'
 
 describe('useSearch', () => {
-  const fetchMock = vi.fn((input: RequestInfo | URL) => {
+  const fetchMock = vi.fn((input: RequestInfo | URL, _init?: RequestInit) => {
     const url = typeof input === 'string' ? input : input.toString()
 
     if (url.includes('/api/events')) {
@@ -166,5 +166,46 @@ describe('useSearch', () => {
       'newer-resolved-event',
       'older-resolved-event',
     ])
+  })
+
+  it('aborts in-flight event and profile searches when the query changes', async () => {
+    fetchMock.mockImplementation((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal
+
+      return new Promise((resolve, reject) => {
+        if (signal?.aborted) {
+          reject(new DOMException('Aborted', 'AbortError'))
+          return
+        }
+
+        signal?.addEventListener('abort', () => {
+          reject(new DOMException('Aborted', 'AbortError'))
+        }, { once: true })
+      }) as Promise<Response>
+    })
+
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.handleQueryChange('brazil')
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(300)
+      await Promise.resolve()
+    })
+
+    const initialSignals = fetchMock.mock.calls
+      .map(([, init]) => init?.signal)
+      .filter((signal): signal is AbortSignal => Boolean(signal))
+
+    expect(initialSignals).toHaveLength(2)
+    expect(initialSignals.every(signal => signal.aborted)).toBe(false)
+
+    act(() => {
+      result.current.handleQueryChange('trump')
+    })
+
+    expect(initialSignals.every(signal => signal.aborted)).toBe(true)
   })
 })

--- a/tests/unit/useSearch.test.ts
+++ b/tests/unit/useSearch.test.ts
@@ -138,6 +138,7 @@ describe('useSearch', () => {
     expect(eventsRequest.searchParams.get('search')).toBe('resolved')
     expect(eventsRequest.searchParams.get('status')).toBe('all')
     expect(eventsRequest.searchParams.get('limit')).toBe('5')
+    expect(eventsRequest.searchParams.get('includeBookmarkState')).toBe('false')
     expect(result.current.results.events).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/tests/unit/useSearch.test.ts
+++ b/tests/unit/useSearch.test.ts
@@ -118,7 +118,7 @@ describe('useSearch', () => {
     expect(result.current.showResults).toBe(true)
   })
 
-  it('requests events with the combined status filter so resolved results are included', async () => {
+  it('requests events with the combined status filter and dropdown limit so resolved results are included', async () => {
     const { result } = renderHook(() => useSearch())
 
     act(() => {
@@ -130,9 +130,14 @@ describe('useSearch', () => {
       await Promise.resolve()
     })
 
-    expect(fetchMock).toHaveBeenCalledWith(
-      expect.stringContaining('/api/events?search=resolved&status=all'),
-    )
+    const eventsRequestUrl = fetchMock.mock.calls
+      .map(([input]) => typeof input === 'string' ? input : input.toString())
+      .find(url => url.includes('/api/events'))
+    const eventsRequest = new URL(eventsRequestUrl!, 'http://localhost')
+
+    expect(eventsRequest.searchParams.get('search')).toBe('resolved')
+    expect(eventsRequest.searchParams.get('status')).toBe('all')
+    expect(eventsRequest.searchParams.get('limit')).toBe('5')
     expect(result.current.results.events).toEqual(
       expect.arrayContaining([
         expect.objectContaining({

--- a/tests/unit/usersRoute.test.ts
+++ b/tests/unit/usersRoute.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getPublicAssetUrl: vi.fn((path: string) => `https://assets.example/${path}`),
+  getUserPublicAddress: vi.fn((user: { deposit_wallet_address?: string | null, address?: string | null }) => user.deposit_wallet_address || user.address || ''),
+  searchPublicProfiles: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/user', () => ({
+  UserRepository: {
+    searchPublicProfiles: (...args: any[]) => mocks.searchPublicProfiles(...args),
+  },
+}))
+
+vi.mock('@/lib/storage', () => ({
+  getPublicAssetUrl: (...args: any[]) => mocks.getPublicAssetUrl(...args),
+}))
+
+vi.mock('@/lib/user-address', () => ({
+  getUserPublicAddress: (...args: any[]) => mocks.getUserPublicAddress(...args),
+}))
+
+const { GET } = await import('@/app/api/users/route')
+
+describe('users route', () => {
+  beforeEach(() => {
+    mocks.getPublicAssetUrl.mockClear()
+    mocks.getUserPublicAddress.mockClear()
+    mocks.searchPublicProfiles.mockReset()
+  })
+
+  it('returns an empty payload for short profile search queries', async () => {
+    const response = await GET(new Request('https://example.com/api/users?search=b'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([])
+    expect(mocks.searchPublicProfiles).not.toHaveBeenCalled()
+  })
+
+  it('uses the public profile search path without requesting user counts', async () => {
+    mocks.searchPublicProfiles.mockResolvedValueOnce({
+      data: [
+        {
+          address: '0xabc',
+          created_at: new Date('2026-01-01T00:00:00.000Z'),
+          deposit_wallet_address: '0xwallet',
+          image: 'avatar.png',
+          username: 'bruno',
+        },
+      ],
+      error: null,
+    })
+
+    const response = await GET(new Request('https://example.com/api/users?search=bruno'))
+
+    expect(response.status).toBe(200)
+    expect(mocks.searchPublicProfiles).toHaveBeenCalledWith({
+      search: 'bruno',
+      limit: 10,
+    })
+    await expect(response.json()).resolves.toEqual([
+      {
+        address: '0xwallet',
+        created_at: '2026-01-01T00:00:00.000Z',
+        deposit_wallet_address: '0xwallet',
+        image: 'https://assets.example/avatar.png',
+        username: 'bruno',
+      },
+    ])
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves header search performance by skipping unnecessary auth lookups, limiting results, and using a faster username query backed by a trigram index. Also makes search more responsive by aborting in-flight requests and fixes a small toast image layout issue.

- **Refactors**
  - Header search requests events with `limit=5` and `includeBookmarkState=false`; the events API now skips current-user lookup unless `bookmarked=true` or bookmark state is requested.
  - Profile search uses `UserRepository.searchPublicProfiles` (username-only, no counts) and a new GIN trigram index `idx_users_username_lower_gin_trgm` on `LOWER(username)`; returns up to 10 results.
  - `useSearch` debounces and aborts in-flight requests and ignores abort errors to avoid stale updates.

- **Bug Fixes**
  - Prevent image shrinking in `EventTradeToast` by adding `shrink-0`.

<sup>Written for commit 85af1d88b62973797622a18fe0c2d58ecad55507. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

