### PR TITLE
feat: disable faucet banner

### DIFF
--- a/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
+++ b/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
@@ -12,6 +12,7 @@ import {
   validateBlockedCountriesInput,
 } from '@/lib/geoblock-settings'
 import {
+  GLOBAL_ANNOUNCEMENT_DISABLE_FAUCET_BANNER_KEY,
   GLOBAL_ANNOUNCEMENT_DISABLED_ON_KEY,
   GLOBAL_ANNOUNCEMENT_LINK_URL_KEY,
   GLOBAL_ANNOUNCEMENT_MESSAGE_KEY,
@@ -195,6 +196,7 @@ export async function updateGeneralSettingsAction(
   const globalAnnouncementMessageRaw = formData.get('global_announcement_message')
   const globalAnnouncementLinkUrlRaw = formData.get('global_announcement_link_url')
   const globalAnnouncementDisabledOnJsonRaw = formData.get('global_announcement_disabled_on_json')
+  const globalAnnouncementDisableFaucetBannerRaw = formData.get('global_announcement_disable_faucet_banner')
   const customJavascriptCodesJsonRaw = formData.get('custom_javascript_codes_json')
   const tosPdfPathRaw = formData.get('tos_pdf_path')
   const tosPdfFileRaw = formData.get('tos_pdf')
@@ -225,6 +227,9 @@ export async function updateGeneralSettingsAction(
   const globalAnnouncementDisabledOnJson = typeof globalAnnouncementDisabledOnJsonRaw === 'string'
     ? globalAnnouncementDisabledOnJsonRaw
     : ''
+  const globalAnnouncementDisableFaucetBanner = typeof globalAnnouncementDisableFaucetBannerRaw === 'string'
+    ? globalAnnouncementDisableFaucetBannerRaw
+    : ''
   const customJavascriptCodesJson = typeof customJavascriptCodesJsonRaw === 'string' ? customJavascriptCodesJsonRaw : ''
   let tosPdfPath = typeof tosPdfPathRaw === 'string' ? tosPdfPathRaw : ''
   const lifiIntegrator = typeof lifiIntegratorRaw === 'string' ? lifiIntegratorRaw : ''
@@ -245,6 +250,7 @@ export async function updateGeneralSettingsAction(
     message: globalAnnouncementMessage,
     linkUrl: globalAnnouncementLinkUrl,
     disabledOnJson: globalAnnouncementDisabledOnJson,
+    disableFaucetBanner: globalAnnouncementDisableFaucetBanner,
   })
   if (!validatedGlobalAnnouncement.data) {
     return { error: validatedGlobalAnnouncement.error ?? 'Invalid global announcement input.' }
@@ -373,6 +379,7 @@ export async function updateGeneralSettingsAction(
     { group: 'general', key: GLOBAL_ANNOUNCEMENT_MESSAGE_KEY, value: validatedGlobalAnnouncement.data.messageValue },
     { group: 'general', key: GLOBAL_ANNOUNCEMENT_LINK_URL_KEY, value: validatedGlobalAnnouncement.data.linkUrlValue },
     { group: 'general', key: GLOBAL_ANNOUNCEMENT_DISABLED_ON_KEY, value: validatedGlobalAnnouncement.data.disabledOnValue },
+    { group: 'general', key: GLOBAL_ANNOUNCEMENT_DISABLE_FAUCET_BANNER_KEY, value: validatedGlobalAnnouncement.data.disableFaucetBannerValue },
     { group: 'general', key: 'site_custom_javascript_codes', value: validated.data.customJavascriptCodesValue },
     { group: 'general', key: TERMS_OF_SERVICE_PDF_PATH_KEY, value: tosPdfPath },
     { group: 'general', key: 'lifi_integrator', value: validated.data.lifiIntegratorValue },

--- a/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
+++ b/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
@@ -49,6 +49,7 @@ interface InitialGlobalAnnouncementSettings {
   message: string
   linkUrl: string
   disabledOn: CustomJavascriptCodeDisablePage[]
+  disableFaucetBanner: boolean
 }
 
 interface AdminGeneralSettingsFormProps {
@@ -106,6 +107,7 @@ function AdminGeneralSettingsFormInner({
   const initialGlobalAnnouncementMessage = initialGlobalAnnouncement.message
   const initialGlobalAnnouncementLinkUrl = initialGlobalAnnouncement.linkUrl
   const initialGlobalAnnouncementDisabledOn = initialGlobalAnnouncement.disabledOn
+  const initialGlobalAnnouncementDisableFaucetBanner = initialGlobalAnnouncement.disableFaucetBanner
   const initialCustomJavascriptCodes = initialThemeSiteSettings.customJavascriptCodes
   const initialLiFiIntegrator = initialThemeSiteSettings.lifiIntegrator
   const initialLiFiApiKey = initialThemeSiteSettings.lifiApiKey
@@ -140,6 +142,9 @@ function AdminGeneralSettingsFormInner({
   const [globalAnnouncementLinkUrl, setGlobalAnnouncementLinkUrl] = useState(initialGlobalAnnouncementLinkUrl)
   const [globalAnnouncementDisabledOn, setGlobalAnnouncementDisabledOn] = useState<CustomJavascriptCodeDisablePage[]>(
     initialGlobalAnnouncementDisabledOn,
+  )
+  const [globalAnnouncementDisableFaucetBanner, setGlobalAnnouncementDisableFaucetBanner] = useState(
+    initialGlobalAnnouncementDisableFaucetBanner,
   )
   const [customJavascriptCodes, setCustomJavascriptCodes] = useState<CustomJavascriptCodeDraft[]>(
     () => initialCustomJavascriptCodes.map(code => createCustomJavascriptCodeDraft(nextCustomJavascriptCodeIdRef.current++, code)),
@@ -378,6 +383,11 @@ function AdminGeneralSettingsFormInner({
       <input type="hidden" name="tos_pdf_path" value={tosPdfPath} />
       <input type="hidden" name="custom_javascript_codes_json" value={serializedCustomJavascriptCodes} />
       <input type="hidden" name="global_announcement_disabled_on_json" value={serializedGlobalAnnouncementDisabledOn} />
+      <input
+        type="hidden"
+        name="global_announcement_disable_faucet_banner"
+        value={String(globalAnnouncementDisableFaucetBanner)}
+      />
       <input type="hidden" name="blocked_countries" value={blockedCountriesValue} />
 
       <div className="grid gap-6">
@@ -443,6 +453,8 @@ function AdminGeneralSettingsFormInner({
           onGlobalAnnouncementLinkUrlChange={setGlobalAnnouncementLinkUrl}
           globalAnnouncementDisabledOn={globalAnnouncementDisabledOn}
           onToggleGlobalAnnouncementDisableOn={handleToggleGlobalAnnouncementDisableOn}
+          globalAnnouncementDisableFaucetBanner={globalAnnouncementDisableFaucetBanner}
+          onGlobalAnnouncementDisableFaucetBannerChange={setGlobalAnnouncementDisableFaucetBanner}
           customJavascriptCodeDisablePageOptions={customJavascriptCodeDisablePageOptions}
         />
 

--- a/src/app/[locale]/admin/(general)/_components/GlobalAnnouncementSection.tsx
+++ b/src/app/[locale]/admin/(general)/_components/GlobalAnnouncementSection.tsx
@@ -91,23 +91,6 @@ function GlobalAnnouncementSection({
           />
         </div>
 
-        <div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 px-3 py-2.5">
-          <div className="grid gap-1">
-            <Label htmlFor="global-announcement-disable-faucet-banner">
-              {t('Disable Faucet Banner')}
-            </Label>
-            <p className="text-xs text-muted-foreground">
-              {t('Hide the test-mode faucet banner for everyone.')}
-            </p>
-          </div>
-          <Switch
-            id="global-announcement-disable-faucet-banner"
-            checked={globalAnnouncementDisableFaucetBanner}
-            disabled={isPending}
-            onCheckedChange={onGlobalAnnouncementDisableFaucetBannerChange}
-          />
-        </div>
-
         <div className="grid gap-2">
           <Label>{t('Disable on')}</Label>
           <div className="flex flex-wrap gap-3">
@@ -137,6 +120,23 @@ function GlobalAnnouncementSection({
               )
             })}
           </div>
+        </div>
+
+        <div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 px-3 py-2.5">
+          <div className="grid gap-1">
+            <Label htmlFor="global-announcement-disable-faucet-banner">
+              {t('Disable Faucet Banner')}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t('Hide the test-mode faucet banner for everyone.')}
+            </p>
+          </div>
+          <Switch
+            id="global-announcement-disable-faucet-banner"
+            checked={globalAnnouncementDisableFaucetBanner}
+            disabled={isPending}
+            onCheckedChange={onGlobalAnnouncementDisableFaucetBannerChange}
+          />
         </div>
       </div>
     </SettingsAccordionSection>

--- a/src/app/[locale]/admin/(general)/_components/GlobalAnnouncementSection.tsx
+++ b/src/app/[locale]/admin/(general)/_components/GlobalAnnouncementSection.tsx
@@ -6,6 +6,7 @@ import { useExtracted } from 'next-intl'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
+import { Switch } from '@/components/ui/switch'
 import { cn } from '@/lib/utils'
 import SettingsAccordionSection from './SettingsAccordionSection'
 
@@ -27,6 +28,8 @@ interface GlobalAnnouncementSectionProps {
   onGlobalAnnouncementLinkUrlChange: (value: string) => void
   globalAnnouncementDisabledOn: CustomJavascriptCodeDisablePage[]
   onToggleGlobalAnnouncementDisableOn: (value: CustomJavascriptCodeDisablePage, checked: boolean) => void
+  globalAnnouncementDisableFaucetBanner: boolean
+  onGlobalAnnouncementDisableFaucetBannerChange: (value: boolean) => void
   customJavascriptCodeDisablePageOptions: DisablePageOption[]
 }
 
@@ -40,6 +43,8 @@ function GlobalAnnouncementSection({
   onGlobalAnnouncementLinkUrlChange,
   globalAnnouncementDisabledOn,
   onToggleGlobalAnnouncementDisableOn,
+  globalAnnouncementDisableFaucetBanner,
+  onGlobalAnnouncementDisableFaucetBannerChange,
   customJavascriptCodeDisablePageOptions,
 }: GlobalAnnouncementSectionProps) {
   const t = useExtracted()
@@ -83,6 +88,23 @@ function GlobalAnnouncementSection({
             onChange={event => onGlobalAnnouncementLinkUrlChange(event.target.value)}
             disabled={isPending}
             placeholder={t('https://example.com/campaign')}
+          />
+        </div>
+
+        <div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 px-3 py-2.5">
+          <div className="grid gap-1">
+            <Label htmlFor="global-announcement-disable-faucet-banner">
+              {t('Disable Faucet Banner')}
+            </Label>
+            <p className="text-xs text-muted-foreground">
+              {t('Hide the test-mode faucet banner for everyone.')}
+            </p>
+          </div>
+          <Switch
+            id="global-announcement-disable-faucet-banner"
+            checked={globalAnnouncementDisableFaucetBanner}
+            disabled={isPending}
+            onCheckedChange={onGlobalAnnouncementDisableFaucetBannerChange}
           />
         </div>
 

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -179,7 +179,7 @@ function LocaleBody({
                     />
                   )
                 : null}
-              {IS_TEST_MODE && <TestModeBannerDeferred />}
+              {IS_TEST_MODE && !globalAnnouncement.disableFaucetBanner && <TestModeBannerDeferred />}
               <PwaInstallStateSync />
               {children}
               <CustomJavascriptCode locale={locale} codes={runtimeTheme.site.customJavascriptCodes} />

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -779,6 +779,8 @@
   "Z4t5DJ": "Wird im Header der Website angezeigt. Leer lassen, um es auszublenden.",
   "mw3aUU": "URL (optional)",
   "Nk1Epq": "https://example.com/campaign",
+  "0CFUYr": "Faucet-Banner deaktivieren",
+  "NkKelp": "Blendet das Testmodus-Faucet-Banner für alle aus.",
   "BB45HI": "Deaktivieren auf",
   "6cBDhe": "Integrationen",
   "ZwFww6": "Google Analytics-ID",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -779,6 +779,8 @@
   "Z4t5DJ": "Displayed in the website header. Leave empty to hide.",
   "mw3aUU": "URL (optional)",
   "Nk1Epq": "https://example.com/campaign",
+  "0CFUYr": "Disable Faucet Banner",
+  "NkKelp": "Hide the test-mode faucet banner for everyone.",
   "BB45HI": "Disable on",
   "6cBDhe": "Integrations",
   "ZwFww6": "Google Analytics ID",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -779,6 +779,8 @@
   "Z4t5DJ": "Se muestra en el encabezado del sitio web. Déjalo vacío para ocultarlo.",
   "mw3aUU": "URL (opcional)",
   "Nk1Epq": "https://example.com/campaign",
+  "0CFUYr": "Desactivar banner del faucet",
+  "NkKelp": "Oculta el banner del faucet del modo de prueba para todos.",
   "BB45HI": "Desactivar en",
   "6cBDhe": "Integraciones",
   "ZwFww6": "ID de Google Analytics",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -779,6 +779,8 @@
   "Z4t5DJ": "Affiché dans l'en-tête du site web. Laissez vide pour le masquer.",
   "mw3aUU": "URL (optionnel)",
   "Nk1Epq": "https://example.com/campaign",
+  "0CFUYr": "Désactiver la bannière du faucet",
+  "NkKelp": "Masque la bannière du faucet du mode test pour tout le monde.",
   "BB45HI": "Désactiver sur",
   "6cBDhe": "Intégrations",
   "ZwFww6": "ID Google Analytics",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -779,6 +779,8 @@
   "Z4t5DJ": "Exibido no cabeçalho do site. Deixe em branco para ocultar.",
   "mw3aUU": "URL (opcional)",
   "Nk1Epq": "https://example.com/campaign",
+  "0CFUYr": "Desativar banner do Faucet",
+  "NkKelp": "Oculta o banner de faucet do modo de teste para todos.",
   "BB45HI": "Desativar em",
   "6cBDhe": "Integrações",
   "ZwFww6": "ID do Google Analytics",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -779,6 +779,8 @@
   "Z4t5DJ": "显示在网站页眉中。留空可隐藏。",
   "mw3aUU": "URL（可选）",
   "Nk1Epq": "https://example.com/campaign",
+  "0CFUYr": "停用 Faucet 横幅",
+  "NkKelp": "为所有人隐藏测试模式 Faucet 横幅。",
   "BB45HI": "禁用于",
   "6cBDhe": "集成",
   "ZwFww6": "Google Analytics 标识",

--- a/src/lib/global-announcement-settings.ts
+++ b/src/lib/global-announcement-settings.ts
@@ -9,6 +9,7 @@ const GENERAL_SETTINGS_GROUP = 'general'
 export const GLOBAL_ANNOUNCEMENT_MESSAGE_KEY = 'global_announcement_message'
 export const GLOBAL_ANNOUNCEMENT_LINK_URL_KEY = 'global_announcement_link_url'
 export const GLOBAL_ANNOUNCEMENT_DISABLED_ON_KEY = 'global_announcement_disabled_on'
+export const GLOBAL_ANNOUNCEMENT_DISABLE_FAUCET_BANNER_KEY = 'global_announcement_disable_faucet_banner'
 export const MAX_GLOBAL_ANNOUNCEMENT_MESSAGE_LENGTH = 220
 const MAX_GLOBAL_ANNOUNCEMENT_LINK_URL_LENGTH = 2048
 export const DEFAULT_GLOBAL_ANNOUNCEMENT_DISABLED_ON: CustomJavascriptCodeDisablePage[] = []
@@ -24,6 +25,7 @@ export interface GlobalAnnouncementSettings {
   message: string
   linkUrl: string
   disabledOn: CustomJavascriptCodeDisablePage[]
+  disableFaucetBanner: boolean
 }
 
 interface GlobalAnnouncementValidationResult {
@@ -32,12 +34,18 @@ interface GlobalAnnouncementValidationResult {
     linkUrlValue: string
     disabledOnValue: string
     disabledOn: CustomJavascriptCodeDisablePage[]
+    disableFaucetBannerValue: string
+    disableFaucetBanner: boolean
   } | null
   error: string | null
 }
 
 function normalizeStringValue(value: string | null | undefined) {
   return typeof value === 'string' ? value.trim() : ''
+}
+
+function parseBooleanSetting(value: string | null | undefined) {
+  return normalizeStringValue(value) === 'true'
 }
 
 function isValidHttpUrl(value: string) {
@@ -118,11 +126,15 @@ export function getGlobalAnnouncementSettingsFromSettings(settings?: SettingsMap
   const disabledOnParsed = parseGlobalAnnouncementDisabledOn(
     settings?.[GENERAL_SETTINGS_GROUP]?.[GLOBAL_ANNOUNCEMENT_DISABLED_ON_KEY]?.value,
   )
+  const disableFaucetBanner = parseBooleanSetting(
+    settings?.[GENERAL_SETTINGS_GROUP]?.[GLOBAL_ANNOUNCEMENT_DISABLE_FAUCET_BANNER_KEY]?.value,
+  )
 
   return {
     message,
     linkUrl,
     disabledOn: disabledOnParsed.value,
+    disableFaucetBanner,
   }
 }
 
@@ -135,10 +147,12 @@ export function validateGlobalAnnouncementInput(params: {
   message: string | null | undefined
   linkUrl: string | null | undefined
   disabledOnJson: string | null | undefined
+  disableFaucetBanner: string | null | undefined
 }): GlobalAnnouncementValidationResult {
   const messageValue = normalizeStringValue(params.message)
   const linkUrlValue = normalizeStringValue(params.linkUrl)
   const disabledOnParsed = parseGlobalAnnouncementDisabledOn(params.disabledOnJson)
+  const disableFaucetBanner = parseBooleanSetting(params.disableFaucetBanner)
 
   if (messageValue.length > MAX_GLOBAL_ANNOUNCEMENT_MESSAGE_LENGTH) {
     return {
@@ -168,6 +182,8 @@ export function validateGlobalAnnouncementInput(params: {
       linkUrlValue,
       disabledOn: disabledOnParsed.value,
       disabledOnValue: JSON.stringify(disabledOnParsed.value),
+      disableFaucetBanner,
+      disableFaucetBannerValue: String(disableFaucetBanner),
     },
     error: null,
   }

--- a/tests/unit/AdminGeneralSettingsForm.test.tsx
+++ b/tests/unit/AdminGeneralSettingsForm.test.tsx
@@ -92,6 +92,7 @@ describe('adminGeneralSettingsForm', () => {
           message: '',
           linkUrl: '',
           disabledOn: [],
+          disableFaucetBanner: false,
         }}
         initialBlockedCountries={[]}
         initialTermsOfServicePdfPath="legal/current-terms.pdf"
@@ -149,6 +150,7 @@ describe('adminGeneralSettingsForm', () => {
           message: '',
           linkUrl: '',
           disabledOn: [],
+          disableFaucetBanner: false,
         }}
         initialBlockedCountries={[]}
         initialTermsOfServicePdfPath=""

--- a/tests/unit/globalAnnouncementSettings.test.ts
+++ b/tests/unit/globalAnnouncementSettings.test.ts
@@ -12,6 +12,7 @@ describe('global announcement settings helpers', () => {
       message: '',
       linkUrl: '',
       disabledOn: DEFAULT_GLOBAL_ANNOUNCEMENT_DISABLED_ON,
+      disableFaucetBanner: false,
     })
   })
 
@@ -30,11 +31,16 @@ describe('global announcement settings helpers', () => {
           value: '["home","docs","home"]',
           updated_at: new Date().toISOString(),
         },
+        global_announcement_disable_faucet_banner: {
+          value: 'true',
+          updated_at: new Date().toISOString(),
+        },
       },
     })).toEqual({
       message: 'Promo this week',
       linkUrl: '/campaign',
       disabledOn: ['home', 'docs'],
+      disableFaucetBanner: true,
     })
   })
 
@@ -43,6 +49,7 @@ describe('global announcement settings helpers', () => {
       message: '',
       linkUrl: '',
       disabledOnJson: '',
+      disableFaucetBanner: '',
     })
 
     expect(result.error).toBeNull()
@@ -51,7 +58,22 @@ describe('global announcement settings helpers', () => {
       linkUrlValue: '',
       disabledOn: DEFAULT_GLOBAL_ANNOUNCEMENT_DISABLED_ON,
       disabledOnValue: JSON.stringify(DEFAULT_GLOBAL_ANNOUNCEMENT_DISABLED_ON),
+      disableFaucetBanner: false,
+      disableFaucetBannerValue: 'false',
     })
+  })
+
+  it('accepts the disable faucet banner flag', () => {
+    const result = validateGlobalAnnouncementInput({
+      message: '',
+      linkUrl: '',
+      disabledOnJson: '',
+      disableFaucetBanner: 'true',
+    })
+
+    expect(result.error).toBeNull()
+    expect(result.data?.disableFaucetBanner).toBe(true)
+    expect(result.data?.disableFaucetBannerValue).toBe('true')
   })
 
   it('accepts http(s) and internal links', () => {
@@ -59,18 +81,21 @@ describe('global announcement settings helpers', () => {
       message: 'A',
       linkUrl: 'https://example.com',
       disabledOnJson: '["admin"]',
+      disableFaucetBanner: '',
     }).error).toBeNull()
 
     expect(validateGlobalAnnouncementInput({
       message: 'A',
       linkUrl: '/markets/new',
       disabledOnJson: '["home","event"]',
+      disableFaucetBanner: '',
     }).error).toBeNull()
 
     const explicitEmptyDisabledPages = validateGlobalAnnouncementInput({
       message: 'A',
       linkUrl: '/markets/new',
       disabledOnJson: '[]',
+      disableFaucetBanner: '',
     })
     expect(explicitEmptyDisabledPages.error).toBeNull()
     expect(explicitEmptyDisabledPages.data?.disabledOn).toEqual([])
@@ -81,12 +106,14 @@ describe('global announcement settings helpers', () => {
       message: 'A',
       linkUrl: 'javascript:alert(1)',
       disabledOnJson: '["admin"]',
+      disableFaucetBanner: '',
     }).error).not.toBeNull()
 
     expect(validateGlobalAnnouncementInput({
       message: 'A',
       linkUrl: '//example.com',
       disabledOnJson: '["admin"]',
+      disableFaucetBanner: '',
     }).error).not.toBeNull()
   })
 
@@ -95,12 +122,14 @@ describe('global announcement settings helpers', () => {
       message: 'A',
       linkUrl: '',
       disabledOnJson: '{"home":true}',
+      disableFaucetBanner: '',
     }).error).not.toBeNull()
 
     expect(validateGlobalAnnouncementInput({
       message: 'A',
       linkUrl: '',
       disabledOnJson: '["unknown"]',
+      disableFaucetBanner: '',
     }).error).not.toBeNull()
   })
 
@@ -109,6 +138,7 @@ describe('global announcement settings helpers', () => {
       message: 'a'.repeat(MAX_GLOBAL_ANNOUNCEMENT_MESSAGE_LENGTH + 1),
       linkUrl: '',
       disabledOnJson: '["admin"]',
+      disableFaucetBanner: '',
     })
 
     expect(result.error).not.toBeNull()

--- a/tests/unit/updateGeneralSettingsAction.test.ts
+++ b/tests/unit/updateGeneralSettingsAction.test.ts
@@ -142,7 +142,7 @@ describe('updateGeneralSettingsAction', () => {
     expect(mocks.encryptSecret).toHaveBeenCalledWith('openrouter-123')
 
     const savedPayload = mocks.updateSettings.mock.calls[0][0] as Array<{ group: string, key: string, value: string }>
-    expect(savedPayload).toHaveLength(26)
+    expect(savedPayload).toHaveLength(27)
     expect(savedPayload.find(entry => entry.key === 'site_name')?.value).toBe('Kuest')
     expect(savedPayload.find(entry => entry.key === 'site_description')?.value).toBe('Prediction market')
     expect(savedPayload.find(entry => entry.key === 'site_logo_mode')?.value).toBe('svg')
@@ -162,6 +162,7 @@ describe('updateGeneralSettingsAction', () => {
     expect(savedPayload.find(entry => entry.key === 'global_announcement_message')?.value).toBe('')
     expect(savedPayload.find(entry => entry.key === 'global_announcement_link_url')?.value).toBe('')
     expect(savedPayload.find(entry => entry.key === 'global_announcement_disabled_on')?.value).toBe('[]')
+    expect(savedPayload.find(entry => entry.key === 'global_announcement_disable_faucet_banner')?.value).toBe('false')
     expect(savedPayload.find(entry => entry.key === 'site_custom_javascript_codes')?.value).toBe('')
     expect(savedPayload.some(entry => entry.key === 'fee_recipient_wallet')).toBe(false)
     expect(savedPayload.find(entry => entry.key === 'tos_pdf_path')?.value).toBe('')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds a global toggle to hide the faucet banner in test mode. This lets admins disable the banner for everyone across the site.

- **New Features**
  - Added “Disable Faucet Banner” switch in Admin → General → Global Announcement; persisted as `global_announcement_disable_faucet_banner`.
  - Layout now skips `TestModeBannerDeferred` when the flag is enabled.
  - Added validation/boolean parsing in `global-announcement-settings`, i18n strings, and updated unit tests.

<sup>Written for commit 51c77331706010d97dce4f9a7adb5e0eb7682e71. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1148?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

