### PR TITLE
fix: stabilize portfolio positions total

### DIFF
--- a/src/app/[locale]/(platform)/profile/_hooks/usePublicPositionsQuery.ts
+++ b/src/app/[locale]/(platform)/profile/_hooks/usePublicPositionsQuery.ts
@@ -5,6 +5,7 @@ import { isClientOnlySort, mapDataApiPosition, resolvePositionsSearchParams, res
 
 const DATA_API_URL = process.env.DATA_URL!
 const UNRESOLVED_STATUS_TTL_MS = 60_000
+const POSITIONS_PAGE_SIZE = 500
 const conditionResolutionCache = new Map<string, { isResolved: boolean, checkedAt: number }>()
 
 function normalizeConditionId(value: string | undefined) {
@@ -106,7 +107,7 @@ async function fetchUserPositions({
   const shouldApplySort = status === 'active' && !isClientOnlySort(sortBy)
   const params = new URLSearchParams({
     user: userAddress,
-    limit: '50',
+    limit: String(POSITIONS_PAGE_SIZE),
     offset: pageParam.toString(),
   })
 
@@ -213,7 +214,7 @@ export function usePublicPositionsQuery({
         signal,
       }),
     getNextPageParam: (lastPage, allPages) => {
-      if (lastPage.length === 50) {
+      if (lastPage.length === POSITIONS_PAGE_SIZE) {
         return allPages.reduce((total, page) => total + page.length, 0)
       }
       return undefined


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Increase positions page size to 500 and use a single constant for pagination to stabilize the portfolio positions total in the profile view.

- **Bug Fixes**
  - Set `POSITIONS_PAGE_SIZE = 500` and use it for `limit` in `usePublicPositionsQuery`.
  - Update `getNextPageParam` to rely on the same constant, ensuring consistent pagination and totals.

<sup>Written for commit 600140afb2e6cd25718cf0a302c169674a86a807. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1189?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

