### PR TITLE
feat: add support for dynamic chain ID configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ DISABLE_IMAGE_OPTIMIZATION=false
 # Optional RPC endpoint used for on-chain reads in the app
 POLYGON_RPC_URL=""
 
+# Active chain id exposed through the runtime config script.
+# Leave empty/80002 for Amoy; set 137 for Polygon mainnet.
+CHAIN_ID=""
+
 # Force public shell prerendering on/off at runtime.
 # Leave empty to infer from SITE_URL/VERCEL_PROJECT_PRODUCTION_URL + POSTGRES_URL + REOWN_APPKIT_PROJECT_ID.
 BUILD_PRERENDER_PUBLIC_SHELL=""

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -4,7 +4,31 @@ export const AMOY_CHAIN_ID = 80_002
 
 export type DefaultNetworkKey = 'amoy' | 'polygon'
 
-export const DEFAULT_NETWORK_KEY: DefaultNetworkKey = 'amoy'
+export function parseNetworkChainId(value: string | number | null | undefined, fallback = AMOY_CHAIN_ID) {
+  const parsed = typeof value === 'number' ? value : Number(value?.trim() ?? '')
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function getRuntimeChainId() {
+  if (typeof window !== 'undefined') {
+    const runtimeChainId = window.__PUBLIC_RUNTIME_CONFIG__?.chainId
+    if (runtimeChainId !== undefined) {
+      return runtimeChainId
+    }
+  }
+
+  if (typeof process !== 'undefined') {
+    return process.env.CHAIN_ID
+  }
+
+  return undefined
+}
+
+function resolveNetworkKeyByChainId(chainId: string | number | null | undefined): DefaultNetworkKey {
+  return parseNetworkChainId(chainId) === POLYGON_MAINNET_CHAIN_ID ? 'polygon' : 'amoy'
+}
+
+export const DEFAULT_NETWORK_KEY: DefaultNetworkKey = resolveNetworkKeyByChainId(getRuntimeChainId())
 
 const NETWORK_CONFIG = {
   amoy: {

--- a/src/lib/public-runtime-config.shared.ts
+++ b/src/lib/public-runtime-config.shared.ts
@@ -1,3 +1,5 @@
+import { AMOY_CHAIN_ID, parseNetworkChainId } from '@/lib/network'
+
 export interface PublicRuntimeConfig {
   clobUrl: string
   commitSha: string
@@ -7,6 +9,7 @@ export interface PublicRuntimeConfig {
   gammaUrl: string
   geoblockUrl: string
   isVercel: string
+  chainId: number
   polygonRpcUrl: string
   priceReferenceUrl: string
   relayerUrl: string
@@ -28,6 +31,7 @@ export const defaultPublicRuntimeConfig: PublicRuntimeConfig = {
   gammaUrl: 'https://gamma-api.kuest.com',
   geoblockUrl: 'https://geoblock.kuest.com',
   isVercel: 'false',
+  chainId: AMOY_CHAIN_ID,
   polygonRpcUrl: '',
   priceReferenceUrl: 'https://price-reference.kuest.com',
   relayerUrl: 'https://relayer.kuest.com',
@@ -54,6 +58,7 @@ export function resolvePublicRuntimeEnv(env: NodeJS.ProcessEnv): Omit<PublicRunt
     gammaUrl: normalizePublicRuntimeEnvValue(env.GAMMA_URL, defaultPublicRuntimeConfig.gammaUrl),
     geoblockUrl: normalizePublicRuntimeEnvValue(env.GEOBLOCK_URL, defaultPublicRuntimeConfig.geoblockUrl),
     isVercel: env.VERCEL_ENV ? 'true' : 'false',
+    chainId: parseNetworkChainId(env.CHAIN_ID, defaultPublicRuntimeConfig.chainId),
     polygonRpcUrl: normalizePublicRuntimeEnvValue(env.POLYGON_RPC_URL),
     priceReferenceUrl: normalizePublicRuntimeEnvValue(env.PRICE_REFERENCE_URL, defaultPublicRuntimeConfig.priceReferenceUrl),
     relayerUrl: normalizePublicRuntimeEnvValue(env.RELAYER_URL, defaultPublicRuntimeConfig.relayerUrl),

--- a/tests/unit/publicRuntimeConfig.test.ts
+++ b/tests/unit/publicRuntimeConfig.test.ts
@@ -11,6 +11,7 @@ const RUNTIME_ENV_KEYS_BY_CONFIG_KEY = {
   dataUrl: 'DATA_URL',
   gammaUrl: 'GAMMA_URL',
   geoblockUrl: 'GEOBLOCK_URL',
+  chainId: 'CHAIN_ID',
   polygonRpcUrl: 'POLYGON_RPC_URL',
   priceReferenceUrl: 'PRICE_REFERENCE_URL',
   relayerUrl: 'RELAYER_URL',
@@ -23,7 +24,7 @@ const RUNTIME_ENV_KEYS_BY_CONFIG_KEY = {
 } as const satisfies Record<keyof Omit<typeof defaultPublicRuntimeConfig, 'commitSha' | 'isVercel' | 'siteUrl'>, string>
 
 const KUEST_DEFAULT_CONFIG_KEYS = Object.entries(defaultPublicRuntimeConfig)
-  .filter(([, value]) => value.includes('.kuest.com'))
+  .filter(([, value]) => typeof value === 'string' && value.includes('.kuest.com'))
   .map(([key]) => key as keyof typeof RUNTIME_ENV_KEYS_BY_CONFIG_KEY)
 
 describe('public runtime config resolution', () => {
@@ -55,5 +56,10 @@ describe('public runtime config resolution', () => {
     for (const key of KUEST_DEFAULT_CONFIG_KEYS) {
       expect(config[key]).toBe(`https://override.example/${key}`)
     }
+  })
+
+  it('parses CHAIN_ID from the environment', () => {
+    expect(resolvePublicRuntimeEnv({ CHAIN_ID: '137' }).chainId).toBe(137)
+    expect(resolvePublicRuntimeEnv({ CHAIN_ID: ' ' }).chainId).toBe(defaultPublicRuntimeConfig.chainId)
   })
 })

--- a/tests/unit/viemNetwork.test.ts
+++ b/tests/unit/viemNetwork.test.ts
@@ -8,10 +8,15 @@ async function importViemNetwork() {
 describe('viem-network RPC URL resolution', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    if (typeof window !== 'undefined') {
+      delete (window as Window & { __PUBLIC_RUNTIME_CONFIG__?: unknown }).__PUBLIC_RUNTIME_CONFIG__
+    }
     vi.resetModules()
   })
 
   it('uses the default network RPC when POLYGON_RPC_URL is empty', async () => {
+    vi.stubEnv('CHAIN_ID', '')
     vi.stubEnv('POLYGON_RPC_URL', '')
 
     const { defaultViemNetwork, defaultViemRpcUrl } = await importViemNetwork()
@@ -20,6 +25,7 @@ describe('viem-network RPC URL resolution', () => {
   })
 
   it('uses a valid POLYGON_RPC_URL override', async () => {
+    vi.stubEnv('CHAIN_ID', '')
     vi.stubEnv('POLYGON_RPC_URL', ' https://rpc.example.com/path ')
 
     const { resolveRuntimeViemRpcUrl } = await importViemNetwork()
@@ -27,11 +33,37 @@ describe('viem-network RPC URL resolution', () => {
     expect(resolveRuntimeViemRpcUrl()).toBe('https://rpc.example.com/path')
   })
 
+  it('uses Polygon mainnet when CHAIN_ID is set to 137', async () => {
+    vi.stubEnv('CHAIN_ID', '137')
+    vi.stubEnv('POLYGON_RPC_URL', '')
+
+    const { defaultViemNetwork, defaultViemRpcUrl } = await importViemNetwork()
+
+    expect(defaultViemNetwork.id).toBe(137)
+    expect(defaultViemRpcUrl).toBe(defaultViemNetwork.rpcUrls.default.http[0])
+  })
+
+  it('uses the runtime chain id from the public config when present', async () => {
+    vi.stubEnv('CHAIN_ID', '')
+    vi.stubEnv('POLYGON_RPC_URL', '')
+    ;(window as Window & {
+      __PUBLIC_RUNTIME_CONFIG__?: { chainId?: number }
+    }).__PUBLIC_RUNTIME_CONFIG__ = {
+      chainId: 137,
+    }
+
+    const { defaultViemNetwork, defaultViemRpcUrl } = await importViemNetwork()
+
+    expect(defaultViemNetwork.id).toBe(137)
+    expect(defaultViemRpcUrl).toBe(defaultViemNetwork.rpcUrls.default.http[0])
+  })
+
   it.each([
     'rpc.example.com',
     'ftp://rpc.example.com',
     'ws://rpc.example.com',
   ])('rejects invalid POLYGON_RPC_URL value %s', async (rpcUrl) => {
+    vi.stubEnv('CHAIN_ID', '')
     vi.stubEnv('POLYGON_RPC_URL', rpcUrl)
 
     const { resolveRuntimeViemRpcUrl } = await importViemNetwork()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds dynamic chain selection via CHAIN_ID from env or injected runtime config. Default stays Amoy (80002); set 137 to use Polygon mainnet, which updates the default viem network and RPC resolution.

- **New Features**
  - Added `CHAIN_ID` to public runtime config and `.env.example`; parsed with `parseNetworkChainId` (fallback to Amoy).
  - `DEFAULT_NETWORK_KEY` now inferred from env `CHAIN_ID` or `window.__PUBLIC_RUNTIME_CONFIG__.chainId`.
  - New unit tests for env parsing and viem network selection.

- **Migration**
  - To use Polygon mainnet, set `CHAIN_ID=137`. Leave empty or set `80002` for Amoy.
  - If injecting a runtime config script, include `chainId` in `window.__PUBLIC_RUNTIME_CONFIG__`.

<sup>Written for commit b6e58b0afac4e64d6ea06749c39b00ec349e8490. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1197?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

