### PR TITLE
fix: sports event timezone labels

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
@@ -23,6 +23,28 @@ export interface EventCardSportsMoneylineProps {
 }
 
 const HOME_OUTCOME_BUTTON_HEIGHT_CLASS = 'h-[40px]'
+const SPORTS_EVENT_TIME_ZONE = 'America/New_York'
+const SPORTS_EVENT_TIME_ZONE_LABEL = 'ET'
+const SPORTS_EVENT_TIME_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  hour: 'numeric',
+  minute: '2-digit',
+  timeZone: SPORTS_EVENT_TIME_ZONE,
+})
+const SPORTS_EVENT_DATE_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  month: 'short',
+  day: 'numeric',
+  timeZone: SPORTS_EVENT_TIME_ZONE,
+})
+const SPORTS_EVENT_WEEKDAY_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  weekday: 'short',
+  timeZone: SPORTS_EVENT_TIME_ZONE,
+})
+const SPORTS_EVENT_DATE_PARTS_FORMATTER = new Intl.DateTimeFormat('en-US', {
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric',
+  timeZone: SPORTS_EVENT_TIME_ZONE,
+})
 
 function normalizeComparableText(value: string | null | undefined) {
   return value
@@ -69,6 +91,19 @@ function resolveSportsCompetitionLabel(event: Event) {
     ?? formatSportsDisplayLabel(event.sports_sport_slug)
 }
 
+function getSportsEventDayNumber(date: Date) {
+  const parts = SPORTS_EVENT_DATE_PARTS_FORMATTER.formatToParts(date)
+  const year = Number(parts.find(part => part.type === 'year')?.value)
+  const month = Number(parts.find(part => part.type === 'month')?.value)
+  const day = Number(parts.find(part => part.type === 'day')?.value)
+
+  if (!Number.isFinite(year) || !Number.isFinite(month) || !Number.isFinite(day)) {
+    return null
+  }
+
+  return Math.floor(Date.UTC(year, month - 1, day) / 86_400_000)
+}
+
 function formatSportsStartTime(value: string | null | undefined, currentTimestamp?: number | null) {
   if (!value) {
     return null
@@ -79,23 +114,22 @@ function formatSportsStartTime(value: string | null | undefined, currentTimestam
     return null
   }
 
-  const timeLabel = parsed.toLocaleTimeString('en-US', {
-    hour: 'numeric',
-    minute: '2-digit',
-  })
+  const timeLabel = `${SPORTS_EVENT_TIME_FORMATTER.format(parsed)} ${SPORTS_EVENT_TIME_ZONE_LABEL}`
 
   if (currentTimestamp == null) {
-    const dateLabel = parsed.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-    })
+    const dateLabel = SPORTS_EVENT_DATE_FORMATTER.format(parsed)
     return `${dateLabel} ${timeLabel}`
   }
 
   const now = new Date(currentTimestamp)
-  const startOfToday = new Date(now.getFullYear(), now.getMonth(), now.getDate())
-  const startOfTarget = new Date(parsed.getFullYear(), parsed.getMonth(), parsed.getDate())
-  const dayDiff = Math.round((startOfTarget.getTime() - startOfToday.getTime()) / 86_400_000)
+  const todayDayNumber = getSportsEventDayNumber(now)
+  const targetDayNumber = getSportsEventDayNumber(parsed)
+
+  if (todayDayNumber == null || targetDayNumber == null) {
+    return timeLabel
+  }
+
+  const dayDiff = targetDayNumber - todayDayNumber
 
   if (dayDiff === 0) {
     return timeLabel
@@ -110,14 +144,11 @@ function formatSportsStartTime(value: string | null | undefined, currentTimestam
   }
 
   if (dayDiff > 1 && dayDiff < 7) {
-    const weekdayLabel = parsed.toLocaleDateString('en-US', { weekday: 'short' })
+    const weekdayLabel = SPORTS_EVENT_WEEKDAY_FORMATTER.format(parsed)
     return `${weekdayLabel} ${timeLabel}`
   }
 
-  const dateLabel = parsed.toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-  })
+  const dateLabel = SPORTS_EVENT_DATE_FORMATTER.format(parsed)
   return `${dateLabel} ${timeLabel}`
 }
 

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
@@ -7,7 +7,9 @@ import Image from 'next/image'
 import EventBookmark from '@/app/[locale]/(platform)/event/[slug]/_components/EventBookmark'
 import AppLink from '@/components/AppLink'
 import { Card, CardContent } from '@/components/ui/card'
