### PR TITLE
fix: resolved outcome label displayed in event order panel

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -223,7 +223,6 @@ function useResolvedMarketDisplay({
     () => resolveResolvedOrderPanelDisplay({
       event,
       selectedMarket: activeMarket,
-      preferBinaryYesNoForSingleUpDown: true,
     }),
     [activeMarket, event],
   )

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/resolved-order-panel-market.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/resolved-order-panel-market.ts
@@ -316,37 +316,6 @@ function resolveExactScoreDisplayTitle(market: Market | null | undefined) {
   return `Exact Score: ${descriptor}`
 }
 
-function isSingleUpOrDownMarket(event: Event | null | undefined, market: Market | null | undefined) {
-  if (!market) {
-    return false
-  }
-
-  const totalMarketsCount = event?.total_markets_count ?? event?.markets?.length ?? 0
-  if (totalMarketsCount !== 1) {
-    return false
-  }
-
-  const outcomeLabels = new Set(
-    (market.outcomes ?? []).map(outcome => normalizeComparableText(outcome.outcome_text)),
-  )
-  if (!outcomeLabels.has('up') || !outcomeLabels.has('down')) {
-    return false
-  }
-
-  const descriptor = normalizeComparableText([
-    event?.slug,
-    event?.title,
-    market.slug,
-    market.short_title,
-    market.title,
-    market.question,
-  ]
-    .filter((value): value is string => Boolean(value?.trim()))
-    .join(' '))
-
-  return descriptor.includes('up or down') || descriptor.includes('up down')
-}
-
 export function resolveWinningOutcomeIndexForBinaryMarket(
   market: Market | null | undefined,
 ) {
@@ -483,9 +452,8 @@ export function resolveResolvedOrderPanelMarket(params: {
 export function resolveResolvedOrderPanelDisplay(params: {
   event: Event | null | undefined
   selectedMarket: Market | null | undefined
-  preferBinaryYesNoForSingleUpDown?: boolean
 }) {
-  const { event, selectedMarket, preferBinaryYesNoForSingleUpDown = false } = params
+  const { event, selectedMarket } = params
   const sportsKind = resolveSportsResolvedDisplayKind(selectedMarket)
   const resolvedState = resolveResolvedOrderPanelMarket(params)
 
@@ -570,31 +538,19 @@ export function resolveResolvedOrderPanelDisplay(params: {
     outcome => outcome.outcome_index === OUTCOME_INDEX.NO,
   )?.outcome_text
   const selectedMarketResolvedOutcomeIndex = resolveWinningOutcomeIndexForBinaryMarket(selectedMarket)
-  const shouldUseBinaryYesNoLabel = preferBinaryYesNoForSingleUpDown
-    && isSingleUpOrDownMarket(event, displayMarket)
 
   return {
     market: displayMarket,
     resolvedOutcomeIndex,
-    outcomeLabel: shouldUseBinaryYesNoLabel
-      ? resolvedOutcomeIndex === OUTCOME_INDEX.NO
-        ? 'No'
-        : resolvedOutcomeIndex === OUTCOME_INDEX.YES
-          ? 'Yes'
-          : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.NO
-            ? 'No'
-            : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.YES
-              ? 'Yes'
-              : null
-      : resolvedOutcomeIndex === OUTCOME_INDEX.NO
-        ? (canonicalizeOutcomeLabel(resolvedOutcomeText) || canonicalizeOutcomeLabel(resolvedNoOutcomeText) || 'No')
-        : resolvedOutcomeIndex === OUTCOME_INDEX.YES
-          ? (canonicalizeOutcomeLabel(resolvedOutcomeText) || canonicalizeOutcomeLabel(resolvedYesOutcomeText) || 'Yes')
-          : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.NO
-            ? (canonicalizeOutcomeLabel(resolvedNoOutcomeText) || 'No')
-            : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.YES
-              ? (canonicalizeOutcomeLabel(resolvedYesOutcomeText) || 'Yes')
-              : null,
+    outcomeLabel: resolvedOutcomeIndex === OUTCOME_INDEX.NO
+      ? (canonicalizeOutcomeLabel(resolvedOutcomeText) || canonicalizeOutcomeLabel(resolvedNoOutcomeText) || 'No')
+      : resolvedOutcomeIndex === OUTCOME_INDEX.YES
+        ? (canonicalizeOutcomeLabel(resolvedOutcomeText) || canonicalizeOutcomeLabel(resolvedYesOutcomeText) || 'Yes')
+        : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.NO
+          ? (canonicalizeOutcomeLabel(resolvedNoOutcomeText) || 'No')
+          : selectedMarketResolvedOutcomeIndex === OUTCOME_INDEX.YES
+            ? (canonicalizeOutcomeLabel(resolvedYesOutcomeText) || 'Yes')
+            : null,
     marketTitle: resolveMarketDescriptor(displayMarket) || null,
   }
 }

--- a/tests/unit/resolvedOrderPanelMarket.test.ts
+++ b/tests/unit/resolvedOrderPanelMarket.test.ts
@@ -543,51 +543,64 @@ describe('resolveResolvedOrderPanelDisplay', () => {
     expect(result.marketTitle).toBe('180-199')
   })
 
-  it('shows yes no labels for resolved single up-or-down markets', () => {
-    const selectedMarket = createMarket({
-      condition_id: 'doge-up-or-down',
-      title: 'Dogecoin Up or Down on June 19?',
-      short_title: '',
-      slug: 'dogecoin-up-or-down-on-june-19-2026',
-      condition: {
-        resolved: true,
-        resolution_price: 1,
-      },
-      outcomes: [
-        {
-          condition_id: 'doge-up-or-down',
-          outcome_index: OUTCOME_INDEX.YES,
-          outcome_text: 'Up',
-          token_id: 'doge-up',
-          is_winning_outcome: true,
-          payout_value: 1,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
+  it('shows up down labels for resolved single up-or-down markets', () => {
+    function createUpDownMarket(winningOutcomeIndex: typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO) {
+      return createMarket({
+        condition_id: 'doge-up-or-down',
+        title: 'Dogecoin Up or Down on June 19?',
+        short_title: '',
+        slug: 'dogecoin-up-or-down-on-june-19-2026',
+        condition: {
+          resolved: true,
+          resolution_price: winningOutcomeIndex === OUTCOME_INDEX.YES ? 1 : 0,
         },
-        {
-          condition_id: 'doge-up-or-down',
-          outcome_index: OUTCOME_INDEX.NO,
-          outcome_text: 'Down',
-          token_id: 'doge-down',
-          is_winning_outcome: false,
-          payout_value: 0,
-          created_at: new Date().toISOString(),
-          updated_at: new Date().toISOString(),
-        },
-      ],
-    })
+        outcomes: [
+          {
+            condition_id: 'doge-up-or-down',
+            outcome_index: OUTCOME_INDEX.YES,
+            outcome_text: 'Up',
+            token_id: 'doge-up',
+            is_winning_outcome: winningOutcomeIndex === OUTCOME_INDEX.YES,
+            payout_value: winningOutcomeIndex === OUTCOME_INDEX.YES ? 1 : 0,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+          {
+            condition_id: 'doge-up-or-down',
+            outcome_index: OUTCOME_INDEX.NO,
+            outcome_text: 'Down',
+            token_id: 'doge-down',
+            is_winning_outcome: winningOutcomeIndex === OUTCOME_INDEX.NO,
+            payout_value: winningOutcomeIndex === OUTCOME_INDEX.NO ? 1 : 0,
+            created_at: new Date().toISOString(),
+            updated_at: new Date().toISOString(),
+          },
+        ],
+      })
+    }
 
-    const result = resolveResolvedOrderPanelDisplay({
-      event: createEvent([selectedMarket], {
+    const upMarket = createUpDownMarket(OUTCOME_INDEX.YES)
+    const upResult = resolveResolvedOrderPanelDisplay({
+      event: createEvent([upMarket], {
         slug: 'dogecoin-up-or-down-on-june-19-2026',
         title: 'Dogecoin Up or Down on June 19?',
         total_markets_count: 1,
       }),
-      selectedMarket,
-      preferBinaryYesNoForSingleUpDown: true,
+      selectedMarket: upMarket,
+    })
+    const downMarket = createUpDownMarket(OUTCOME_INDEX.NO)
+    const downResult = resolveResolvedOrderPanelDisplay({
+      event: createEvent([downMarket], {
+        slug: 'dogecoin-up-or-down-on-june-19-2026',
+        title: 'Dogecoin Up or Down on June 19?',
+        total_markets_count: 1,
+      }),
+      selectedMarket: downMarket,
     })
 
-    expect(result.outcomeLabel).toBe('Yes')
-    expect(result.marketTitle).toBe('Dogecoin Up or Down on June 19?')
+    expect(upResult.outcomeLabel).toBe('Up')
+    expect(upResult.marketTitle).toBe('Dogecoin Up or Down on June 19?')
+    expect(downResult.outcomeLabel).toBe('Down')
+    expect(downResult.marketTitle).toBe('Dogecoin Up or Down on June 19?')
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes resolved outcome labels in the Event Order Panel so binary markets show the correct final label. Up/Down markets now display “Up” or “Down” instead of “Yes/No”.

- **Bug Fixes**
  - Use canonical outcome text when available, with Yes/No as fallback.
  - Single-market Up/Down events now show “Up” or “Down” as the resolved label.

- **Refactors**
  - Removed the single-market Up/Down special-case flag and helper; simplified outcome resolution logic.
  - Dropped `preferBinaryYesNoForSingleUpDown` from the form and display resolver.
  - Updated unit tests to cover both Up and Down resolutions.

<sup>Written for commit 76af93329506c437531a57a185b97a88614c1cbf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

