### PR TITLE
fix: refresh creator site wallets during market sync

### DIFF
--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -1,7 +1,10 @@
 import { and, eq, inArray, lt, ne, or } from 'drizzle-orm'
 import { revalidateTag } from 'next/cache'
 import { NextResponse } from 'next/server'
-import { loadAllowedMarketCreatorWallets } from '@/lib/allowed-market-creators-server'
+import {
+  loadAllowedMarketCreatorWallets,
+  refreshAllowedMarketCreatorSiteSources,
+} from '@/lib/allowed-market-creators-server'
 import { isCronAuthorized } from '@/lib/auth-cron'
 import { cacheTags } from '@/lib/cache-tags'
 import {
@@ -222,6 +225,27 @@ async function getAllowedCreators(): Promise<string[]> {
 
   return data
 }
+
+function shouldForceCreatorSourceRefresh(request: Request) {
+  const searchParams = new URL(request.url).searchParams
+  const rawValue = searchParams.get('refreshCreatorSources')
+  return rawValue === '1' || rawValue === 'true'
+}
+
+async function refreshCreatorSourcesBeforeSync(force: boolean) {
+  try {
+    const result = await refreshAllowedMarketCreatorSiteSources({ force })
+    if (result.checked > 0 || result.errors.length > 0) {
+      console.log('🔄 Allowed market creator source refresh:', result)
+    }
+    return result
+  }
+  catch (error) {
+    console.error('Failed to refresh allowed market creator sources:', error)
+    return null
+  }
+}
+
 /**
  * 🔄 Market Synchronization Script for Vercel Functions
  *
@@ -249,6 +273,9 @@ export async function GET(request: Request) {
 
     console.log('🚀 Starting incremental market synchronization...')
 
+    const forceCreatorSourceRefresh = shouldForceCreatorSourceRefresh(request)
+    const creatorSourceRefreshPromise = refreshCreatorSourcesBeforeSync(forceCreatorSourceRefresh)
+    const autoDeployNewEventsPromise = loadAutoDeployNewEventsEnabled()
     const lastCursor = await getLastPnLCursor()
     if (lastCursor) {
       console.log(
@@ -259,9 +286,10 @@ export async function GET(request: Request) {
       console.log('📊 Last PnL cursor: none (full scan from subgraph start)')
     }
 
+    await creatorSourceRefreshPromise
     const [allowedCreators, autoDeployNewEvents] = await Promise.all([
       getAllowedCreators(),
-      loadAutoDeployNewEventsEnabled(),
+      autoDeployNewEventsPromise,
     ])
     const syncResult = await syncMarkets(new Set(allowedCreators), { autoDeployNewEvents })
 

--- a/src/lib/allowed-market-creators-server.ts
+++ b/src/lib/allowed-market-creators-server.ts
@@ -1,7 +1,31 @@
+import {
+  isPublicAllowedMarketCreatorsResponse,
+  normalizeAllowedMarketCreatorSiteInput,
+} from '@/lib/allowed-market-creators'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { AllowedMarketCreatorRepository } from '@/lib/db/queries/allowed-market-creators'
 
 const WALLET_ADDRESS_PATTERN = /^0x[0-9a-fA-F]{40}$/
+const SITE_SOURCE_REFRESH_INTERVAL_MS = 24 * 60 * 60 * 1000
+
+interface RefreshAllowedMarketCreatorSiteSourcesOptions {
+  force?: boolean
+  now?: Date
+}
+
+interface RefreshAllowedMarketCreatorSiteSourcesError {
+  sourceUrl: string
+  message: string
+}
+
+export interface RefreshAllowedMarketCreatorSiteSourcesResult {
+  scanned: number
+  checked: number
+  refreshed: number
+  skippedFresh: number
+  wallets: number
+  errors: RefreshAllowedMarketCreatorSiteSourcesError[]
+}
 
 export function normalizeAllowedMarketCreatorWallets(wallets: Iterable<string>) {
   const deduped = new Set<string>()
@@ -13,6 +37,113 @@ export function normalizeAllowedMarketCreatorWallets(wallets: Iterable<string>) 
   }
 
   return [...deduped].sort()
+}
+
+function shouldRefreshSiteSource(refreshedAt: Date | null, now: Date) {
+  if (!refreshedAt) {
+    return true
+  }
+
+  return now.getTime() - refreshedAt.getTime() >= SITE_SOURCE_REFRESH_INTERVAL_MS
+}
+
+function errorMessageFromUnknown(error: unknown) {
+  return error instanceof Error ? error.message : DEFAULT_ERROR_MESSAGE
+}
+
+async function fetchCreatorWalletsFromSite(sourceUrl: string) {
+  const normalizedSite = normalizeAllowedMarketCreatorSiteInput(sourceUrl)
+  if ('error' in normalizedSite) {
+    throw new Error(normalizedSite.error)
+  }
+
+  if (!normalizedSite.origin.startsWith('https://')) {
+    throw new Error('Site URL must use https.')
+  }
+
+  const response = await fetch(normalizedSite.endpointUrl, {
+    method: 'GET',
+    cache: 'no-store',
+    redirect: 'error',
+    headers: {
+      Accept: 'application/json',
+    },
+    signal: AbortSignal.timeout(12_000),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Site endpoint failed (${response.status}).`)
+  }
+
+  const payload = await response.json().catch(() => null)
+  if (!isPublicAllowedMarketCreatorsResponse(payload)) {
+    throw new Error('Site endpoint returned an invalid payload.')
+  }
+
+  const wallets = normalizeAllowedMarketCreatorWallets(payload.wallets)
+  if (wallets.length === 0) {
+    throw new Error('Site endpoint did not return any valid wallets.')
+  }
+
+  return {
+    displayName: normalizedSite.displayName,
+    sourceUrl: normalizedSite.origin,
+    wallets,
+  }
+}
+
+export async function refreshAllowedMarketCreatorSiteSources(
+  options: RefreshAllowedMarketCreatorSiteSourcesOptions = {},
+): Promise<RefreshAllowedMarketCreatorSiteSourcesResult> {
+  const now = options.now ?? new Date()
+  const result: RefreshAllowedMarketCreatorSiteSourcesResult = {
+    scanned: 0,
+    checked: 0,
+    refreshed: 0,
+    skippedFresh: 0,
+    wallets: 0,
+    errors: [],
+  }
+
+  const sourcesResult = await AllowedMarketCreatorRepository.listSiteSources()
+  if (sourcesResult.error || !sourcesResult.data) {
+    throw new Error(sourcesResult.error ?? 'Could not load allowed creator site sources.')
+  }
+
+  result.scanned = sourcesResult.data.length
+
+  for (const source of sourcesResult.data) {
+    if (!options.force && !shouldRefreshSiteSource(source.refreshedAt, now)) {
+      result.skippedFresh += 1
+      continue
+    }
+
+    result.checked += 1
+
+    try {
+      const remoteSource = await fetchCreatorWalletsFromSite(source.sourceUrl)
+      const replaceResult = await AllowedMarketCreatorRepository.replaceSiteSource({
+        sourceUrl: remoteSource.sourceUrl,
+        displayName: remoteSource.displayName,
+        walletAddresses: remoteSource.wallets,
+      })
+
+      if (replaceResult.error) {
+        throw new Error(replaceResult.error)
+      }
+
+      result.refreshed += 1
+      result.wallets += remoteSource.wallets.length
+    }
+    catch (error) {
+      result.errors.push({
+        sourceUrl: source.sourceUrl,
+        message: errorMessageFromUnknown(error),
+      })
+    }
+  }
+
+  return result
 }
 
 export async function loadAllowedMarketCreatorWallets() {

--- a/src/lib/db/migrations/2026_03_15_001_allowed_market_creators.sql
+++ b/src/lib/db/migrations/2026_03_15_001_allowed_market_creators.sql
@@ -49,7 +49,7 @@ INSERT INTO allowed_market_creators (
   source_type
 )
 VALUES (
-  '0x1fd81e09da67d84f02db0c0ebabd5a217d1b928d',
+  '0x183d590c4d7f74b11f265ff131bfe3259a25969b',
   'demo.kuest.com',
   'https://demo.kuest.com',
   'site'

--- a/src/lib/db/queries/allowed-market-creators.ts
+++ b/src/lib/db/queries/allowed-market-creators.ts
@@ -13,6 +13,12 @@ interface UpsertAllowedMarketCreatorInput {
   sourceType: AllowedMarketCreatorSourceType
 }
 
+export interface AllowedMarketCreatorSiteSourceRecord {
+  sourceUrl: string
+  displayName: string
+  refreshedAt: Date | null
+}
+
 function normalizeWalletAddress(walletAddress: string) {
   return getAddress(walletAddress).toLowerCase()
 }
@@ -53,6 +59,36 @@ export const AllowedMarketCreatorRepository = {
 
       return {
         data: rows.map(row => row.walletAddress),
+        error: null,
+      }
+    })
+  },
+
+  async listSiteSources(): Promise<QueryResult<AllowedMarketCreatorSiteSourceRecord[]>> {
+    return runQuery(async () => {
+      const rows = await db
+        .select({
+          sourceUrl: allowed_market_creators.source_url,
+          displayName: allowed_market_creators.display_name,
+          refreshedAt: sql<Date | null>`MAX(${allowed_market_creators.updated_at})`,
+        })
+        .from(allowed_market_creators)
+        .where(and(
+          eq(allowed_market_creators.source_type, 'site'),
+          sql`${allowed_market_creators.source_url} IS NOT NULL`,
+        ))
+        .groupBy(
+          allowed_market_creators.source_url,
+          allowed_market_creators.display_name,
+        )
+        .orderBy(
+          asc(allowed_market_creators.source_url),
+          asc(allowed_market_creators.display_name),
+        )
+
+      return {
+        data: rows
+          .filter((row): row is AllowedMarketCreatorSiteSourceRecord => Boolean(row.sourceUrl)),
         error: null,
       }
     })

--- a/src/lib/db/queries/allowed-market-creators.ts
+++ b/src/lib/db/queries/allowed-market-creators.ts
@@ -69,7 +69,7 @@ export const AllowedMarketCreatorRepository = {
       const rows = await db
         .select({
           sourceUrl: allowed_market_creators.source_url,
-          displayName: allowed_market_creators.display_name,
+          displayName: sql<string>`MIN(${allowed_market_creators.display_name})`,
           refreshedAt: sql<Date | null>`MAX(${allowed_market_creators.updated_at})`,
         })
         .from(allowed_market_creators)
@@ -79,11 +79,9 @@ export const AllowedMarketCreatorRepository = {
         ))
         .groupBy(
           allowed_market_creators.source_url,
-          allowed_market_creators.display_name,
         )
         .orderBy(
           asc(allowed_market_creators.source_url),
-          asc(allowed_market_creators.display_name),
         )
 
       return {

--- a/tests/unit/allowedMarketCreatorsServer.test.ts
+++ b/tests/unit/allowedMarketCreatorsServer.test.ts
@@ -1,19 +1,32 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
   listWallets: vi.fn(),
+  listSiteSources: vi.fn(),
+  replaceSiteSource: vi.fn(),
 }))
 
 vi.mock('@/lib/db/queries/allowed-market-creators', () => ({
   AllowedMarketCreatorRepository: {
     listWallets: (...args: any[]) => mocks.listWallets(...args),
+    listSiteSources: (...args: any[]) => mocks.listSiteSources(...args),
+    replaceSiteSource: (...args: any[]) => mocks.replaceSiteSource(...args),
   },
 }))
 
 describe('allowed market creators server helpers', () => {
   beforeEach(() => {
     vi.resetModules()
+    vi.stubGlobal('fetch', mocks.fetch)
+    mocks.fetch.mockReset()
     mocks.listWallets.mockReset()
+    mocks.listSiteSources.mockReset()
+    mocks.replaceSiteSource.mockReset()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
   })
 
   it('normalizes wallet lists without casing duplicates', async () => {
@@ -40,6 +53,84 @@ describe('allowed market creators server helpers', () => {
     await expect(loadAllowedMarketCreatorWallets()).resolves.toEqual({
       data: ['0x1111111111111111111111111111111111111111'],
       error: null,
+    })
+  })
+
+  it('skips recently refreshed site sources', async () => {
+    const now = new Date('2026-06-18T12:00:00.000Z')
+    mocks.listSiteSources.mockResolvedValueOnce({
+      data: [{
+        sourceUrl: 'https://site2.com',
+        displayName: 'site2.com',
+        refreshedAt: now,
+      }],
+      error: null,
+    })
+
+    const { refreshAllowedMarketCreatorSiteSources } = await import('@/lib/allowed-market-creators-server')
+
+    await expect(refreshAllowedMarketCreatorSiteSources({ now })).resolves.toEqual({
+      scanned: 1,
+      checked: 0,
+      refreshed: 0,
+      skippedFresh: 1,
+      wallets: 0,
+      errors: [],
+    })
+    expect(mocks.fetch).not.toHaveBeenCalled()
+    expect(mocks.replaceSiteSource).not.toHaveBeenCalled()
+  })
+
+  it('refreshes stale site sources and persists normalized wallets', async () => {
+    const now = new Date('2026-06-18T12:00:00.000Z')
+    mocks.listSiteSources.mockResolvedValueOnce({
+      data: [{
+        sourceUrl: 'https://site2.com',
+        displayName: 'site2.com',
+        refreshedAt: new Date('2026-06-16T12:00:00.000Z'),
+      }],
+      error: null,
+    })
+    mocks.fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        wallets: [
+          '0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA',
+          '0xaAaAaAaaAaAaAaaAaAAAAAAAAaaaAaAaAaaAaaAa',
+          'not-a-wallet',
+        ],
+      }),
+    })
+    mocks.replaceSiteSource.mockResolvedValueOnce({
+      data: true,
+      error: null,
+    })
+
+    const { refreshAllowedMarketCreatorSiteSources } = await import('@/lib/allowed-market-creators-server')
+
+    await expect(refreshAllowedMarketCreatorSiteSources({ now })).resolves.toEqual({
+      scanned: 1,
+      checked: 1,
+      refreshed: 1,
+      skippedFresh: 0,
+      wallets: 1,
+      errors: [],
+    })
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      'https://site2.com/api/allowed-market-creators',
+      expect.objectContaining({
+        method: 'GET',
+        cache: 'no-store',
+        redirect: 'error',
+        headers: {
+          Accept: 'application/json',
+        },
+      }),
+    )
+    expect(mocks.replaceSiteSource).toHaveBeenCalledWith({
+      sourceUrl: 'https://site2.com',
+      displayName: 'site2.com',
+      walletAddresses: ['0xaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
     })
   })
 })

--- a/tests/unit/syncEventsRoute.test.ts
+++ b/tests/unit/syncEventsRoute.test.ts
@@ -5,6 +5,7 @@ const mocks = vi.hoisted(() => ({
   isCronAuthorized: vi.fn(),
   loadAllowedMarketCreatorWallets: vi.fn(),
   loadAutoDeployNewEventsEnabled: vi.fn(),
+  refreshAllowedMarketCreatorSiteSources: vi.fn(),
   select: vi.fn(),
   update: vi.fn(),
 }))
@@ -15,6 +16,7 @@ vi.mock('@/lib/auth-cron', () => ({
 
 vi.mock('@/lib/allowed-market-creators-server', () => ({
   loadAllowedMarketCreatorWallets: (...args: any[]) => mocks.loadAllowedMarketCreatorWallets(...args),
+  refreshAllowedMarketCreatorSiteSources: (...args: any[]) => mocks.refreshAllowedMarketCreatorSiteSources(...args),
 }))
 
 vi.mock('@/lib/db/utils/run-query', () => ({
@@ -61,6 +63,7 @@ describe('sync events route', () => {
     mocks.isCronAuthorized.mockReset()
     mocks.loadAllowedMarketCreatorWallets.mockReset()
     mocks.loadAutoDeployNewEventsEnabled.mockReset()
+    mocks.refreshAllowedMarketCreatorSiteSources.mockReset()
     mocks.select.mockReset()
     mocks.update.mockReset()
   })
@@ -89,6 +92,14 @@ describe('sync events route', () => {
       error: null,
     })
     mocks.loadAutoDeployNewEventsEnabled.mockResolvedValue(false)
+    mocks.refreshAllowedMarketCreatorSiteSources.mockResolvedValue({
+      scanned: 0,
+      checked: 0,
+      refreshed: 0,
+      skippedFresh: 0,
+      wallets: 0,
+      errors: [],
+    })
     mocks.select.mockImplementation(() => makeSelectChain([]))
     mocks.update.mockImplementation(() => makeUpdateChain([{ id: 'sync-row' }]))
     mocks.fetch.mockResolvedValueOnce({
@@ -126,6 +137,7 @@ describe('sync events route', () => {
 
     const requestBody = JSON.parse(String(mocks.fetch.mock.calls[0][1].body))
     expect(requestBody.variables.creators).toEqual(['0xabcdef0000000000000000000000000000000001'])
+    expect(mocks.refreshAllowedMarketCreatorSiteSources).toHaveBeenCalledWith({ force: false })
     expect(mocks.update).toHaveBeenCalledTimes(2)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refreshes allowed creator wallets from site sources before each market sync to prevent stale lists. Adds a daily refresh (24h) with an optional force flag via `?refreshCreatorSources=1|true`.

- **Bug Fixes**
  - Run a pre-sync site source refresh in `GET /api/sync/events`; executes alongside config load and logs refresh stats.
  - Validate and normalize site endpoints and wallets (HTTPS-only, strict JSON shape, dedupe/lowercase); skip sources refreshed within 24h.
  - Add `listSiteSources` query to dedupe sources by URL and track last update; update demo seed address; expand unit tests for refresh flow and route.

<sup>Written for commit 92cc914df79de792ea1954077a8fe9144c43f33d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1159?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

