### PR TITLE
refactor: separate predictions search query from home page query

### DIFF
--- a/src/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsClient.tsx
+++ b/src/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsClient.tsx
@@ -32,16 +32,16 @@ import { useAppKit } from '@/hooks/useAppKit'
 import { useOutcomeLabel } from '@/hooks/useOutcomeLabel'
 import { usePathname, useRouter } from '@/i18n/navigation'
 import { OUTCOME_INDEX } from '@/lib/constants'
-import { fetchEventsApi } from '@/lib/events-api'
 import { resolveEventPagePath } from '@/lib/events-routing'
 import { formatCompactCurrency, formatDate } from '@/lib/formatters'
-import { HOME_EVENTS_PAGE_SIZE, isEventResolvedLike } from '@/lib/home-events'
+import { isEventResolvedLike } from '@/lib/home-events'
+import { fetchPredictionResultsApi } from '@/lib/prediction-results-api'
+import { PREDICTION_RESULTS_PAGE_SIZE } from '@/lib/prediction-results-constants'
 import {
   buildPredictionResultsUrlSearchParams,
   DEFAULT_PREDICTION_RESULTS_SORT,
   DEFAULT_PREDICTION_RESULTS_STATUS,
   resolvePredictionResultsRequestedApiSort,
-  resolvePredictionResultsRequestedApiStatus,
 } from '@/lib/prediction-results-filters'
 import { buildPredictionResultsPath } from '@/lib/prediction-search'
 import { cn } from '@/lib/utils'
