### PR TITLE
fix: reconnect orderbook websocket on tab restore

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
@@ -321,10 +321,19 @@ function useMarketChannelConnection({
       }
     }
 
+    function disconnectSocket(socket: WebSocket) {
+      socket.onopen = null
+      socket.onmessage = null
+      socket.onerror = null
+      socket.onclose = null
+      closeWebSocketWhenReady(socket)
+    }
+
     function connect() {
       if (!isActive || ws || document.hidden) {
         return
       }
+      setConnectionStatus('connecting')
       const socket = new WebSocket(`${wsUrl}/ws/market`)
       socket.onopen = handleOpen
       socket.onmessage = handleMessage
@@ -335,8 +344,10 @@ function useMarketChannelConnection({
 
     reconnectController = createWebSocketReconnectController({
       connect,
+      disconnectWebSocket: disconnectSocket,
       getWebSocket: () => ws,
       isActive: () => isActive,
+      reconnectOnVisible: true,
       resetWebSocket: () => {
         ws = null
       },
@@ -351,11 +362,7 @@ function useMarketChannelConnection({
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       const socket = ws
       if (socket) {
-        socket.onopen = null
-        socket.onmessage = null
-        socket.onerror = null
-        socket.onclose = null
-        closeWebSocketWhenReady(socket)
+        disconnectSocket(socket)
       }
     }
   }, [hasMarketChannel, queryClient, tokenIds, tokenIdToConditionId, wsUrl])

--- a/src/lib/websocket-reconnect.ts
+++ b/src/lib/websocket-reconnect.ts
@@ -3,23 +3,30 @@ const DEFAULT_RECONNECT_DELAY_MS = 1500
 interface CreateWebSocketReconnectControllerOptions {
   connect: () => void
   delayMs?: number
+  disconnectWebSocket?: (ws: WebSocket) => void
   getWebSocket: () => WebSocket | null
   isActive: () => boolean
+  reconnectOnVisible?: boolean
   resetWebSocket: () => void
 }
 
 export function createWebSocketReconnectController({
   connect,
   delayMs = DEFAULT_RECONNECT_DELAY_MS,
+  disconnectWebSocket,
   getWebSocket,
   isActive,
+  reconnectOnVisible = false,
   resetWebSocket,
 }: CreateWebSocketReconnectControllerOptions) {
   let reconnectTimeout: number | null = null
 
-  function shouldReconnect() {
-    const ws = getWebSocket()
+  function isClosedOrClosing(ws: WebSocket | null) {
     return !ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING
+  }
+
+  function shouldReconnect() {
+    return isClosedOrClosing(getWebSocket())
   }
 
   function clearReconnect() {
@@ -27,6 +34,20 @@ export function createWebSocketReconnectController({
       window.clearTimeout(reconnectTimeout)
       reconnectTimeout = null
     }
+  }
+
+  function disconnectCurrentWebSocket() {
+    const ws = getWebSocket()
+    if (!ws) {
+      return
+    }
+
+    resetWebSocket()
+    if (disconnectWebSocket) {
+      disconnectWebSocket(ws)
+      return
+    }
+    closeWebSocketWhenReady(ws)
   }
 
   function reconnectIfNeeded() {
@@ -47,6 +68,15 @@ export function createWebSocketReconnectController({
 
   function handleVisibilityChange() {
     if (!document.hidden) {
+      if (!isActive()) {
+        return
+      }
+      if (reconnectOnVisible) {
+        clearReconnect()
+        disconnectCurrentWebSocket()
+        connect()
+        return
+      }
       reconnectIfNeeded()
     }
   }

--- a/tests/unit/websocketReconnect.test.ts
+++ b/tests/unit/websocketReconnect.test.ts
@@ -1,4 +1,8 @@
-import { closeWebSocketWhenReady } from '@/lib/websocket-reconnect'
+import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
 
 function createWebSocketStub(readyState: number) {
   return {
@@ -41,5 +45,83 @@ describe('closeWebSocketWhenReady', () => {
     expect(closingSocket.close).not.toHaveBeenCalled()
     expect(closedSocket.close).not.toHaveBeenCalled()
     expect(closeOpenSocket).not.toHaveBeenCalled()
+  })
+})
+
+describe('createWebSocketReconnectController', () => {
+  function mockDocumentHidden(hidden: boolean) {
+    return vi.spyOn(document, 'hidden', 'get').mockReturnValue(hidden)
+  }
+
+  it('does not reconnect an open socket on tab visibility by default', () => {
+    const hiddenSpy = mockDocumentHidden(false)
+    let ws: WebSocket | null = createWebSocketStub(WebSocket.OPEN)
+    const connect = vi.fn()
+    const resetWebSocket = vi.fn(() => {
+      ws = null
+    })
+
+    const controller = createWebSocketReconnectController({
+      connect,
+      getWebSocket: () => ws,
+      isActive: () => true,
+      resetWebSocket,
+    })
+
+    controller.handleVisibilityChange()
+
+    expect(connect).not.toHaveBeenCalled()
+    expect(resetWebSocket).not.toHaveBeenCalled()
+    hiddenSpy.mockRestore()
+  })
+
+  it('forces a fresh socket when a configured stream becomes visible again', () => {
+    const hiddenSpy = mockDocumentHidden(false)
+    const staleSocket = createWebSocketStub(WebSocket.OPEN)
+    let ws: WebSocket | null = staleSocket
+    const connect = vi.fn()
+    const disconnectWebSocket = vi.fn()
+    const resetWebSocket = vi.fn(() => {
+      ws = null
+    })
+
+    const controller = createWebSocketReconnectController({
+      connect,
+      disconnectWebSocket,
+      getWebSocket: () => ws,
+      isActive: () => true,
+      reconnectOnVisible: true,
+      resetWebSocket,
+    })
+
+    controller.handleVisibilityChange()
+
+    expect(resetWebSocket).toHaveBeenCalledTimes(1)
+    expect(disconnectWebSocket).toHaveBeenCalledWith(staleSocket)
+    expect(connect).toHaveBeenCalledTimes(1)
+    hiddenSpy.mockRestore()
+  })
+
+  it('does not reconnect while the document is hidden', () => {
+    const hiddenSpy = mockDocumentHidden(true)
+    let ws: WebSocket | null = createWebSocketStub(WebSocket.CLOSED)
+    const connect = vi.fn()
+    const resetWebSocket = vi.fn(() => {
+      ws = null
+    })
+
+    const controller = createWebSocketReconnectController({
+      connect,
+      getWebSocket: () => ws,
+      isActive: () => true,
+      reconnectOnVisible: true,
+      resetWebSocket,
+    })
+
+    controller.handleVisibilityChange()
+
+    expect(connect).not.toHaveBeenCalled()
+    expect(resetWebSocket).not.toHaveBeenCalled()
+    hiddenSpy.mockRestore()
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Reconnects the orderbook WebSocket when the tab is restored or becomes visible, so live data resumes immediately and stale streams are dropped.

- **Bug Fixes**
  - Added `reconnectOnVisible` to the reconnect controller to force a fresh socket on visibility.
  - Cleanly disconnect the current socket via `disconnectWebSocket`, reset it, and set status to "connecting" before reconnecting.
  - Skip reconnection while the document is hidden; visibility alone does not reconnect unless enabled.
  - Added unit tests covering visibility behavior and clean disconnects.

<sup>Written for commit e73ebafc00ba999f874dccf601dc19f36a51cfd5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1155?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

