### PR TITLE
fix: usage of drawer title instead of dialog title in mobile order panel

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelMobile.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelMobile.tsx
@@ -8,8 +8,7 @@ import EventOrderPanelForm from '@/app/[locale]/(platform)/event/[slug]/_compone
 import EventOrderPanelTermsDisclaimer
   from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelTermsDisclaimer'
 import { Button } from '@/components/ui/button'
-import { DialogTitle } from '@/components/ui/dialog'
-import { Drawer, DrawerContent, DrawerTrigger } from '@/components/ui/drawer'
+import { Drawer, DrawerContent, DrawerTitle, DrawerTrigger } from '@/components/ui/drawer'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { ORDER_SIDE, OUTCOME_INDEX } from '@/lib/constants'
 import { formatCentsLabel } from '@/lib/formatters'
@@ -151,7 +150,7 @@ export default function EventOrderPanelMobile({
       )}
 
       <DrawerContent className="max-h-[95vh] w-full">
-        <DialogTitle className="sr-only">{event.title}</DialogTitle>
+        <DrawerTitle className="sr-only">{event.title}</DrawerTitle>
 
         <EventOrderPanelForm
           event={event}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Replaced `DialogTitle` with `DrawerTitle` in the mobile event order panel to match the `Drawer` component and fix title semantics. This ensures the drawer title is correctly associated and announced by screen readers.

<sup>Written for commit b5f644ec88adb7e918abb38fe1a0242b15b3a8ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1178?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

