### PR TITLE
fix: open order cent formatting

### DIFF
--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -18,7 +18,7 @@ import { filterActivitiesByMinAmount } from '@/lib/activity/filter'
 import { PUBLIC_ALLOWED_MARKET_CREATORS_PATH } from '@/lib/allowed-market-creators'
 import { MICRO_UNIT } from '@/lib/constants'
 import { mapDataApiActivityToActivityOrder } from '@/lib/data-api/user'
-import { formatCurrency, formatSharePriceLabel, formatTimeAgo, toMicro } from '@/lib/formatters'
+import { formatDollarValueLabel, formatSharePriceLabel, formatTimeAgo, toMicro } from '@/lib/formatters'
 import { POLYGON_SCAN_BASE } from '@/lib/network'
 import { buildPublicProfilePath, isDynamicHomeCategorySlug } from '@/lib/platform-routing'
 import { cn } from '@/lib/utils'
@@ -694,7 +694,7 @@ export default function ActivityFeed() {
               ? Number(activity.total_value) / MICRO_UNIT
               : 0
             const totalValueLabel = totalValue > 0
-              ? formatCurrency(totalValue, { minimumFractionDigits: 0, maximumFractionDigits: 0 })
+              ? formatDollarValueLabel(totalValue, { minimumFractionDigits: 0, maximumFractionDigits: 0 })
               : null
             const timeAgoLabel = formatTimeAgo(activity.created_at)
             const txUrl = activity.tx_hash ? `${POLYGON_SCAN_BASE}/tx/${activity.tx_hash}` : null

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketHistory.tsx
@@ -10,7 +10,7 @@ import { Button } from '@/components/ui/button'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { MICRO_UNIT, OUTCOME_INDEX } from '@/lib/constants'
 import { fetchUserActivityData, mapDataApiActivityToActivityOrder } from '@/lib/data-api/user'
-import { formatCurrency, formatSharePriceLabel, formatSharesLabel, formatTimeAgo, fromMicro } from '@/lib/formatters'
+import { formatDollarValueLabel, formatSharePriceLabel, formatSharesLabel, formatTimeAgo, fromMicro } from '@/lib/formatters'
 import { POLYGON_SCAN_BASE } from '@/lib/network'
 import { getUserPublicAddress } from '@/lib/user-address'
 import { cn } from '@/lib/utils'
@@ -215,10 +215,7 @@ export default function EventMarketHistory({ market }: EventMarketHistoryProps) 
           const actionLabel = activity.side === 'sell' ? t('Sold') : t('Bought')
           const priceLabel = formatSharePriceLabel(Number(activity.price), { fallback: '—' })
           const totalValue = Number(activity.total_value) / MICRO_UNIT
-          const totalValueLabel = formatCurrency(totalValue, {
-            minimumFractionDigits: 2,
-            maximumFractionDigits: 2,
-          })
+          const totalValueLabel = formatDollarValueLabel(totalValue, { fallback: '0¢' })
           const timeAgoLabel = formatTimeAgo(activity.created_at)
           const fullDateLabel = new Date(activity.created_at).toLocaleString(locale, {
             month: 'long',

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketOpenOrders.tsx
@@ -34,7 +34,7 @@ import { DEPOSIT_WALLET_BALANCE_QUERY_KEY } from '@/hooks/useBalance'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { MICRO_UNIT, OUTCOME_INDEX, tableHeaderClass } from '@/lib/constants'
-import { formatCurrency, formatSharePriceLabel, formatSharesLabel } from '@/lib/formatters'
+import { formatDollarValueLabel, formatSharePriceLabel, formatSharesLabel } from '@/lib/formatters'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import { cn } from '@/lib/utils'
 import { useIsSingleMarket } from '@/stores/useOrder'
@@ -474,10 +474,7 @@ function OpenOrderRow({ order, onCancel, isCancelling }: OpenOrderRowProps) {
   const filledShares = microToUnit(order.size_matched)
   const filledLabel = formatFilledLabel(filledShares, totalShares)
   const totalValueMicro = isBuy ? order.maker_amount : order.taker_amount
-  const totalValueLabel = formatCurrency(microToUnit(totalValueMicro), {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })
+  const totalValueLabel = formatDollarValueLabel(microToUnit(totalValueMicro), { fallback: '0¢' })
   const expirationLabel = formatExpirationLabel(order, locale, t('Until Cancelled'))
   const isNoOutcome = order.outcome.index === OUTCOME_INDEX.NO
   const outcomeLabel = normalizeOutcomeLabel(order.outcome.text || (isNoOutcome ? 'No' : 'Yes'))

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
@@ -20,7 +20,7 @@ import { fetchUserPositionsForMarket } from '@/lib/data-api/user'
 import {
   formatAmountInputValue,
   formatCentsLabel,
-  formatCurrency,
+  formatDollarValueLabel,
   formatPercent,
   formatSharesLabel,
   fromMicro,
@@ -540,13 +540,10 @@ function MarketPositionRow({
     market.outcomes.find(outcome => outcome.outcome_index === resolvedOutcomeIndex)?.buy_price,
   )
   const totalValue = resolvePositionValue(position, outcomePrice)
-  const valueLabel = formatCurrency(Math.max(0, totalValue), {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })
+  const valueLabel = formatDollarValueLabel(Math.max(0, totalValue), { fallback: '0¢' })
   const baseCostValue = resolvePositionCost(position)
   const costLabel = baseCostValue != null
-    ? formatCurrency(baseCostValue, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    ? formatDollarValueLabel(baseCostValue, { fallback: '0¢' })
     : null
   const rawRealizedPnl = toNumber(position.realizedPnl)
     ?? toNumber(position.cashPnl)
@@ -570,10 +567,7 @@ function MarketPositionRow({
   const percentLabel = formatPercent(Math.abs(normalizedPercent), { digits: percentDigits })
   const isPositive = totalProfitLossValue >= 0
   const isNeutralReturn = Math.abs(totalProfitLossValue) < 0.005
-  const neutralReturnLabel = formatCurrency(Math.abs(totalProfitLossValue), {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })
+  const neutralReturnLabel = formatDollarValueLabel(Math.abs(totalProfitLossValue), { fallback: '0¢' })
   const displayedReturnValue = isNeutralReturn
     ? neutralReturnLabel
     : `${isPositive ? '+' : '-'}${neutralReturnLabel}`
@@ -584,7 +578,7 @@ function MarketPositionRow({
   const signedPercentLabel = `${isPositive ? '+' : '-'}${percentLabel}`
 
   function formatSignedCurrency(value: number) {
-    const abs = formatCurrency(Math.abs(value), { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+    const abs = formatDollarValueLabel(Math.abs(value), { fallback: '0¢' })
     if (value > 0) {
       return `+${abs}`
     }
@@ -761,8 +755,8 @@ function NetPositionsDialog({
         <div className="max-h-[60vh] divide-y divide-border overflow-y-auto pr-2">
           {rows.map((row) => {
             const isPositive = row.netValue >= 0
-            const netLabel = formatCurrency(Math.abs(row.netValue), { minimumFractionDigits: 2, maximumFractionDigits: 2 })
-            const payoutLabel = formatCurrency(row.payout, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+            const netLabel = formatDollarValueLabel(Math.abs(row.netValue), { fallback: '0¢' })
+            const payoutLabel = formatDollarValueLabel(row.payout, { fallback: '0¢' })
             return (
               <div
                 key={row.id}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -54,7 +54,7 @@ import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
 import { addressToBuilderCode } from '@/lib/builder-code'
 import { CLOB_ORDER_TYPE, getExchangeEip712Domain, ORDER_SIDE, ORDER_TYPE, OUTCOME_INDEX } from '@/lib/constants'
 import { resolveEventPagePath } from '@/lib/events-routing'
-import { formatCentsLabel, formatCurrency, formatDollarValueLabel, formatSharesLabel, toCents } from '@/lib/formatters'
+import { formatCentsLabel, formatCentsValueLabel, formatCurrency, formatDollarValueLabel, formatSharesLabel, toCents } from '@/lib/formatters'
 import { resolveFallbackOutcomeUnitPrice, resolveMarketOutcome } from '@/lib/market-pricing'
 import {
   isCurrentNegRiskAdapterAddress,
@@ -1428,7 +1428,7 @@ export default function EventOrderPanelForm({
         const isSell = submittedSide === ORDER_SIDE.SELL
         const buyAmountLabel = formatDollarValueLabel(submittedBuyAmountValue, { fallback: '0¢' })
         const sellAmountNotificationLabel = formatDollarValueLabel(submittedSellAmountValue, { fallback: '0¢' })
-        const priceLabel = formatCentsLabel(submittedBuyPriceCents, { fallback: '—' })
+        const priceLabel = formatCentsValueLabel(submittedBuyPriceCents, { fallback: '—' })
         const displayShares = submittedSellSharesLabel && submittedSellSharesLabel.trim().length > 0
           ? submittedSellSharesLabel.trim()
           : submittedAmountInput

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -54,7 +54,7 @@ import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
 import { addressToBuilderCode } from '@/lib/builder-code'
 import { CLOB_ORDER_TYPE, getExchangeEip712Domain, ORDER_SIDE, ORDER_TYPE, OUTCOME_INDEX } from '@/lib/constants'
 import { resolveEventPagePath } from '@/lib/events-routing'
-import { formatCentsLabel, formatCurrency, formatSharesLabel, toCents } from '@/lib/formatters'
+import { formatCentsLabel, formatCurrency, formatDollarValueLabel, formatSharesLabel, toCents } from '@/lib/formatters'
 import { resolveFallbackOutcomeUnitPrice, resolveMarketOutcome } from '@/lib/market-pricing'
 import {
   isCurrentNegRiskAdapterAddress,
@@ -1087,7 +1087,7 @@ export default function EventOrderPanelForm({
   const avgSellPriceCentsValue = Number.isFinite(sellOrderSnapshot.priceCents) && sellOrderSnapshot.priceCents > 0
     ? sellOrderSnapshot.priceCents
     : null
-  const sellAmountLabel = formatCurrency(sellAmountValue)
+  const sellAmountLabel = formatDollarValueLabel(sellAmountValue, { fallback: '0¢' })
   const showSlippageWarning = Boolean(user?.settings?.trading?.show_slippage_warning)
 
   const filledSharesForCurrentSide = state.side === ORDER_SIDE.BUY
@@ -1426,7 +1426,8 @@ export default function EventOrderPanelForm({
 
       if (user?.settings?.notifications?.inapp_order_fills) {
         const isSell = submittedSide === ORDER_SIDE.SELL
-        const buyAmountLabel = formatCurrency(submittedBuyAmountValue)
+        const buyAmountLabel = formatDollarValueLabel(submittedBuyAmountValue, { fallback: '0¢' })
+        const sellAmountNotificationLabel = formatDollarValueLabel(submittedSellAmountValue, { fallback: '0¢' })
         const priceLabel = formatCentsLabel(submittedBuyPriceCents, { fallback: '—' })
         const displayShares = submittedSellSharesLabel && submittedSellSharesLabel.trim().length > 0
           ? submittedSellSharesLabel.trim()
@@ -1445,7 +1446,7 @@ export default function EventOrderPanelForm({
               ? `Buy ${displayBuyShares} shares on ${submittedOutcomeText}`
               : `Buy ${buyAmountLabel} on ${submittedOutcomeText}`,
           description: isSell
-            ? `${eventContextLabel} • ${amountPrefix} ${formatCurrency(submittedSellAmountValue)} @ ${submittedAvgSellPriceLabel}`
+            ? `${eventContextLabel} • ${amountPrefix} ${sellAmountNotificationLabel} @ ${submittedAvgSellPriceLabel}`
             : `${eventContextLabel} • Total ${buyAmountLabel} @ ${priceLabel}`,
           eventPath: resolveEventPagePath(event),
           marketIconUrl: submittedMarketImage,

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelLimitControls.tsx
@@ -31,7 +31,7 @@ import { useBalance } from '@/hooks/useBalance'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { formatDisplayAmount, getAmountSizeClass, MAX_AMOUNT_INPUT, sanitizeNumericInput } from '@/lib/amount-input'
 import { ORDER_SIDE } from '@/lib/constants'
-import { formatAmountInputValue, formatCurrency, formatSharesLabel } from '@/lib/formatters'
+import { formatAmountInputValue, formatCurrency, formatDollarValueLabel, formatSharesLabel } from '@/lib/formatters'
 import { MIN_LIMIT_ORDER_SHARES } from '@/lib/orders/validation'
 import { cn } from '@/lib/utils'
 import { usePortfolioValueVisibility } from '@/stores/usePortfolioValueVisibility'
@@ -167,7 +167,7 @@ export default function EventOrderPanelLimitControls({
   const maxSharesForSide = MAX_AMOUNT_INPUT
 
   const locale = useLocale()
-  const totalValueLabel = formatCurrency(totalValue)
+  const totalValueLabel = formatDollarValueLabel(totalValue, { fallback: '0¢' })
   const safeTotalValueLabel = totalValueLabel.trim() ? totalValueLabel : '0'
   const americanOddsLabel = americanOdds != null
     ? `${americanOdds >= 0 ? '+' : ''}${americanOdds.toFixed(1)}`

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelSlippageOverlay.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelSlippageOverlay.tsx
@@ -4,7 +4,7 @@ import { useExtracted } from 'next-intl'
 import { useId } from 'react'
 import { Button } from '@/components/ui/button'
 import { ORDER_SIDE } from '@/lib/constants'
-import { formatCentsLabel, formatDollarValueLabel, formatSharesLabel } from '@/lib/formatters'
+import { formatCentsValueLabel, formatDollarValueLabel, formatSharesLabel } from '@/lib/formatters'
 import { cn } from '@/lib/utils'
 
 interface EventOrderPanelSlippageOverlayProps {
@@ -32,7 +32,7 @@ export default function EventOrderPanelSlippageOverlay({
   const rows = [
     {
       label: t('Avg'),
-      value: formatCentsLabel(avgPriceCents, { fallback: '—' }),
+      value: formatCentsValueLabel(avgPriceCents, { fallback: '—' }),
     },
     {
       label: t('Shares'),

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelSlippageOverlay.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelSlippageOverlay.tsx
@@ -4,7 +4,7 @@ import { useExtracted } from 'next-intl'
 import { useId } from 'react'
 import { Button } from '@/components/ui/button'
 import { ORDER_SIDE } from '@/lib/constants'
-import { formatCentsLabel, formatCurrency, formatSharesLabel } from '@/lib/formatters'
+import { formatCentsLabel, formatDollarValueLabel, formatSharesLabel } from '@/lib/formatters'
 import { cn } from '@/lib/utils'
 
 interface EventOrderPanelSlippageOverlayProps {
@@ -43,7 +43,7 @@ export default function EventOrderPanelSlippageOverlay({
     },
     {
       label: isSell ? t('Receive') : t('Cost'),
-      value: formatCurrency(totalValue),
+      value: formatDollarValueLabel(totalValue, { fallback: '0¢' }),
     },
   ]
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/feedback.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/feedback.tsx
@@ -4,7 +4,7 @@ import type { OrderSide } from '@/types'
 import { toast } from 'sonner'
 import EventTradeToast from '@/app/[locale]/(platform)/event/[slug]/_components/EventTradeToast'
 import { ORDER_SIDE, OUTCOME_INDEX } from '@/lib/constants'
-import { formatCentsLabel, formatDollarValueLabel } from '@/lib/formatters'
+import { formatCentsValueLabel, formatDollarValueLabel } from '@/lib/formatters'
 import { triggerConfetti } from '@/lib/utils'
 
 interface HandleValidationErrorArgs {
@@ -136,7 +136,7 @@ export function handleOrderSuccessFeedback({
       : (Number.parseFloat(amountInput || '0') || 0)
     const normalizedBuySharesLabel = buySharesLabel?.trim()
     const buyAmountLabel = formatDollarValueLabel(amountValue, { fallback: '0¢' })
-    const priceLabel = formatCentsLabel(buyPrice, { fallback: '—' })
+    const priceLabel = formatCentsValueLabel(buyPrice, { fallback: '—' })
 
     toast.success(
       normalizedBuySharesLabel

--- a/src/app/[locale]/(platform)/event/[slug]/_components/feedback.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/feedback.tsx
@@ -4,7 +4,7 @@ import type { OrderSide } from '@/types'
 import { toast } from 'sonner'
 import EventTradeToast from '@/app/[locale]/(platform)/event/[slug]/_components/EventTradeToast'
 import { ORDER_SIDE, OUTCOME_INDEX } from '@/lib/constants'
-import { formatCentsLabel, formatCurrency } from '@/lib/formatters'
+import { formatCentsLabel, formatDollarValueLabel } from '@/lib/formatters'
 import { triggerConfetti } from '@/lib/utils'
 
 interface HandleValidationErrorArgs {
@@ -120,7 +120,7 @@ export function handleOrderSuccessFeedback({
           <EventTradeToast title={eventTitle} marketImage={marketImage} marketTitle={marketTitle}>
             {amountPrefix}
             {' '}
-            {formatCurrency(sellAmountValue)}
+            {formatDollarValueLabel(sellAmountValue, { fallback: '0¢' })}
             {' '}
             @
             {' '}
@@ -135,7 +135,7 @@ export function handleOrderSuccessFeedback({
       ? buyAmountValue
       : (Number.parseFloat(amountInput || '0') || 0)
     const normalizedBuySharesLabel = buySharesLabel?.trim()
-    const buyAmountLabel = formatCurrency(amountValue)
+    const buyAmountLabel = formatDollarValueLabel(amountValue, { fallback: '0¢' })
     const priceLabel = formatCentsLabel(buyPrice, { fallback: '—' })
 
     toast.success(

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventChartAnnotations.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useEventChartAnnotations.tsx
@@ -12,7 +12,7 @@ import {
 import EventIconImage from '@/components/EventIconImage'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { OUTCOME_INDEX } from '@/lib/constants'
-import { formatCurrency, formatSharePriceLabel, formatSharesLabel, fromMicro } from '@/lib/formatters'
+import { formatDollarValueLabel, formatSharePriceLabel, formatSharesLabel, fromMicro } from '@/lib/formatters'
 
 import { cn } from '@/lib/utils'
 
@@ -103,10 +103,7 @@ function buildMarkerFromActivity(
   const actionLabel = activity.side === 'sell' ? 'Sold' : 'Bought'
   const priceLabel = formatSharePriceLabel(rawPrice, { fallback: '—' })
   const totalValue = Number.parseFloat(fromMicro(activity.total_value, 2))
-  const totalValueLabel = formatCurrency(Number.isFinite(totalValue) ? totalValue : 0, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  })
+  const totalValueLabel = formatDollarValueLabel(Number.isFinite(totalValue) ? totalValue : 0, { fallback: '0¢' })
   const outcomeIconUrl = resolveOutcomeIconUrl(activity.market.icon_url)
   const outcomeColorClass = isYesOutcome ? 'text-yes' : 'text-no'
   const markerColor = isYesOutcome ? 'var(--color-yes)' : 'var(--color-no)'

--- a/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersRow.tsx
+++ b/src/app/[locale]/(platform)/portfolio/_components/PortfolioOpenOrdersRow.tsx
@@ -14,7 +14,7 @@ import EventIconImage from '@/components/EventIconImage'
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
-import { formatCurrency } from '@/lib/formatters'
+import { formatDollarValueLabel } from '@/lib/formatters'
 import { cn } from '@/lib/utils'
 
 interface PortfolioOpenOrdersRowProps {
@@ -101,7 +101,7 @@ export default function PortfolioOpenOrdersRow({ order, onCancel, isCancelling }
       </td>
 
       <td className="px-2 py-3 text-center text-sm font-semibold sm:px-3">
-        {formatCurrency(totalValue)}
+        {formatDollarValueLabel(totalValue, { fallback: '0¢' })}
       </td>
 
       <td className="px-2 py-3 text-left text-xs font-medium text-muted-foreground sm:px-3">

--- a/src/app/[locale]/(platform)/portfolio/_utils/PortfolioOpenOrdersUtils.ts
+++ b/src/app/[locale]/(platform)/portfolio/_utils/PortfolioOpenOrdersUtils.ts
@@ -1,8 +1,9 @@
 import type { PortfolioOpenOrdersSort, PortfolioUserOpenOrder } from '@/app/[locale]/(platform)/portfolio/_types/PortfolioOpenOrdersTypes'
 import { MICRO_UNIT } from '@/lib/constants'
+import { formatSharePriceLabel } from '@/lib/formatters'
 
 export function formatCents(price?: number) {
-  return `${Math.round((price ?? 0) * 100)}¢`
+  return formatSharePriceLabel(price, { fallback: '0¢' })
 }
 
 export function microToUnit(value?: number) {

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameDetailsPanel.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameDetailsPanel.ts
@@ -16,7 +16,7 @@ import { ORDER_SIDE, ORDER_TYPE, OUTCOME_INDEX } from '@/lib/constants'
 import { fetchUserPositionsForMarket } from '@/lib/data-api/user'
 import {
   formatAmountInputValue,
-  formatCentsLabel,
+  formatCentsValueLabel,
   fromMicro,
 } from '@/lib/formatters'
 import { formatOddsFromCents } from '@/lib/odds-format'
@@ -792,7 +792,7 @@ export function useSportsPositionOddsFormatters(oddsFormat: OddsFormat) {
 
   const formatAverageCellLabel = useCallback((cents: number | null) => {
     if (oddsFormat === 'price') {
-      return formatCentsLabel(cents, { fallback: '—' })
+      return formatCentsValueLabel(cents, { fallback: '—' })
     }
     return formatOddsFromCents(cents, oddsFormat)
   }, [oddsFormat])

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -333,6 +333,24 @@ export function formatCentsLabel(
   return `${priceFormatter.format(cents)}¢`
 }
 
+export function formatCentsValueLabel(
+  value: number | string | null | undefined,
+  options: CentsFormatOptions = {},
+) {
+  const fallback = options.fallback ?? '—'
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) {
+    return fallback
+  }
+
+  const cents = Math.max(0, Number(numeric.toFixed(1)))
+  return `${priceFormatter.format(cents)}¢`
+}
+
 interface SharePriceFormatOptions extends CentsFormatOptions {
   currencyDigits?: number
 }
@@ -352,12 +370,14 @@ export function formatSharePriceLabel(
     return fallback
   }
 
-  if (numeric < 1) {
-    return formatDollarValueLabel(numeric, { fallback })
+  const normalizedPrice = Math.max(0, numeric)
+
+  if (normalizedPrice < 1) {
+    return formatDollarValueLabel(normalizedPrice, { fallback })
   }
 
   const digits = options.currencyDigits ?? 2
-  return formatCurrency(numeric, {
+  return formatCurrency(normalizedPrice, {
     minimumFractionDigits: digits,
     maximumFractionDigits: digits,
   })

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -109,6 +109,10 @@ interface CurrencyFormatOptions {
   includeSymbol?: boolean
 }
 
+interface DollarValueFormatOptions extends CurrencyFormatOptions {
+  fallback?: string
+}
+
 export function formatCurrency(
   value: number | null | undefined,
   options: CurrencyFormatOptions = {},
@@ -129,6 +133,37 @@ export function formatCurrency(
     .map(part => part.value)
     .join('')
     .trim()
+}
+
+export function formatDollarValueLabel(
+  value: number | string | null | undefined,
+  options: DollarValueFormatOptions = {},
+) {
+  const fallback = options.fallback ?? '—'
+  if (value === null || value === undefined) {
+    return fallback
+  }
+
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric)) {
+    return fallback
+  }
+
+  if (Math.abs(numeric) < 1) {
+    const cents = toCents(Math.abs(numeric))
+    if (cents === null) {
+      return fallback
+    }
+    const prefix = numeric < 0 && cents > 0 ? '-' : ''
+    return `${prefix}${priceFormatter.format(cents)}¢`
+  }
+
+  const digits = options.maximumFractionDigits ?? options.minimumFractionDigits ?? 2
+  return formatCurrency(numeric, {
+    minimumFractionDigits: options.minimumFractionDigits ?? digits,
+    maximumFractionDigits: digits,
+    includeSymbol: options.includeSymbol,
+  })
 }
 
 interface PercentFormatOptions {
@@ -318,7 +353,7 @@ export function formatSharePriceLabel(
   }
 
   if (numeric < 1) {
-    return formatCentsLabel(toCents(numeric), { fallback })
+    return formatDollarValueLabel(numeric, { fallback })
   }
 
   const digits = options.currencyDigits ?? 2

--- a/tests/unit/formattersMoney.test.ts
+++ b/tests/unit/formattersMoney.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatAmountInputValue, formatCentsLabel, formatCurrency, formatDate, formatDollarValueLabel, formatPercent, formatSharePriceLabel, formatTimeAgo, formatVolume, fromMicro, toCents, toMicro, truncateAddress } from '@/lib/formatters'
+import { formatAmountInputValue, formatCentsLabel, formatCentsValueLabel, formatCurrency, formatDate, formatDollarValueLabel, formatPercent, formatSharePriceLabel, formatTimeAgo, formatVolume, fromMicro, toCents, toMicro, truncateAddress } from '@/lib/formatters'
 
 describe('money/price formatters', () => {
   it('toMicro rounds to nearest micro', () => {
@@ -33,8 +33,18 @@ describe('money/price formatters', () => {
     expect(formatCentsLabel(55.56)).toBe('55.6¢')
   })
 
+  it('formatCentsValueLabel treats input as cents', () => {
+    expect(formatCentsValueLabel(null)).toBe('—')
+    expect(formatCentsValueLabel('nope')).toBe('—')
+    expect(formatCentsValueLabel(-1)).toBe('0¢')
+    expect(formatCentsValueLabel(0.1)).toBe('0.1¢')
+    expect(formatCentsValueLabel(1)).toBe('1¢')
+    expect(formatCentsValueLabel(100)).toBe('100¢')
+  })
+
   it('formatSharePriceLabel formats sub-dollar as cents and >=1 as currency', () => {
     expect(formatSharePriceLabel(null)).toBe('50.0¢')
+    expect(formatSharePriceLabel(-0.01)).toBe('0¢')
     expect(formatSharePriceLabel(0.01)).toBe('1¢')
     expect(formatSharePriceLabel('0.5')).toBe('50¢')
     expect(formatSharePriceLabel(1)).toBe('$1.00')

--- a/tests/unit/formattersMoney.test.ts
+++ b/tests/unit/formattersMoney.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { formatAmountInputValue, formatCentsLabel, formatCurrency, formatDate, formatPercent, formatSharePriceLabel, formatTimeAgo, formatVolume, fromMicro, toCents, toMicro, truncateAddress } from '@/lib/formatters'
+import { formatAmountInputValue, formatCentsLabel, formatCurrency, formatDate, formatDollarValueLabel, formatPercent, formatSharePriceLabel, formatTimeAgo, formatVolume, fromMicro, toCents, toMicro, truncateAddress } from '@/lib/formatters'
 
 describe('money/price formatters', () => {
   it('toMicro rounds to nearest micro', () => {
@@ -35,9 +35,18 @@ describe('money/price formatters', () => {
 
   it('formatSharePriceLabel formats sub-dollar as cents and >=1 as currency', () => {
     expect(formatSharePriceLabel(null)).toBe('50.0¢')
+    expect(formatSharePriceLabel(0.01)).toBe('1¢')
     expect(formatSharePriceLabel('0.5')).toBe('50¢')
     expect(formatSharePriceLabel(1)).toBe('$1.00')
     expect(formatSharePriceLabel(12.345, { currencyDigits: 1 })).toBe('$12.3')
+  })
+
+  it('formatDollarValueLabel formats sub-dollar totals as cents', () => {
+    expect(formatDollarValueLabel(null)).toBe('—')
+    expect(formatDollarValueLabel(0.001)).toBe('0.1¢')
+    expect(formatDollarValueLabel(0.01)).toBe('1¢')
+    expect(formatDollarValueLabel(1)).toBe('$1.00')
+    expect(formatDollarValueLabel(12.345)).toBe('$12.35')
   })
 
   it('formatAmountInputValue normalizes to 2 decimals and omits zeros', () => {

--- a/tests/unit/orderFeedback.test.ts
+++ b/tests/unit/orderFeedback.test.ts
@@ -55,4 +55,32 @@ describe('handleOrderSuccessFeedback', () => {
       queryKey: ['user-conditional-shares'],
     })
   })
+
+  it('formats limit order toast prices from cents', () => {
+    const queryClient = {
+      invalidateQueries: vi.fn(),
+    }
+
+    handleOrderSuccessFeedback({
+      side: ORDER_SIDE.BUY,
+      amountInput: '0.1',
+      buyAmountValue: 0.1,
+      buySharesLabel: '10',
+      isLimitOrder: true,
+      outcomeText: 'Yes',
+      eventTitle: 'Event',
+      marketImage: undefined,
+      marketTitle: 'Market',
+      sellAmountValue: 0,
+      avgSellPrice: '—',
+      buyPrice: 1,
+      queryClient: queryClient as any,
+      outcomeIndex: OUTCOME_INDEX.YES,
+      lastMouseEvent: null,
+    })
+
+    const [, options] = vi.mocked(toast.success).mock.calls[0]
+    const children = (options as any).description.props.children
+    expect(children.join('')).toBe('Total 10¢ @ 1¢')
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes sub-dollar money formatting across open orders, toasts, and related views. Totals and prices under $1 now render as cents (e.g., 50¢, 0.1¢) instead of $0.00.

- **Bug Fixes**
  - Introduced `formatDollarValueLabel` for totals (<$1 in cents, ≥$1 in dollars) and replaced `formatCurrency` across open orders and related UI (activity, history, positions, portfolio, chart annotations, order panel).
  - Added `formatCentsValueLabel` for cents-based inputs; used in limit order notifications, slippage overlay, and odds/average labels to fix cents-based prices.
  - Updated `formatSharePriceLabel` to use the new cents formatting for sub-$1 values and clamp negatives to 0; added unit tests for both formatters and toast output.

<sup>Written for commit 38847c66b279abd8479fac4ae5ff327cdd8987ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1138?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

