### PR TITLE
fix: clamp merge amounts to onchain balances

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -984,9 +984,7 @@ export default function EventOrderPanelForm({
   const availableNoTokenShares = Math.max(0, noTokenShares - lockedNoShares)
   const availableYesPositionShares = Math.max(0, yesPositionShares - lockedYesShares)
   const availableNoPositionShares = Math.max(0, noPositionShares - lockedNoShares)
-  const mergeableYesShares = Math.max(availableYesTokenShares, availableYesPositionShares)
-  const mergeableNoShares = Math.max(availableNoTokenShares, availableNoPositionShares)
-  const availableMergeShares = Math.max(0, Math.min(mergeableYesShares, mergeableNoShares))
+  const availableMergeShares = Math.max(0, Math.min(availableYesTokenShares, availableNoTokenShares))
   const availableSplitBalance = Math.max(0, balance.raw)
   const outcomeIndex = activeOutcome?.outcome_index as typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO | undefined
   const selectedShares = outcomeIndex === undefined

--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
@@ -1066,7 +1066,6 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
   })
 
   const {
-    positionsByCondition,
     availableMergeableMarkets,
   } = useMergeableMarketsAvailability({ canSell, positionsWithIcons })
 
@@ -1074,7 +1073,6 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
 
   const { isMergeProcessing, mergeBatchCount, handleMergeAll } = useMergePositionsAction({
     mergeableMarkets: availableMergeableMarkets,
-    positionsByCondition,
     hasMergeableMarkets,
     user,
     ensureTradingReady,

--- a/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
+++ b/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
@@ -2,12 +2,11 @@ import type { InfiniteData, QueryClient } from '@tanstack/react-query'
 import type { SharesByCondition } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserShareBalances'
 import type { MergeableMarket } from '@/app/[locale]/(platform)/profile/_components/MergePositionsDialog'
 import type { PublicPosition } from '@/app/[locale]/(platform)/profile/_components/PublicPositionItem'
-import type { ConditionShares } from '@/app/[locale]/(platform)/profile/_types/PublicPositionsTypes'
 import type { User } from '@/types'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 import { useSignTypedData } from 'wagmi'
-import { fetchLockedSharesByCondition } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
+import { fetchLockedSharesByCondition, fetchOnchainSharesByCondition } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
 import { DEPOSIT_WALLET_BALANCE_QUERY_KEY } from '@/hooks/useBalance'
 import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
 import { DEFAULT_CONDITION_PARTITION } from '@/lib/constants'
@@ -22,7 +21,6 @@ import { useNotifications } from '@/stores/useNotifications'
 
 interface UseMergePositionsActionOptions {
   mergeableMarkets: MergeableMarket[]
-  positionsByCondition: Record<string, ConditionShares>
   hasMergeableMarkets: boolean
   user: User | null
   ensureTradingReady: () => boolean
@@ -33,7 +31,6 @@ interface UseMergePositionsActionOptions {
 
 export function useMergePositionsAction({
   mergeableMarkets,
-  positionsByCondition,
   hasMergeableMarkets,
   user,
   ensureTradingReady,
@@ -68,7 +65,10 @@ export function useMergePositionsAction({
     try {
       setIsMergeProcessing(true)
 
-      const availabilityByCondition = await fetchLockedSharesByCondition(mergeableMarkets)
+      const [availabilityByCondition, onchainSharesByCondition] = await Promise.all([
+        fetchLockedSharesByCondition(mergeableMarkets),
+        fetchOnchainSharesByCondition(mergeableMarkets, user.deposit_wallet_address as `0x${string}`),
+      ])
 
       const preparedMerges = mergeableMarkets
         .filter(market =>
@@ -79,8 +79,8 @@ export function useMergePositionsAction({
         )
         .map((market) => {
           const conditionId = market.conditionId as string
-          const positionShares = positionsByCondition[conditionId]
-          if (!positionShares) {
+          const onchainShares = onchainSharesByCondition[conditionId]
+          if (!onchainShares) {
             return null
           }
 
@@ -88,11 +88,11 @@ export function useMergePositionsAction({
           const locked = availabilityByCondition[conditionId]?.lockedShares ?? {}
           const availableFirst = Math.max(
             0,
-            (positionShares[firstOutcome] ?? 0) - (locked[firstOutcome] ?? 0),
+            (onchainShares[firstOutcome] ?? 0) - (locked[firstOutcome] ?? 0),
           )
           const availableSecond = Math.max(
             0,
-            (positionShares[secondOutcome] ?? 0) - (locked[secondOutcome] ?? 0),
+            (onchainShares[secondOutcome] ?? 0) - (locked[secondOutcome] ?? 0),
           )
           const safeMergeAmount = Math.min(market.mergeAmount, availableFirst, availableSecond)
           const normalizedMergeAmount = Math.floor(safeMergeAmount * 100 + 1e-8) / 100
@@ -230,7 +230,6 @@ export function useMergePositionsAction({
     mergeableMarkets,
     onSuccess,
     openTradeRequirements,
-    positionsByCondition,
     queryClient,
     runWithSignaturePrompt,
     signTypedDataAsync,

--- a/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
+++ b/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
@@ -1,9 +1,13 @@
+import type { PublicClient } from 'viem'
 import type { MergeableMarket } from '@/app/[locale]/(platform)/profile/_components/MergePositionsDialog'
 import type { PublicPosition } from '@/app/[locale]/(platform)/profile/_components/PublicPositionItem'
 import type { ConditionShares, PositionsTotals, SortDirection, SortOption } from '@/app/[locale]/(platform)/profile/_types/PublicPositionsTypes'
+import { createPublicClient, erc1155Abi, http } from 'viem'
 import { fetchUserOpenOrders } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useUserOpenOrdersQuery'
 import { MICRO_UNIT, OUTCOME_INDEX } from '@/lib/constants'
+import { CONDITIONAL_TOKENS_CONTRACT } from '@/lib/contracts'
 import { formatCurrency } from '@/lib/formatters'
+import { defaultViemNetwork, defaultViemRpcUrl } from '@/lib/viem-network'
 
 export interface DataApiPosition {
   proxyWallet?: string
@@ -35,6 +39,26 @@ export interface DataApiPosition {
   timestamp?: number
   negativeRisk?: boolean
   negative_risk?: boolean
+}
+
+let publicClient: PublicClient | null = null
+
+function getPublicClient() {
+  publicClient ??= createPublicClient({
+    chain: defaultViemNetwork,
+    transport: http(defaultViemRpcUrl),
+  })
+
+  return publicClient
+}
+
+function normalizeSharesFromBalance(balance: bigint): number {
+  if (balance <= 0n) {
+    return 0
+  }
+
+  const decimalValue = Number(balance) / MICRO_UNIT
+  return Math.max(0, Math.floor(decimalValue * MICRO_UNIT) / MICRO_UNIT)
 }
 
 export function formatCurrencyValue(value?: number) {
@@ -519,6 +543,42 @@ export async function fetchLockedSharesByCondition(markets: MergeableMarket[]): 
   }))
 
   return availabilityByCondition
+}
+
+export async function fetchOnchainSharesByCondition(
+  markets: MergeableMarket[],
+  ownerAddress: `0x${string}`,
+): Promise<Record<string, Record<string, number>>> {
+  const descriptors = markets.flatMap((market) => {
+    if (!market.conditionId || !Array.isArray(market.outcomeAssets) || market.outcomeAssets.length !== 2) {
+      return []
+    }
+
+    return market.outcomeAssets.map(asset => ({
+      conditionId: market.conditionId!,
+      asset,
+    }))
+  })
+
+  if (descriptors.length === 0) {
+    return {}
+  }
+
+  const balances = await getPublicClient().readContract({
+    address: CONDITIONAL_TOKENS_CONTRACT,
+    abi: erc1155Abi,
+    functionName: 'balanceOfBatch',
+    args: [
+      descriptors.map(() => ownerAddress),
+      descriptors.map(descriptor => BigInt(descriptor.asset)),
+    ],
+  }) as bigint[]
+
+  return descriptors.reduce<Record<string, Record<string, number>>>((acc, descriptor, index) => {
+    acc[descriptor.conditionId] ??= {}
+    acc[descriptor.conditionId][descriptor.asset] = normalizeSharesFromBalance(balances[index] ?? 0n)
+    return acc
+  }, {})
 }
 
 export function sortPositions(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Clamp merge amounts to on-chain ERC-1155 balances and locked shares to prevent over-merging and failed transactions. The merge flow now reads balances directly from the `CONDITIONAL_TOKENS_CONTRACT` and ignores derived position totals.

- **Bug Fixes**
  - Read outcome token balances via `viem` `balanceOfBatch` and normalize to `MICRO_UNIT`.
  - Limit each merge to the min of requested amount and available on-chain balances minus locked shares.
  - Event order panel now computes `availableMergeShares` using only token shares.
  - Removed `positionsByCondition` from merge logic to avoid stale or inflated estimates.

<sup>Written for commit 4ea22dae5b27e1cf8bd5bc6b5a96034dfb09a337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1196?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

