### PR TITLE
fix: inject sentry dsn at runtime

### DIFF
--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -1,5 +1,5 @@
 import * as Sentry from '@sentry/nextjs'
-import { isNextNotFoundError } from './src/lib/next-http-fallback'
+import { isNextNotFoundError } from '@/lib/next-http-fallback.ts'
 
 Sentry.init({
   dsn: process.env.SENTRY_DSN,

--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -8,6 +8,7 @@ import { notFound } from 'next/navigation'
 import { Suspense } from 'react'
 import CustomJavascriptCode from '@/components/CustomJavascriptCode'
 import GlobalAnnouncementBanner from '@/components/GlobalAnnouncementBanner'
+import PublicRuntimeConfigScript from '@/components/PublicRuntimeConfigScript'
 import PwaInstallStateSync from '@/components/PwaInstallStateSync'
 import PwaServiceWorker from '@/components/PwaServiceWorker'
 import SiteStructuredData from '@/components/seo/SiteStructuredData'
@@ -162,6 +163,7 @@ function LocaleBody({
 }: LocaleDocumentProps & LocaleRuntimeData & { syncRootPreset: boolean }) {
   return (
     <body className="flex min-h-screen flex-col font-sans">
+      <PublicRuntimeConfigScript config={publicRuntimeConfig} />
       <ThemeDocumentState runtimeTheme={runtimeTheme} syncRootPreset={syncRootPreset} />
       <SiteStructuredData locale={locale} site={runtimeTheme.site} />
       <PwaServiceWorker />

--- a/src/components/PublicRuntimeConfigScript.tsx
+++ b/src/components/PublicRuntimeConfigScript.tsx
@@ -1,0 +1,17 @@
+import type { PublicRuntimeConfig } from '@/lib/public-runtime-config'
+import { serializePublicRuntimeConfig } from '@/lib/public-runtime-config'
+
+interface PublicRuntimeConfigScriptProps {
+  config: PublicRuntimeConfig
+}
+
+export default function PublicRuntimeConfigScript({ config }: PublicRuntimeConfigScriptProps) {
+  const script = `window.__PUBLIC_RUNTIME_CONFIG__=${serializePublicRuntimeConfig(config)};`
+
+  return (
+    <script
+      id="kuest-public-runtime-config"
+      dangerouslySetInnerHTML={{ __html: script }}
+    />
+  )
+}

--- a/src/hooks/usePublicRuntimeConfig.ts
+++ b/src/hooks/usePublicRuntimeConfig.ts
@@ -5,6 +5,7 @@ import { createContext, use } from 'react'
 
 const defaultPublicRuntimeConfig: PublicRuntimeConfig = {
   reownAppKitProjectId: '',
+  sentryDsn: '',
   siteUrl: 'http://localhost:3000',
 }
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,8 +1,28 @@
+import type { PublicRuntimeConfig } from '@/lib/public-runtime-config'
 import * as Sentry from '@sentry/nextjs'
 import { isNextNotFoundError } from '@/lib/next-http-fallback'
 
+declare global {
+  interface Window {
+    __PUBLIC_RUNTIME_CONFIG__?: Partial<PublicRuntimeConfig>
+  }
+}
+
+function normalizeSentryDsn(value: string | undefined) {
+  const normalized = value?.trim()
+  return normalized && normalized.length > 0 ? normalized : undefined
+}
+
+function resolveSentryDsn() {
+  const runtimeDsn = typeof window === 'undefined'
+    ? undefined
+    : normalizeSentryDsn(window.__PUBLIC_RUNTIME_CONFIG__?.sentryDsn)
+
+  return runtimeDsn ?? normalizeSentryDsn(process.env.SENTRY_DSN)
+}
+
 Sentry.init({
-  dsn: process.env.SENTRY_DSN,
+  dsn: resolveSentryDsn(),
   tracesSampleRate: 0.1,
   enableLogs: true,
   beforeSend(event, hint) {

--- a/src/lib/public-runtime-config.ts
+++ b/src/lib/public-runtime-config.ts
@@ -2,6 +2,7 @@ import resolveSiteUrl from '@/lib/site-url'
 
 export interface PublicRuntimeConfig {
   reownAppKitProjectId: string
+  sentryDsn: string
   siteUrl: string
 }
 
@@ -13,6 +14,11 @@ function normalizePublicEnvValue(value: string | undefined) {
 export function getPublicRuntimeConfig(env: NodeJS.ProcessEnv = process.env): PublicRuntimeConfig {
   return {
     reownAppKitProjectId: normalizePublicEnvValue(env.REOWN_APPKIT_PROJECT_ID),
+    sentryDsn: normalizePublicEnvValue(env.SENTRY_DSN),
     siteUrl: resolveSiteUrl(env),
   }
+}
+
+export function serializePublicRuntimeConfig(config: PublicRuntimeConfig) {
+  return JSON.stringify(config).replace(/</g, '\\u003c')
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Inject Sentry DSN at runtime so the client picks up environment-specific config without rebuilds. Fixes missing or empty DSN during client initialization.

- **Bug Fixes**
  - Initialize `@sentry/nextjs` on the client using DSN from runtime config, with env fallback and empty-value normalization.
  - Add PublicRuntimeConfigScript to embed serialized public config safely; included in `[locale]/layout` to expose DSN at load.
  - Extend public runtime config with `sentryDsn` and `serializePublicRuntimeConfig`; update default config.

<sup>Written for commit fe4b05ca851daf546ae5900c8cae5089a8cebd94. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1179?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

