### PR TITLE
fix: esports upcoming count

### DIFF
--- a/src/lib/sports-menu-counts.ts
+++ b/src/lib/sports-menu-counts.ts
@@ -182,7 +182,7 @@ function incrementCountForGroup(params: {
 
 function addMenuCountKey(
   countKeysBySlug: Map<string, Set<string>>,
-  entry: Extract<SportsMenuEntry, { type: 'link' }>,
+  entry: Extract<SportsMenuEntry, { type: 'group' | 'link' }>,
 ) {
   const menuSlug = normalizeComparableValue(entry.menuSlug)
   if (!menuSlug) {
@@ -214,6 +214,8 @@ function collectMenuCountKeysBySlug(entries: SportsMenuEntry[]) {
     if (entry.type !== 'group') {
       continue
     }
+
+    addMenuCountKey(countKeysBySlug, entry)
 
     for (const link of entry.links) {
       addMenuCountKey(countKeysBySlug, link)

--- a/tests/unit/sportsMenuCounts.test.ts
+++ b/tests/unit/sportsMenuCounts.test.ts
@@ -123,6 +123,70 @@ describe('buildSportsMenuCountsBySlug', () => {
     })
   })
 
+  it('counts future esports rows when group child links do not expose menu slugs', () => {
+    const resolver = buildSportsSlugResolver([
+      {
+        menuSlug: 'league-of-legends',
+        h1Title: 'League of Legends',
+        aliases: ['lol'],
+        sections: {
+          gamesEnabled: true,
+          propsEnabled: true,
+        },
+      },
+    ])
+
+    const menuEntries: SportsMenuEntry[] = [
+      buildLinkEntry({ id: 'upcoming', label: 'Upcoming', href: '/esports/soon' }),
+      {
+        type: 'group',
+        id: 'lol',
+        label: 'LoL',
+        href: '/esports/league-of-legends/games',
+        iconPath: '/icons/lol.svg',
+        menuSlug: 'league-of-legends',
+        links: [
+          {
+            type: 'link',
+            id: 'lol-games',
+            label: 'Games',
+            href: '/esports/league-of-legends/games',
+            iconPath: '/icons/lol.svg',
+            menuSlug: null,
+          },
+        ],
+      },
+    ]
+
+    const counts = buildSportsMenuCountsBySlug(
+      resolver,
+      [
+        {
+          slug: null,
+          series_slug: 'lol',
+          event_slug: 'league-of-legends-match-1',
+          sports_event_id: 'league-of-legends-match-1',
+          sports_event_slug: 'league-of-legends-match-1',
+          parent_event_id: null,
+          tags: ['Games'],
+          is_hidden: false,
+          sports_live: false,
+          sports_ended: false,
+          sports_start_time: new Date('2026-04-02T15:00:00.000Z'),
+          start_date: new Date('2026-04-02T15:00:00.000Z'),
+          end_date: new Date('2026-04-02T17:00:00.000Z'),
+        },
+      ],
+      menuEntries,
+      new Date('2026-04-02T12:00:00.000Z').getTime(),
+    )
+
+    expect(counts).toMatchObject({
+      'league-of-legends::games': 1,
+      [SPORTS_SIDEBAR_FUTURE_COUNT_KEY]: 1,
+    })
+  })
+
   it('ignores slugs that are not present in the current vertical menu', () => {
     const resolver = buildSportsSlugResolver([
       {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing esports “Upcoming” counts by using the group’s `menuSlug` when child links don’t expose one. Future events now show up in the sidebar and per-sport counts.

- **Bug Fixes**
  - Include `group` entries when collecting menu count keys (`addMenuCountKey` now accepts `group | link`, and groups are registered in `collectMenuCountKeysBySlug`).
  - Added a unit test to confirm future esports rows are counted when group child links have `menuSlug: null`.

<sup>Written for commit 14430bfd3a218a09a7353ac9a89bdc2d4460bad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1158?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

