### PR TITLE
refactor: remove redundant locale header from market context

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
@@ -86,7 +86,6 @@ async function requestMarketContext({
     headers: {
       'Accept': 'application/json',
       'Content-Type': 'application/json',
-      'X-Kuest-Locale': locale,
     },
     body: JSON.stringify({
       slug,

--- a/src/app/api/market-context/route.ts
+++ b/src/app/api/market-context/route.ts
@@ -10,8 +10,7 @@ export async function POST(request: Request) {
     )
   }
 
-  const localeHeader = request.headers.get('x-kuest-locale')
-  const result = await resolveMarketContextRequest(parsedPayload.data, localeHeader)
+  const result = await resolveMarketContextRequest(parsedPayload.data)
 
   return Response.json(result)
 }

--- a/src/lib/market-context-service.ts
+++ b/src/lib/market-context-service.ts
@@ -34,10 +34,7 @@ function resolveSupportedLocale(locale: string | null | undefined): SupportedLoc
   return DEFAULT_LOCALE
 }
 
-export async function resolveMarketContextRequest(
-  input: unknown,
-  fallbackLocale?: string | null,
-): Promise<MarketContextResponse> {
+export async function resolveMarketContextRequest(input: unknown): Promise<MarketContextResponse> {
   const parsed = MarketContextRequestSchema.safeParse(input)
 
   if (!parsed.success) {
@@ -46,7 +43,7 @@ export async function resolveMarketContextRequest(
 
   try {
     const { slug, marketConditionId, readOnly = false, locale } = parsed.data
-    const resolvedLocale = resolveSupportedLocale(locale ?? fallbackLocale)
+    const resolvedLocale = resolveSupportedLocale(locale)
     const { data: event, error } = await EventRepository.getEventBySlug(slug, '', resolvedLocale)
 
     if (error || !event) {

--- a/tests/unit/generateMarketContextAction.test.ts
+++ b/tests/unit/generateMarketContextAction.test.ts
@@ -73,8 +73,8 @@ describe('resolveMarketContextRequest', () => {
       {
         slug: 'event-slug',
         marketConditionId: 'condition-1',
+        locale: 'en',
       },
-      'en',
     )
 
     expect(result).toEqual({
@@ -98,8 +98,8 @@ describe('resolveMarketContextRequest', () => {
         slug: 'event-slug',
         marketConditionId: 'condition-1',
         readOnly: true,
+        locale: 'en',
       },
-      'en',
     )
 
     expect(result).toEqual({
@@ -133,8 +133,8 @@ describe('resolveMarketContextRequest', () => {
       {
         slug: 'event-slug',
         marketConditionId: 'condition-1',
+        locale: 'en',
       },
-      'en',
     )
 
     expect(result).toEqual({

--- a/tests/unit/marketContextRoute.test.ts
+++ b/tests/unit/marketContextRoute.test.ts
@@ -42,6 +42,7 @@ describe('market context route', () => {
       slug: 'event-slug',
       marketConditionId: 'condition-1',
       readOnly: true,
+      locale: 'pt',
     }
 
     mocks.safeParse.mockReturnValue({
@@ -59,7 +60,6 @@ describe('market context route', () => {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'x-kuest-locale': 'pt',
       },
       body: JSON.stringify(payload),
     }))
@@ -71,6 +71,6 @@ describe('market context route', () => {
       updatedAt: null,
       cached: false,
     })
-    expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload, 'pt')
+    expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the X-Kuest-Locale header from the market context flow. Locale is now read only from the request payload for a simpler, consistent API.

- **Refactors**
  - Removed header usage in the API route and the client request.
  - Simplified `resolveMarketContextRequest` by dropping the fallback locale param; uses `payload.locale` only.
  - Updated tests to pass `locale` in the payload and adjust expectations.

- **Migration**
  - If you call this API directly, stop sending the X-Kuest-Locale header.
  - Include `locale` in the request body instead.

<sup>Written for commit e463e62bdf0b1fed75d66ba6a8553017696457a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1180?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

