### PR TITLE
fix: notifications container scroll

### DIFF
--- a/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
@@ -22,6 +22,10 @@ import {
   useUnreadNotificationCount,
 } from '@/stores/useNotifications'
 
+const WHEEL_DELTA_LINE_MODE = 1
+const WHEEL_DELTA_PAGE_MODE = 2
+const FALLBACK_WHEEL_LINE_HEIGHT = 16
+
 function getNotificationTimeLabel(notification: Notification, currentTimestamp: number | null) {
   if (notification.time_ago) {
     return notification.time_ago
@@ -93,6 +97,28 @@ function isLocalMergeNotification(notification: Notification) {
   return metadata?.action === 'merge'
 }
 
+function getWheelLineHeight(element: HTMLElement) {
+  const lineHeight = Number.parseFloat(window.getComputedStyle(element).lineHeight)
+
+  if (Number.isFinite(lineHeight)) {
+    return lineHeight
+  }
+
+  return FALLBACK_WHEEL_LINE_HEIGHT
+}
+
+function getWheelDeltaYInPixels(event: ReactWheelEvent<HTMLDivElement>, element: HTMLElement) {
+  if (event.deltaMode === WHEEL_DELTA_LINE_MODE) {
+    return event.deltaY * getWheelLineHeight(element)
+  }
+
+  if (event.deltaMode === WHEEL_DELTA_PAGE_MODE) {
+    return event.deltaY * element.clientHeight
+  }
+
+  return event.deltaY
+}
+
 function useLoadNotificationsOnMount() {
   const setNotifications = useNotifications(state => state.setNotifications)
 
@@ -126,13 +152,19 @@ export default function HeaderNotifications() {
   }
 
   function handleNotificationsWheel(event: ReactWheelEvent<HTMLDivElement>) {
+    const notificationsList = notificationsListRef.current
+
+    if (!notificationsList) {
+      return
+    }
+
     event.stopPropagation()
 
     if (event.cancelable) {
       event.preventDefault()
     }
 
-    scrollNotificationsList(event.deltaY)
+    scrollNotificationsList(getWheelDeltaYInPixels(event, notificationsList))
   }
 
   function handleNotificationsTouchStart(event: ReactTouchEvent<HTMLDivElement>) {

--- a/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderNotifications.tsx
@@ -1,11 +1,12 @@
 'use client'
 
 import type { Route } from 'next'
+import type { TouchEvent as ReactTouchEvent, WheelEvent as ReactWheelEvent } from 'react'
 import type { Notification } from '@/types'
 import { BellIcon, ExternalLinkIcon, MergeIcon } from 'lucide-react'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
-import { useEffect } from 'react'
+import { useEffect, useRef } from 'react'
 import EventIconImage, { isEventMarketIconUrl } from '@/components/EventIconImage'
 import { Button } from '@/components/ui/button'
 import { DropdownMenu, DropdownMenuContent, DropdownMenuTrigger } from '@/components/ui/dropdown-menu'
@@ -102,6 +103,8 @@ function useLoadNotificationsOnMount() {
 
 export default function HeaderNotifications() {
   const router = useRouter()
+  const notificationsListRef = useRef<HTMLDivElement>(null)
+  const previousTouchYRef = useRef<number | null>(null)
   const notifications = useNotificationList()
   const currentTimestamp = useCurrentTimestamp({ intervalMs: 60_000 })
   const unreadCount = useUnreadNotificationCount()
@@ -111,6 +114,52 @@ export default function HeaderNotifications() {
   const hasNotifications = notifications.length > 0
 
   useLoadNotificationsOnMount()
+
+  function scrollNotificationsList(deltaY: number) {
+    const notificationsList = notificationsListRef.current
+
+    if (!notificationsList || deltaY === 0) {
+      return
+    }
+
+    notificationsList.scrollTop += deltaY
+  }
+
+  function handleNotificationsWheel(event: ReactWheelEvent<HTMLDivElement>) {
+    event.stopPropagation()
+
+    if (event.cancelable) {
+      event.preventDefault()
+    }
+
+    scrollNotificationsList(event.deltaY)
+  }
+
+  function handleNotificationsTouchStart(event: ReactTouchEvent<HTMLDivElement>) {
+    previousTouchYRef.current = event.touches[0]?.clientY ?? null
+  }
+
+  function handleNotificationsTouchMove(event: ReactTouchEvent<HTMLDivElement>) {
+    event.stopPropagation()
+
+    const touchY = event.touches[0]?.clientY ?? null
+    const previousTouchY = previousTouchYRef.current
+    previousTouchYRef.current = touchY
+
+    if (touchY == null || previousTouchY == null) {
+      return
+    }
+
+    if (event.cancelable) {
+      event.preventDefault()
+    }
+
+    scrollNotificationsList(previousTouchY - touchY)
+  }
+
+  function handleNotificationsTouchEnd() {
+    previousTouchYRef.current = null
+  }
 
   function handleLocalOrderFillClick(notification: Notification) {
     if (!isLocalOrderFillNotification(notification)) {
@@ -150,12 +199,23 @@ export default function HeaderNotifications() {
         align="end"
         collisionPadding={32}
         data-sports-wheel-ignore="true"
+        onWheelCapture={handleNotificationsWheel}
+        onTouchStartCapture={handleNotificationsTouchStart}
+        onTouchMoveCapture={handleNotificationsTouchMove}
+        onTouchEndCapture={handleNotificationsTouchEnd}
+        onTouchCancelCapture={handleNotificationsTouchEnd}
       >
         <div className="border-b border-border px-3 py-2">
           <h3 className="text-sm font-semibold text-foreground">Notifications</h3>
         </div>
 
-        <div className="max-h-100 overflow-y-auto">
+        <div
+          ref={notificationsListRef}
+          className="
+            max-h-[calc(min(25rem,var(--radix-dropdown-menu-content-available-height))-2.75rem)] overflow-y-auto
+            overscroll-contain
+          "
+        >
           {isLoading && (
             <div className="p-4 text-center text-muted-foreground">
               <BellIcon className="mx-auto mb-2 size-8 animate-pulse opacity-50" />


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes scrolling inside the notifications dropdown so the page no longer scrolls when the list is scrolled. Works for mouse wheel and touch across browsers (incl. Firefox), and the list now fits the available dropdown height.

- **Bug Fixes**
  - Normalize wheel delta to pixels across delta modes (line/page) using computed line height/clientHeight for consistent Firefox scrolling.
  - Capture wheel and touch events (`onWheelCapture`, `onTouchStart/Move/EndCapture`) to stop propagation, prevent default, and scroll the list via a ref.
  - Add `overscroll-contain` and a computed `max-h-[calc(min(25rem,var(--radix-dropdown-menu-content-available-height))-2.75rem)]` so the list fits the viewport and avoids bounce/overflow.
  - Track touch deltas for smooth mobile scrolling.

<sup>Written for commit ef061f00d5d99890928af3a559dca6fa30b7a93b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1166?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

