### PR TITLE
feat: support rpc url override

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,9 @@ CRON_SECRET=""
 # Disable Next.js image optimization
 DISABLE_IMAGE_OPTIMIZATION=false
 
+# Optional RPC endpoint used for on-chain reads in the app
+NEXT_PUBLIC_RPC_URL=""
+
 # Force public shell prerendering on/off at build time.
 # Leave empty to infer from SITE_URL/VERCEL_PROJECT_PRODUCTION_URL + POSTGRES_URL + REOWN_APPKIT_PROJECT_ID.
 BUILD_PRERENDER_PUBLIC_SHELL=""

--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ CRON_SECRET=""
 DISABLE_IMAGE_OPTIMIZATION=false
 
 # Optional RPC endpoint used for on-chain reads in the app
-NEXT_PUBLIC_RPC_URL=""
+POLYGON_RPC_URL=""
 
 # Force public shell prerendering on/off at build time.
 # Leave empty to infer from SITE_URL/VERCEL_PROJECT_PRODUCTION_URL + POSTGRES_URL + REOWN_APPKIT_PROJECT_ID.

--- a/next.config.ts
+++ b/next.config.ts
@@ -86,6 +86,7 @@ const config: NextConfig = {
     IS_VERCEL: process.env.VERCEL_ENV ? 'true' : 'false',
     BUILD_PRERENDER_PUBLIC_SHELL: shouldPrerenderPublicShell ? 'true' : 'false',
     SENTRY_DSN: process.env.SENTRY_DSN,
+    POLYGON_RPC_URL: process.env.POLYGON_RPC_URL,
     CREATE_MARKET_URL: process.env.CREATE_MARKET_URL ?? 'https://create-market.kuest.com',
     GAMMA_URL: process.env.GAMMA_URL ?? 'https://gamma-api.kuest.com',
     GEOBLOCK_URL: process.env.GEOBLOCK_URL ?? 'https://geoblock.kuest.com',

--- a/src/lib/viem-network.ts
+++ b/src/lib/viem-network.ts
@@ -13,7 +13,26 @@ const VIEM_NETWORKS_BY_CHAIN_ID = new Map<number, Chain>(
 )
 
 export const defaultViemNetwork = VIEM_NETWORKS_BY_KEY[DEFAULT_NETWORK_KEY]
-export const defaultViemRpcUrl = process.env.NEXT_PUBLIC_RPC_URL?.trim() || defaultViemNetwork.rpcUrls.default.http[0]
+
+function resolveDefaultViemRpcUrl() {
+  const configuredRpcUrl = process.env.NEXT_PUBLIC_RPC_URL?.trim()
+  if (!configuredRpcUrl) {
+    return defaultViemNetwork.rpcUrls.default.http[0]
+  }
+
+  try {
+    const parsedUrl = new URL(configuredRpcUrl)
+    if (parsedUrl.protocol !== 'http:' && parsedUrl.protocol !== 'https:') {
+      throw new Error('invalid protocol')
+    }
+    return configuredRpcUrl
+  }
+  catch {
+    throw new Error('Invalid NEXT_PUBLIC_RPC_URL. Expected an absolute http(s) URL.')
+  }
+}
+
+export const defaultViemRpcUrl = resolveDefaultViemRpcUrl()
 
 export function resolveViemNetworkByChainId(chainId: number | string | null | undefined) {
   if (typeof chainId === 'number' && Number.isFinite(chainId)) {

--- a/src/lib/viem-network.ts
+++ b/src/lib/viem-network.ts
@@ -13,7 +13,7 @@ const VIEM_NETWORKS_BY_CHAIN_ID = new Map<number, Chain>(
 )
 
 export const defaultViemNetwork = VIEM_NETWORKS_BY_KEY[DEFAULT_NETWORK_KEY]
-export const defaultViemRpcUrl = defaultViemNetwork.rpcUrls.default.http[0]
+export const defaultViemRpcUrl = process.env.NEXT_PUBLIC_RPC_URL?.trim() || defaultViemNetwork.rpcUrls.default.http[0]
 
 export function resolveViemNetworkByChainId(chainId: number | string | null | undefined) {
   if (typeof chainId === 'number' && Number.isFinite(chainId)) {

--- a/src/lib/viem-network.ts
+++ b/src/lib/viem-network.ts
@@ -15,7 +15,7 @@ const VIEM_NETWORKS_BY_CHAIN_ID = new Map<number, Chain>(
 export const defaultViemNetwork = VIEM_NETWORKS_BY_KEY[DEFAULT_NETWORK_KEY]
 
 function resolveDefaultViemRpcUrl() {
-  const configuredRpcUrl = process.env.NEXT_PUBLIC_RPC_URL?.trim()
+  const configuredRpcUrl = process.env.POLYGON_RPC_URL?.trim()
   if (!configuredRpcUrl) {
     return defaultViemNetwork.rpcUrls.default.http[0]
   }
@@ -28,7 +28,7 @@ function resolveDefaultViemRpcUrl() {
     return configuredRpcUrl
   }
   catch {
-    throw new Error('Invalid NEXT_PUBLIC_RPC_URL. Expected an absolute http(s) URL.')
+    throw new Error('Invalid POLYGON_RPC_URL. Expected an absolute http(s) URL.')
   }
 }
 

--- a/tests/unit/viemNetwork.test.ts
+++ b/tests/unit/viemNetwork.test.ts
@@ -11,16 +11,16 @@ describe('viem-network RPC URL resolution', () => {
     vi.resetModules()
   })
 
-  it('uses the default network RPC when NEXT_PUBLIC_RPC_URL is empty', async () => {
-    vi.stubEnv('NEXT_PUBLIC_RPC_URL', '')
+  it('uses the default network RPC when POLYGON_RPC_URL is empty', async () => {
+    vi.stubEnv('POLYGON_RPC_URL', '')
 
     const { defaultViemNetwork, defaultViemRpcUrl } = await importViemNetwork()
 
     expect(defaultViemRpcUrl).toBe(defaultViemNetwork.rpcUrls.default.http[0])
   })
 
-  it('uses a valid NEXT_PUBLIC_RPC_URL override', async () => {
-    vi.stubEnv('NEXT_PUBLIC_RPC_URL', ' https://rpc.example.com/path ')
+  it('uses a valid POLYGON_RPC_URL override', async () => {
+    vi.stubEnv('POLYGON_RPC_URL', ' https://rpc.example.com/path ')
 
     const { defaultViemRpcUrl } = await importViemNetwork()
 
@@ -31,9 +31,9 @@ describe('viem-network RPC URL resolution', () => {
     'rpc.example.com',
     'ftp://rpc.example.com',
     'ws://rpc.example.com',
-  ])('rejects invalid NEXT_PUBLIC_RPC_URL value %s', async (rpcUrl) => {
-    vi.stubEnv('NEXT_PUBLIC_RPC_URL', rpcUrl)
+  ])('rejects invalid POLYGON_RPC_URL value %s', async (rpcUrl) => {
+    vi.stubEnv('POLYGON_RPC_URL', rpcUrl)
 
-    await expect(importViemNetwork()).rejects.toThrow('Invalid NEXT_PUBLIC_RPC_URL')
+    await expect(importViemNetwork()).rejects.toThrow('Invalid POLYGON_RPC_URL')
   })
 })

--- a/tests/unit/viemNetwork.test.ts
+++ b/tests/unit/viemNetwork.test.ts
@@ -1,0 +1,39 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+async function importViemNetwork() {
+  vi.resetModules()
+  return await import('@/lib/viem-network')
+}
+
+describe('viem-network RPC URL resolution', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('uses the default network RPC when NEXT_PUBLIC_RPC_URL is empty', async () => {
+    vi.stubEnv('NEXT_PUBLIC_RPC_URL', '')
+
+    const { defaultViemNetwork, defaultViemRpcUrl } = await importViemNetwork()
+
+    expect(defaultViemRpcUrl).toBe(defaultViemNetwork.rpcUrls.default.http[0])
+  })
+
+  it('uses a valid NEXT_PUBLIC_RPC_URL override', async () => {
+    vi.stubEnv('NEXT_PUBLIC_RPC_URL', ' https://rpc.example.com/path ')
+
+    const { defaultViemRpcUrl } = await importViemNetwork()
+
+    expect(defaultViemRpcUrl).toBe('https://rpc.example.com/path')
+  })
+
+  it.each([
+    'rpc.example.com',
+    'ftp://rpc.example.com',
+    'ws://rpc.example.com',
+  ])('rejects invalid NEXT_PUBLIC_RPC_URL value %s', async (rpcUrl) => {
+    vi.stubEnv('NEXT_PUBLIC_RPC_URL', rpcUrl)
+
+    await expect(importViemNetwork()).rejects.toThrow('Invalid NEXT_PUBLIC_RPC_URL')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Allow overriding the RPC endpoint for on-chain reads via `POLYGON_RPC_URL` (absolute http(s) URL). The app trims and validates it; if unset it falls back to the network’s default.

<sup>Written for commit 7c03a0203aed0b44d206e9990c33071a759cd5aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

