### PR TITLE
fix: subcategory filters

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventsGrid.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventsGrid.tsx
@@ -18,7 +18,7 @@ import { useCurrentTimestamp } from '@/hooks/useCurrentTimestamp'
 import { useDebounce } from '@/hooks/useDebounce'
 import { useHasHydrated } from '@/hooks/useHasHydrated'
 import { fetchEventsApi } from '@/lib/events-api'
-import { HOME_EVENTS_PAGE_SIZE, isEventResolvedLike } from '@/lib/home-events'
+import { filterHomeEvents, HOME_EVENTS_PAGE_SIZE, isEventResolvedLike } from '@/lib/home-events'
 import { getDefaultHomeRouteSortBy } from '@/lib/home-route-sort'
 import { resolveDisplayPrice } from '@/lib/market-chance'
 import { buildHomeSportsMoneylineModel } from '@/lib/sports-home-card'
@@ -127,7 +127,9 @@ async function fetchEvents({
 
 interface UseEventsListParams {
   bookmarkedOnly: boolean
+  currentTimestamp: number | null
   data: InfiniteData<Event[], unknown> | undefined
+  filters: FilterState
   snapshotKey: string
   status: string
   initialSnapshotEvents: Event[]
@@ -157,16 +159,118 @@ function filterBookmarkedOnlyEvents(events: Event[], bookmarkedOnly: boolean) {
   return bookmarkedOnly ? events.filter(event => event.is_bookmarked) : events
 }
 
+function normalizeFilterSlug(value: string | null | undefined) {
+  const normalized = value?.trim().toLowerCase()
+  return normalized || null
+}
+
+function eventMatchesSelectedTags(event: Event, tag: string, mainTag: string) {
+  const requiredSlugs = Array.from(new Set([tag, mainTag]
+    .map(normalizeFilterSlug)
+    .filter((slug): slug is string => Boolean(slug) && slug !== 'trending' && slug !== 'new')))
+
+  if (requiredSlugs.length === 0) {
+    return true
+  }
+
+  const eventTagSlugs = new Set((event.tags ?? [])
+    .map(eventTag => normalizeFilterSlug(eventTag?.slug))
+    .filter((slug): slug is string => Boolean(slug)))
+
+  return requiredSlugs.every(slug => eventTagSlugs.has(slug))
+}
+
+function hasKnownEventStatus(event: Event) {
+  return event.status === 'draft'
+    || event.status === 'active'
+    || event.status === 'resolved'
+    || event.status === 'archived'
+}
+
+function eventMatchesSelectedStatus(event: Event, status: FilterState['status']) {
+  if (!hasKnownEventStatus(event)) {
+    return true
+  }
+
+  if (status === 'resolved') {
+    return isEventResolvedLike(event)
+  }
+
+  return event.status === 'active' && !isEventResolvedLike(event)
+}
+
+function eventMatchesSelectedFrequency(event: Event, frequency: FilterState['frequency']) {
+  if (frequency === 'all') {
+    return true
+  }
+
+  const recurrence = event.series_recurrence?.trim().toLowerCase()
+  return recurrence ? recurrence === frequency : true
+}
+
+function eventMatchesSelectedSearch(event: Event, search: string) {
+  const searchTerms = search.trim().toLowerCase().split(/\s+/).filter(Boolean)
+  if (searchTerms.length === 0) {
+    return true
+  }
+
+  const title = event.title?.toLowerCase()
+  return title ? searchTerms.every(term => title.includes(term)) : true
+}
+
+function filterEventsForCurrentFilters(events: Event[], filters: FilterState, currentTimestamp: number | null) {
+  if (events.length === 0) {
+    return EMPTY_EVENTS
+  }
+
+  const matchingEvents = events.filter(event =>
+    eventMatchesSelectedTags(event, filters.tag, filters.mainTag)
+    && eventMatchesSelectedStatus(event, filters.status)
+    && eventMatchesSelectedFrequency(event, filters.frequency)
+    && eventMatchesSelectedSearch(event, filters.search),
+  )
+
+  if (matchingEvents.length === 0) {
+    return EMPTY_EVENTS
+  }
+
+  return filterHomeEvents(matchingEvents, {
+    currentTimestamp,
+    hideSports: filters.hideSports,
+    hideCrypto: filters.hideCrypto,
+    hideEarnings: filters.hideEarnings,
+    status: filters.status,
+  })
+}
+
 function useEventsList({
   bookmarkedOnly,
+  currentTimestamp,
   data,
+  filters,
   snapshotKey,
   status,
   initialSnapshotEvents,
 }: UseEventsListParams) {
   const allEvents = useMemo(
-    () => filterBookmarkedOnlyEvents(data ? data.pages.flat() : [], bookmarkedOnly),
-    [bookmarkedOnly, data],
+    () => {
+      const currentEvents = data ? data.pages.flat() : []
+      const matchingEvents = filterEventsForCurrentFilters(currentEvents, filters, currentTimestamp)
+      return filterBookmarkedOnlyEvents(matchingEvents, bookmarkedOnly)
+    },
+    [
+      bookmarkedOnly,
+      currentTimestamp,
+      data,
+      filters.frequency,
+      filters.hideSports,
+      filters.hideCrypto,
+      filters.hideEarnings,
+      filters.mainTag,
+      filters.search,
+      filters.status,
+      filters.tag,
+    ],
   )
   const visibleEvents = useMemo(
     () => (allEvents.length === 0 ? EMPTY_EVENTS : allEvents),
@@ -496,6 +600,7 @@ export default function EventsGrid({
     fetchNextPage,
     hasNextPage,
     isPending,
+    isPlaceholderData,
   } = useInfiniteQuery({
     queryKey: eventsQueryKey,
     queryFn: ({ pageParam }) => fetchEvents({
@@ -519,7 +624,9 @@ export default function EventsGrid({
 
   const { allEvents, visibleEvents, cachedSnapshotEvents } = useEventsList({
     bookmarkedOnly: filters.bookmarked,
+    currentTimestamp: resolvedCurrentTimestamp,
     data,
+    filters,
     snapshotKey,
     status,
     initialSnapshotEvents,
@@ -543,7 +650,10 @@ export default function EventsGrid({
   })
 
   const isLoadingNewData = eventsToRender.length === 0
-    && (isPending || (isFetching && !isFetchingNextPage && (!data || data.pages.length === 0)))
+    && (
+      isPending
+      || (isFetching && !isFetchingNextPage && (!data || data.pages.length === 0 || isPlaceholderData))
+    )
 
   const { loadMoreRef, infiniteScrollError } = useInfiniteScrollLoadMore({
     hasNextPage,

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -1,6 +1,5 @@
 import type { SQL } from 'drizzle-orm'
 import type { SupportedLocale } from '@/i18n/locales'
-import type { conditions } from '@/lib/db/schema/events/tables'
 import type { EventListSortBy, EventListStatusFilter } from '@/lib/event-list-filters'
 import type { SportsSlugResolver } from '@/lib/sports-slug-mapping'
 import type { SportsVertical } from '@/lib/sports-vertical'
@@ -13,6 +12,7 @@ import { OUTCOME_INDEX } from '@/lib/constants'
 import { getSportsSlugResolverFromDb } from '@/lib/db/queries/sports-menu'
 import { bookmarks } from '@/lib/db/schema/bookmarks/tables'
 import {
+  conditions,
   conditions_audit,
   event_live_chart_configs,
   event_sports,
@@ -1191,6 +1191,27 @@ function buildResolvedLikeCondition(input: {
   return sql<boolean>`${events.status} = 'resolved' OR (${input.hasAnyMarkets} AND NOT ${input.hasUnresolvedMarkets})`
 }
 
+function buildHasAnyMarketsCondition() {
+  return exists(
+    db.select({ condition_id: markets.condition_id })
+      .from(markets)
+      .where(eq(markets.event_id, events.id)),
+  )
+}
+
+function buildHasUnresolvedMarketsCondition() {
+  return exists(
+    db.select({ condition_id: markets.condition_id })
+      .from(markets)
+      .leftJoin(conditions, eq(conditions.id, markets.condition_id))
+      .where(and(
+        eq(markets.event_id, events.id),
+        eq(markets.is_resolved, false),
+        sql`COALESCE(${conditions.resolved}, false) = false`,
+      )),
+  )
+}
+
 function buildEventStatusFilterCondition(
   status: EventListStatusFilter,
   input: {
@@ -1287,19 +1308,8 @@ async function buildEventListQueryContext({
   const normalizedRequestedSportsSportSlug = sportsSportSlug.trim().toLowerCase()
   const whereConditions: SQL<unknown>[] = []
 
-  const hasAnyMarkets = exists(
-    db.select({ condition_id: markets.condition_id })
-      .from(markets)
-      .where(eq(markets.event_id, events.id)),
-  )
-  const hasUnresolvedMarkets = exists(
-    db.select({ condition_id: markets.condition_id })
-      .from(markets)
-      .where(and(
-        eq(markets.event_id, events.id),
-        eq(markets.is_resolved, false),
-      )),
-  )
+  const hasAnyMarkets = buildHasAnyMarketsCondition()
+  const hasUnresolvedMarkets = buildHasUnresolvedMarketsCondition()
   const statusFilterCondition = buildEventStatusFilterCondition(status, {
     hasAnyMarkets,
     hasUnresolvedMarkets,
@@ -1555,19 +1565,8 @@ export const EventRepository = {
       const whereConditions: SQL<unknown>[] = []
       const normalizedSearch = search.trim().toLowerCase()
       const isSearchOrderedQuery = normalizedSearch.length > 0 && !sortBy
-      const hasAnyMarkets = exists(
-        db.select({ condition_id: markets.condition_id })
-          .from(markets)
-          .where(eq(markets.event_id, events.id)),
-      )
-      const hasUnresolvedMarkets = exists(
-        db.select({ condition_id: markets.condition_id })
-          .from(markets)
-          .where(and(
-            eq(markets.event_id, events.id),
-            eq(markets.is_resolved, false),
-          )),
-      )
+      const hasAnyMarkets = buildHasAnyMarketsCondition()
+      const hasUnresolvedMarkets = buildHasUnresolvedMarketsCondition()
       const statusFilterCondition = buildEventStatusFilterCondition(status, {
         hasAnyMarkets,
         hasUnresolvedMarkets,

--- a/tests/unit/EventsGrid.test.tsx
+++ b/tests/unit/EventsGrid.test.tsx
@@ -81,6 +81,21 @@ vi.mock('@/stores/useUser', () => ({
 }))
 
 describe('eventsGrid', () => {
+  function createEvent(overrides: Record<string, any>) {
+    return {
+      id: 'event-1',
+      slug: 'event-1',
+      title: 'Event 1',
+      status: 'active',
+      created_at: '2026-03-16T12:00:00.000Z',
+      updated_at: '2026-03-16T12:00:00.000Z',
+      tags: [],
+      markets: [{ is_resolved: false, condition: { resolved: false } }],
+      is_bookmarked: false,
+      ...overrides,
+    } as any
+  }
+
   beforeEach(() => {
     mocks.eventsStaticGrid.mockClear()
     mocks.filterHomeEvents.mockClear()
@@ -215,6 +230,117 @@ describe('eventsGrid', () => {
     )
 
     expect(mocks.eventsStaticGrid.mock.calls.at(-1)?.[0].events).toEqual([bookmarkedEvent])
+  })
+
+  it('renders only resolved weather events for the resolved weather filter', () => {
+    const activeWeatherEvent = createEvent({
+      id: 'active-weather',
+      slug: 'active-weather',
+      title: 'Active weather',
+      status: 'active',
+      tags: [{ slug: 'weather' }],
+      markets: [{ is_resolved: false, condition: { resolved: false } }],
+    })
+    const resolvedWeatherEvent = createEvent({
+      id: 'resolved-weather',
+      slug: 'resolved-weather',
+      title: 'Resolved weather',
+      status: 'resolved',
+      tags: [{ slug: 'weather' }],
+      markets: [{ is_resolved: true, condition: { resolved: true } }],
+    })
+    const resolvedFinanceEvent = createEvent({
+      id: 'resolved-finance',
+      slug: 'resolved-finance',
+      title: 'Resolved finance',
+      status: 'resolved',
+      tags: [{ slug: 'finance' }],
+      markets: [{ is_resolved: true, condition: { resolved: true } }],
+    })
+
+    mocks.useInfiniteQuery.mockImplementation(() => ({
+      status: 'success',
+      data: { pages: [[activeWeatherEvent, resolvedWeatherEvent, resolvedFinanceEvent]] },
+      dataUpdatedAt: 1,
+      isFetching: false,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isPending: false,
+      isPlaceholderData: false,
+      refetch: mocks.refetch,
+    }))
+
+    render(
+      <EventsGrid
+        filters={{
+          tag: 'weather',
+          mainTag: 'weather',
+          search: '',
+          bookmarked: false,
+          frequency: 'all',
+          sortBy: 'volume_24h',
+          status: 'resolved',
+          hideSports: false,
+          hideCrypto: false,
+          hideEarnings: false,
+        }}
+        initialEvents={[]}
+        initialCurrentTimestamp={Date.parse('2026-03-16T12:00:00.000Z')}
+        routeMainTag="weather"
+        routeTag="weather"
+      />,
+    )
+
+    expect(mocks.eventsStaticGrid.mock.calls.at(-1)?.[0].events).toEqual([resolvedWeatherEvent])
+  })
+
+  it('does not render stale active weather placeholder data while resolved weather loads', () => {
+    const activeWeatherEvent = createEvent({
+      id: 'active-weather',
+      slug: 'active-weather',
+      title: 'Active weather',
+      status: 'active',
+      tags: [{ slug: 'weather' }],
+      markets: [{ is_resolved: false, condition: { resolved: false } }],
+    })
+
+    mocks.useInfiniteQuery.mockImplementation(() => ({
+      status: 'success',
+      data: { pages: [[activeWeatherEvent]] },
+      dataUpdatedAt: 0,
+      isFetching: true,
+      isFetchingNextPage: false,
+      fetchNextPage: vi.fn(),
+      hasNextPage: false,
+      isPending: false,
+      isPlaceholderData: true,
+      refetch: mocks.refetch,
+    }))
+
+    const view = render(
+      <EventsGrid
+        filters={{
+          tag: 'weather',
+          mainTag: 'weather',
+          search: '',
+          bookmarked: false,
+          frequency: 'all',
+          sortBy: 'volume_24h',
+          status: 'resolved',
+          hideSports: false,
+          hideCrypto: false,
+          hideEarnings: false,
+        }}
+        initialEvents={[]}
+        initialCurrentTimestamp={Date.parse('2026-03-16T12:00:00.000Z')}
+        routeMainTag="weather"
+        routeTag="weather"
+      />,
+    )
+
+    expect(view.getByTestId('events-grid-skeleton')).toBeTruthy()
+    expect(mocks.eventsStaticGrid).not.toHaveBeenCalled()
   })
 
   it('keeps server-rendered events visible while a logged-in query is still hydrating', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes subcategory filtering on the home Events grid so tag- and status-based views (e.g., resolved weather) show the correct events and don’t flash stale data.

- **Bug Fixes**
  - Client-side: filters now combine `mainTag` + `tag`, ignore `trending/new`, and respect status (using `isEventResolvedLike`), frequency, and search before bookmark filtering.
  - Applies `filterHomeEvents` with `hideSports`, `hideCrypto`, `hideEarnings`, and current timestamp for consistent results.
  - Loading state no longer renders stale placeholder data; uses `isPlaceholderData` to show the skeleton until real results load.
  - Server: unified status filtering by extracting `buildHasAnyMarketsCondition` and `buildHasUnresolvedMarketsCondition`, aligning query behavior with the client.
  - Tests: added cases for resolved subcategory filtering and placeholder-data handling.

<sup>Written for commit 19d2f886847aa0af2cecb91c8f7a5221d210129e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1156?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

