### PR TITLE
refactor: remove trust device feature from 2fa

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "@aws-sdk/client-s3": "3.1057.0",
     "@better-auth/drizzle-adapter": "1.6.20",
-    "@better-auth/utils": "0.4.1",
     "@bprogress/next": "3.2.12",
     "@daypicker/react": "10.0.1",
     "@fullcalendar/core": "6.1.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,10 +19,7 @@ importers:
         version: 3.1057.0
       '@better-auth/drizzle-adapter':
         specifier: 1.6.20
-        version: 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))
-      '@better-auth/utils':
-        specifier: 0.4.1
-        version: 0.4.1
+        version: 1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))
       '@bprogress/next':
         specifier: 3.2.12
         version: 3.2.12(next@16.2.7(@babel/core@7.29.7)(@opentelemetry/api@1.9.1)(@playwright/test@1.60.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -645,9 +642,6 @@ packages:
       '@better-auth/core': ^1.6.20
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-
-  '@better-auth/utils@0.4.1':
-    resolution: {integrity: sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA==}
 
   '@better-auth/utils@0.4.2':
     resolution: {integrity: sha512-AUxrvu+HaaODsUyzDxFgwd/8RZ1yZaYo42LXKSrU2oGgR38pS1ij8nqQKNgtTWoYGpNevNXtCfgTy6loHveW9A==}
@@ -9611,20 +9605,6 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@better-auth/core@1.6.20(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
-    dependencies:
-      '@better-auth/utils': 0.4.1
-      '@better-fetch/fetch': 1.3.1
-      '@opentelemetry/semantic-conventions': 1.41.1
-      '@standard-schema/spec': 1.1.0
-      better-call: 1.3.6(zod@4.4.3)
-      jose: 6.2.3
-      kysely: 0.29.2
-      nanostores: 1.3.0
-      zod: 4.4.3
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.1
-
   '@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)':
     dependencies:
       '@better-auth/utils': 0.4.2
@@ -9638,13 +9618,6 @@ snapshots:
       zod: 4.4.3
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
-
-  '@better-auth/drizzle-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))':
-    dependencies:
-      '@better-auth/core': 1.6.20(@better-auth/utils@0.4.1)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
-      '@better-auth/utils': 0.4.1
-    optionalDependencies:
-      drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9)
 
   '@better-auth/drizzle-adapter@1.6.20(@better-auth/core@1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0))(@better-auth/utils@0.4.2)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.29.2)(postgres@3.4.9))':
     dependencies:
@@ -9680,10 +9653,6 @@ snapshots:
       '@better-auth/core': 1.6.20(@better-auth/utils@0.4.2)(@better-fetch/fetch@1.3.1)(@opentelemetry/api@1.9.1)(better-call@1.3.6(zod@4.4.3))(jose@6.2.3)(kysely@0.29.2)(nanostores@1.3.0)
       '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
-
-  '@better-auth/utils@0.4.1':
-    dependencies:
-      '@noble/hashes': 2.2.0
 
   '@better-auth/utils@0.4.2':
     dependencies:
@@ -15544,7 +15513,7 @@ snapshots:
 
   better-call@1.3.6(zod@4.4.3):
     dependencies:
-      '@better-auth/utils': 0.4.1
+      '@better-auth/utils': 0.4.2
       '@better-fetch/fetch': 1.3.1
       rou3: 0.7.12
       set-cookie-parser: 3.1.0

--- a/src/app/[locale]/(platform)/settings/_components/SettingsTwoFactorAuthContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsTwoFactorAuthContent.tsx
@@ -10,7 +10,6 @@ import { enableTwoFactorAction } from '@/app/[locale]/(platform)/settings/_actio
 import { Button } from '@/components/ui/button'
 import { InputOTP, InputOTPGroup, InputOTPSlot } from '@/components/ui/input-otp'
 import { Label } from '@/components/ui/label'
-import { Switch } from '@/components/ui/switch'
 import { useClipboard } from '@/hooks/useClipboard'
 import { authClient } from '@/lib/auth-client'
 import { useUser } from '@/stores/useUser'
@@ -25,7 +24,6 @@ interface ComponentState {
   isLoading: boolean
   setupData: SetupData | null
   isEnabled: boolean
-  trustDevice: boolean
   code: string
   isVerifying: boolean
   isDisabling: boolean
@@ -41,7 +39,6 @@ function useTwoFactorState(user: User) {
     isLoading: false,
     setupData: null,
     isEnabled: user?.twoFactorEnabled || false,
-    trustDevice: false,
     code: '',
     isVerifying: false,
     isDisabling: false,
@@ -97,13 +94,6 @@ export default function SettingsTwoFactorAuthContent({ user }: { user: User }) {
         })}
       </span>
     )
-  }
-
-  function handleTrustDeviceChange(checked: boolean) {
-    setState(prev => ({
-      ...prev,
-      trustDevice: checked,
-    }))
   }
 
   async function handleEnableTwoFactor() {
@@ -192,7 +182,6 @@ export default function SettingsTwoFactorAuthContent({ user }: { user: User }) {
     try {
       const { error } = await authClient.twoFactor.verifyTotp({
         code: state.code,
-        trustDevice: state.trustDevice,
       })
 
       if (error) {
@@ -293,23 +282,6 @@ export default function SettingsTwoFactorAuthContent({ user }: { user: User }) {
                   )
                 : null}
 
-            {state.setupData && (
-              <div className="flex items-center justify-between">
-                <div className="grid gap-1">
-                  <Label className="text-sm font-medium">
-                    {t('Trust Device')}
-                  </Label>
-                  <p className="text-sm text-muted-foreground">
-                    {t('Trust this device for 30 days after activating 2FA')}
-                  </p>
-                </div>
-                <Switch
-                  id="trust-device"
-                  checked={state.trustDevice}
-                  onCheckedChange={handleTrustDeviceChange}
-                />
-              </div>
-            )}
           </div>
         </div>
       </div>

--- a/src/i18n/messages/de.json
+++ b/src/i18n/messages/de.json
@@ -655,8 +655,6 @@
   "5FfMEd": "Die Zwei-Faktor-Authentifizierung ist jetzt für dein Konto aktiv",
   "Omj2fC": "Wird deaktiviert...",
   "e7Db3T": "2FA deaktivieren",
-  "LmFahl": "Gerät vertrauen",
-  "Bu5zv4": "Diesem Gerät nach der Aktivierung von 2FA 30 Tage lang vertrauen",
   "OLqOyf": "Einrichtungsanleitung",
   "mpk3Qc": "Lade eine Authenticator-App wie Google Authenticator oder Authy herunter",
   "xdu7NK": "Scanne den QR-Code mit deiner Authenticator-App (oder kopiere den Code).",

--- a/src/i18n/messages/en.json
+++ b/src/i18n/messages/en.json
@@ -655,8 +655,6 @@
   "5FfMEd": "Two-factor authentication is now active on your account",
   "Omj2fC": "Disabling...",
   "e7Db3T": "Disable 2FA",
-  "LmFahl": "Trust Device",
-  "Bu5zv4": "Trust this device for 30 days after activating 2FA",
   "OLqOyf": "Setup Instructions",
   "mpk3Qc": "Download an authenticator app like Google Authenticator or Authy",
   "xdu7NK": "Scan the QR code with your authenticator app (or copy the code).",

--- a/src/i18n/messages/es.json
+++ b/src/i18n/messages/es.json
@@ -655,8 +655,6 @@
   "5FfMEd": "La autenticación de dos factores ya está activa en tu cuenta",
   "Omj2fC": "Deshabilitando...",
   "e7Db3T": "Deshabilitar 2FA",
-  "LmFahl": "Confiar en este dispositivo",
-  "Bu5zv4": "Confiar en este dispositivo durante 30 días después de activar 2FA",
   "OLqOyf": "Instrucciones de configuración",
   "mpk3Qc": "Descarga una app de autenticación como Google Authenticator o Authy",
   "xdu7NK": "Escanea el código QR con tu app de autenticación (o copia el código).",

--- a/src/i18n/messages/fr.json
+++ b/src/i18n/messages/fr.json
@@ -655,8 +655,6 @@
   "5FfMEd": "L'authentification à deux facteurs est maintenant active sur votre compte",
   "Omj2fC": "Désactivation...",
   "e7Db3T": "Désactiver la 2FA",
-  "LmFahl": "Faire confiance à l'appareil",
-  "Bu5zv4": "Faire confiance à cet appareil pendant 30 jours après l'activation de la 2FA",
   "OLqOyf": "Instructions de configuration",
   "mpk3Qc": "Téléchargez une application d'authentification comme Google Authenticator ou Authy",
   "xdu7NK": "Scannez le QR code avec votre application d'authentification (ou copiez le code).",

--- a/src/i18n/messages/pt.json
+++ b/src/i18n/messages/pt.json
@@ -655,8 +655,6 @@
   "5FfMEd": "A autenticação de dois fatores está ativa na sua conta",
   "Omj2fC": "Desativando...",
   "e7Db3T": "Desativar 2FA",
-  "LmFahl": "Confiar neste dispositivo",
-  "Bu5zv4": "Confiar neste dispositivo por 30 dias após ativar o 2FA",
   "OLqOyf": "Instruções de configuração",
   "mpk3Qc": "Baixe um aplicativo autenticador como Google Authenticator ou Authy",
   "xdu7NK": "Escaneie o QR code com seu aplicativo autenticador (ou copie o código).",

--- a/src/i18n/messages/zh.json
+++ b/src/i18n/messages/zh.json
@@ -655,8 +655,6 @@
   "5FfMEd": "你的账户已启用双重身份验证",
   "Omj2fC": "关闭中...",
   "e7Db3T": "关闭 2FA",
-  "LmFahl": "信任设备",
-  "Bu5zv4": "启用 2FA 后信任此设备 30 天",
   "OLqOyf": "设置说明",
   "mpk3Qc": "下载身份验证器应用，例如 Google Authenticator 或 Authy",
   "xdu7NK": "使用身份验证器应用扫描二维码（或复制代码）。",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,5 +1,4 @@
 import { drizzleAdapter } from '@better-auth/drizzle-adapter'
-import { createHMAC } from '@better-auth/utils/hmac'
 import { getChainIdFromMessage } from '@reown/appkit-siwe'
 import { betterAuth } from 'better-auth'
 import { createAuthMiddleware } from 'better-auth/api'
@@ -21,8 +20,6 @@ import { isWalletPlaceholderEmail } from '@/lib/user-email'
 import * as schema from './db/schema'
 
 const TWO_FACTOR_COOKIE_NAME = 'two_factor'
-const TRUST_DEVICE_COOKIE_NAME = 'trust_device'
-const TRUST_DEVICE_COOKIE_MAX_AGE = 720 * 60 * 60
 const TWO_FACTOR_PENDING_MAX_AGE = 3 * 60
 const AFFILIATE_COOKIE_NAME = 'platform_affiliate'
 const AFFILIATE_COOKIE_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000
@@ -97,37 +94,6 @@ function siweTwoFactorRedirect() {
             if (sessionToken) {
               const existingSession = await ctx.context.internalAdapter.findSession(sessionToken)
               if (existingSession?.session?.userId === data.user.id) {
-                return
-              }
-            }
-
-            const trustDeviceCookieAttrs = ctx.context.createAuthCookie(TRUST_DEVICE_COOKIE_NAME, {
-              maxAge: TRUST_DEVICE_COOKIE_MAX_AGE,
-            })
-            const trustDeviceCookie = await ctx.getSignedCookie(trustDeviceCookieAttrs.name, ctx.context.secret)
-
-            if (trustDeviceCookie) {
-              const [token, sessionToken] = trustDeviceCookie.split('!')
-              const expected = await createHMAC('SHA-256', 'base64urlnopad').sign(
-                ctx.context.secret,
-                `${data.user.id}!${sessionToken}`,
-              )
-
-              if (token === expected) {
-                const newTrustDeviceCookie = ctx.context.createAuthCookie(TRUST_DEVICE_COOKIE_NAME, {
-                  maxAge: TRUST_DEVICE_COOKIE_MAX_AGE,
-                })
-                const newToken = await createHMAC('SHA-256', 'base64urlnopad').sign(
-                  ctx.context.secret,
-                  `${data.user.id}!${data.session.token}`,
-                )
-
-                await ctx.setSignedCookie(
-                  newTrustDeviceCookie.name,
-                  `${newToken}!${data.session.token}`,
-                  ctx.context.secret,
-                  trustDeviceCookieAttrs.attributes,
-                )
                 return
               }
             }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed the “Trust Device” option from 2FA to simplify the flow and require code verification on every sign-in. Existing trust-device cookies are ignored.

- **Refactors**
  - UI: removed the trust-device toggle and text; no longer sends `trustDevice` to `authClient.twoFactor.verifyTotp`.
  - Server: removed the `trust_device` cookie and related constants and HMAC logic.
  - i18n: removed trust-device strings from `en`, `de`, `es`, `fr`, `pt`, `zh`.

- **Dependencies**
  - Removed direct `@better-auth/utils` dependency.

<sup>Written for commit 5461338d1ac155e83c76057a0bc5777dd7911e47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

