### PR TITLE
fix: remove split fake position

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketPositions.tsx
@@ -26,7 +26,6 @@ import {
   formatSharesLabel,
   fromMicro,
 } from '@/lib/formatters'
-import { applyPositionDeltasToUserPositions } from '@/lib/optimistic-trading'
 import { buildShareCardPayload } from '@/lib/share-card'
 import { getUserPublicAddress } from '@/lib/user-address'
 import { cn } from '@/lib/utils'
@@ -128,28 +127,6 @@ function resolvePositionOutcomeIndex(position: UserPosition) {
   return resolvedOutcomeIndex === OUTCOME_INDEX.NO ? OUTCOME_INDEX.NO : OUTCOME_INDEX.YES
 }
 
-function resolveMarketOutcomePrice(
-  market: Event['markets'][number],
-  outcomeIndex: typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO,
-) {
-  const outcome = market.outcomes.find(currentOutcome => currentOutcome.outcome_index === outcomeIndex)
-    ?? market.outcomes[outcomeIndex]
-  const explicitPrice = normalizePositionPrice(outcome?.buy_price)
-
-  if (typeof explicitPrice === 'number' && explicitPrice > 0) {
-    return explicitPrice
-  }
-
-  const marketPrice = normalizePositionPrice(market.price)
-  if (typeof marketPrice === 'number' && marketPrice > 0) {
-    return outcomeIndex === OUTCOME_INDEX.NO
-      ? Math.max(0, Math.min(1, 1 - marketPrice))
-      : marketPrice
-  }
-
-  return 0.5
-}
-
 function normalizePnlValue(value: number | null, baseCostValue: number | null) {
   if (!Number.isFinite(value)) {
     return 0
@@ -203,16 +180,12 @@ async function fetchAllUserPositions({
 function useMarketPositionsQuery({
   userAddress,
   market,
-  eventSlug,
   positionStatus,
 }: {
   userAddress: string
   market: Event['markets'][number]
-  eventSlug: string
   positionStatus: 'active' | 'closed'
 }) {
-  const orderUserShares = useOrder(state => state.userShares)
-
   const query = useQuery({
     queryKey: ['user-market-positions', userAddress, market.condition_id, positionStatus],
     queryFn: ({ signal }) =>
@@ -230,47 +203,7 @@ function useMarketPositionsQuery({
     gcTime: 1000 * 60 * 10,
   })
 
-  const rawPositions = useMemo(() => query.data ?? [], [query.data])
-  const positions = useMemo(() => {
-    const tokenShares = orderUserShares[market.condition_id]
-    if (!tokenShares) {
-      return rawPositions
-    }
-
-    const deltas = [OUTCOME_INDEX.YES, OUTCOME_INDEX.NO].flatMap((outcomeIndex) => {
-      const tokenBalance = tokenShares[outcomeIndex] ?? 0
-      const currentPositionShares = rawPositions.reduce((sum, positionItem) => {
-        if (resolvePositionOutcomeIndex(positionItem) !== outcomeIndex) {
-          return sum
-        }
-        return sum + resolvePositionShares(positionItem)
-      }, 0)
-      const missingShares = Number((tokenBalance - currentPositionShares).toFixed(6))
-
-      if (!(missingShares >= POSITION_VISIBILITY_THRESHOLD)) {
-        return []
-      }
-
-      const currentPrice = resolveMarketOutcomePrice(market, outcomeIndex)
-
-      return [{
-        conditionId: market.condition_id,
-        outcomeIndex,
-        sharesDelta: missingShares,
-        avgPrice: currentPrice,
-        currentPrice,
-        title: market.short_title || market.title,
-        slug: market.slug,
-        eventSlug,
-        iconUrl: market.icon_url,
-        outcomeText: outcomeIndex === OUTCOME_INDEX.NO ? 'No' : 'Yes',
-        isActive: !market.is_resolved,
-        isResolved: market.is_resolved,
-      }]
-    })
-
-    return applyPositionDeltasToUserPositions(rawPositions, deltas) ?? rawPositions
-  }, [eventSlug, market, orderUserShares, rawPositions])
+  const positions = useMemo(() => query.data ?? [], [query.data])
 
   const visiblePositions = useMemo(
     () => positions.filter(position => resolvePositionShares(position) >= POSITION_VISIBILITY_THRESHOLD),
@@ -843,7 +776,6 @@ export default function EventMarketPositions({
   const { status, refetch, visiblePositions } = useMarketPositionsQuery({
     userAddress,
     market,
-    eventSlug,
     positionStatus,
   })
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarkets.tsx
@@ -2,7 +2,6 @@
 
 import type { MarketPositionTag } from '@/app/[locale]/(platform)/event/[slug]/_components/EventMarketCard'
 import type { EventMarketRow } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventMarketRows'
-import type { SharesByCondition } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances'
 import type { OrderBookSummariesResponse } from '@/app/[locale]/(platform)/event/[slug]/_types/EventOrderBookTypes'
 import type { NormalizedBookLevel } from '@/lib/order-panel-utils'
 import type { Event, UserPosition } from '@/types'
@@ -25,7 +24,7 @@ import { useUserOpenOrdersQuery } from '@/app/[locale]/(platform)/event/[slug]/_
 import { useUserShareBalances } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances'
 import { useXTrackerTweetCount } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useXTrackerTweetCount'
 import { applyCachedChartDeltaToEventMarketRow } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventMarketChanceMeta'
-import { isMarketResolved, POSITION_VISIBILITY_THRESHOLD } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventMarketUtils'
+import { isMarketResolved } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventMarketUtils'
 import {
   resolveEventResolvedOutcomeIndex,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventResolvedOutcome'
@@ -39,7 +38,6 @@ import { fetchUserOtherBalance, fetchUserPositionsForMarket } from '@/lib/data-a
 import { formatAmountInputValue, fromMicro } from '@/lib/formatters'
 import { resolveDisplayPrice } from '@/lib/market-chance'
 import { resolveOutcomeUnitPrice } from '@/lib/market-pricing'
-import { applyPositionDeltasToUserPositions } from '@/lib/optimistic-trading'
 import { calculateMarketFill, normalizeBookLevels } from '@/lib/order-panel-utils'
 import { cn } from '@/lib/utils'
 import { useIsSingleMarket, useOrder } from '@/stores/useOrder'
@@ -309,7 +307,6 @@ function useMarketInteractionHandlers({
 function useEventUserPositionsData({
   event,
   ownerAddress,
-  sharesByCondition,
   isNegRiskEnabled,
   isNegRiskAugmented,
   userId,
@@ -317,7 +314,6 @@ function useEventUserPositionsData({
 }: {
   event: Event
   ownerAddress: `0x${string}`
-  sharesByCondition: SharesByCondition
   isNegRiskEnabled: boolean
   isNegRiskAugmented: boolean
   userId: string | undefined
@@ -369,66 +365,7 @@ function useEventUserPositionsData({
     enabled: Boolean(userId),
   })
 
-  const mergedEventUserPositions = useMemo(() => {
-    const basePositions = userPositions ?? []
-    const deltas = event.markets.flatMap((market) => {
-      const tokenShares = sharesByCondition[market.condition_id]
-      if (!tokenShares) {
-        return []
-      }
-
-      return [OUTCOME_INDEX.YES, OUTCOME_INDEX.NO].flatMap((outcomeIndex) => {
-        const tokenBalance = tokenShares[outcomeIndex] ?? 0
-        const existingShares = basePositions.reduce((sum, position) => {
-          if (position.market?.condition_id !== market.condition_id) {
-            return sum
-          }
-
-          const normalizedOutcome = position.outcome_text?.toLowerCase()
-          const explicitOutcomeIndex = typeof position.outcome_index === 'number' ? position.outcome_index : undefined
-          const resolvedOutcomeIndex = explicitOutcomeIndex ?? (
-            normalizedOutcome === 'no'
-              ? OUTCOME_INDEX.NO
-              : OUTCOME_INDEX.YES
-          )
-
-          if (resolvedOutcomeIndex !== outcomeIndex) {
-            return sum
-          }
-
-          const quantity = typeof position.total_shares === 'number'
-            ? position.total_shares
-            : (typeof position.size === 'number' ? position.size : 0)
-
-          return sum + (quantity > 0 ? quantity : 0)
-        }, 0)
-
-        const missingShares = Number((tokenBalance - existingShares).toFixed(6))
-        if (!(missingShares >= POSITION_VISIBILITY_THRESHOLD)) {
-          return []
-        }
-
-        const currentPrice = resolveOutcomeUnitPrice(market, outcomeIndex)
-
-        return [{
-          conditionId: market.condition_id,
-          outcomeIndex,
-          sharesDelta: missingShares,
-          avgPrice: currentPrice,
-          currentPrice,
-          title: market.short_title || market.title,
-          slug: market.slug,
-          eventSlug: event.slug,
-          iconUrl: market.icon_url,
-          outcomeText: outcomeIndex === OUTCOME_INDEX.NO ? 'No' : 'Yes',
-          isActive: !market.is_resolved,
-          isResolved: market.is_resolved,
-        }]
-      })
-    })
-
-    return applyPositionDeltasToUserPositions(basePositions, deltas) ?? basePositions
-  }, [event.markets, event.slug, sharesByCondition, userPositions])
+  const eventUserPositions = useMemo(() => userPositions ?? [], [userPositions])
 
   const openOrdersCountByCondition = useMemo(() => {
     const pages = eventOpenOrdersData?.pages ?? []
@@ -445,7 +382,7 @@ function useEventUserPositionsData({
   }, [eventOpenOrdersData?.pages])
 
   const positionTagsByCondition = useMemo(() => {
-    if (!mergedEventUserPositions.length) {
+    if (!eventUserPositions.length) {
       return {}
     }
 
@@ -460,7 +397,7 @@ function useEventUserPositionsData({
       }>
     > = {}
 
-    mergedEventUserPositions.forEach((position) => {
+    eventUserPositions.forEach((position) => {
       const conditionId = position.market?.condition_id
       if (!conditionId || !validConditionIds.has(conditionId)) {
         return
@@ -522,10 +459,10 @@ function useEventUserPositionsData({
       }
       return acc
     }, {})
-  }, [event.markets, mergedEventUserPositions, normalizeOutcomeLabel, t])
+  }, [event.markets, eventUserPositions, normalizeOutcomeLabel, t])
 
   const convertOptions = useMemo(() => {
-    if (!isNegRiskEnabled || !mergedEventUserPositions.length) {
+    if (!isNegRiskEnabled || !eventUserPositions.length) {
       return []
     }
 
@@ -533,7 +470,7 @@ function useEventUserPositionsData({
       event.markets.map(market => [market.condition_id, market]),
     )
 
-    return mergedEventUserPositions.reduce<Array<{ id: string, label: string, shares: number, conditionId: string }>>(
+    return eventUserPositions.reduce<Array<{ id: string, label: string, shares: number, conditionId: string }>>(
       (options, position, index) => {
         const conditionId = position.market?.condition_id
         if (!conditionId) {
@@ -571,7 +508,7 @@ function useEventUserPositionsData({
       },
       [],
     )
-  }, [event.markets, isNegRiskEnabled, mergedEventUserPositions])
+  }, [event.markets, isNegRiskEnabled, eventUserPositions])
 
   const eventOutcomes = useMemo(() => {
     return event.markets.map(market => ({
@@ -824,7 +761,6 @@ export default function EventMarkets({ event, isMobile }: EventMarketsProps) {
   } = useEventUserPositionsData({
     event,
     ownerAddress,
-    sharesByCondition,
     isNegRiskEnabled,
     isNegRiskAugmented,
     userId: user?.id,

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
@@ -296,9 +296,6 @@ export default function EventOrderPanelBuySellTabs({
         onOpenChange={setIsSplitDialogOpen}
         availableUsdc={availableSplitBalance}
         conditionId={conditionId}
-        eventId={eventId}
-        eventSlug={eventSlug}
-        marketSlug={marketSlug ?? undefined}
         eventPath={eventPath}
         marketTitle={marketTitle ?? undefined}
         marketIconUrl={marketIconUrl}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -984,9 +984,7 @@ export default function EventOrderPanelForm({
   const availableNoTokenShares = Math.max(0, noTokenShares - lockedNoShares)
   const availableYesPositionShares = Math.max(0, yesPositionShares - lockedYesShares)
   const availableNoPositionShares = Math.max(0, noPositionShares - lockedNoShares)
-  const mergeableYesShares = Math.max(availableYesTokenShares, availableYesPositionShares)
-  const mergeableNoShares = Math.max(availableNoTokenShares, availableNoPositionShares)
-  const availableMergeShares = Math.max(0, Math.min(mergeableYesShares, mergeableNoShares))
+  const availableMergeShares = Math.max(0, Math.min(availableYesTokenShares, availableNoTokenShares))
   const availableSplitBalance = Math.max(0, balance.raw)
   const outcomeIndex = activeOutcome?.outcome_index as typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO | undefined
   const selectedShares = outcomeIndex === undefined

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventSplitSharesDialog.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventSplitSharesDialog.tsx
@@ -1,5 +1,4 @@
 import type { SharesByCondition } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances'
-import type { UserPosition } from '@/types'
 import { useQueryClient } from '@tanstack/react-query'
 import { useExtracted } from 'next-intl'
 import { useMemo, useState } from 'react'
@@ -29,7 +28,7 @@ import { DEFAULT_CONDITION_PARTITION, MICRO_UNIT } from '@/lib/constants'
 import { ZERO_BYTES32 } from '@/lib/contracts'
 import { formatAmountInputValue, toMicro } from '@/lib/formatters'
 import { isCurrentNegRiskAdapterAddress } from '@/lib/neg-risk-adapter'
-import { applyPositionDeltasToUserPositions, applyShareDeltas, updateQueryDataWhere } from '@/lib/optimistic-trading'
+import { applyShareDeltas, updateQueryDataWhere } from '@/lib/optimistic-trading'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import { cn } from '@/lib/utils'
 import { signAndSubmitDepositWalletCalls } from '@/lib/wallet/client'
@@ -44,9 +43,6 @@ interface EventSplitSharesDialogProps {
   open: boolean
   availableUsdc: number
   conditionId?: string
-  eventId?: string
-  eventSlug?: string
-  marketSlug?: string
   eventPath?: string | null
   marketTitle?: string
   marketIconUrl?: string | null
@@ -86,9 +82,6 @@ export default function EventSplitSharesDialog({
   open,
   availableUsdc,
   conditionId,
-  eventId,
-  eventSlug,
-  marketSlug,
   eventPath,
   marketTitle,
   marketIconUrl,
@@ -241,61 +234,6 @@ export default function EventSplitSharesDialog({
         description: marketTitle ?? t('Request submitted.'),
       })
 
-      const optimisticDeltas = [
-        {
-          conditionId,
-          outcomeIndex: 0 as const,
-          sharesDelta: numericAmount,
-          avgPrice: 0.5,
-          currentPrice: 0.5,
-          title: marketTitle,
-          slug: marketSlug ?? conditionId,
-          eventSlug,
-          iconUrl: marketIconUrl,
-          outcomeText: 'Yes',
-          isActive: true,
-          isResolved: false,
-        },
-        {
-          conditionId,
-          outcomeIndex: 1 as const,
-          sharesDelta: numericAmount,
-          avgPrice: 0.5,
-          currentPrice: 0.5,
-          title: marketTitle,
-          slug: marketSlug ?? conditionId,
-          eventSlug,
-          iconUrl: marketIconUrl,
-          outcomeText: 'No',
-          isActive: true,
-          isResolved: false,
-        },
-      ]
-
-      updateQueryDataWhere<UserPosition[]>(
-        queryClient,
-        ['order-panel-user-positions'],
-        currentQueryKey => currentQueryKey[2] === conditionId,
-        current => applyPositionDeltasToUserPositions(current, optimisticDeltas),
-      )
-      updateQueryDataWhere<UserPosition[]>(
-        queryClient,
-        ['user-market-positions'],
-        currentQueryKey => currentQueryKey[2] === conditionId && currentQueryKey[3] === 'active',
-        current => applyPositionDeltasToUserPositions(current, optimisticDeltas),
-      )
-      updateQueryDataWhere<UserPosition[]>(
-        queryClient,
-        ['event-user-positions'],
-        currentQueryKey => currentQueryKey[2] === eventId,
-        current => applyPositionDeltasToUserPositions(current, optimisticDeltas),
-      )
-      updateQueryDataWhere<UserPosition[]>(
-        queryClient,
-        ['user-event-positions'],
-        currentQueryKey => currentQueryKey[2] === 'active' && String(currentQueryKey[3] ?? '').includes(conditionId),
-        current => applyPositionDeltasToUserPositions(current, optimisticDeltas),
-      )
       updateQueryDataWhere<SharesByCondition>(
         queryClient,
         ['user-conditional-shares'],

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances.ts
@@ -2,10 +2,10 @@ import type { PublicClient } from 'viem'
 import type { Event } from '@/types'
 import { useQuery } from '@tanstack/react-query'
 import { useMemo, useRef } from 'react'
-import { createPublicClient, erc1155Abi, http } from 'viem'
-import { MICRO_UNIT, OUTCOME_INDEX } from '@/lib/constants'
+import { erc1155Abi } from 'viem'
+import { createConditionalTokenBalanceClient, normalizeSharesFromBalance } from '@/lib/conditional-token-balances'
+import { OUTCOME_INDEX } from '@/lib/constants'
 import { CONDITIONAL_TOKENS_CONTRACT } from '@/lib/contracts'
-import { defaultViemNetwork, defaultViemRpcUrl } from '@/lib/viem-network'
 
 export interface SharesByCondition {
   [conditionId: string]: {
@@ -19,26 +19,10 @@ interface UseUserShareBalancesOptions {
   ownerAddress?: `0x${string}` | null
 }
 
-function createBrowserPublicClient(): PublicClient {
-  return createPublicClient({
-    chain: defaultViemNetwork,
-    transport: http(defaultViemRpcUrl),
-  })
-}
-
-function normalizeSharesFromBalance(balance: bigint): number {
-  if (balance <= 0n) {
-    return 0
-  }
-
-  const decimalValue = Number(balance) / MICRO_UNIT
-  return Math.max(0, Math.floor(decimalValue * MICRO_UNIT) / MICRO_UNIT)
-}
-
 export function useUserShareBalances({ event, ownerAddress }: UseUserShareBalancesOptions) {
   const clientRef = useRef<PublicClient | null>(null)
   if (clientRef.current === null && typeof window !== 'undefined') {
-    clientRef.current = createBrowserPublicClient()
+    clientRef.current = createConditionalTokenBalanceClient()
   }
   const client = clientRef.current
 

--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
@@ -1066,7 +1066,6 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
   })
 
   const {
-    positionsByCondition,
     availableMergeableMarkets,
   } = useMergeableMarketsAvailability({ canSell, positionsWithIcons })
 
@@ -1074,7 +1073,6 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
 
   const { isMergeProcessing, mergeBatchCount, handleMergeAll } = useMergePositionsAction({
     mergeableMarkets: availableMergeableMarkets,
-    positionsByCondition,
     hasMergeableMarkets,
     user,
     ensureTradingReady,

--- a/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
+++ b/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
@@ -2,12 +2,11 @@ import type { InfiniteData, QueryClient } from '@tanstack/react-query'
 import type { SharesByCondition } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances'
 import type { MergeableMarket } from '@/app/[locale]/(platform)/profile/_components/MergePositionsDialog'
 import type { PublicPosition } from '@/app/[locale]/(platform)/profile/_components/PublicPositionItem'
-import type { ConditionShares } from '@/app/[locale]/(platform)/profile/_types/PublicPositionsTypes'
 import type { User } from '@/types'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 import { useSignTypedData } from 'wagmi'
-import { fetchLockedSharesByCondition } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
+import { fetchLockedSharesByCondition, fetchOnchainSharesByCondition } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
 import { DEPOSIT_WALLET_BALANCE_QUERY_KEY } from '@/hooks/useBalance'
 import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
 import { DEFAULT_CONDITION_PARTITION } from '@/lib/constants'
@@ -22,7 +21,6 @@ import { useNotifications } from '@/stores/useNotifications'
 
 interface UseMergePositionsActionOptions {
   mergeableMarkets: MergeableMarket[]
-  positionsByCondition: Record<string, ConditionShares>
   hasMergeableMarkets: boolean
   user: User | null
   ensureTradingReady: () => boolean
@@ -33,7 +31,6 @@ interface UseMergePositionsActionOptions {
 
 export function useMergePositionsAction({
   mergeableMarkets,
-  positionsByCondition,
   hasMergeableMarkets,
   user,
   ensureTradingReady,
@@ -68,7 +65,10 @@ export function useMergePositionsAction({
     try {
       setIsMergeProcessing(true)
 
-      const availabilityByCondition = await fetchLockedSharesByCondition(mergeableMarkets)
+      const [availabilityByCondition, onchainSharesByCondition] = await Promise.all([
+        fetchLockedSharesByCondition(mergeableMarkets),
+        fetchOnchainSharesByCondition(mergeableMarkets, user.deposit_wallet_address as `0x${string}`),
+      ])
 
       const preparedMerges = mergeableMarkets
         .filter(market =>
@@ -79,8 +79,8 @@ export function useMergePositionsAction({
         )
         .map((market) => {
           const conditionId = market.conditionId as string
-          const positionShares = positionsByCondition[conditionId]
-          if (!positionShares) {
+          const onchainShares = onchainSharesByCondition[conditionId]
+          if (!onchainShares) {
             return null
           }
 
@@ -88,11 +88,11 @@ export function useMergePositionsAction({
           const locked = availabilityByCondition[conditionId]?.lockedShares ?? {}
           const availableFirst = Math.max(
             0,
-            (positionShares[firstOutcome] ?? 0) - (locked[firstOutcome] ?? 0),
+            (onchainShares[firstOutcome] ?? 0) - (locked[firstOutcome] ?? 0),
           )
           const availableSecond = Math.max(
             0,
-            (positionShares[secondOutcome] ?? 0) - (locked[secondOutcome] ?? 0),
+            (onchainShares[secondOutcome] ?? 0) - (locked[secondOutcome] ?? 0),
           )
           const safeMergeAmount = Math.min(market.mergeAmount, availableFirst, availableSecond)
           const normalizedMergeAmount = Math.floor(safeMergeAmount * 100 + 1e-8) / 100
@@ -230,7 +230,6 @@ export function useMergePositionsAction({
     mergeableMarkets,
     onSuccess,
     openTradeRequirements,
-    positionsByCondition,
     queryClient,
     runWithSignaturePrompt,
     signTypedDataAsync,

--- a/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
+++ b/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
@@ -2,12 +2,12 @@ import type { PublicClient } from 'viem'
 import type { MergeableMarket } from '@/app/[locale]/(platform)/profile/_components/MergePositionsDialog'
 import type { PublicPosition } from '@/app/[locale]/(platform)/profile/_components/PublicPositionItem'
 import type { ConditionShares, PositionsTotals, SortDirection, SortOption } from '@/app/[locale]/(platform)/profile/_types/PublicPositionsTypes'
-import { createPublicClient, erc1155Abi, http } from 'viem'
+import { erc1155Abi } from 'viem'
 import { fetchUserOpenOrders } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserOpenOrdersQuery'
+import { createConditionalTokenBalanceClient, normalizeSharesFromBalance } from '@/lib/conditional-token-balances'
 import { MICRO_UNIT, OUTCOME_INDEX } from '@/lib/constants'
 import { CONDITIONAL_TOKENS_CONTRACT } from '@/lib/contracts'
 import { formatCurrency } from '@/lib/formatters'
-import { defaultViemNetwork, defaultViemRpcUrl } from '@/lib/viem-network'
 
 export interface DataApiPosition {
   proxyWallet?: string
@@ -44,21 +44,9 @@ export interface DataApiPosition {
 let publicClient: PublicClient | null = null
 
 function getPublicClient() {
-  publicClient ??= createPublicClient({
-    chain: defaultViemNetwork,
-    transport: http(defaultViemRpcUrl),
-  })
+  publicClient ??= createConditionalTokenBalanceClient()
 
   return publicClient
-}
-
-function normalizeSharesFromBalance(balance: bigint): number {
-  if (balance <= 0n) {
-    return 0
-  }
-
-  const decimalValue = Number(balance) / MICRO_UNIT
-  return Math.max(0, Math.floor(decimalValue * MICRO_UNIT) / MICRO_UNIT)
 }
 
 export function formatCurrencyValue(value?: number) {

--- a/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
+++ b/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
@@ -1,9 +1,13 @@
+import type { PublicClient } from 'viem'
 import type { MergeableMarket } from '@/app/[locale]/(platform)/profile/_components/MergePositionsDialog'
 import type { PublicPosition } from '@/app/[locale]/(platform)/profile/_components/PublicPositionItem'
 import type { ConditionShares, PositionsTotals, SortDirection, SortOption } from '@/app/[locale]/(platform)/profile/_types/PublicPositionsTypes'
+import { createPublicClient, erc1155Abi, http } from 'viem'
 import { fetchUserOpenOrders } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserOpenOrdersQuery'
 import { MICRO_UNIT, OUTCOME_INDEX } from '@/lib/constants'
+import { CONDITIONAL_TOKENS_CONTRACT } from '@/lib/contracts'
 import { formatCurrency } from '@/lib/formatters'
+import { defaultViemNetwork, defaultViemRpcUrl } from '@/lib/viem-network'
 
 export interface DataApiPosition {
   proxyWallet?: string
@@ -35,6 +39,26 @@ export interface DataApiPosition {
   timestamp?: number
   negativeRisk?: boolean
   negative_risk?: boolean
+}
+
+let publicClient: PublicClient | null = null
+
+function getPublicClient() {
+  publicClient ??= createPublicClient({
+    chain: defaultViemNetwork,
+    transport: http(defaultViemRpcUrl),
+  })
+
+  return publicClient
+}
+
+function normalizeSharesFromBalance(balance: bigint): number {
+  if (balance <= 0n) {
+    return 0
+  }
+
+  const decimalValue = Number(balance) / MICRO_UNIT
+  return Math.max(0, Math.floor(decimalValue * MICRO_UNIT) / MICRO_UNIT)
 }
 
 export function formatCurrencyValue(value?: number) {
@@ -519,6 +543,42 @@ export async function fetchLockedSharesByCondition(markets: MergeableMarket[]): 
   }))
 
   return availabilityByCondition
+}
+
+export async function fetchOnchainSharesByCondition(
+  markets: MergeableMarket[],
+  ownerAddress: `0x${string}`,
+): Promise<Record<string, Record<string, number>>> {
+  const descriptors = markets.flatMap((market) => {
+    if (!market.conditionId || !Array.isArray(market.outcomeAssets) || market.outcomeAssets.length !== 2) {
+      return []
+    }
+
+    return market.outcomeAssets.map(asset => ({
+      conditionId: market.conditionId!,
+      asset,
+    }))
+  })
+
+  if (descriptors.length === 0) {
+    return {}
+  }
+
+  const balances = await getPublicClient().readContract({
+    address: CONDITIONAL_TOKENS_CONTRACT,
+    abi: erc1155Abi,
+    functionName: 'balanceOfBatch',
+    args: [
+      descriptors.map(() => ownerAddress),
+      descriptors.map(descriptor => BigInt(descriptor.asset)),
+    ],
+  }) as bigint[]
+
+  return descriptors.reduce<Record<string, Record<string, number>>>((acc, descriptor, index) => {
+    acc[descriptor.conditionId] ??= {}
+    acc[descriptor.conditionId][descriptor.asset] = normalizeSharesFromBalance(balances[index] ?? 0n)
+    return acc
+  }, {})
 }
 
 export function sortPositions(

--- a/src/lib/conditional-token-balances.ts
+++ b/src/lib/conditional-token-balances.ts
@@ -1,0 +1,20 @@
+import type { PublicClient } from 'viem'
+import { createPublicClient, http } from 'viem'
+import { MICRO_UNIT } from '@/lib/constants'
+import { defaultViemNetwork, defaultViemRpcUrl } from '@/lib/viem-network'
+
+export function createConditionalTokenBalanceClient(): PublicClient {
+  return createPublicClient({
+    chain: defaultViemNetwork,
+    transport: http(defaultViemRpcUrl),
+  })
+}
+
+export function normalizeSharesFromBalance(balance: bigint): number {
+  if (balance <= 0n) {
+    return 0
+  }
+
+  const decimalValue = Number(balance) / MICRO_UNIT
+  return Math.max(0, Math.floor(decimalValue * MICRO_UNIT) / MICRO_UNIT)
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes synthetic “split” positions from event/profile views and stops optimistic position injection. Merge amounts are now clamped to on‑chain ERC‑1155 balances to prevent over-merge and UI inconsistencies, and ERC‑1155 balance helpers are consolidated.

- **Bug Fixes**
  - Stop generating fake positions in market lists and after split; show only real positions from queries.
  - After split, update only share balances, not positions caches.
  - Clamp merge amounts to on‑chain balances minus locked shares to avoid exceeding wallet holdings.

- **Refactors**
  - Added `fetchOnchainSharesByCondition` using `viem` `balanceOfBatch` for ERC‑1155 balances.
  - Extracted `createConditionalTokenBalanceClient` and `normalizeSharesFromBalance` to `lib/conditional-token-balances.ts` and reused in share balance hooks and profile utilities.
  - Simplified merge availability in the order panel to consider only token shares.
  - Removed unused props from `EventSplitSharesDialog` and related components.

<sup>Written for commit 86456fe3cc9743b4f6f690f18bf35f6762188830. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

