### PR TITLE
refactor: remove duplicated sports market context

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook.tsx
@@ -37,6 +37,8 @@ import EventOrderBookRow from './EventOrderBookRow'
 
 export { useOrderBookSummaries }
 
+const orderBookHeaderLabelClass = 'inline-flex -translate-y-px whitespace-nowrap text-[10px] leading-3 tracking-normal sm:text-xs sm:tracking-wide'
+
 function useOrderBookRecenter(summary: unknown) {
   const orderBookScrollRef = useRef<HTMLDivElement | null>(null)
   const centerRowRef = useRef<HTMLDivElement | null>(null)
@@ -420,8 +422,10 @@ export default function EventOrderBook({
             surfaceClass,
           )}
         >
-          <div className="flex h-full items-center gap-2">
-            <span className="inline-flex -translate-y-px">{displayTradeLabel}</span>
+          <div className="flex h-full min-w-0 items-center gap-1">
+            <span className={orderBookHeaderLabelClass}>
+              {displayTradeLabel}
+            </span>
             {onToggleOutcome && toggleOutcomeTooltip && (
               <Tooltip>
                 <TooltipTrigger asChild>
@@ -464,13 +468,13 @@ export default function EventOrderBook({
             </Tooltip>
           </div>
           <div className="flex h-full items-center justify-center">
-            <span className="inline-flex -translate-y-px">{t('Price')}</span>
+            <span className={orderBookHeaderLabelClass}>{t('Price')}</span>
           </div>
           <div className="flex h-full items-center justify-center">
-            <span className="inline-flex -translate-y-px">{t('Shares')}</span>
+            <span className={orderBookHeaderLabelClass}>{t('Shares')}</span>
           </div>
           <div className="flex h-full items-center justify-center">
-            <span className="inline-flex -translate-y-px">{t('Total')}</span>
+            <span className={orderBookHeaderLabelClass}>{t('Total')}</span>
           </div>
         </div>
 

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventAboutPanel.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventAboutPanel.tsx
@@ -129,7 +129,6 @@ export default function SportsEventAboutPanel({
 
   return (
     <div className="grid gap-3 pb-2">
-      {marketContextEnabled && <EventMarketContext event={event} marketConditionId={market?.condition_id ?? null} />}
       <EventRules event={aboutRulesEvent} mode="inline" showEndDate />
 
       {market && shouldShowResolution && (

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -799,7 +799,6 @@ export default function SportsEventCenter({
             aboutEvent={activeCard.event}
             rulesEvent={heroCard.event}
             showRedeemInPositions
-            marketContextEnabled={marketContextEnabled}
             onOpenRedeemForCondition={handleOpenRedeemForCondition}
             oddsFormat={oddsFormat}
             onChangeTab={tab => setTabByAuxiliaryConditionId(current => ({ ...current, [panelKey]: tab }))}
@@ -1272,7 +1271,6 @@ export default function SportsEventCenter({
                         showAboutTab
                         aboutEvent={activeCard.event}
                         rulesEvent={heroCard.event}
-                        marketContextEnabled={marketContextEnabled}
                         oddsFormat={oddsFormat}
                         onChangeTab={tab => setTabBySection(current => ({ ...current, [section.key]: tab }))}
                         onSelectButton={(buttonKey, options) => {

--- a/src/app/[locale]/(platform)/sports/_components/SportsGamesCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsGamesCenter.tsx
@@ -1,15 +1,11 @@
 'use client'
 
 import type { Route } from 'next'
-import type {
-  KeyboardEvent as ReactKeyboardEvent,
-  MouseEvent as ReactMouseEvent,
-} from 'react'
 import type { SportsGamesCenterProps, SportsGamesMarketType } from './_sports-games-center/sports-games-center-types'
 import type { SportsGamesCard } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 import {
+  BookOpenTextIcon,
   CheckIcon,
-  ChevronRightIcon,
   RadioIcon,
   SearchIcon,
   SettingsIcon,
@@ -263,15 +259,11 @@ export default function SportsGamesCenter({
     setOrderSide,
   })
 
-  function toggleCard(
+  function toggleCardBook(
     card: SportsGamesCard,
-    event?: ReactMouseEvent<HTMLElement> | ReactKeyboardEvent<HTMLElement>,
   ) {
-    if (event) {
-      const target = event.target as HTMLElement | null
-      if (target?.closest('[data-sports-card-control="true"]')) {
-        return
-      }
+    if (isMobile) {
+      return
     }
 
     if (card.event.sports_ended === true) {
@@ -424,7 +416,7 @@ export default function SportsGamesCenter({
     )
       ? (teamScores[0] > teamScores[1] ? 0 : 1)
       : null
-    const shouldRenderDetailsPanel = isExpanded && (effectiveIsDetailsContentVisible || isSpreadOrTotalSelected)
+    const shouldRenderDetailsPanel = !isMobile && isExpanded && (effectiveIsDetailsContentVisible || isSpreadOrTotalSelected)
     const activeMarketType = resolveActiveMarketType(card, selectedButtonKey)
     const buttonGroups = groupButtonsByMarketType(card.buttons)
     const shouldUseClosedDetailsSpacing = Boolean(
@@ -456,21 +448,25 @@ export default function SportsGamesCenter({
       >
         <div
           className={cn(
-            `-mx-2.5 -mt-2.5 bg-card px-2.5 pt-2.5 transition-colors hover:bg-secondary/30`,
+            `
+              group/sports-card-body relative -mx-2.5 -mt-2.5 bg-card px-2.5 pt-2.5 transition-colors
+              hover:bg-secondary/30
+            `,
             shouldRenderDetailsPanel ? 'rounded-t-xl' : 'rounded-xl',
             isFinalizedCard ? 'pb-3' : 'pb-2.5',
           )}
-          role="button"
-          tabIndex={0}
-          onClick={event => toggleCard(card, event)}
-          onKeyDown={(event) => {
-            if (event.key === 'Enter' || event.key === ' ') {
-              event.preventDefault()
-              toggleCard(card, event)
-            }
-          }}
         >
-          <div className="mb-2 flex items-start justify-between gap-2 sm:items-center">
+          <AppLink
+            intentPrefetch
+            href={card.eventHref as Route}
+            aria-label={`Open ${card.title}`}
+            className={cn(`
+              absolute inset-0 z-10 rounded-[inherit]
+              focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none
+            `)}
+          />
+
+          <div className="pointer-events-none relative z-20 mb-2 flex items-start justify-between gap-2 sm:items-center">
             <div className="flex min-w-0 flex-1 items-center gap-2">
               {options.topBadgeMode === 'live'
                 ? isFinalizedCard
@@ -514,7 +510,7 @@ export default function SportsGamesCenter({
               </div>
             </div>
 
-            <div className="flex shrink-0 items-start gap-2 sm:items-center">
+            <div className="pointer-events-auto relative z-30 flex shrink-0 items-start gap-2 sm:items-center">
               {canWatchLivestream && (
                 <Tooltip>
                   <TooltipTrigger asChild>
@@ -546,40 +542,33 @@ export default function SportsGamesCenter({
                 </Tooltip>
               )}
 
-              <AppLink
-                intentPrefetch
-                href={card.eventHref}
-                data-sports-card-control="true"
-                onClick={event => event.stopPropagation()}
-                className={cn(
-                  `
-                    inline-flex shrink-0 items-center gap-1 rounded-lg bg-secondary/80 px-2 py-1.5 text-xs font-semibold
-                    text-foreground transition-colors
-                    sm:px-2.5
-                  `,
-                  'hover:bg-secondary hover:ring-1 hover:ring-border',
-                )}
-              >
-                {card.marketsCount > 0 && (
-                  <span
-                    className={cn(
-                      `
-                        inline-flex size-5 items-center justify-center rounded-sm bg-muted text-2xs font-semibold
-                        text-foreground/80
-                      `,
-                    )}
-                  >
-                    {card.marketsCount}
-                  </span>
-                )}
-                <span>Game View</span>
-                <ChevronRightIcon className="size-3.5" />
-              </AppLink>
+              {!isMobile && (
+                <button
+                  type="button"
+                  data-sports-card-control="true"
+                  aria-label={isExpanded && effectiveIsDetailsContentVisible ? 'Close order book' : 'Open order book'}
+                  onClick={(event) => {
+                    event.preventDefault()
+                    event.stopPropagation()
+                    toggleCardBook(card)
+                  }}
+                  className={cn(
+                    `
+                      hidden size-8 shrink-0 items-center justify-center rounded-lg bg-secondary/80 text-foreground
+                      transition-colors
+                      lg:inline-flex
+                    `,
+                    'hover:bg-secondary hover:ring-1 hover:ring-border',
+                  )}
+                >
+                  <BookOpenTextIcon className="size-3.5" />
+                </button>
+              )}
             </div>
           </div>
 
           <div className={cn(`
-            flex flex-col gap-2.5
+            pointer-events-none relative z-20 flex flex-col gap-2.5
             min-[1200px]:flex-row min-[1200px]:items-center min-[1200px]:justify-between
           `)}
           >
@@ -739,7 +728,7 @@ export default function SportsGamesCenter({
               <div
                 data-sports-card-control="true"
                 className={cn(
-                  'grid grid-cols-1 gap-2',
+                  'pointer-events-auto relative z-30 grid grid-cols-1 gap-2',
                   shouldCollapseCardControlsToMoneylineOnly
                     ? (
                         showSpreadsAndTotals

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameDetailsPanel.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameDetailsPanel.tsx
@@ -53,7 +53,6 @@ export default function SportsGameDetailsPanel({
   showRedeemInPositions = false,
   onOpenRedeemForCondition = null,
   oddsFormat = 'price',
-  marketContextEnabled = true,
   onChangeTab,
   onSelectButton,
 }: SportsGameDetailsPanelProps) {
@@ -397,7 +396,6 @@ export default function SportsGameDetailsPanel({
               event={aboutEvent}
               rulesEvent={rulesEvent}
               market={selectedMarket}
-              marketContextEnabled={marketContextEnabled}
             />
           )}
         </>

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-types.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-types.ts
@@ -102,7 +102,6 @@ export interface SportsGameDetailsPanelProps {
   showRedeemInPositions?: boolean
   onOpenRedeemForCondition?: ((conditionId: string) => void) | null
   oddsFormat?: OddsFormat
-  marketContextEnabled?: boolean
   onChangeTab: (tab: DetailsTab) => void
   onSelectButton: (
     buttonKey: string,

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
@@ -742,6 +742,21 @@ export function resolveSelectedTradeLabel(
   return button.label.trim().toUpperCase()
 }
 
+export function resolveSelectedOrderBookTradeLabel(
+  button: SportsGamesButton | null,
+  selectedOutcome: Outcome | null,
+) {
+  if (!button) {
+    return selectedOutcome?.outcome_text?.trim().toUpperCase() || 'YES'
+  }
+
+  if (button.marketType === 'total') {
+    return resolveTotalButtonLabel(button, selectedOutcome)
+  }
+
+  return button.label.trim().toUpperCase()
+}
+
 function resolveMarketDescriptor(market: Market | null) {
   if (!market) {
     return null

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameDetailsPanel.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameDetailsPanel.ts
@@ -36,8 +36,8 @@ import {
   resolvePreferredLinePickerButton,
   resolveSelectedButton,
   resolveSelectedMarket,
+  resolveSelectedOrderBookTradeLabel,
   resolveSelectedOutcome,
-  resolveSelectedTradeLabel,
   resolveSwitchTooltip,
   toFiniteNumber,
 } from './sports-games-center-utils'
@@ -471,8 +471,8 @@ export function useSportsSelectedMarketDerivations({
   }, [card.buttons, nextOutcome, selectedMarket])
 
   const tradeSelectionLabel = useMemo(
-    () => resolveSelectedTradeLabel(card, selectedButton, selectedOutcome),
-    [card, selectedButton, selectedOutcome],
+    () => resolveSelectedOrderBookTradeLabel(selectedButton, selectedOutcome),
+    [selectedButton, selectedOutcome],
   )
 
   const switchTooltip = useMemo(() => {

--- a/tests/unit/SportsGamesCenter.test.tsx
+++ b/tests/unit/SportsGamesCenter.test.tsx
@@ -1,0 +1,281 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import SportsGamesCenter from '@/app/[locale]/(platform)/sports/_components/SportsGamesCenter'
+
+const mocks = vi.hoisted(() => ({
+  isMobile: false,
+  push: vi.fn(),
+  setIsMobileOrderPanelOpen: vi.fn(),
+}))
+
+vi.mock('next/image', () => ({
+  default: function MockImage({ fill: _fill, ...props }: any) {
+    return <img {...props} />
+  },
+}))
+
+vi.mock('next-intl', () => ({
+  useLocale: () => 'en',
+}))
+
+vi.mock('@/i18n/navigation', () => ({
+  Link: function MockLink({ children, href, ...props }: any) {
+    return <a href={href} {...props}>{children}</a>
+  },
+  useRouter: () => ({ push: mocks.push }),
+}))
+
+vi.mock('@/hooks/useCurrentTimestamp', () => ({
+  useCurrentTimestamp: () => Date.parse('2026-03-12T12:00:00.000Z'),
+}))
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => mocks.isMobile,
+}))
+
+vi.mock('@/stores/useOrder', () => ({
+  useOrder: Object.assign((selector: any) => selector({
+    event: null,
+    market: null,
+    outcome: null,
+    setEvent: vi.fn(),
+    setMarket: vi.fn(),
+    setOutcome: vi.fn(),
+    setSide: vi.fn(),
+    setIsMobileOrderPanelOpen: mocks.setIsMobileOrderPanelOpen,
+  }), {
+    getState: () => ({
+      event: null,
+      market: null,
+      outcome: null,
+    }),
+  }),
+}))
+
+vi.mock('@/stores/useSportsLivestream', () => ({
+  useSportsLivestream: (selector: any) => selector({ openStream: vi.fn() }),
+}))
+
+vi.mock('@/app/[locale]/(platform)/event/[slug]/_components/EventOrderBook', () => ({
+  useOrderBookSummaries: () => ({ data: null, isLoading: false, isRefetching: false, refetch: vi.fn() }),
+}))
+
+vi.mock('@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm', () => ({
+  default: function MockEventOrderPanelForm() {
+    return <div data-testid="order-panel-form" />
+  },
+}))
+
+vi.mock('@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelMobile', () => ({
+  default: function MockEventOrderPanelMobile() {
+    return <div data-testid="mobile-order-panel" />
+  },
+}))
+
+vi.mock('@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelTermsDisclaimer', () => ({
+  default: function MockEventOrderPanelTermsDisclaimer() {
+    return <div data-testid="order-panel-disclaimer" />
+  },
+}))
+
+vi.mock('@/app/[locale]/(platform)/sports/_components/SportsLivestreamFloatingPlayer', () => ({
+  default: function MockSportsLivestreamFloatingPlayer() {
+    return null
+  },
+}))
+
+vi.mock('@/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameDetailsPanel', () => ({
+  default: function MockSportsGameDetailsPanel(props: { showBottomContent: boolean, activeDetailsTab: string }) {
+    if (!props.showBottomContent) {
+      return null
+    }
+
+    return (
+      <div
+        data-testid="sports-game-details-panel"
+        data-active-details-tab={props.activeDetailsTab}
+      />
+    )
+  },
+}))
+
+vi.mock('@/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo', () => ({
+  default: function MockSportsOrderPanelMarketInfo() {
+    return <div data-testid="sports-order-panel-market-info" />
+  },
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: function MockButton(props: any) {
+    return <button {...props} />
+  },
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onSelect, ...props }: any) => (
+    <button type="button" onClick={onSelect} {...props}>{children}</button>
+  ),
+  DropdownMenuLabel: ({ children }: any) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <div />,
+  DropdownMenuTrigger: ({ children }: any) => <>{children}</>,
+}))
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({ children }: any) => <div>{children}</div>,
+  SelectContent: ({ children }: any) => <div>{children}</div>,
+  SelectItem: ({ children }: any) => <div>{children}</div>,
+  SelectTrigger: ({ children, ...props }: any) => <button type="button" {...props}>{children}</button>,
+  SelectValue: ({ placeholder }: any) => <span>{placeholder}</span>,
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: any) => <>{children}</>,
+  TooltipContent: ({ children }: any) => <div>{children}</div>,
+  TooltipTrigger: ({ children }: any) => <>{children}</>,
+}))
+
+function createSportsCard() {
+  const market = {
+    id: 'market-1',
+    condition_id: 'condition-moneyline',
+    slug: 'alpha-vs-beta-moneyline',
+    title: 'Alpha vs Beta',
+    short_title: 'Alpha vs Beta',
+    sports_market_type: 'moneyline',
+    is_resolved: false,
+    outcomes: [
+      {
+        id: 'outcome-alpha',
+        outcome_index: 0,
+        outcome_text: 'Alpha',
+        token_id: 'token-alpha',
+      },
+      {
+        id: 'outcome-beta',
+        outcome_index: 1,
+        outcome_text: 'Beta',
+        token_id: 'token-beta',
+      },
+    ],
+  }
+
+  return {
+    id: 'card-1',
+    slug: 'alpha-vs-beta',
+    title: 'Alpha vs Beta',
+    eventHref: '/sports/nba/alpha-vs-beta',
+    volume: 12500,
+    marketsCount: 1,
+    eventCreatedAt: '2026-03-01T00:00:00.000Z',
+    eventResolvedAt: null,
+    startTime: '2026-03-14T23:00:00.000Z',
+    week: 1,
+    event: {
+      id: 'event-1',
+      slug: 'alpha-vs-beta',
+      title: 'Alpha vs Beta',
+      status: 'active',
+      volume: 12500,
+      sports_ended: false,
+      sports_live: false,
+      sports_score: null,
+      sports_sport_slug: 'nba',
+      sports_start_time: '2026-03-14T23:00:00.000Z',
+      markets: [market],
+    },
+    teams: [
+      {
+        name: 'Alpha',
+        abbreviation: 'ALP',
+        record: '10-2',
+        color: '#2563eb',
+        logoUrl: null,
+        hostStatus: 'home',
+      },
+      {
+        name: 'Beta',
+        abbreviation: 'BET',
+        record: '8-4',
+        color: '#dc2626',
+        logoUrl: null,
+        hostStatus: 'away',
+      },
+    ],
+    detailMarkets: [market],
+    defaultConditionId: 'condition-moneyline',
+    buttons: [
+      {
+        key: 'condition-moneyline-alpha',
+        conditionId: 'condition-moneyline',
+        outcomeIndex: 0,
+        fallbackIsNoOutcome: false,
+        label: 'ALP',
+        cents: 62,
+        color: '#2563eb',
+        marketType: 'moneyline',
+        tone: 'team1',
+      },
+      {
+        key: 'condition-moneyline-beta',
+        conditionId: 'condition-moneyline',
+        outcomeIndex: 1,
+        fallbackIsNoOutcome: true,
+        label: 'BET',
+        cents: 38,
+        color: '#dc2626',
+        marketType: 'moneyline',
+        tone: 'team2',
+      },
+    ],
+  } as any
+}
+
+function renderSportsGamesCenter() {
+  return render(
+    <SportsGamesCenter
+      cards={[createSportsCard()]}
+      sportSlug="nba"
+      sportTitle="NBA"
+      initialWeek={1}
+      showHeading={false}
+    />,
+  )
+}
+
+describe('sportsGamesCenter card actions', () => {
+  beforeEach(() => {
+    mocks.isMobile = false
+    mocks.push.mockReset()
+    mocks.setIsMobileOrderPanelOpen.mockReset()
+  })
+
+  it('navigates from the card body and opens the order book from the icon-only right-side control', async () => {
+    const user = userEvent.setup()
+    renderSportsGamesCenter()
+
+    expect(screen.getByRole('link', { name: 'Open Alpha vs Beta' })).toHaveAttribute(
+      'href',
+      '/sports/nba/alpha-vs-beta',
+    )
+    expect(screen.queryByText('Game View')).not.toBeInTheDocument()
+    expect(screen.queryByTestId('sports-game-details-panel')).not.toBeInTheDocument()
+
+    const orderBookButton = screen.getByRole('button', { name: 'Open order book' })
+    expect(orderBookButton.textContent).toBe('')
+
+    await user.click(orderBookButton)
+    expect(mocks.push).not.toHaveBeenCalled()
+    expect(screen.getByTestId('sports-game-details-panel')).toHaveAttribute('data-active-details-tab', 'orderBook')
+  })
+
+  it('does not render the order-book opener on mobile', () => {
+    mocks.isMobile = true
+
+    renderSportsGamesCenter()
+
+    expect(screen.queryByRole('button', { name: 'Open order book' })).not.toBeInTheDocument()
+    expect(screen.queryByTestId('sports-game-details-panel')).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/sportsOrderBookTradeLabel.test.ts
+++ b/tests/unit/sportsOrderBookTradeLabel.test.ts
@@ -1,0 +1,45 @@
+import { resolveSelectedOrderBookTradeLabel } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils'
+
+describe('sports order-book trade label', () => {
+  it('uses the displayed moneyline button abbreviation for team outcomes', () => {
+    const button = {
+      key: 'scotland-moneyline',
+      conditionId: 'match-winner',
+      outcomeIndex: 0,
+      fallbackIsNoOutcome: false,
+      label: 'SCO',
+      cents: 42,
+      color: null,
+      marketType: 'moneyline',
+      tone: 'team1',
+    } as const
+
+    const outcome = {
+      outcome_index: 0,
+      outcome_text: 'Scotland',
+    }
+
+    expect(resolveSelectedOrderBookTradeLabel(button, outcome as any)).toBe('SCO')
+  })
+
+  it('preserves total side and line labels', () => {
+    const button = {
+      key: 'total-over-2-5',
+      conditionId: 'total-goals',
+      outcomeIndex: 0,
+      fallbackIsNoOutcome: false,
+      label: 'O 2.5',
+      cents: 54,
+      color: null,
+      marketType: 'total',
+      tone: 'over',
+    } as const
+
+    const outcome = {
+      outcome_index: 0,
+      outcome_text: 'Over',
+    }
+
+    expect(resolveSelectedOrderBookTradeLabel(button, outcome as any)).toBe('OVER 2.5')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed duplicated sports market context and streamlined Sports Games Center card interactions. The card body now navigates to the game, and a desktop-only button opens the order book; order book headers and trade labels are standardized.

- **Refactors**
  - Removed duplicated market context in sports panels; dropped `marketContextEnabled` and `EventMarketContext` usage.
  - Card body in `SportsGamesCenter` is now an `AppLink` overlay; added a desktop-only "open order book" icon; details panel no longer opens on mobile.
  - Adjusted pointer-events and z-index so the overlay is clickable while right-side controls remain interactive.
  - Standardized order book header text via a shared class and improved layout.
  - Switched the order book trade label to short team labels for moneyline and kept full labels for totals (`resolveSelectedOrderBookTradeLabel`); updated hook usage.
  - Added unit tests for card navigation/order book behavior and trade label logic.

<sup>Written for commit d25ef619b23b5047f6afb5cc7925b96ff1c9a56b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1183?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