@@ -221,7 +221,6 @@ function filterPredictionEventsByQuery(events: Event[], query: string) {
 }
 
 async function fetchPredictionResults({
-  currentTimestamp,
   locale,
   pageParam = 0,
   query,
@@ -231,7 +230,6 @@ async function fetchPredictionResults({
   status,
   bookmarked = false,
 }: {
-  currentTimestamp: number | null
   locale: string
   pageParam?: number
   query: string
@@ -241,24 +239,18 @@ async function fetchPredictionResults({
   status: PredictionResultsStatusOption
   bookmarked?: boolean
 }): Promise<Event[]> {
-  const requestStatus = resolvePredictionResultsRequestedApiStatus({
-    query,
-    status,
-  })
   const sortBy = resolvePredictionResultsRequestedApiSort({
     query,
     sort,
   })
-  return fetchEventsApi({
+  return fetchPredictionResultsApi({
     tag: routeTag,
     mainTag: routeMainTag,
     search: query,
     bookmarked,
-    homeFeed: true,
     locale,
     offset: pageParam,
-    status: requestStatus,
-    currentTimestamp,
+    status,
     sort: sortBy,
   })
 }
@@ -524,7 +516,6 @@ export default function PredictionResultsClient({
     ],
     queryFn: ({ pageParam }) => fetchPredictionResults({
       bookmarked: isBookmarked,
-      currentTimestamp,
       locale,
       pageParam,
       query: initialQuery,
@@ -533,7 +524,7 @@ export default function PredictionResultsClient({
       sort: selectedSort,
       status: selectedStatus,
     }),
-    getNextPageParam: (lastPage, allPages) => lastPage.length === HOME_EVENTS_PAGE_SIZE ? allPages.length * HOME_EVENTS_PAGE_SIZE : undefined,
+    getNextPageParam: (lastPage, allPages) => lastPage.length === PREDICTION_RESULTS_PAGE_SIZE ? allPages.length * PREDICTION_RESULTS_PAGE_SIZE : undefined,
     initialData: canUseInitialData ? { pageParams: [0], pages: [initialEvents] } : undefined,
     initialPageParam: 0,
     refetchOnMount: false,

--- a/src/app/[locale]/(platform)/predictions/[slug]/_lib/prediction-results-page.tsx
+++ b/src/app/[locale]/(platform)/predictions/[slug]/_lib/prediction-results-page.tsx
@@ -12,12 +12,9 @@ import {
 } from '@/app/[locale]/(platform)/_lib/prediction-results-metadata'
 import PredictionResultsClient from '@/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsClient'
 import { TagRepository } from '@/lib/db/queries/tag'
-import { listHomeEventsPage } from '@/lib/home-events-page'
 import { buildPlatformNavigationTags } from '@/lib/platform-navigation'
-import {
-  resolvePredictionResultsRequestedApiSort,
-  resolvePredictionResultsRequestedApiStatus,
-} from '@/lib/prediction-results-filters'
+import { listPredictionResultsPage } from '@/lib/prediction-results-events'
+import { resolvePredictionResultsRequestedApiSort } from '@/lib/prediction-results-filters'
 import { resolvePredictionSearchContext } from '@/lib/prediction-search'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -103,11 +100,10 @@ export async function renderPredictionResultsPage({
   slug: string
 }) {
   const context = await getPredictionPageContext(locale, slug)
-  let initialCurrentTimestamp: number | null = null
   let initialEvents: Event[] = []
 
   try {
-    const { data, error, currentTimestamp } = await listHomeEventsPage({
+    const { data, error } = await listPredictionResultsPage({
       bookmarked: false,
       locale,
       mainTag: context.mainTag,
@@ -116,15 +112,10 @@ export async function renderPredictionResultsPage({
         query: context.query,
         sort: initialSort,
       }),
-      status: resolvePredictionResultsRequestedApiStatus({
-        query: context.query,
-        status: initialStatus,
-      }),
+      status: initialStatus,
       tag: context.tag,
       userId: '',
     })
-
-    initialCurrentTimestamp = currentTimestamp ?? null
 
     if (!error) {
       initialEvents = data ?? []
@@ -138,7 +129,7 @@ export async function renderPredictionResultsPage({
     <main className="container py-6 lg:py-8">
       <PredictionResultsClient
         displayLabel={context.label}
-        initialCurrentTimestamp={initialCurrentTimestamp}
+        initialCurrentTimestamp={null}
         initialEvents={initialEvents}
         initialInputValue={context.inputValue}
         initialQuery={context.query}

--- a/src/app/api/predictions/events/route.ts
+++ b/src/app/api/predictions/events/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from 'next/server'
+import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/i18n/locales'
+import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
+import { UserRepository } from '@/lib/db/queries/user'
+import { isEventListSortBy, isEventListStatusFilter } from '@/lib/event-list-filters'
+import { listPredictionResultsPage } from '@/lib/prediction-results-events'
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url)
+  const tag = searchParams.get('tag') || 'trending'
+  const mainTag = searchParams.get('mainTag') || ''
+  const search = searchParams.get('search') || ''
+  const bookmarked = searchParams.get('bookmarked') === 'true'
+  const includeBookmarkState = searchParams.get('includeBookmarkState') !== 'false'
+  const statusParam = searchParams.get('status')
+  const status = statusParam ?? 'active'
+  const sortParam = searchParams.get('sort')
+  const sortBy = isEventListSortBy(sortParam) ? sortParam : undefined
+  const localeParam = searchParams.get('locale') ?? DEFAULT_LOCALE
+  const locale = SUPPORTED_LOCALES.includes(localeParam as typeof SUPPORTED_LOCALES[number])
+    ? localeParam as typeof SUPPORTED_LOCALES[number]
+    : DEFAULT_LOCALE
+  const offset = Number.parseInt(searchParams.get('offset') || '0', 10)
+  const clampedOffset = Number.isNaN(offset) ? 0 : Math.max(0, offset)
+
+  if (!isEventListStatusFilter(status)) {
+    return NextResponse.json({ error: 'Invalid status filter.' }, { status: 400 })
+  }
+
+  const shouldResolveCurrentUser = bookmarked || includeBookmarkState
+  const user = shouldResolveCurrentUser
+    ? await UserRepository.getCurrentUser({ minimal: true })
+    : null
+  const userId = user?.id
+
+  try {
+    if (bookmarked && !userId) {
+      return NextResponse.json([])
+    }
+
+    const { data: events, error } = await listPredictionResultsPage({
+      bookmarked,
+      locale,
+      mainTag,
+      offset: clampedOffset,
+      search,
+      sortBy,
+      status,
+      tag,
+      userId: userId ?? '',
+    })
+
+    if (error) {
+      return NextResponse.json({ error: DEFAULT_ERROR_MESSAGE }, { status: 500 })
+    }
+
+    return NextResponse.json(events)
+  }
+  catch (error) {
+    console.error('Prediction results API error:', error)
+    return NextResponse.json({ error: DEFAULT_ERROR_MESSAGE }, { status: 500 })
+  }
+}

--- a/src/lib/prediction-results-api.ts
+++ b/src/lib/prediction-results-api.ts
@@ -1,0 +1,59 @@
+import type { EventListSortBy, EventListStatusFilter } from '@/lib/event-list-filters'
+import type { Event } from '@/types'
+
+interface BuildPredictionResultsApiSearchParamsOptions {
+  bookmarked?: boolean
+  locale: string
+  mainTag?: string
+  offset?: number
+  search?: string
+  sort?: EventListSortBy
+  status?: EventListStatusFilter
+  tag: string
+}
+
+function buildPredictionResultsApiSearchParams({
+  bookmarked = false,
+  locale,
+  mainTag,
+  offset = 0,
+  search = '',
+  sort,
+  status = 'active',
+  tag,
+}: BuildPredictionResultsApiSearchParamsOptions) {
+  const params = new URLSearchParams({
+    bookmarked: String(bookmarked),
+    locale,
+    offset: offset.toString(),
+    status,
+    tag,
+  })
+
+  const normalizedMainTag = mainTag?.trim()
+  if (normalizedMainTag) {
+    params.set('mainTag', normalizedMainTag)
+  }
+
+  const normalizedSearch = search.trim()
+  if (normalizedSearch) {
+    params.set('search', normalizedSearch)
+  }
+
+  if (sort) {
+    params.set('sort', sort)
+  }
+
+  return params
+}
+
+export async function fetchPredictionResultsApi(options: BuildPredictionResultsApiSearchParamsOptions): Promise<Event[]> {
+  const params = buildPredictionResultsApiSearchParams(options)
+  const response = await fetch(`/api/predictions/events?${params.toString()}`)
+
+  if (!response.ok) {
+    throw new Error('Failed to fetch prediction results')
+  }
+
+  return response.json()
+}

--- a/src/lib/prediction-results-constants.ts
+++ b/src/lib/prediction-results-constants.ts
@@ -1,0 +1,1 @@
+export const PREDICTION_RESULTS_PAGE_SIZE = 32

--- a/src/lib/prediction-results-events.ts
+++ b/src/lib/prediction-results-events.ts
@@ -1,0 +1,54 @@
+import type { SupportedLocale } from '@/i18n/locales'
+import type { EventListSortBy, EventListStatusFilter } from '@/lib/event-list-filters'
+import type { Event } from '@/types'
+import { EventRepository } from '@/lib/db/queries/event'
+import { PREDICTION_RESULTS_PAGE_SIZE } from '@/lib/prediction-results-constants'
+
+interface ListPredictionResultsPageOptions {
+  bookmarked: boolean
+  locale: SupportedLocale
+  mainTag: string
+  offset?: number
+  search?: string
+  sortBy?: EventListSortBy
+  status?: EventListStatusFilter
+  tag: string
+  userId: string
+}
+
+export async function listPredictionResultsPage({
+  bookmarked,
+  locale,
+  mainTag,
+  offset = 0,
+  search = '',
+  sortBy,
+  status = 'active',
+  tag,
+  userId,
+}: ListPredictionResultsPageOptions): Promise<{
+  data: Event[]
+  error: string | null
+}> {
+  const targetOffset = Math.max(0, offset)
+  const { data, error } = await EventRepository.listEvents({
+    bookmarked,
+    excludeSportsAuxiliary: true,
+    limit: PREDICTION_RESULTS_PAGE_SIZE,
+    locale,
+    mainTag,
+    offset: targetOffset,
+    preferResolvedDateOrder: status === 'resolved' && !sortBy,
+    search,
+    skipLivePricing: status === 'resolved',
+    sortBy,
+    status,
+    tag,
+    userId,
+  })
+
+  return {
+    data: data ?? [],
+    error,
+  }
+}

--- a/src/lib/prediction-results-filters.ts
+++ b/src/lib/prediction-results-filters.ts
@@ -109,20 +109,6 @@ export function resolvePredictionResultsRequestedApiSort({
   return resolvePredictionResultsApiSort(sort)
 }
 
-export function resolvePredictionResultsRequestedApiStatus({
-  query,
-  status,
-}: {
-  query: string
-  status: PredictionResultsStatusOption
-}): PredictionResultsStatusOption {
-  if (!query.trim() && status === 'resolved') {
-    return 'all'
-  }
-
-  return status
-}
-
 function resolveSearchParamValue(value: string | string[] | null | undefined) {
   return Array.isArray(value) ? value[0] : value
 }

--- a/tests/unit/PredictionResultsClient.test.tsx
+++ b/tests/unit/PredictionResultsClient.test.tsx
@@ -404,8 +404,10 @@ describe('predictionResultsClient', () => {
       await queryOptions.queryFn({ pageParam: 0 })
 
       const requestUrl = fetchMock.mock.calls[0]?.[0] as string
+      expect(requestUrl).toContain('/api/predictions/events?')
       expect(requestUrl).toContain('search=paulo')
       expect(requestUrl).toContain('status=resolved')
+      expect(requestUrl).not.toContain('homeFeed=')
       expect(requestUrl).not.toContain('sort=')
     }
     finally {
@@ -567,9 +569,11 @@ describe('predictionResultsClient', () => {
       await queryOptions.queryFn({ pageParam: 0 })
 
       const requestUrl = fetchMock.mock.calls[0]?.[0] as string
+      expect(requestUrl).toContain('/api/predictions/events?')
       expect(requestUrl).toContain('bookmarked=true')
       expect(requestUrl).toContain('search=paulo')
       expect(requestUrl).toContain('status=resolved')
+      expect(requestUrl).not.toContain('homeFeed=')
     }
     finally {
       vi.unstubAllGlobals()

--- a/tests/unit/predictionResultsEvents.test.ts
+++ b/tests/unit/predictionResultsEvents.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  listEvents: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/event', () => ({
+  EventRepository: {
+    listEvents: (...args: any[]) => mocks.listEvents(...args),
+  },
+}))
+
+describe('listPredictionResultsPage', () => {
+  beforeEach(() => {
+    mocks.listEvents.mockReset()
+  })
+
+  it('returns every matching active prediction event without compacting shared series slugs', async () => {
+    const june23 = {
+      id: 'doge-june-23',
+      slug: 'dogecoin-up-or-down-on-june-23-2026',
+      title: 'Dogecoin Up or Down on June 23?',
+      status: 'active',
+      series_slug: 'dogecoin-up-or-down-daily',
+    }
+    const june24 = {
+      id: 'doge-june-24',
+      slug: 'dogecoin-up-or-down-on-june-24-2026',
+      title: 'Dogecoin Up or Down on June 24?',
+      status: 'active',
+      series_slug: 'dogecoin-up-or-down-daily',
+    }
+
+    mocks.listEvents.mockResolvedValueOnce({ data: [june23, june24], error: null })
+
+    const { listPredictionResultsPage } = await import('@/lib/prediction-results-events')
+    const result = await listPredictionResultsPage({
+      bookmarked: false,
+      locale: 'en',
+      mainTag: 'trending',
+      search: 'doge',
+      status: 'active',
+      tag: 'trending',
+      userId: '',
+    })
+
+    expect(result).toEqual({
+      data: [june23, june24],
+      error: null,
+    })
+    expect(mocks.listEvents).toHaveBeenCalledWith(expect.objectContaining({
+      excludeSportsAuxiliary: true,
+      limit: 32,
+      offset: 0,
+      search: 'doge',
+      status: 'active',
+    }))
+  })
+
+  it('uses resolved-date ordering and skips live pricing for direct resolved pages', async () => {
+    mocks.listEvents.mockResolvedValueOnce({ data: [], error: null })
+
+    const { listPredictionResultsPage } = await import('@/lib/prediction-results-events')
+    await listPredictionResultsPage({
+      bookmarked: false,
+      locale: 'en',
+      mainTag: 'crypto',
+      status: 'resolved',
+      tag: 'dogecoin',
+      userId: '',
+    })
+
+    expect(mocks.listEvents).toHaveBeenCalledWith(expect.objectContaining({
+      preferResolvedDateOrder: true,
+      skipLivePricing: true,
+      status: 'resolved',
+    }))
+  })
+})

--- a/tests/unit/predictionResultsEventsRoute.test.ts
+++ b/tests/unit/predictionResultsEventsRoute.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
+  listPredictionResultsPage: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/user', () => ({
+  UserRepository: {
+    getCurrentUser: (...args: any[]) => mocks.getCurrentUser(...args),
+  },
+}))
+
+vi.mock('@/lib/prediction-results-events', () => ({
+  listPredictionResultsPage: (...args: any[]) => mocks.listPredictionResultsPage(...args),
+}))
+
+const { GET } = await import('@/app/api/predictions/events/route')
+
+describe('prediction results events route', () => {
+  beforeEach(() => {
+    mocks.getCurrentUser.mockReset()
+    mocks.listPredictionResultsPage.mockReset()
+  })
+
+  it('returns an empty payload for anonymous bookmarked prediction requests', async () => {
+    mocks.getCurrentUser.mockResolvedValueOnce(null)
+
+    const response = await GET(new Request('https://example.com/api/predictions/events?bookmarked=true&locale=en'))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual([])
+    expect(mocks.listPredictionResultsPage).not.toHaveBeenCalled()
+  })
+
+  it('forwards validated prediction filters to the prediction results loader', async () => {
+    mocks.getCurrentUser.mockResolvedValueOnce({ id: 'user-1' })
+    mocks.listPredictionResultsPage.mockResolvedValueOnce({ data: [], error: null })
+
+    const response = await GET(new Request(
+      'https://example.com/api/predictions/events?tag=dogecoin&mainTag=crypto&search=doge&sort=end_date&status=active&offset=32&locale=en',
+    ))
+
+    expect(response.status).toBe(200)
+    expect(mocks.listPredictionResultsPage).toHaveBeenCalledWith(expect.objectContaining({
+      locale: 'en',
+      mainTag: 'crypto',
+      offset: 32,
+      search: 'doge',
+      sortBy: 'end_date',
+      status: 'active',
+      tag: 'dogecoin',
+      userId: 'user-1',
+    }))
+  })
+})

--- a/tests/unit/predictionSearch.test.ts
+++ b/tests/unit/predictionSearch.test.ts
@@ -8,7 +8,6 @@ import {
   resolvePredictionResultsApiSort,
   resolvePredictionResultsFiltersFromSearchParams,
   resolvePredictionResultsRequestedApiSort,
-  resolvePredictionResultsRequestedApiStatus,
 } from '@/lib/prediction-results-filters'
 import {
   buildPredictionResultsPath,
@@ -140,22 +139,5 @@ describe('prediction search helpers', () => {
       query: 'meta',
       sort: 'volume',
     })).toBe('volume')
-  })
-
-  it('uses the combined status dataset for resolved category pages only', () => {
-    expect(resolvePredictionResultsRequestedApiStatus({
-      query: '',
-      status: 'resolved',
-    })).toBe('all')
-
-    expect(resolvePredictionResultsRequestedApiStatus({
-      query: 'meta',
-      status: 'resolved',
-    })).toBe('resolved')
-
-    expect(resolvePredictionResultsRequestedApiStatus({
-      query: '',
-      status: 'active',
-    })).toBe('active')
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Separated the prediction results search from the home feed by introducing a dedicated API and data layer. This makes the results page independent and removes home-feed-specific logic.

- **New Features**
  - Added `GET /api/predictions/events` with filters: `tag`, `mainTag`, `search`, `sort`, `status`, `bookmarked`, `locale`, `offset`.
  - Introduced `fetchPredictionResultsApi`, `listPredictionResultsPage`, and `PREDICTION_RESULTS_PAGE_SIZE`.

- **Refactors**
  - `PredictionResultsClient` now uses the new API and `PREDICTION_RESULTS_PAGE_SIZE`; removed `homeFeed` and `currentTimestamp`; passes `status` directly.
  - Server page uses `listPredictionResultsPage` and no longer sets `initialCurrentTimestamp`.
  - Removed `resolvePredictionResultsRequestedApiStatus`.
  - Updated/added unit tests for the new route and loader.

<sup>Written for commit 614139bbd873f5af029e61b2cc23287137c7fff3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1184?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

