### PR TITLE
fix: freeze resolved live chart prices

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -37,6 +37,7 @@ import {
   parseUtcDate,
   readPersistedLivePrice,
   resolveEventEndTimestamp,
+  resolveLiveSeriesDisplayPrice,
   SERIES_KEY,
   toCountdownLeftLabel,
 } from '../_utils/eventLiveSeriesChartUtils'
@@ -392,11 +393,16 @@ function EventLiveSeriesChartContent({
   }, [chartNowMs, dataSource])
 
   const lastPoint = renderData.at(-1)
-  const currentPrice = isEventClosed
-    ? finalPrice
-    : typeof lastPoint?.[SERIES_KEY] === 'number'
-      ? lastPoint[SERIES_KEY] as number
-      : fallbackCurrentPrice
+  const rawRenderedPrice = lastPoint?.[SERIES_KEY]
+  const renderedPrice = typeof rawRenderedPrice === 'number' && Number.isFinite(rawRenderedPrice)
+    ? rawRenderedPrice
+    : null
+  const currentPrice = resolveLiveSeriesDisplayPrice({
+    isEventClosed,
+    finalPrice,
+    renderedPrice,
+    fallbackCurrentPrice,
+  })
   const axisSourceData = isEventClosed
     ? renderData
     : data.length > 0 ? data : renderData

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -55,6 +55,51 @@ const PredictionChart = dynamic<PredictionChartProps>(
   { ssr: false, loading: () => <div className="h-83 w-full" /> },
 )
 