+import { NewBadge } from '@/components/ui/new-badge'
 import { ensureReadableTextColorOnDark } from '@/lib/color-contrast'
+import { shouldShowEventNewBadge } from '@/lib/event-new-badge'
 import { resolveEventOutcomePath } from '@/lib/events-routing'
 import { formatDate, formatVolume } from '@/lib/formatters'
 import { isEventResolvedLike } from '@/lib/home-events'
@@ -207,6 +209,7 @@ export default function EventCardSportsMoneyline({
   const isResolvedEvent = isEventResolvedLike(event)
   const sportsCompetitionLabel = resolveSportsCompetitionLabel(event)
   const startTimeLabel = formatSportsStartTime(event.sports_start_time ?? event.start_date, currentTimestamp)
+  const shouldShowNewBadge = shouldShowEventNewBadge(event, currentTimestamp ?? null)
   const endedLabel = isResolvedEvent && event.resolved_at
     ? (() => {
         const resolvedDate = new Date(event.resolved_at)
@@ -377,11 +380,15 @@ export default function EventCardSportsMoneyline({
 
         <div className="relative flex w-full items-center justify-between gap-2 text-xs text-muted-foreground">
           <div className="flex min-w-0 items-center gap-1.5 overflow-x-auto whitespace-nowrap">
-            <span>
-              {formatVolume(event.volume)}
-              {' '}
-              Vol.
-            </span>
+            {shouldShowNewBadge
+              ? <NewBadge />
+              : (
+                  <span>
+                    {formatVolume(event.volume)}
+                    {' '}
+                    Vol.
+                  </span>
+                )}
             {isResolvedEvent
               ? (
                   sportsCompetitionLabel

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -45,6 +45,7 @@ import {
   headerIconButtonClass,
 } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-types'
 import {
+  formatSportsEventStartLabels,
   normalizeLivestreamUrl,
   parseSportsScore,
   resolveMoneylineButtonGridClass,
@@ -468,12 +469,11 @@ export default function SportsEventCenter({
         ? Date.parse(heroCard.event.start_date)
         : Number.NaN
   const startTimestamp = Number.isFinite(parsedStartTimestamp) ? parsedStartTimestamp : null
-  const timeLabel = startTimestamp !== null
-    ? new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit', timeZone: 'UTC' }).format(startTimestamp)
-    : 'TBD'
-  const dayLabel = startTimestamp !== null
-    ? new Intl.DateTimeFormat(locale, { month: 'long', day: 'numeric', timeZone: 'UTC' }).format(startTimestamp)
-    : 'Date TBD'
+  const startLabels = startTimestamp !== null
+    ? formatSportsEventStartLabels(startTimestamp, locale)
+    : null
+  const timeLabel = startLabels?.timeLabel ?? 'TBD'
+  const dayLabel = startLabels?.dayLabel ?? 'Date TBD'
 
   const team1 = heroCard.teams[0] ?? null
   const team2 = heroCard.teams[1] ?? null

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameGraph.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameGraph.tsx
@@ -126,6 +126,7 @@ export default function SportsGameGraph({
     isSecondaryMarketGraph,
     isSportsEventHeroVariant,
   })
+  const shouldPairOutcomeHistory = isSecondaryMarketGraph || Boolean(selectedConditionId)
 
   const { chartData, latestSnapshot, leadingGapStart } = useSportsGameGraphHistory({
     card,
@@ -133,7 +134,7 @@ export default function SportsGameGraph({
     activeTimeRange,
     chartSeries,
     graphSeriesTargets,
-    isSecondaryMarketGraph,
+    shouldPairOutcomeHistory,
   })
 
   const {

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
@@ -97,7 +97,6 @@ export function useSportsGameGraphSeries({
     () => {
       if (
         selectedConditionId
-        && isSecondaryMarketGraph
       ) {
         const selectedMarket = card.detailMarkets.find(
           market => market.condition_id === selectedConditionId,
@@ -120,7 +119,7 @@ export function useSportsGameGraphSeries({
                 tokenId: outcome.token_id ?? null,
                 market: selectedMarket,
                 outcomeIndex: outcome.outcome_index,
-                name: relatedButton?.label ?? fallbackLabel,
+                name: relatedButton ? resolveGraphSeriesName(card, relatedButton, selectedMarket) : fallbackLabel,
                 color: resolveGraphSeriesColor(card, relatedButton, fallbackColors[index % fallbackColors.length]!),
               }
             })
@@ -254,14 +253,14 @@ export function useSportsGameGraphHistory({
   activeTimeRange,
   chartSeries,
   graphSeriesTargets,
-  isSecondaryMarketGraph,
+  shouldPairOutcomeHistory,
 }: {
   card: SportsGamesCard
   marketTargets: Array<{ conditionId: string, tokenId: string }>
   activeTimeRange: (typeof TIME_RANGES)[number]
   chartSeries: Array<{ key: string, name: string, color: string }>
   graphSeriesTargets: SportsGraphSeriesTarget[]
-  isSecondaryMarketGraph: boolean
+  shouldPairOutcomeHistory: boolean
 }) {
   const { normalizedHistory } = useEventPriceHistory({
     eventId: card.id,
@@ -294,7 +293,7 @@ export function useSportsGameGraphHistory({
   }, [chartSeries, normalizedHistory])
 
   const pairedHistoryChartData = useMemo<DataPoint[]>(() => {
-    if (!isSecondaryMarketGraph || chartSeries.length !== 2) {
+    if (!shouldPairOutcomeHistory || chartSeries.length !== 2) {
       return historyChartData
     }
 
@@ -321,7 +320,7 @@ export function useSportsGameGraphHistory({
         return nextPoint
       })
       .filter((point): point is DataPoint => point !== null)
-  }, [chartSeries, historyChartData, isSecondaryMarketGraph])
+  }, [chartSeries, historyChartData, shouldPairOutcomeHistory])
 
   const fallbackChartData = useMemo<DataPoint[]>(() => {
     if (graphSeriesTargets.length === 0) {

--- a/src/app/[locale]/(platform)/sports/_components/sports-event-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/sports-event-center-utils.ts
@@ -15,6 +15,9 @@ import { ORDER_SIDE, OUTCOME_INDEX } from '@/lib/constants'
 import { resolveOutcomeSelectionPriceCents } from '@/lib/market-pricing'
 import { ODDS_FORMAT_OPTIONS } from '@/lib/odds-format'
 
+const SPORTS_EVENT_DISPLAY_TIME_ZONE = 'America/New_York'
+const SPORTS_EVENT_DISPLAY_TIME_ZONE_LABEL = 'ET'
+
 function resolveInitialOddsFormat(): OddsFormat {
   if (typeof window === 'undefined') {
     return 'price'
@@ -23,6 +26,25 @@ function resolveInitialOddsFormat(): OddsFormat {
   const storedOddsFormat = window.localStorage.getItem(SPORTS_EVENT_ODDS_FORMAT_STORAGE_KEY)
   const matchedOption = ODDS_FORMAT_OPTIONS.find(option => option.value === storedOddsFormat)
   return matchedOption?.value ?? 'price'
+}
+
+export function formatSportsEventStartLabels(timestamp: number, locale: string) {
+  const date = new Date(timestamp)
+  const timeLabel = new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: SPORTS_EVENT_DISPLAY_TIME_ZONE,
+  }).format(date)
+  const dayLabel = new Intl.DateTimeFormat(locale, {
+    month: 'long',
+    day: 'numeric',
+    timeZone: SPORTS_EVENT_DISPLAY_TIME_ZONE,
+  }).format(date)
+
+  return {
+    timeLabel: `${timeLabel} ${SPORTS_EVENT_DISPLAY_TIME_ZONE_LABEL}`,
+    dayLabel,
+  }
 }
 
 export function subscribeToOddsFormatStorage(listener: () => void) {

--- a/src/lib/event-new-badge.ts
+++ b/src/lib/event-new-badge.ts
@@ -8,7 +8,7 @@ const EVENT_NEW_BADGE_WINDOW_MS_DEFAULT = 24 * MS_IN_HOUR
 const EVENT_NEW_BADGE_WINDOW_MS_DAILY = 2 * MS_IN_HOUR
 const EVENT_NEW_BADGE_WINDOW_MS_SUB_HOURLY = 10 * MS_IN_MINUTE
 
-type EventNewBadgeInput = Pick<Event, 'status' | 'series_recurrence' | 'created_at'> & {
+type EventNewBadgeInput = Pick<Event, 'status' | 'series_recurrence' | 'created_at' | 'volume'> & {
   markets: Array<Pick<Event['markets'][number], 'created_at'>>
 }
 
@@ -94,11 +94,15 @@ function getNewBadgeWindowMs(seriesRecurrence: string | null | undefined): numbe
 }
 
 export function shouldShowEventNewBadge(event: EventNewBadgeInput, currentTime: number | null) {
-  if (currentTime == null) {
+  if (event.status !== 'active') {
     return false
   }
 
-  if (event.status !== 'active') {
+  if (Number(event.volume) === 0) {
+    return true
+  }
+
+  if (currentTime == null) {
     return false
   }
 

--- a/src/lib/home-events.ts
+++ b/src/lib/home-events.ts
@@ -10,6 +10,7 @@ interface HomeEventVisibilityOptions {
 }
 
 export const HOME_EVENTS_PAGE_SIZE = 32
+const UTC_DAY_MS = 24 * 60 * 60 * 1000
 
 interface HomeVisibleEventTagCandidate {
   slug?: string | null
@@ -84,6 +85,12 @@ function isOverdueUnresolved<T extends HomeVisibleEventCandidate>(event: T, nowM
   return !isEventResolvedLike(event) && Number.isFinite(endTimestamp) && endTimestamp < nowMs
 }
 
+function isSameUtcDay(leftTimestamp: number, rightTimestamp: number) {
+  return Number.isFinite(leftTimestamp)
+    && Number.isFinite(rightTimestamp)
+    && Math.floor(leftTimestamp / UTC_DAY_MS) === Math.floor(rightTimestamp / UTC_DAY_MS)
+}
+
 function isPreferredSeriesEvent<T extends HomeVisibleEventCandidate>(candidate: T, current: T, nowMs: number) {
   const candidateEnd = toTimestamp(candidate.end_date)
   const currentEnd = toTimestamp(current.end_date)
@@ -115,6 +122,14 @@ function isPreferredSeriesEvent<T extends HomeVisibleEventCandidate>(candidate: 
   }
 
   if (candidateHasFutureEnd !== currentHasFutureEnd) {
+    if (candidateHasFutureEnd && currentOverdueUnresolved && isSameUtcDay(currentEnd, nowMs)) {
+      return false
+    }
+
+    if (currentHasFutureEnd && candidateOverdueUnresolved && isSameUtcDay(candidateEnd, nowMs)) {
+      return true
+    }
+
     return candidateHasFutureEnd
   }
 

--- a/tests/unit/EventCardSportsMoneyline.test.tsx
+++ b/tests/unit/EventCardSportsMoneyline.test.tsx
@@ -35,6 +35,10 @@ vi.mock('@/app/[locale]/(platform)/event/[slug]/_components/EventBookmark', () =
   },
 }))
 
+vi.mock('@/components/ui/new-badge', () => ({
+  NewBadge: () => <span data-testid="new-badge">New</span>,
+}))
+
 vi.mock('@/lib/events-routing', () => ({
   resolveEventOutcomePath: (_event: unknown, payload: { conditionId: string, outcomeIndex: number }) =>
     `/event/${payload.conditionId}/${payload.outcomeIndex}`,
@@ -182,5 +186,64 @@ describe('eventCardSportsMoneyline', () => {
     expect(screen.queryByText('ARS')).not.toBeInTheDocument()
     expect(screen.queryByText('CHE')).not.toBeInTheDocument()
     expect(screen.queryByTestId('event-bookmark')).not.toBeInTheDocument()
+  })
+
+  it('shows the new badge instead of volume for active zero-volume sports cards', () => {
+    const event = {
+      status: 'active',
+      volume: 0,
+      created_at: '2026-03-01T00:00:00.000Z',
+      series_recurrence: null,
+      sports_sport_slug: 'soccer',
+      markets: [
+        {
+          condition_id: 'match-winner-condition',
+          slug: 'arsenal-vs-chelsea-match-winner',
+          created_at: '2026-03-01T00:00:00.000Z',
+        },
+      ],
+    } as any
+
+    const model = {
+      team1: {
+        name: 'Arsenal',
+        abbreviation: 'ARS',
+        color: null,
+        logoUrl: null,
+        hostStatus: 'home',
+      },
+      team2: {
+        name: 'Chelsea',
+        abbreviation: 'CHE',
+        color: null,
+        logoUrl: null,
+        hostStatus: 'away',
+      },
+      team1Button: {
+        conditionId: 'match-winner-condition',
+        outcomeIndex: 0,
+        label: 'ARS',
+        tone: 'team1',
+        color: null,
+      },
+      team2Button: {
+        conditionId: 'match-winner-condition',
+        outcomeIndex: 1,
+        label: 'CHE',
+        tone: 'team2',
+        color: null,
+      },
+    } as any
+
+    render(
+      <EventCardSportsMoneyline
+        event={event}
+        model={model}
+        getDisplayChance={() => 50}
+      />,
+    )
+
+    expect(screen.getByTestId('new-badge')).toBeInTheDocument()
+    expect(screen.queryByText('$0 Vol.')).not.toBeInTheDocument()
   })
 })

--- a/tests/unit/EventCardSportsMoneyline.test.tsx
+++ b/tests/unit/EventCardSportsMoneyline.test.tsx
@@ -101,6 +101,7 @@ describe('eventCardSportsMoneyline', () => {
 
     expect(container.querySelectorAll('[class~=\"bg-primary\"]')).toHaveLength(1)
     expect(container.querySelectorAll('[class~=\"bg-primary/60\"]')).toHaveLength(1)
+    expect(screen.getByText('Sat 7:00 PM ET')).toBeInTheDocument()
     expect(mocks.eventBookmark).toHaveBeenCalledWith(expect.objectContaining({
       refreshStatusOnMount: false,
     }))

--- a/tests/unit/eventNewBadge.test.ts
+++ b/tests/unit/eventNewBadge.test.ts
@@ -6,6 +6,7 @@ function buildEvent(overrides: Partial<Parameters<typeof shouldShowEventNewBadge
     status: 'active',
     series_recurrence: null,
     created_at: new Date(0).toISOString(),
+    volume: 100,
     markets: [{ created_at: new Date(0).toISOString() }],
     ...overrides,
   }
@@ -59,5 +60,15 @@ describe('shouldShowEventNewBadge', () => {
     })
 
     expect(shouldShowEventNewBadge(event, 24 * 60 * 60 * 1000)).toBe(true)
+  })
+
+  it('shows NEW for active zero-volume events', () => {
+    const event = buildEvent({
+      volume: 0,
+      created_at: new Date(0).toISOString(),
+      markets: [{ created_at: new Date(0).toISOString() }],
+    })
+
+    expect(shouldShowEventNewBadge(event, null)).toBe(true)
   })
 })

--- a/tests/unit/homeEvents.test.ts
+++ b/tests/unit/homeEvents.test.ts
@@ -166,4 +166,35 @@ describe('home-events', () => {
       },
     )).toEqual([currentEvent])
   })
+
+  it('keeps the same-day overdue unresolved series event over the next occurrence', () => {
+    const todayEvent = {
+      id: 'today-event',
+      slug: 'highest-temperature-in-sao-paulo-on-june-9-2026',
+      series_slug: 'sao-paulo-daily-weather',
+      status: 'active' as const,
+      end_date: '2026-06-09T12:00:00.000Z',
+      created_at: '2026-06-08T16:20:05.000Z',
+      updated_at: '2026-06-09T12:15:01.833Z',
+      markets: [{ is_resolved: false, condition: { resolved: false } }],
+    }
+    const tomorrowEvent = {
+      id: 'tomorrow-event',
+      slug: 'highest-temperature-in-sao-paulo-on-june-10-2026',
+      series_slug: 'sao-paulo-daily-weather',
+      status: 'active' as const,
+      end_date: '2026-06-10T12:00:00.000Z',
+      created_at: '2026-06-09T03:59:21.000Z',
+      updated_at: '2026-06-09T12:15:01.867Z',
+      markets: [{ is_resolved: false, condition: { resolved: false } }],
+    }
+
+    expect(filterHomeEvents(
+      [tomorrowEvent, todayEvent],
+      {
+        currentTimestamp: Date.parse('2026-06-09T12:30:00.000Z'),
+        status: 'active',
+      },
+    )).toEqual([todayEvent])
+  })
 })

--- a/tests/unit/sportsEventCenterUtils.test.ts
+++ b/tests/unit/sportsEventCenterUtils.test.ts
@@ -1,0 +1,10 @@
+import { formatSportsEventStartLabels } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-utils'
+
+describe('sportsEventCenterUtils', () => {
+  it('formats event hero start labels in ET', () => {
+    expect(formatSportsEventStartLabels(Date.parse('2026-06-09T12:00:00.000Z'), 'en-US')).toEqual({
+      timeLabel: '8:00 AM ET',
+      dayLabel: 'June 9',
+    })
+  })
+})

--- a/tests/unit/sportsGameGraphHeroLegend.test.tsx
+++ b/tests/unit/sportsGameGraphHeroLegend.test.tsx
@@ -1,7 +1,10 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-constants'
-import { useSportsGameGraphHeroLegend } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph'
+import {
+  useSportsGameGraphHeroLegend,
+  useSportsGameGraphSeries,
+} from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph'
 
 const chartSeries = [
   { key: 'chiefs', name: 'Chiefs', color: '#f4c400' },
@@ -81,5 +84,91 @@ describe('sportsGameGraphHeroLegend', () => {
     expect((entry?.left ?? 0) + (entry?.width ?? 0)).toBeLessThanOrEqual(
       860 - 46 - SPORTS_EVENT_HERO_POSITIONED_LEGEND_LAYOUT.rightInsetPx,
     )
+  })
+})
+
+describe('sportsGameGraphSeries', () => {
+  it('scopes selected moneyline graphs to both outcomes of the selected market', () => {
+    const card = {
+      id: 'event-1',
+      teams: [
+        { name: '99DIVINE', abbreviation: '99D', color: null, logoUrl: null, record: null, hostStatus: 'home' },
+        { name: 'ENTER FORCE.36', abbreviation: 'EF36', color: null, logoUrl: null, record: null, hostStatus: 'away' },
+      ],
+      detailMarkets: [
+        {
+          condition_id: 'match-winner',
+          outcomes: [
+            { outcome_index: 0, outcome_text: '99DIVINE', token_id: 'match-99d-token' },
+            { outcome_index: 1, outcome_text: 'ENTER FORCE.36', token_id: 'match-ef36-token' },
+          ],
+        },
+        {
+          condition_id: 'game-1-winner',
+          outcomes: [
+            { outcome_index: 0, outcome_text: '99DIVINE', token_id: 'game1-99d-token' },
+            { outcome_index: 1, outcome_text: 'ENTER FORCE.36', token_id: 'game1-ef36-token' },
+          ],
+        },
+        {
+          condition_id: 'game-2-winner',
+          outcomes: [
+            { outcome_index: 0, outcome_text: '99DIVINE', token_id: 'game2-99d-token' },
+            { outcome_index: 1, outcome_text: 'ENTER FORCE.36', token_id: 'game2-ef36-token' },
+          ],
+        },
+      ],
+      buttons: [
+        {
+          key: 'match-winner:0',
+          conditionId: 'match-winner',
+          outcomeIndex: 0,
+          label: '99D',
+          color: null,
+          marketType: 'moneyline',
+          tone: 'team1',
+        },
+        {
+          key: 'match-winner:1',
+          conditionId: 'match-winner',
+          outcomeIndex: 1,
+          label: 'EF36',
+          color: null,
+          marketType: 'moneyline',
+          tone: 'team2',
+        },
+        {
+          key: 'game-1-winner:0',
+          conditionId: 'game-1-winner',
+          outcomeIndex: 0,
+          label: '99D',
+          color: null,
+          marketType: 'moneyline',
+          tone: 'team1',
+        },
+        {
+          key: 'game-2-winner:0',
+          conditionId: 'game-2-winner',
+          outcomeIndex: 0,
+          label: '99D',
+          color: null,
+          marketType: 'moneyline',
+          tone: 'team1',
+        },
+      ],
+    } as any
+
+    const { result } = renderHook(() => useSportsGameGraphSeries({
+      card,
+      selectedConditionId: 'match-winner',
+      isSecondaryMarketGraph: false,
+      isSportsEventHeroVariant: false,
+    }))
+
+    expect(result.current.chartSeries.map(series => series.name)).toEqual(['99DIVINE', 'ENTER FORCE.36'])
+    expect(result.current.marketTargets).toEqual([
+      { conditionId: 'match-winner:0', tokenId: 'match-99d-token' },
+      { conditionId: 'match-winner:1', tokenId: 'match-ef36-token' },
+    ])
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show all sports event start times in ET, fix moneyline graph series pairing and names, and show a NEW badge for zero‑volume events. Also keep same‑day overdue unresolved series events on the homepage.

- **Bug Fixes**
  - Format times in `America/New_York` with an `ET` suffix and compute relative labels (today/tomorrow/weekday/date) in ET; use `formatSportsEventStartLabels` for the hero.
  - Scope selected moneyline charts to both outcomes and use correct team names.
  - Pair outcome history when a condition is selected or on secondary graphs to close gaps.
  - Show `NewBadge` for active zero‑volume events instead of volume.
  - Keep same‑day overdue unresolved series events visible over the next occurrence on the homepage.

<sup>Written for commit 1a627563ccb1d4982dd650c9fb74f20cdc3a52e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1133?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

