### PR TITLE
fix: runtime robots site url

### DIFF
--- a/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
+++ b/src/app/[locale]/(platform)/_components/HeaderDropdownUserMenuGuest.tsx
@@ -151,6 +151,7 @@ export default function HeaderDropdownUserMenuGuest() {
             variant="ghost"
             size="headerIconCompact"
             data-testid="header-menu-button"
+            aria-label="User menu"
           >
             <MenuIcon />
           </Button>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,10 @@
 import type { MetadataRoute } from 'next'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 import resolveSiteUrl from '@/lib/site-url'
 
-export default function robots(): MetadataRoute.Robots {
+export default async function robots(): Promise<MetadataRoute.Robots> {
+  await deferPublicShellPrerenderIfNeeded()
+
   const siteUrl = resolveSiteUrl(process.env)
 
   return {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix robots.txt generation to resolve the site URL at runtime, preventing wrong hostnames in production. Also adds an aria-label to the guest user menu button for better accessibility.

- **Bug Fixes**
  - Made `robots.ts` async and deferred public shell prerender to ensure `resolveSiteUrl` uses runtime env vars.
  - Added aria-label "User menu" to the header menu button for screen reader support.

<sup>Written for commit 3227fc960bfe4ab2598aeceb88a4235b73ec4d84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1193?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

