### PR TITLE
fix: show dro propose with source

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
@@ -319,7 +319,7 @@ export default function EventRules({ event, mode = 'accordion', showEndDate = fa
   )
 
   const resolverDetails = (
-    <div className="flex items-start gap-3">
+    <div className="flex min-w-0 items-start gap-3">
       <div
         className={cn(`size-10 ${resolverBadgeClassName}
           flex shrink-0 items-center justify-center rounded-sm
@@ -353,27 +353,41 @@ export default function EventRules({ event, mode = 'accordion', showEndDate = fa
     </div>
   )
 
+  const resolverAction = (() => {
+    if (isDirectResolver && primaryMarket) {
+      return <DirectResolutionButton market={primaryMarket} event={event} />
+    }
+
+    if (hasResolutionSourceUrl) {
+      return null
+    }
+
+    if (proposeUrl) {
+      return (
+        <Button variant="outline" size="sm" asChild>
+          <a href={proposeUrl} target="_blank" rel="noopener noreferrer">
+            {t('Propose resolution')}
+          </a>
+        </Button>
+      )
+    }
+
+    return (
+      <Button variant="outline" size="sm" disabled>
+        {t('Propose resolution')}
+      </Button>
+    )
+  })()
+
   const resolverBlock = (
     <div className="rounded-lg border p-3">
-      <div className={cn(hasResolutionSourceUrl ? 'flex items-center' : 'flex items-center justify-between')}>
+      <div className={cn(
+        'flex items-center',
+        resolverAction && 'justify-between gap-3',
+      )}
+      >
         {resolverDetails}
-        {!hasResolutionSourceUrl && (
-          isDirectResolver && primaryMarket
-            ? <DirectResolutionButton market={primaryMarket} event={event} />
-            : proposeUrl
-              ? (
-                  <Button variant="outline" size="sm" asChild>
-                    <a href={proposeUrl} target="_blank" rel="noopener noreferrer">
-                      {t('Propose resolution')}
-                    </a>
-                  </Button>
-                )
-              : (
-                  <Button variant="outline" size="sm" disabled>
-                    {t('Propose resolution')}
-                  </Button>
-                )
-        )}
+        {resolverAction}
       </div>
     </div>
   )


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show the Direct Resolution action even when a resolution source link is present, so DROs can still propose/resolve. Also tidy up the layout to prevent text overflow and only space the row when an action is shown.

- **Bug Fixes**
  - Always render `DirectResolutionButton` for direct resolvers, even if `hasResolutionSourceUrl` is true.
  - Keep "Propose resolution" hidden when a source exists; otherwise show via `proposeUrl` or disabled state.
  - Add `min-w-0` to resolver details to prevent overflow; apply `justify-between` only when an action is present.

<sup>Written for commit da31898890ddf5639eb3e327082925a0c887fdf3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