+function isFinitePositivePrice(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function normalizeReferencePrice(value: unknown, topic: string) {
+  const numeric = typeof value === 'number' ? value : Number(value)
+  return normalizeLiveChartPrice(numeric, topic)
+}
+
+function resolveTimestampBoundedPrice({
+  value,
+  topic,
+  timestamp,
+  endTimestamp,
+}: {
+  value: unknown
+  topic: string
+  timestamp: unknown
+  endTimestamp: number
+}) {
+  const numericTimestamp = typeof timestamp === 'number' ? timestamp : Number(timestamp)
+  if (!Number.isFinite(numericTimestamp) || numericTimestamp > endTimestamp) {
+    return null
+  }
+
+  return normalizeReferencePrice(value, topic)
+}
+
+function buildClosedLiveSeriesData(endTimestamp: number, finalPrice: number | null) {
+  if (!isFinitePositivePrice(finalPrice) || !Number.isFinite(endTimestamp)) {
+    return []
+  }
+
+  return [
+    {
+      date: new Date(Math.max(0, endTimestamp - LIVE_WINDOW_MS)),
+      [SERIES_KEY]: finalPrice,
+    },
+    {
+      date: new Date(endTimestamp),
+      [SERIES_KEY]: finalPrice,
+    },
+  ] satisfies DataPoint[]
+}
+
 interface EventLiveSeriesChartProps {
   event: Event
   isMobile: boolean
@@ -109,10 +154,22 @@ function EventLiveSeriesChartContent({
   const startTimestamp = useMemo(() => parseUtcDate(event.start_date ?? null), [event.start_date])
   const explicitEndTimestamp = useMemo(() => resolveEventEndTimestamp(event), [event])
   const hasExplicitEndTimestamp = explicitEndTimestamp != null
+  const resolvedMarketsCount = event.markets.filter(market => market.is_resolved || market.condition?.resolved).length
+  const hasResolvedState = Boolean(
+    event.resolved_at
+    || event.status === 'resolved'
+    || event.status === 'archived'
+    || (
+      resolvedMarketsCount > 0
+      && (
+        event.total_markets_count <= 1
+        || resolvedMarketsCount === event.markets.length
+      )
+    ),
+  )
 
   const nowMs = useLiveSeriesClock(isLiveView)
   const endTimestamp = explicitEndTimestamp ?? nowMs
-  const isEventClosed = hasExplicitEndTimestamp && nowMs >= endTimestamp
 
   const {
     referenceSnapshot,
@@ -125,6 +182,13 @@ function EventLiveSeriesChartContent({
     explicitEndTimestamp,
     startTimestamp,
   })
+  const isEventClosed = hasExplicitEndTimestamp
+    && (
+      hasResolvedState
+      || Boolean(referenceSnapshot?.is_event_closed)
+      || nowMs >= endTimestamp
+    )
+  const chartNowMs = isEventClosed ? endTimestamp : nowMs
 
   const [initialPersistedFallbackPrice] = useState(
     () => readPersistedLivePrice(config.topic, subscriptionSymbol),
@@ -135,7 +199,7 @@ function EventLiveSeriesChartContent({
     topic: config.topic,
     eventType: config.event_type,
     subscriptionSymbol,
-    isLiveView,
+    isLiveView: isLiveView && !isEventClosed,
     setBaselinePrice,
   })
 
@@ -165,7 +229,50 @@ function EventLiveSeriesChartContent({
     return Math.min(windowWidth * 0.55, 900)
   }, [isMobile, windowWidth])
 
+  const referenceOpeningPrice = useMemo(
+    () => normalizeReferencePrice(referenceSnapshot?.opening_price, config.topic),
+    [config.topic, referenceSnapshot?.opening_price],
+  )
+  const referenceClosingPrice = useMemo(
+    () => normalizeReferencePrice(referenceSnapshot?.closing_price, config.topic),
+    [config.topic, referenceSnapshot?.closing_price],
+  )
+  const latestReferencePriceBeforeEnd = useMemo(
+    () => resolveTimestampBoundedPrice({
+      value: referenceSnapshot?.latest_price,
+      topic: config.topic,
+      timestamp: referenceSnapshot?.latest_source_timestamp_ms ?? referenceSnapshot?.latest_window_end_ms,
+      endTimestamp,
+    }),
+    [
+      config.topic,
+      endTimestamp,
+      referenceSnapshot?.latest_price,
+      referenceSnapshot?.latest_source_timestamp_ms,
+      referenceSnapshot?.latest_window_end_ms,
+    ],
+  )
+  const persistedFallbackPriceBeforeEnd = useMemo(() => {
+    if (
+      !persistedFallbackPrice
+      || !isFinitePositivePrice(persistedFallbackPrice.price)
+      || !Number.isFinite(persistedFallbackPrice.timestamp)
+      || persistedFallbackPrice.timestamp > endTimestamp
+    ) {
+      return null
+    }
+
+    return persistedFallbackPrice.price
+  }, [endTimestamp, persistedFallbackPrice])
+  const finalPrice = isEventClosed
+    ? referenceClosingPrice ?? latestReferencePriceBeforeEnd ?? persistedFallbackPriceBeforeEnd
+    : null
+
   const fallbackCurrentPrice = useMemo(() => {
+    if (isEventClosed) {
+      return finalPrice
+    }
+
     if (referenceSnapshot) {
       const snapshotPrice = normalizeLiveChartPrice(
         referenceSnapshot.latest_price ?? referenceSnapshot.closing_price ?? Number.NaN,
@@ -182,7 +289,7 @@ function EventLiveSeriesChartContent({
     }
 
     return null
-  }, [config.topic, persistedFallbackPrice, referenceSnapshot])
+  }, [config.topic, finalPrice, isEventClosed, persistedFallbackPrice, referenceSnapshot])
 
   const tradingWindowMs = useMemo(() => {
     const configuredWindowMinutes = Number(config.active_window_minutes)
@@ -212,18 +319,34 @@ function EventLiveSeriesChartContent({
   }, [endTimestamp, referenceSnapshot?.event_window_start_ms, startTimestamp, tradingWindowMs])
 
   const isTradingWindowActive = !isEventClosed && nowMs >= tradingWindowStartMs
-
-  const renderData = useMemo(() => {
-    if (!data.length) {
+  const closedFallbackData = useMemo(
+    () => buildClosedLiveSeriesData(endTimestamp, finalPrice),
+    [endTimestamp, finalPrice],
+  )
+  const dataSource = useMemo(() => {
+    if (!isEventClosed) {
       return data
     }
 
-    const domainStart = nowMs - LIVE_WINDOW_MS
-    const domainEnd = nowMs
+    const hasPreCloseData = data.some((point) => {
+      const timestamp = point.date.getTime()
+      return Number.isFinite(timestamp) && timestamp <= endTimestamp
+    })
+
+    return hasPreCloseData ? data : closedFallbackData
+  }, [closedFallbackData, data, endTimestamp, isEventClosed])
+
+  const renderData = useMemo(() => {
+    if (!dataSource.length) {
+      return dataSource
+    }
+
+    const domainStart = chartNowMs - LIVE_WINDOW_MS
+    const domainEnd = chartNowMs
     let lastPointBeforeDomainStart: DataPoint | null = null
     const pointsWithinDomain: DataPoint[] = []
 
-    for (const point of data) {
+    for (const point of dataSource) {
       const timestamp = point.date.getTime()
       if (!Number.isFinite(timestamp)) {
         continue
@@ -254,26 +377,32 @@ function EventLiveSeriesChartContent({
       typeof lastPrice === 'number'
       && Number.isFinite(lastPrice)
       && Number.isFinite(lastTimestamp)
-      && nowMs > lastTimestamp
+      && chartNowMs > lastTimestamp
     ) {
       next = [
         ...next,
         {
-          date: new Date(nowMs),
+          date: new Date(chartNowMs),
           [SERIES_KEY]: lastPrice,
         },
       ].slice(-MAX_POINTS)
     }
 
     return next
-  }, [data, nowMs])
+  }, [chartNowMs, dataSource])
 
   const lastPoint = renderData.at(-1)
-  const currentPrice = typeof lastPoint?.[SERIES_KEY] === 'number'
-    ? lastPoint[SERIES_KEY] as number
-    : fallbackCurrentPrice
-  const axisSourceData = data.length > 0 ? data : renderData
-  const resolvedBaselinePrice = baselinePrice ?? referenceSnapshot?.opening_price ?? null
+  const currentPrice = isEventClosed
+    ? finalPrice
+    : typeof lastPoint?.[SERIES_KEY] === 'number'
+      ? lastPoint[SERIES_KEY] as number
+      : fallbackCurrentPrice
+  const axisSourceData = isEventClosed
+    ? renderData
+    : data.length > 0 ? data : renderData
+  const resolvedBaselinePrice = isEventClosed
+    ? referenceOpeningPrice
+    : baselinePrice ?? referenceOpeningPrice
   const precisionReferencePrice = currentPrice
     ?? resolvedBaselinePrice
     ?? referenceSnapshot?.latest_price
@@ -300,6 +429,10 @@ function EventLiveSeriesChartContent({
       values.push(currentPrice)
     }
 
+    if (typeof resolvedBaselinePrice === 'number' && Number.isFinite(resolvedBaselinePrice)) {
+      values.push(resolvedBaselinePrice)
+    }
+
     return buildAxis(values, priceDisplayDigits)
   })()
 
@@ -317,7 +450,11 @@ function EventLiveSeriesChartContent({
   })()
 
   const targetLine = (() => {
-    if (!isTradingWindowActive || resolvedBaselinePrice == null || !Number.isFinite(resolvedBaselinePrice)) {
+    if (
+      (!isTradingWindowActive && !isEventClosed)
+      || resolvedBaselinePrice == null
+      || !Number.isFinite(resolvedBaselinePrice)
+    ) {
       return null
     }
 
@@ -364,12 +501,12 @@ function EventLiveSeriesChartContent({
   const shouldShowCountdown = hasExplicitEndTimestamp && !isEventClosed && countdown.totalSeconds > 0
 
   const xAxisTickValues = useMemo(() => {
-    const startMs = nowMs - LIVE_WINDOW_MS
+    const startMs = chartNowMs - LIVE_WINDOW_MS
     const visibleStartMs = startMs + LIVE_X_AXIS_LEFT_LABEL_GUARD_MS
     const firstTickMs = Math.ceil(startMs / LIVE_X_AXIS_STEP_MS) * LIVE_X_AXIS_STEP_MS
     const ticks: Date[] = []
 
-    for (let tickMs = firstTickMs; tickMs <= nowMs; tickMs += LIVE_X_AXIS_STEP_MS) {
+    for (let tickMs = firstTickMs; tickMs <= chartNowMs; tickMs += LIVE_X_AXIS_STEP_MS) {
       if (tickMs >= visibleStartMs) {
         ticks.push(new Date(tickMs))
       }
@@ -381,16 +518,16 @@ function EventLiveSeriesChartContent({
 
     return [
       new Date(visibleStartMs),
-      new Date(nowMs),
+      new Date(chartNowMs),
     ]
-  }, [nowMs])
+  }, [chartNowMs])
 
   const liveXAxisDomain = useMemo(
     () => ({
-      start: new Date(nowMs - LIVE_WINDOW_MS),
-      end: new Date(nowMs),
+      start: new Date(chartNowMs - LIVE_WINDOW_MS),
+      end: new Date(chartNowMs),
     }),
-    [nowMs],
+    [chartNowMs],
   )
 
   const visibleCountdownUnits = useMemo(

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
@@ -81,6 +81,7 @@ export default function EventLiveSeriesChartHeader({
         </div>
       )
     : null
+  const priceStatusLabel = isEventClosed ? 'Final Price' : 'Current Price'
 
   return (
     <div className="flex flex-wrap items-end gap-4 pr-4 pl-0 sm:pr-6 sm:pl-0">
@@ -99,7 +100,7 @@ export default function EventLiveSeriesChartHeader({
             className="flex items-center gap-2 text-[11px] font-semibold tracking-[0.12em] uppercase"
             style={{ color: liveColor }}
           >
-            <span>Current Price</span>
+            <span>{priceStatusLabel}</span>
             {delta != null && (
               <span className={`inline-flex items-center gap-0.5 text-[11px] font-semibold ${delta >= 0
                 ? 'text-yes'

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
@@ -381,6 +381,24 @@ export function keepWithinLiveWindow(points: DataPoint[], cutoffMs: number) {
   }]
 }
 
+export function resolveLiveSeriesDisplayPrice({
+  isEventClosed,
+  finalPrice,
+  renderedPrice,
+  fallbackCurrentPrice,
+}: {
+  isEventClosed: boolean
+  finalPrice: number | null
+  renderedPrice: number | null
+  fallbackCurrentPrice: number | null
+}) {
+  if (isEventClosed) {
+    return finalPrice ?? renderedPrice
+  }
+
+  return renderedPrice ?? fallbackCurrentPrice
+}
+
 export function formatUsd(value: number, digits = 2) {
   return formatCurrency(value, {
     minimumFractionDigits: digits,

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
@@ -464,6 +464,26 @@ export function parseUtcDate(value: string | null | undefined) {
 }
 
 export function resolveEventEndTimestamp(event: Event) {
+  const eventResolved = parseUtcDate(event.resolved_at)
+  if (eventResolved != null) {
+    return eventResolved
+  }
+
+  const resolvedMarkets = event.markets.filter(market => market.is_resolved || market.condition?.resolved)
+  const canUseResolvedMarketTimestamp = event.status === 'resolved'
+    || event.status === 'archived'
+    || event.total_markets_count <= 1
+    || resolvedMarkets.length === event.markets.length
+  const resolvedConditionTimestamps = canUseResolvedMarketTimestamp
+    ? resolvedMarkets
+        .map(market => parseUtcDate(market.condition?.resolved_at))
+        .filter((timestamp): timestamp is number => timestamp != null)
+    : []
+
+  if (resolvedConditionTimestamps.length > 0) {
+    return Math.max(...resolvedConditionTimestamps)
+  }
+
   const eventEnd = parseUtcDate(event.end_date)
   const marketEnd = parseUtcDate(event.markets[0]?.end_time)
 

--- a/tests/unit/eventLiveSeriesChartUtils.test.ts
+++ b/tests/unit/eventLiveSeriesChartUtils.test.ts
@@ -1,6 +1,9 @@
 import type { Event } from '@/types'
 import { describe, expect, it } from 'vitest'
-import { resolveEventEndTimestamp } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils'
+import {
+  resolveEventEndTimestamp,
+  resolveLiveSeriesDisplayPrice,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils'
 
 function createEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -123,5 +126,32 @@ describe('event live series chart utils', () => {
     })
 
     expect(resolveEventEndTimestamp(event)).toBe(Date.parse('2026-06-23T00:00:00.000Z'))
+  })
+
+  it('uses the final price for closed live series charts', () => {
+    expect(resolveLiveSeriesDisplayPrice({
+      isEventClosed: true,
+      finalPrice: 105,
+      renderedPrice: 104,
+      fallbackCurrentPrice: 103,
+    })).toBe(105)
+  })
+
+  it('falls back to the rendered chart price for closed live series charts without a final price', () => {
+    expect(resolveLiveSeriesDisplayPrice({
+      isEventClosed: true,
+      finalPrice: null,
+      renderedPrice: 104,
+      fallbackCurrentPrice: 103,
+    })).toBe(104)
+  })
+
+  it('uses the live fallback price only for open live series charts without rendered data', () => {
+    expect(resolveLiveSeriesDisplayPrice({
+      isEventClosed: false,
+      finalPrice: null,
+      renderedPrice: null,
+      fallbackCurrentPrice: 103,
+    })).toBe(103)
   })
 })

--- a/tests/unit/eventLiveSeriesChartUtils.test.ts
+++ b/tests/unit/eventLiveSeriesChartUtils.test.ts
@@ -1,0 +1,127 @@
+import type { Event } from '@/types'
+import { describe, expect, it } from 'vitest'
+import { resolveEventEndTimestamp } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils'
+
+function createEvent(overrides: Partial<Event> = {}): Event {
+  return {
+    id: 'event-1',
+    slug: 'bitcoin-up-or-down-on-june-22-2026',
+    title: 'Bitcoin Up or Down on June 22, 2026?',
+    creator: 'creator',
+    icon_url: '',
+    show_market_icons: false,
+    status: 'active',
+    active_markets_count: 1,
+    total_markets_count: 1,
+    volume: 0,
+    start_date: '2026-06-22T23:55:00.000Z',
+    end_date: '2026-06-23T00:00:00.000Z',
+    resolved_at: null,
+    created_at: '2026-06-22T00:00:00.000Z',
+    updated_at: '2026-06-22T00:00:00.000Z',
+    markets: [
+      {
+        condition_id: 'condition-1',
+        question_id: 'question-1',
+        event_id: 'event-1',
+        title: 'Bitcoin Up or Down on June 22, 2026?',
+        slug: 'bitcoin-up-or-down-on-june-22-2026',
+        icon_url: '',
+        is_active: false,
+        is_resolved: false,
+        block_number: 1,
+        block_timestamp: '2026-06-22T00:00:00.000Z',
+        volume_24h: 0,
+        volume: 0,
+        end_time: '2026-06-23T00:00:00.000Z',
+        created_at: '2026-06-22T00:00:00.000Z',
+        updated_at: '2026-06-22T00:00:00.000Z',
+        price: 0,
+        probability: 0,
+        outcomes: [],
+        condition: {
+          id: 'condition-1',
+          oracle: 'oracle',
+          question_id: 'question-1',
+          outcome_slot_count: 2,
+          resolved: false,
+          volume: 0,
+          open_interest: 0,
+          active_positions_count: 0,
+          created_at: '2026-06-22T00:00:00.000Z',
+          updated_at: '2026-06-22T00:00:00.000Z',
+        },
+      },
+    ],
+    tags: [],
+    main_tag: 'Crypto',
+    is_bookmarked: false,
+    is_trending: false,
+    ...overrides,
+  }
+}
+
+describe('event live series chart utils', () => {
+  it('uses event resolved_at as the live chart end timestamp', () => {
+    const resolvedAt = '2026-06-22T23:59:12.000Z'
+    const event = createEvent({
+      status: 'resolved',
+      resolved_at: resolvedAt,
+      end_date: '2026-06-23T00:00:00.000Z',
+    })
+
+    expect(resolveEventEndTimestamp(event)).toBe(Date.parse(resolvedAt))
+  })
+
+  it('falls back to resolved condition timestamps for resolved events', () => {
+    const conditionResolvedAt = '2026-06-22T23:59:40.000Z'
+    const baseMarket = createEvent().markets[0]!
+    const event = createEvent({
+      status: 'resolved',
+      resolved_at: null,
+      markets: [
+        {
+          ...baseMarket,
+          is_resolved: true,
+          condition: {
+            ...baseMarket.condition,
+            resolved: true,
+            resolved_at: conditionResolvedAt,
+          },
+        },
+      ],
+    })
+
+    expect(resolveEventEndTimestamp(event)).toBe(Date.parse(conditionResolvedAt))
+  })
+
+  it('does not use one resolved market timestamp for active multi-market events', () => {
+    const conditionResolvedAt = '2026-06-22T23:59:40.000Z'
+    const baseMarket = createEvent().markets[0]!
+    const event = createEvent({
+      status: 'active',
+      total_markets_count: 2,
+      markets: [
+        {
+          ...baseMarket,
+          is_resolved: true,
+          condition: {
+            ...baseMarket.condition,
+            resolved: true,
+            resolved_at: conditionResolvedAt,
+          },
+        },
+        {
+          ...baseMarket,
+          condition_id: 'condition-2',
+          condition: {
+            ...baseMarket.condition,
+            id: 'condition-2',
+          },
+        },
+      ],
+    })
+
+    expect(resolveEventEndTimestamp(event)).toBe(Date.parse('2026-06-23T00:00:00.000Z'))
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Freeze the live chart when an event is closed and show a fixed final price, keeping it visible and preventing post‑resolution updates. Axis, target line, and labels reflect the frozen state.

- **Bug Fixes**
  - Stop live updates once closed; derive end timestamp from `resolved_at` → resolved market timestamps (for resolved/archived, single‑market, or all‑resolved cases) → event/market end.
  - Lock and display the final price via closing price → latest price before end → persisted fallback; prefer it on closed charts using `resolveLiveSeriesDisplayPrice`.
  - Keep the final price visible by anchoring the window to the end time and, when no pre‑close data exists, rendering a flat series across the last window.
  - Use opening price as the baseline; keep the target line and y‑axis aligned with the frozen state.
  - Update header to “Final Price”; disable live subscriptions post‑close; add unit tests for `resolveEventEndTimestamp` and `resolveLiveSeriesDisplayPrice` (resolved events, resolved‑market fallback, multi‑market active cases).

<sup>Written for commit 93cf4f81b910b1886b126b45b9fc0989896d62df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1186?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

