### PR TITLE
fix: resolve missing outcome payouts

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -223,6 +223,7 @@ function useResolvedMarketDisplay({
     () => resolveResolvedOrderPanelDisplay({
       event,
       selectedMarket: activeMarket,
+      preferBinaryYesNoForSingleUpDown: true,
     }),
     [activeMarket, event],
   )

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/resolved-order-panel-market.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/resolved-order-panel-market.ts
@@ -316,6 +316,37 @@ function resolveExactScoreDisplayTitle(market: Market | null | undefined) {
   return `Exact Score: ${descriptor}`
 }
 
+function isSingleUpOrDownMarket(event: Event | null | undefined, market: Market | null | undefined) {
+  if (!market) {
+    return false
+  }
+
+  const totalMarketsCount = event?.total_markets_count ?? event?.markets?.length ?? 0
+  if (totalMarketsCount !== 1) {
+    return false
+  }
+
+  const outcomeLabels = new Set(
+    (market.outcomes ?? []).map(outcome => normalizeComparableText(outcome.outcome_text)),
+  )
+  if (!outcomeLabels.has('up') || !outcomeLabels.has('down')) {
+    return false
+  }
+
+  const descriptor = normalizeComparableText([
+    event?.slug,
+    event?.title,
+    market.slug,
+    market.short_title,
+    market.title,
+    market.question,
+  ]
+    .filter((value): value is string => Boolean(value?.trim()))
+    .join(' '))
+
+  return descriptor.includes('up or down') || descriptor.includes('up down')
+}
+
 export function resolveWinningOutcomeIndexForBinaryMarket(
   market: Market | null | undefined,
 ) {
@@ -452,8 +483,9 @@ export function resolveResolvedOrderPanelMarket(params: {
 export function resolveResolvedOrderPanelDisplay(params: {
   event: Event | null | undefined
   selectedMarket: Market | null | undefined
+  preferBinaryYesNoForSingleUpDown?: boolean
 }) {
-  const { event, selectedMarket } = params
+  const { event, selectedMarket, preferBinaryYesNoForSingleUpDown = false } = params
   const sportsKind = resolveSportsResolvedDisplayKind(selectedMarket)
   const resolvedState = resolveResolvedOrderPanelMarket(params)
 
@@ -538,19 +570,31 @@ export function resolveResolvedOrderPanelDisplay(params: {
     outcome => outcome.outcome_index === OUTCOME_INDEX.NO,
   )?.outcome_text
   const selectedMarketResolvedOutcomeIndex = resolveWinningOutcomeIndexForBinaryMarket(selectedMarket)
+  const shouldUseBinaryYesNoLabel = preferBinaryYesNoForSingleUpDown
+    && isSingleUpOrDownMarket(event, displayMarket)
 
   return {
     market: displayMarket,
     resolvedOutcomeIndex,
-    outcomeLabel: resolvedOutcomeIndex === OUTCOME_INDEX.NO
-      ? (canonicalizeOutcomeLabel(resolvedOutcomeText) || canonicalizeOutcomeLabel(resolvedNoOutcomeText) || 'No')
-      : resolvedOutcomeIndex === OUTCOME_INDEX.YES
-        ? (canonicalizeOutcomeLabel(resolvedOutcomeText) || canonicalizeOutcomeLabel(resolvedYesOutcomeText) || 'Yes')
-        : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.NO
-          ? (canonicalizeOutcomeLabel(resolvedNoOutcomeText) || 'No')
-          : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.YES
-            ? (canonicalizeOutcomeLabel(resolvedYesOutcomeText) || 'Yes')
-            : null,
+    outcomeLabel: shouldUseBinaryYesNoLabel
+      ? resolvedOutcomeIndex === OUTCOME_INDEX.NO
+        ? 'No'
+        : resolvedOutcomeIndex === OUTCOME_INDEX.YES
+          ? 'Yes'
+          : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.NO
+            ? 'No'
+            : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.YES
+              ? 'Yes'
+              : null
+      : resolvedOutcomeIndex === OUTCOME_INDEX.NO
+        ? (canonicalizeOutcomeLabel(resolvedOutcomeText) || canonicalizeOutcomeLabel(resolvedNoOutcomeText) || 'No')
+        : resolvedOutcomeIndex === OUTCOME_INDEX.YES
+          ? (canonicalizeOutcomeLabel(resolvedOutcomeText) || canonicalizeOutcomeLabel(resolvedYesOutcomeText) || 'Yes')
+          : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.NO
+            ? (canonicalizeOutcomeLabel(resolvedNoOutcomeText) || 'No')
+            : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.YES
+              ? (canonicalizeOutcomeLabel(resolvedYesOutcomeText) || 'Yes')
+              : null,
     marketTitle: resolveMarketDescriptor(displayMarket) || null,
   }
 }

--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -21,6 +21,7 @@ import {
 import { db } from '@/lib/drizzle'
 import { loadAutoDeployNewEventsEnabled } from '@/lib/event-sync-settings'
 import { setEventHiddenFromNew } from '@/lib/event-visibility'
+import { syncMissingOnChainResolvedPayouts } from '@/lib/resolution-payout-sync'
 import { slugifyText } from '@/lib/slug'
 import { uploadPublicAsset } from '@/lib/storage'
 
@@ -1236,10 +1237,14 @@ async function processMarketData(
   }
 
   if (!marketNeedsUpdate) {
+    const payoutsChanged = market.resolved
+      ? await syncMissingOnChainResolvedPayouts(market.id)
+      : false
+
     return {
       eventIdForStatusUpdate,
       eventIdsForHiddenSync: [],
-      marketChanged: false,
+      marketChanged: payoutsChanged,
       urlSetChanged: false,
     }
   }
@@ -1379,6 +1384,9 @@ async function processMarketData(
 
   if (!marketAlreadyExists && metadata.outcomes?.length > 0) {
     await processOutcomes(market.id, metadata.outcomes)
+  }
+  if (market.resolved) {
+    await syncMissingOnChainResolvedPayouts(market.id)
   }
 
   const incomingSlug = String(metadata.slug ?? '').trim()

--- a/src/app/api/sync/resolution/route.ts
+++ b/src/app/api/sync/resolution/route.ts
@@ -8,7 +8,6 @@ import {
   conditions as conditionsTable,
   events as eventsTable,
   markets as marketsTable,
-  outcomes as outcomesTable,
   subgraph_syncs,
 } from '@/lib/db/schema'
 import { db } from '@/lib/drizzle'
@@ -25,7 +24,6 @@ const RESOLUTION_PAGE_SIZE = 200
 const SYNC_RUNNING_STALE_MS = 15 * 60 * 1000
 const SAFETY_PERIOD_V4_SECONDS = 60 * 60
 const SAFETY_PERIOD_NEGRISK_SECONDS = 60 * 60
-const RESOLUTION_PAYOUT_REPAIR_LIMIT = 50
 const RESOLUTION_LIVENESS_DEFAULT_SECONDS = parseOptionalInt(process.env.RESOLUTION_LIVENESS_DEFAULT_SECONDS)
 const RESOLUTION_UNPROPOSED_PRICE_SENTINEL = 69n
 const RESOLUTION_PRICE_YES = 1000000000000000000n
@@ -65,7 +63,6 @@ interface SyncStats {
   fetchedCount: number
   processedCount: number
   skippedCount: number
-  repairedCount: number
   errors: { questionId: string, error: string }[]
   timeLimitReached: boolean
 }
@@ -157,7 +154,6 @@ export async function GET(request: Request) {
       fetched: syncResult.fetchedCount,
       processed: syncResult.processedCount,
       skipped: syncResult.skippedCount,
-      repaired: syncResult.repairedCount,
       errors: syncResult.errors.length,
       errorDetails: syncResult.errors,
       timeLimitReached: syncResult.timeLimitReached,
@@ -272,7 +268,6 @@ async function syncResolutions(): Promise<SyncStats> {
       fetchedCount: 0,
       processedCount: 0,
       skippedCount: 0,
-      repairedCount: 0,
       errors: [],
       timeLimitReached: false,
     }
@@ -283,7 +278,6 @@ async function syncResolutions(): Promise<SyncStats> {
   let fetchedCount = 0
   let processedCount = 0
   let skippedCount = 0
-  let repairedCount = 0
   const errors: { questionId: string, error: string }[] = []
   let timeLimitReached = false
   const eventIdsNeedingStatusUpdate = new Set<string>()
@@ -413,15 +407,6 @@ async function syncResolutions(): Promise<SyncStats> {
     }
   }
 
-  const repairResult = await repairResolvedMarketsMissingPayouts()
-  repairedCount = repairResult.changedCount
-  for (const eventId of repairResult.changedEventIds) {
-    eventIdsNeedingCacheInvalidation.add(eventId)
-  }
-  if (repairResult.changedCount > 0) {
-    shouldInvalidateListCache = true
-  }
-
   if (eventIdsNeedingCacheInvalidation.size > 0 || shouldInvalidateListCache) {
     const invalidationSummary = await invalidateEventCaches(Array.from(eventIdsNeedingCacheInvalidation), {
       includeList: shouldInvalidateListCache,
@@ -433,61 +418,8 @@ async function syncResolutions(): Promise<SyncStats> {
     fetchedCount,
     processedCount,
     skippedCount,
-    repairedCount,
     errors,
     timeLimitReached,
-  }
-}
-
-async function repairResolvedMarketsMissingPayouts() {
-  const rows = await db.execute(
-    sql`
-      SELECT DISTINCT
-        ${marketsTable.condition_id} AS condition_id,
-        ${marketsTable.event_id} AS event_id
-      FROM ${marketsTable}
-      INNER JOIN ${conditionsTable}
-        ON ${conditionsTable.id} = ${marketsTable.condition_id}
-      INNER JOIN ${outcomesTable}
-        ON ${outcomesTable.condition_id} = ${marketsTable.condition_id}
-      WHERE (
-          ${marketsTable.is_resolved} = TRUE
-          OR ${conditionsTable.resolved} = TRUE
-        )
-        AND (
-          ${conditionsTable.resolution_price} IS NULL
-          OR ${outcomesTable.payout_value} IS NULL
-        )
-      ORDER BY ${marketsTable.condition_id}
-      LIMIT ${RESOLUTION_PAYOUT_REPAIR_LIMIT}
-    `,
-  ) as Array<{ condition_id?: string | null, event_id?: string | null }>
-
-  let changedCount = 0
-  const changedEventIds = new Set<string>()
-  for (const row of rows) {
-    const conditionId = row.condition_id?.trim()
-    if (!conditionId) {
-      continue
-    }
-
-    try {
-      const changed = await syncMissingOnChainResolvedPayouts(conditionId)
-      if (changed) {
-        changedCount++
-        if (row.event_id) {
-          changedEventIds.add(row.event_id)
-        }
-      }
-    }
-    catch (error) {
-      console.error(`Failed to repair resolved payouts for ${conditionId}:`, error)
-    }
-  }
-
-  return {
-    changedCount,
-    changedEventIds: Array.from(changedEventIds),
   }
 }
 

--- a/src/app/api/sync/resolution/route.ts
+++ b/src/app/api/sync/resolution/route.ts
@@ -12,6 +12,10 @@ import {
   subgraph_syncs,
 } from '@/lib/db/schema'
 import { db } from '@/lib/drizzle'
+import {
+  syncMissingOnChainResolvedPayouts,
+  updateOutcomePayoutsFromResolutionPrice,
+} from '@/lib/resolution-payout-sync'
 
 export const maxDuration = 300
 
@@ -21,6 +25,7 @@ const RESOLUTION_PAGE_SIZE = 200
 const SYNC_RUNNING_STALE_MS = 15 * 60 * 1000
 const SAFETY_PERIOD_V4_SECONDS = 60 * 60
 const SAFETY_PERIOD_NEGRISK_SECONDS = 60 * 60
+const RESOLUTION_PAYOUT_REPAIR_LIMIT = 50
 const RESOLUTION_LIVENESS_DEFAULT_SECONDS = parseOptionalInt(process.env.RESOLUTION_LIVENESS_DEFAULT_SECONDS)
 const RESOLUTION_UNPROPOSED_PRICE_SENTINEL = 69n
 const RESOLUTION_PRICE_YES = 1000000000000000000n
@@ -60,6 +65,7 @@ interface SyncStats {
   fetchedCount: number
   processedCount: number
   skippedCount: number
+  repairedCount: number
   errors: { questionId: string, error: string }[]
   timeLimitReached: boolean
 }
@@ -151,6 +157,7 @@ export async function GET(request: Request) {
       fetched: syncResult.fetchedCount,
       processed: syncResult.processedCount,
       skipped: syncResult.skippedCount,
+      repaired: syncResult.repairedCount,
       errors: syncResult.errors.length,
       errorDetails: syncResult.errors,
       timeLimitReached: syncResult.timeLimitReached,
@@ -265,6 +272,7 @@ async function syncResolutions(): Promise<SyncStats> {
       fetchedCount: 0,
       processedCount: 0,
       skippedCount: 0,
+      repairedCount: 0,
       errors: [],
       timeLimitReached: false,
     }
@@ -275,6 +283,7 @@ async function syncResolutions(): Promise<SyncStats> {
   let fetchedCount = 0
   let processedCount = 0
   let skippedCount = 0
+  let repairedCount = 0
   const errors: { questionId: string, error: string }[] = []
   let timeLimitReached = false
   const eventIdsNeedingStatusUpdate = new Set<string>()
@@ -404,6 +413,15 @@ async function syncResolutions(): Promise<SyncStats> {
     }
   }
 
+  const repairResult = await repairResolvedMarketsMissingPayouts()
+  repairedCount = repairResult.changedCount
+  for (const eventId of repairResult.changedEventIds) {
+    eventIdsNeedingCacheInvalidation.add(eventId)
+  }
+  if (repairResult.changedCount > 0) {
+    shouldInvalidateListCache = true
+  }
+
   if (eventIdsNeedingCacheInvalidation.size > 0 || shouldInvalidateListCache) {
     const invalidationSummary = await invalidateEventCaches(Array.from(eventIdsNeedingCacheInvalidation), {
       includeList: shouldInvalidateListCache,
@@ -415,8 +433,61 @@ async function syncResolutions(): Promise<SyncStats> {
     fetchedCount,
     processedCount,
     skippedCount,
+    repairedCount,
     errors,
     timeLimitReached,
+  }
+}
+
+async function repairResolvedMarketsMissingPayouts() {
+  const rows = await db.execute(
+    sql`
+      SELECT DISTINCT
+        ${marketsTable.condition_id} AS condition_id,
+        ${marketsTable.event_id} AS event_id
+      FROM ${marketsTable}
+      INNER JOIN ${conditionsTable}
+        ON ${conditionsTable.id} = ${marketsTable.condition_id}
+      INNER JOIN ${outcomesTable}
+        ON ${outcomesTable.condition_id} = ${marketsTable.condition_id}
+      WHERE (
+          ${marketsTable.is_resolved} = TRUE
+          OR ${conditionsTable.resolved} = TRUE
+        )
+        AND (
+          ${conditionsTable.resolution_price} IS NULL
+          OR ${outcomesTable.payout_value} IS NULL
+        )
+      ORDER BY ${marketsTable.condition_id}
+      LIMIT ${RESOLUTION_PAYOUT_REPAIR_LIMIT}
+    `,
+  ) as Array<{ condition_id?: string | null, event_id?: string | null }>
+
+  let changedCount = 0
+  const changedEventIds = new Set<string>()
+  for (const row of rows) {
+    const conditionId = row.condition_id?.trim()
+    if (!conditionId) {
+      continue
+    }
+
+    try {
+      const changed = await syncMissingOnChainResolvedPayouts(conditionId)
+      if (changed) {
+        changedCount++
+        if (row.event_id) {
+          changedEventIds.add(row.event_id)
+        }
+      }
+    }
+    catch (error) {
+      console.error(`Failed to repair resolved payouts for ${conditionId}:`, error)
+    }
+  }
+
+  return {
+    changedCount,
+    changedEventIds: Array.from(changedEventIds),
   }
 }
 
@@ -704,7 +775,10 @@ async function processResolution(
   let payoutsChanged = false
 
   if (isResolved && resolutionPrice != null) {
-    payoutsChanged = await updateOutcomePayouts(conditionId, resolutionPrice)
+    payoutsChanged = await updateOutcomePayoutsFromResolutionPrice(conditionId, resolutionPrice)
+  }
+  else if (isResolved) {
+    payoutsChanged = await syncMissingOnChainResolvedPayouts(conditionId)
   }
 
   return {
@@ -781,44 +855,6 @@ function normalizeResolutionPrice(rawValue: string | null): number | null {
   catch {
     return null
   }
-}
-
-async function updateOutcomePayouts(conditionId: string, price: number): Promise<boolean> {
-  const payoutYes = price >= 1 ? 1 : price <= 0 ? 0 : price
-  const payoutNo = price <= 0 ? 1 : price >= 1 ? 0 : price
-
-  const updates = [
-    { index: 0, payout: payoutYes },
-    { index: 1, payout: payoutNo },
-  ]
-  let didChange = false
-
-  for (const update of updates) {
-    const isWinningOutcome = update.payout > 0
-    const changedRows = await db
-      .update(outcomesTable)
-      .set({
-        is_winning_outcome: isWinningOutcome,
-        payout_value: String(update.payout),
-      })
-      .where(and(
-        eq(outcomesTable.condition_id, conditionId),
-        eq(outcomesTable.outcome_index, update.index),
-        or(
-          ne(outcomesTable.is_winning_outcome, isWinningOutcome),
-          isNull(outcomesTable.is_winning_outcome),
-          isNull(outcomesTable.payout_value),
-          ne(outcomesTable.payout_value, String(update.payout)),
-        ),
-      ))
-      .returning({ condition_id: outcomesTable.condition_id })
-
-    if (changedRows.length > 0) {
-      didChange = true
-    }
-  }
-
-  return didChange
 }
 
 async function updateEventStatusesFromMarketsBatch(eventIds: string[]) {

--- a/src/lib/resolution-payout-sync.ts
+++ b/src/lib/resolution-payout-sync.ts
@@ -1,0 +1,201 @@
+import { and, eq, isNull, ne, or } from 'drizzle-orm'
+import { createPublicClient, http, parseAbi } from 'viem'
+import { CONDITIONAL_TOKENS_CONTRACT } from '@/lib/contracts'
+import { conditions as conditionsTable, outcomes as outcomesTable } from '@/lib/db/schema'
+import { db } from '@/lib/drizzle'
+import { defaultViemNetwork, defaultViemRpcUrl } from '@/lib/viem-network'
+
+const BINARY_OUTCOME_INDICES = [0, 1] as const
+const PAYOUT_SCALE = 1_000_000n
+const CONDITIONAL_TOKENS_PAYOUT_ABI = parseAbi([
+  'function payoutDenominator(bytes32) view returns (uint256)',
+  'function payoutNumerators(bytes32,uint256) view returns (uint256)',
+])
+
+interface OutcomePayoutUpdate {
+  index: 0 | 1
+  payout: string
+}
+
+let conditionalTokensClient: ReturnType<typeof createPublicClient> | null = null
+
+function getConditionalTokensClient() {
+  conditionalTokensClient ??= createPublicClient({
+    chain: defaultViemNetwork,
+    transport: http(defaultViemRpcUrl),
+  })
+  return conditionalTokensClient
+}
+
+function normalizeConditionId(value: string): `0x${string}` | null {
+  const normalized = value.trim().toLowerCase()
+  return /^0x[a-f0-9]{64}$/.test(normalized) ? normalized as `0x${string}` : null
+}
+
+function formatScaledPayout(value: bigint) {
+  const whole = value / PAYOUT_SCALE
+  const fraction = value % PAYOUT_SCALE
+  if (fraction === 0n) {
+    return whole.toString()
+  }
+
+  return `${whole.toString()}.${fraction.toString().padStart(6, '0').replace(/0+$/, '')}`
+}
+
+function formatPayoutRatio(numerator: bigint, denominator: bigint) {
+  const scaled = (numerator * PAYOUT_SCALE + denominator / 2n) / denominator
+  return formatScaledPayout(scaled)
+}
+
+function buildBinaryPayoutUpdatesFromResolutionPrice(price: number): OutcomePayoutUpdate[] {
+  const payoutYes = price >= 1 ? '1' : price <= 0 ? '0' : String(price)
+  const payoutNo = price <= 0 ? '1' : price >= 1 ? '0' : String(1 - price)
+
+  return [
+    { index: 0, payout: payoutYes },
+    { index: 1, payout: payoutNo },
+  ]
+}
+
+async function readBinaryPayoutsFromConditionalTokens(conditionId: string): Promise<{
+  resolutionPrice: string
+  updates: OutcomePayoutUpdate[]
+} | null> {
+  const normalizedConditionId = normalizeConditionId(conditionId)
+  if (!normalizedConditionId) {
+    return null
+  }
+
+  const client = getConditionalTokensClient()
+  const denominator = await client.readContract({
+    address: CONDITIONAL_TOKENS_CONTRACT,
+    abi: CONDITIONAL_TOKENS_PAYOUT_ABI,
+    functionName: 'payoutDenominator',
+    args: [normalizedConditionId],
+  })
+
+  if (denominator <= 0n) {
+    return null
+  }
+
+  const [yesNumerator, noNumerator] = await Promise.all(
+    BINARY_OUTCOME_INDICES.map(index => client.readContract({
+      address: CONDITIONAL_TOKENS_CONTRACT,
+      abi: CONDITIONAL_TOKENS_PAYOUT_ABI,
+      functionName: 'payoutNumerators',
+      args: [normalizedConditionId, BigInt(index)],
+    })),
+  )
+
+  if (yesNumerator === 0n && noNumerator === 0n) {
+    return null
+  }
+
+  const yesPayout = formatPayoutRatio(yesNumerator, denominator)
+  const noPayout = formatPayoutRatio(noNumerator, denominator)
+
+  return {
+    resolutionPrice: yesPayout,
+    updates: [
+      { index: 0, payout: yesPayout },
+      { index: 1, payout: noPayout },
+    ],
+  }
+}
+
+export async function updateOutcomePayoutsFromResolutionPrice(
+  conditionId: string,
+  price: number,
+): Promise<boolean> {
+  return updateOutcomePayouts(conditionId, buildBinaryPayoutUpdatesFromResolutionPrice(price))
+}
+
+async function updateOutcomePayouts(
+  conditionId: string,
+  updates: OutcomePayoutUpdate[],
+): Promise<boolean> {
+  let didChange = false
+
+  for (const update of updates) {
+    const isWinningOutcome = Number(update.payout) > 0
+    const changedRows = await db
+      .update(outcomesTable)
+      .set({
+        is_winning_outcome: isWinningOutcome,
+        payout_value: update.payout,
+      })
+      .where(and(
+        eq(outcomesTable.condition_id, conditionId),
+        eq(outcomesTable.outcome_index, update.index),
+        or(
+          ne(outcomesTable.is_winning_outcome, isWinningOutcome),
+          isNull(outcomesTable.is_winning_outcome),
+          isNull(outcomesTable.payout_value),
+          ne(outcomesTable.payout_value, update.payout),
+        ),
+      ))
+      .returning({ condition_id: outcomesTable.condition_id })
+
+    if (changedRows.length > 0) {
+      didChange = true
+    }
+  }
+
+  return didChange
+}
+
+async function updateConditionResolutionPrice(conditionId: string, resolutionPrice: string) {
+  const changedRows = await db
+    .update(conditionsTable)
+    .set({ resolution_price: resolutionPrice })
+    .where(and(
+      eq(conditionsTable.id, conditionId),
+      or(
+        isNull(conditionsTable.resolution_price),
+        ne(conditionsTable.resolution_price, resolutionPrice),
+      ),
+    ))
+    .returning({ id: conditionsTable.id })
+
+  return changedRows.length > 0
+}
+
+export async function syncMissingOnChainResolvedPayouts(conditionId: string): Promise<boolean> {
+  const [conditionRows, outcomeRows] = await Promise.all([
+    db
+      .select({
+        resolution_price: conditionsTable.resolution_price,
+      })
+      .from(conditionsTable)
+      .where(eq(conditionsTable.id, conditionId))
+      .limit(1),
+    db
+      .select({
+        outcome_index: outcomesTable.outcome_index,
+        payout_value: outcomesTable.payout_value,
+      })
+      .from(outcomesTable)
+      .where(eq(outcomesTable.condition_id, conditionId)),
+  ])
+
+  if (outcomeRows.length < 2) {
+    return false
+  }
+
+  const hasMissingPayoutState = conditionRows[0]?.resolution_price == null
+    || outcomeRows.some(outcome => outcome.payout_value == null)
+
+  if (!hasMissingPayoutState) {
+    return false
+  }
+
+  const chainPayouts = await readBinaryPayoutsFromConditionalTokens(conditionId)
+  if (!chainPayouts) {
+    return false
+  }
+
+  const conditionChanged = await updateConditionResolutionPrice(conditionId, chainPayouts.resolutionPrice)
+  const payoutsChanged = await updateOutcomePayouts(conditionId, chainPayouts.updates)
+
+  return conditionChanged || payoutsChanged
+}

--- a/src/lib/resolution-payout-sync.ts
+++ b/src/lib/resolution-payout-sync.ts
@@ -115,9 +115,12 @@ async function updateOutcomePayouts(
   updates: OutcomePayoutUpdate[],
 ): Promise<boolean> {
   let didChange = false
+  const payoutValues = updates.map(update => Number(update.payout))
+  const maxPayout = Math.max(...payoutValues)
+  const hasSingleWinner = maxPayout > 0 && payoutValues.filter(payout => payout === maxPayout).length === 1
 
   for (const update of updates) {
-    const isWinningOutcome = Number(update.payout) > 0
+    const isWinningOutcome = hasSingleWinner && Number(update.payout) === maxPayout
     const changedRows = await db
       .update(outcomesTable)
       .set({

--- a/tests/unit/resolutionPayoutSync.test.ts
+++ b/tests/unit/resolutionPayoutSync.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  createPublicClient: vi.fn(),
+  http: vi.fn((url: string) => ({ url })),
+  parseAbi: vi.fn((abi: string[]) => abi),
+  readContract: vi.fn(),
+  select: vi.fn(),
+  update: vi.fn(),
+  updatePayloads: [] as Array<Record<string, unknown>>,
+}))
+
+vi.mock('viem', () => ({
+  createPublicClient: (...args: unknown[]) => mocks.createPublicClient(...args),
+  http: (...args: [string]) => mocks.http(...args),
+  parseAbi: (...args: [string[]]) => mocks.parseAbi(...args),
+}))
+
+vi.mock('@/lib/viem-network', () => ({
+  defaultViemNetwork: { id: 80002, name: 'amoy' },
+  defaultViemRpcUrl: 'https://rpc-amoy.polygon.technology',
+}))
+
+vi.mock('@/lib/drizzle', () => ({
+  db: {
+    select: (...args: unknown[]) => mocks.select(...args),
+    update: (...args: unknown[]) => mocks.update(...args),
+  },
+}))
+
+function makeSelectChain(result: unknown[]) {
+  const whereResult = {
+    limit: async () => result,
+    then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
+      Promise.resolve(result).then(resolve, reject),
+  }
+
+  return {
+    from: () => ({
+      where: () => whereResult,
+    }),
+  }
+}
+
+function makeUpdateChain(result: unknown[]) {
+  return {
+    set: (payload: Record<string, unknown>) => {
+      mocks.updatePayloads.push(payload)
+      return {
+        where: () => ({
+          returning: async () => result,
+        }),
+      }
+    },
+  }
+}
+
+describe('resolution payout sync', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.createPublicClient.mockReset()
+    mocks.http.mockClear()
+    mocks.parseAbi.mockClear()
+    mocks.readContract.mockReset()
+    mocks.select.mockReset()
+    mocks.update.mockReset()
+    mocks.updatePayloads.length = 0
+    mocks.createPublicClient.mockReturnValue({ readContract: mocks.readContract })
+  })
+
+  it('repairs missing binary payouts from ConditionalTokens', async () => {
+    mocks.select
+      .mockReturnValueOnce(makeSelectChain([{ resolution_price: null }]))
+      .mockReturnValueOnce(makeSelectChain([
+        { outcome_index: 0, payout_value: null },
+        { outcome_index: 1, payout_value: null },
+      ]))
+    mocks.update.mockImplementation(() => makeUpdateChain([{ id: 'changed' }]))
+    mocks.readContract
+      .mockResolvedValueOnce(1n)
+      .mockResolvedValueOnce(1n)
+      .mockResolvedValueOnce(0n)
+
+    const { syncMissingOnChainResolvedPayouts } = await import('@/lib/resolution-payout-sync')
+    const changed = await syncMissingOnChainResolvedPayouts(
+      '0x261e5587c891b0ca15cf061286b8da346cb96ee414d6b4b827596797ba59bbc2',
+    )
+
+    expect(changed).toBe(true)
+    expect(mocks.readContract).toHaveBeenCalledTimes(3)
+    expect(mocks.updatePayloads).toContainEqual({ resolution_price: '1' })
+    expect(mocks.updatePayloads).toContainEqual({
+      is_winning_outcome: true,
+      payout_value: '1',
+    })
+    expect(mocks.updatePayloads).toContainEqual({
+      is_winning_outcome: false,
+      payout_value: '0',
+    })
+  })
+
+  it('skips chain reads when payout state is already present', async () => {
+    mocks.select
+      .mockReturnValueOnce(makeSelectChain([{ resolution_price: '1.000000' }]))
+      .mockReturnValueOnce(makeSelectChain([
+        { outcome_index: 0, payout_value: '1.000000' },
+        { outcome_index: 1, payout_value: '0.000000' },
+      ]))
+
+    const { syncMissingOnChainResolvedPayouts } = await import('@/lib/resolution-payout-sync')
+    const changed = await syncMissingOnChainResolvedPayouts(
+      '0x261e5587c891b0ca15cf061286b8da346cb96ee414d6b4b827596797ba59bbc2',
+    )
+
+    expect(changed).toBe(false)
+    expect(mocks.readContract).not.toHaveBeenCalled()
+    expect(mocks.update).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/resolutionPayoutSync.test.ts
+++ b/tests/unit/resolutionPayoutSync.test.ts
@@ -28,9 +28,23 @@ vi.mock('@/lib/drizzle', () => ({
   },
 }))
 
-function makeSelectChain(result: unknown[]) {
+function makeSelectWithLimitChain(result: unknown[]) {
   const whereResult = {
-    limit: async () => result,
+    limit: async (limit: number) => {
+      expect(limit).toBe(1)
+      return result
+    },
+  }
+
+  return {
+    from: () => ({
+      where: () => whereResult,
+    }),
+  }
+}
+
+function makeSelectWithoutLimitChain(result: unknown[]) {
+  const whereResult = {
     then: (resolve: (value: unknown[]) => unknown, reject?: (reason: unknown) => unknown) =>
       Promise.resolve(result).then(resolve, reject),
   }
@@ -70,8 +84,8 @@ describe('resolution payout sync', () => {
 
   it('repairs missing binary payouts from ConditionalTokens', async () => {
     mocks.select
-      .mockReturnValueOnce(makeSelectChain([{ resolution_price: null }]))
-      .mockReturnValueOnce(makeSelectChain([
+      .mockReturnValueOnce(makeSelectWithLimitChain([{ resolution_price: null }]))
+      .mockReturnValueOnce(makeSelectWithoutLimitChain([
         { outcome_index: 0, payout_value: null },
         { outcome_index: 1, payout_value: null },
       ]))
@@ -88,6 +102,21 @@ describe('resolution payout sync', () => {
 
     expect(changed).toBe(true)
     expect(mocks.readContract).toHaveBeenCalledTimes(3)
+    expect(mocks.readContract).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      address: '0x4682048725865bf17067bd85fF518527A262A9C7',
+      functionName: 'payoutDenominator',
+      args: ['0x261e5587c891b0ca15cf061286b8da346cb96ee414d6b4b827596797ba59bbc2'],
+    }))
+    expect(mocks.readContract).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      address: '0x4682048725865bf17067bd85fF518527A262A9C7',
+      functionName: 'payoutNumerators',
+      args: ['0x261e5587c891b0ca15cf061286b8da346cb96ee414d6b4b827596797ba59bbc2', 0n],
+    }))
+    expect(mocks.readContract).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      address: '0x4682048725865bf17067bd85fF518527A262A9C7',
+      functionName: 'payoutNumerators',
+      args: ['0x261e5587c891b0ca15cf061286b8da346cb96ee414d6b4b827596797ba59bbc2', 1n],
+    }))
     expect(mocks.updatePayloads).toContainEqual({ resolution_price: '1' })
     expect(mocks.updatePayloads).toContainEqual({
       is_winning_outcome: true,
@@ -101,8 +130,8 @@ describe('resolution payout sync', () => {
 
   it('skips chain reads when payout state is already present', async () => {
     mocks.select
-      .mockReturnValueOnce(makeSelectChain([{ resolution_price: '1.000000' }]))
-      .mockReturnValueOnce(makeSelectChain([
+      .mockReturnValueOnce(makeSelectWithLimitChain([{ resolution_price: '1.000000' }]))
+      .mockReturnValueOnce(makeSelectWithoutLimitChain([
         { outcome_index: 0, payout_value: '1.000000' },
         { outcome_index: 1, payout_value: '0.000000' },
       ]))
@@ -115,5 +144,34 @@ describe('resolution payout sync', () => {
     expect(changed).toBe(false)
     expect(mocks.readContract).not.toHaveBeenCalled()
     expect(mocks.update).not.toHaveBeenCalled()
+  })
+
+  it('does not mark a winner for tied binary payouts', async () => {
+    mocks.select
+      .mockReturnValueOnce(makeSelectWithLimitChain([{ resolution_price: null }]))
+      .mockReturnValueOnce(makeSelectWithoutLimitChain([
+        { outcome_index: 0, payout_value: null },
+        { outcome_index: 1, payout_value: null },
+      ]))
+    mocks.update.mockImplementation(() => makeUpdateChain([{ id: 'changed' }]))
+    mocks.readContract
+      .mockResolvedValueOnce(2n)
+      .mockResolvedValueOnce(1n)
+      .mockResolvedValueOnce(1n)
+
+    const { syncMissingOnChainResolvedPayouts } = await import('@/lib/resolution-payout-sync')
+    const changed = await syncMissingOnChainResolvedPayouts(
+      '0x261e5587c891b0ca15cf061286b8da346cb96ee414d6b4b827596797ba59bbc2',
+    )
+
+    expect(changed).toBe(true)
+    expect(mocks.updatePayloads).toContainEqual({ resolution_price: '0.5' })
+    expect(mocks.updatePayloads.filter(payload =>
+      payload.is_winning_outcome === false && payload.payout_value === '0.5',
+    )).toHaveLength(2)
+    expect(mocks.updatePayloads).not.toContainEqual({
+      is_winning_outcome: true,
+      payout_value: '0.5',
+    })
   })
 })

--- a/tests/unit/resolvedOrderPanelMarket.test.ts
+++ b/tests/unit/resolvedOrderPanelMarket.test.ts
@@ -542,4 +542,52 @@ describe('resolveResolvedOrderPanelDisplay', () => {
     expect(result.outcomeLabel).toBeNull()
     expect(result.marketTitle).toBe('180-199')
   })
+
+  it('shows yes no labels for resolved single up-or-down markets', () => {
+    const selectedMarket = createMarket({
+      condition_id: 'doge-up-or-down',
+      title: 'Dogecoin Up or Down on June 19?',
+      short_title: '',
+      slug: 'dogecoin-up-or-down-on-june-19-2026',
+      condition: {
+        resolved: true,
+        resolution_price: 1,
+      },
+      outcomes: [
+        {
+          condition_id: 'doge-up-or-down',
+          outcome_index: OUTCOME_INDEX.YES,
+          outcome_text: 'Up',
+          token_id: 'doge-up',
+          is_winning_outcome: true,
+          payout_value: 1,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        {
+          condition_id: 'doge-up-or-down',
+          outcome_index: OUTCOME_INDEX.NO,
+          outcome_text: 'Down',
+          token_id: 'doge-down',
+          is_winning_outcome: false,
+          payout_value: 0,
+          created_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+      ],
+    })
+
+    const result = resolveResolvedOrderPanelDisplay({
+      event: createEvent([selectedMarket], {
+        slug: 'dogecoin-up-or-down-on-june-19-2026',
+        title: 'Dogecoin Up or Down on June 19?',
+        total_markets_count: 1,
+      }),
+      selectedMarket,
+      preferBinaryYesNoForSingleUpDown: true,
+    })
+
+    expect(result.outcomeLabel).toBe('Yes')
+    expect(result.marketTitle).toBe('Dogecoin Up or Down on June 19?')
+  })
 })

--- a/tests/unit/syncResolutionRoute.test.ts
+++ b/tests/unit/syncResolutionRoute.test.ts
@@ -63,11 +63,13 @@ describe('sync resolution route', () => {
 
   it('hits the resolution subgraph and exits cleanly when no tracked authors are returned', async () => {
     mocks.isCronAuthorized.mockReturnValue(true)
-    mocks.execute.mockResolvedValue([
-      {
-        creator: '0xABCDEF0000000000000000000000000000000001',
-      },
-    ])
+    mocks.execute
+      .mockResolvedValueOnce([
+        {
+          creator: '0xABCDEF0000000000000000000000000000000001',
+        },
+      ])
+      .mockResolvedValueOnce([])
     mocks.select.mockImplementation(() => makeSelectChain([]))
     mocks.update.mockImplementation(() => makeUpdateChain([{ id: 'sync-row' }]))
     mocks.fetch.mockResolvedValueOnce({
@@ -92,6 +94,7 @@ describe('sync resolution route', () => {
       fetched: 0,
       processed: 0,
       skipped: 0,
+      repaired: 0,
       errors: 0,
       errorDetails: [],
       timeLimitReached: false,

--- a/tests/unit/syncResolutionRoute.test.ts
+++ b/tests/unit/syncResolutionRoute.test.ts
@@ -63,13 +63,11 @@ describe('sync resolution route', () => {
 
   it('hits the resolution subgraph and exits cleanly when no tracked authors are returned', async () => {
     mocks.isCronAuthorized.mockReturnValue(true)
-    mocks.execute
-      .mockResolvedValueOnce([
-        {
-          creator: '0xABCDEF0000000000000000000000000000000001',
-        },
-      ])
-      .mockResolvedValueOnce([])
+    mocks.execute.mockResolvedValueOnce([
+      {
+        creator: '0xABCDEF0000000000000000000000000000000001',
+      },
+    ])
     mocks.select.mockImplementation(() => makeSelectChain([]))
     mocks.update.mockImplementation(() => makeUpdateChain([{ id: 'sync-row' }]))
     mocks.fetch.mockResolvedValueOnce({
@@ -94,7 +92,6 @@ describe('sync resolution route', () => {
       fetched: 0,
       processed: 0,
       skipped: 0,
-      repaired: 0,
       errors: 0,
       errorDetails: [],
       timeLimitReached: false,


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing outcome payouts for resolved markets by reading on-chain payouts and updating our DB. Also shows Yes/No labels for single “Up or Down” markets and correctly handles tied payouts (no winner set).

- **Bug Fixes**
  - Added `syncMissingOnChainResolvedPayouts` and `updateOutcomePayoutsFromResolutionPrice` in `src/lib/resolution-payout-sync.ts` to backfill `resolution_price` and outcome `payout_value` from Conditional Tokens via `viem`.
  - Handled tied resolution payouts by not marking a winner when payouts are equal.
  - Integrated payout repair into resolution and events sync; runs per resolved market and flags changes to trigger cache invalidation.
  - Removed retroactive batch repair logic from resolution sync.
  - Enabled binary Yes/No labels for single “Up or Down” markets via `preferBinaryYesNoForSingleUpDown` in `EventOrderPanelForm`.
  - Added unit tests for payout sync, tie handling, and resolved display.

<sup>Written for commit 7f05a1d4d8b5aab6eeb06eba201c50c61a26efdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1175?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

