### PR TITLE
Fix/activity redeem history

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,10 @@ DISABLE_IMAGE_OPTIMIZATION=false
 # Optional RPC endpoint used for on-chain reads in the app
 POLYGON_RPC_URL=""
 
+# Active chain id exposed through the runtime config script.
+# Leave empty/80002 for Amoy; set 137 for Polygon mainnet.
+CHAIN_ID=""
+
 # Force public shell prerendering on/off at runtime.
 # Leave empty to infer from SITE_URL/VERCEL_PROJECT_PRODUCTION_URL + POSTGRES_URL + REOWN_APPKIT_PROJECT_ID.
 BUILD_PRERENDER_PUBLIC_SHELL=""

--- a/src/app/[locale]/(platform)/profile/_components/PublicActivityList.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicActivityList.tsx
@@ -4,7 +4,14 @@ import type { RefObject } from 'react'
 import type { ActivitySort, ActivityTypeFilter } from '@/app/[locale]/(platform)/profile/_types/PublicActivityTypes'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { usePublicActivityQuery } from '@/app/[locale]/(platform)/profile/_hooks/usePublicActivityQuery'
-import { buildActivityCsv, getActivityTimestampMs, matchesSearchQuery, matchesTypeFilter, toNumeric } from '@/app/[locale]/(platform)/profile/_utils/PublicActivityUtils'
+import {
+  buildActivityCsv,
+  getActivityTimestampMs,
+  matchesSearchQuery,
+  matchesTypeFilter,
+  normalizeActivityHistoryDisplay,
+  toNumeric,
+} from '@/app/[locale]/(platform)/profile/_utils/PublicActivityUtils'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import PublicActivityFilters from './PublicActivityFilters'
 import PublicActivityTable from './PublicActivityTable'
@@ -45,7 +52,7 @@ function useVisibleActivities({
   sortFilter: ActivitySort
 }) {
   const activities = useMemo(
-    () => data?.pages.flat() ?? [],
+    () => normalizeActivityHistoryDisplay(data?.pages.flat() ?? []),
     [data?.pages],
   )
   const visibleActivities = useMemo(() => {

--- a/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicActivityRow.tsx
@@ -2,7 +2,7 @@ import type { Route } from 'next'
 import type { PublicActivityRowProps } from '@/app/[locale]/(platform)/profile/_types/PublicActivityTypes'
 import { CircleDollarSignIcon } from 'lucide-react'
 import { createElement } from 'react'
-import { activityIcon, formatPriceCents, formatShares, resolveVariant } from '@/app/[locale]/(platform)/profile/_utils/PublicActivityUtils'
+import { activityIcon, formatActivityShares, formatPriceCents, resolveVariant } from '@/app/[locale]/(platform)/profile/_utils/PublicActivityUtils'
 import AppLink from '@/components/AppLink'
 import EventIconImage from '@/components/EventIconImage'
 import { MICRO_UNIT } from '@/lib/constants'
@@ -12,7 +12,7 @@ import { cn } from '@/lib/utils'
 export default function PublicActivityRow({ activity }: PublicActivityRowProps) {
   const variant = resolveVariant(activity)
   const icon = activityIcon(variant)
-  const sharesText = formatShares(activity.amount)
+  const sharesText = formatActivityShares(activity)
   const priceText = formatPriceCents(activity.price)
   const eventSlug = activity.market.event?.slug || activity.market.slug
   const marketSlug = activity.market.event?.slug ? activity.market.slug : null
@@ -20,7 +20,7 @@ export default function PublicActivityRow({ activity }: PublicActivityRowProps) 
   const outcomeText = activity.outcome?.text || 'Outcome'
   const outcomeIsYes = outcomeText.toLowerCase().includes('yes') || activity.outcome?.index === 0
   const outcomeColor = outcomeIsYes ? 'bg-yes/15 text-yes' : 'bg-no/15 text-no'
-  const showOutcomeBadge = (variant === 'buy' || variant === 'sell' || variant === 'redeem')
+  const showOutcomeBadge = (variant === 'buy' || variant === 'sell')
     && outcomeText !== 'Outcome'
   const imageUrl = activity.market.icon_url
     ? (
@@ -38,6 +38,11 @@ export default function PublicActivityRow({ activity }: PublicActivityRowProps) 
   const isNegative = isDebitVariant || (!isCreditVariant && hasValue && valueNumber < 0)
   const valueDisplay = hasValue ? formatCurrency(Math.abs(valueNumber)) : '—'
   const valuePrefix = hasValue ? (isNegative ? '-' : '+') : ''
+  const valueContent = variant === 'loss'
+    ? '-'
+    : Number.isFinite(valueNumber)
+      ? `${valuePrefix}${valueDisplay}`
+      : '—'
   const marketContent = isFundsFlow
     ? (
         <div className="flex min-w-0 items-center gap-2.5 pl-1">
@@ -132,7 +137,7 @@ export default function PublicActivityRow({ activity }: PublicActivityRowProps) 
         ? 'text-yes'
         : `text-foreground`)}
       >
-        {Number.isFinite(valueNumber) ? `${valuePrefix}${valueDisplay}` : '—'}
+        {valueContent}
       </td>
 
       <td className="px-2 py-3 text-right text-xs text-muted-foreground sm:px-3">

--- a/src/app/[locale]/(platform)/profile/_types/PublicActivityTypes.ts
+++ b/src/app/[locale]/(platform)/profile/_types/PublicActivityTypes.ts
@@ -2,7 +2,7 @@ import type { ActivityOrder } from '@/types'
 
 export type ActivityTypeFilter = 'all' | 'trades' | 'buy' | 'merge' | 'redeem'
 export type ActivitySort = 'newest' | 'oldest' | 'value' | 'shares'
-export type ActivityVariant = 'split' | 'merge' | 'redeem' | 'convert' | 'deposit' | 'withdraw' | 'sell' | 'buy' | 'trade'
+export type ActivityVariant = 'split' | 'merge' | 'redeem' | 'loss' | 'convert' | 'deposit' | 'withdraw' | 'sell' | 'buy' | 'trade'
 
 export interface PublicActivityRowProps {
   activity: ActivityOrder

--- a/src/app/[locale]/(platform)/profile/_utils/PublicActivityUtils.ts
+++ b/src/app/[locale]/(platform)/profile/_utils/PublicActivityUtils.ts
@@ -4,9 +4,9 @@ import {
   ArrowDownToLineIcon,
   ArrowUpToLineIcon,
   CircleCheckIcon,
-  CircleDollarSignIcon,
   CircleMinusIcon,
   CirclePlusIcon,
+  CircleXIcon,
   MergeIcon,
   UnfoldHorizontalIcon,
 } from 'lucide-react'
@@ -41,7 +41,7 @@ export function resolveActivityTypeParams(typeFilter: ActivityTypeFilter) {
   }
 }
 
-export function formatShares(amount: string | number | undefined) {
+function formatShares(amount: string | number | undefined) {
   if (amount == null) {
     return null
   }
@@ -57,6 +57,20 @@ export function formatShares(amount: string | number | undefined) {
   return `${formatted} ${numeric === 1 ? 'share' : 'shares'}`
 }
 
+export function formatActivityShares(activity: ActivityOrder) {
+  const variant = resolveVariant(activity)
+  if (variant === 'redeem') {
+    return null
+  }
+  if (variant === 'loss') {
+    return '0.0 shares'
+  }
+  const amount = variant === 'split'
+    ? Number(activity.amount) / 2
+    : activity.amount
+  return formatShares(amount)
+}
+
 export function formatPriceCents(price?: string | number) {
   const numeric = Number(price)
   if (!Number.isFinite(numeric)) {
@@ -67,6 +81,9 @@ export function formatPriceCents(price?: string | number) {
 
 export function resolveVariant(activity: ActivityOrder): ActivityVariant {
   const type = activity.type?.toLowerCase()
+  if (type === 'loss') {
+    return 'loss'
+  }
   if (type === 'split') {
     return 'split'
   }
@@ -107,7 +124,9 @@ export function activityIcon(variant: ActivityVariant) {
     case 'merge':
       return { Icon: MergeIcon, label: 'Merged', className: 'rotate-90' }
     case 'redeem':
-      return { Icon: CircleDollarSignIcon, label: 'Redeemed', className: '' }
+      return { Icon: CircleCheckIcon, label: 'Redeem', className: 'text-yes' }
+    case 'loss':
+      return { Icon: CircleXIcon, label: 'Loss', className: 'text-no' }
     case 'convert':
       return { Icon: CircleCheckIcon, label: 'Convert', className: 'text-yes' }
     case 'deposit':
@@ -160,10 +179,154 @@ export function matchesTypeFilter(activity: ActivityOrder, typeFilter: ActivityT
     case 'merge':
       return variant === 'merge'
     case 'redeem':
-      return variant === 'redeem'
+      return variant === 'redeem' || variant === 'loss'
     default:
       return true
   }
+}
+
+function buildRedeemSettlementKey(activity: ActivityOrder) {
+  const txHash = activity.tx_hash?.trim().toLowerCase()
+  const marketKey = activity.market.condition_id?.trim().toLowerCase()
+    || activity.market.slug?.trim().toLowerCase()
+  const timestamp = activity.created_at?.trim()
+
+  if (!txHash || !marketKey || !timestamp) {
+    return null
+  }
+
+  return `${txHash}:${marketKey}:${timestamp}`
+}
+
+function hasDistinctRedeemOutcomes(activities: ActivityOrder[]) {
+  const outcomes = new Set(
+    activities.map((activity) => {
+      const outcomeText = activity.outcome?.text?.trim().toLowerCase() || ''
+      return `${activity.outcome?.index ?? ''}:${outcomeText}`
+    }),
+  )
+  return outcomes.size === activities.length
+}
+
+function hasEquivalentRedeemAmounts(activities: ActivityOrder[]) {
+  const [first] = activities
+  if (!first) {
+    return false
+  }
+
+  const firstAmount = Math.abs(toNumeric(first.amount))
+  const firstValue = Math.abs(toNumeric(first.total_value))
+  return activities.every((activity) => {
+    const amount = Math.abs(toNumeric(activity.amount))
+    const value = Math.abs(toNumeric(activity.total_value))
+    return amount > 0
+      && value > 0
+      && Math.abs(amount - firstAmount) < 1
+      && Math.abs(value - firstValue) < 1
+  })
+}
+
+function buildSettlementActivity(
+  activity: ActivityOrder,
+  overrides: {
+    id: string
+    type: 'redeem' | 'loss'
+    amount: string
+    totalValue: number
+  },
+): ActivityOrder {
+  return {
+    ...activity,
+    id: overrides.id,
+    type: overrides.type,
+    amount: overrides.amount,
+    total_value: overrides.totalValue,
+    outcome: {
+      index: 0,
+      text: 'Outcome',
+    },
+  }
+}
+
+function normalizeRedeemSettlementGroup(key: string, activities: ActivityOrder[]) {
+  if (activities.length !== 2 || !hasDistinctRedeemOutcomes(activities) || !hasEquivalentRedeemAmounts(activities)) {
+    return activities
+  }
+
+  const [base] = activities
+  if (!base) {
+    return activities
+  }
+
+  const amount = String(Math.max(...activities.map(activity => Math.abs(toNumeric(activity.amount)))))
+  const totalValue = Math.max(...activities.map(activity => Math.abs(toNumeric(activity.total_value))))
+
+  return [
+    buildSettlementActivity(base, {
+      id: `${key}:loss`,
+      type: 'loss',
+      amount: '0',
+      totalValue: 0,
+    }),
+    buildSettlementActivity(base, {
+      id: `${key}:redeem`,
+      type: 'redeem',
+      amount,
+      totalValue,
+    }),
+  ]
+}
+
+export function normalizeActivityHistoryDisplay(activities: ActivityOrder[]) {
+  const redeemGroups = new Map<string, ActivityOrder[]>()
+
+  for (const activity of activities) {
+    if (resolveVariant(activity) !== 'redeem') {
+      continue
+    }
+
+    const key = buildRedeemSettlementKey(activity)
+    if (!key) {
+      continue
+    }
+
+    const group = redeemGroups.get(key)
+    if (group) {
+      group.push(activity)
+    }
+    else {
+      redeemGroups.set(key, [activity])
+    }
+  }
+
+  const processedKeys = new Set<string>()
+  const normalized: ActivityOrder[] = []
+
+  for (const activity of activities) {
+    const key = resolveVariant(activity) === 'redeem'
+      ? buildRedeemSettlementKey(activity)
+      : null
+
+    if (!key) {
+      normalized.push(activity)
+      continue
+    }
+
+    const group = redeemGroups.get(key)
+    if (!group || group.length === 1) {
+      normalized.push(activity)
+      continue
+    }
+
+    if (processedKeys.has(key)) {
+      continue
+    }
+
+    processedKeys.add(key)
+    normalized.push(...normalizeRedeemSettlementGroup(key, group))
+  }
+
+  return normalized
 }
 
 export function matchesSearchQuery(activity: ActivityOrder, searchQuery: string) {
@@ -217,9 +380,12 @@ export function buildActivityCsv(activities: ActivityOrder[], siteName: string) 
         ? 'Withdrew funds'
         : activity.market.title
     const usdcAmount = formatCsvNumber(Math.abs(Number(activity.total_value)) / MICRO_UNIT)
-    const tokenAmount = (variant === 'deposit' || variant === 'withdraw')
+    const tokenAmountValue = variant === 'split'
+      ? Math.abs(Number(activity.amount)) / 2
+      : Math.abs(Number(activity.amount))
+    const tokenAmount = (variant === 'deposit' || variant === 'withdraw' || variant === 'redeem')
       ? ''
-      : formatCsvNumber(Math.abs(Number(activity.amount)) / MICRO_UNIT)
+      : formatCsvNumber(tokenAmountValue / MICRO_UNIT)
     const tokenName = (variant === 'buy' || variant === 'sell' || variant === 'trade')
       ? (activity.outcome?.text ?? '')
       : ''

--- a/src/lib/data-api/user.ts
+++ b/src/lib/data-api/user.ts
@@ -24,7 +24,7 @@ export interface DataApiActivity {
   slug?: string
   icon?: string
   eventSlug?: string
-  outcome?: string
+  outcome?: string | null
   name?: string
   pseudonym?: string
   profileImage?: string
@@ -177,7 +177,11 @@ export function mapDataApiActivityToActivityOrder(activity: DataApiActivity): Ac
   const timestampMs = typeof activity.timestamp === 'number'
     ? activity.timestamp * 1000
     : Date.now()
-  const isSplit = activity.type?.toLowerCase() === 'split'
+  const normalizedType = activity.type?.toLowerCase()
+  const isSplit = normalizedType === 'split'
+  const isRedeem = normalizedType === 'redeem'
+    || normalizedType === 'redeemed'
+    || normalizedType === 'redemption'
   const normalizedUsd = normalizeUsd(activity.usdcSize)
   let normalizedPrice = sanitizePrice(normalizeValue(activity.price))
   if (normalizedPrice < 0) {
@@ -202,10 +206,13 @@ export function mapDataApiActivityToActivityOrder(activity: DataApiActivity): Ac
   else if (totalUsd === 0) {
     totalUsd = derivedTotal
   }
+  const isZeroRedeem = isRedeem && baseSize <= 0 && totalUsd <= 0
   const outcomeText = isSplit
     ? 'Yes / No'
-    : (activity.outcome || 'Outcome')
-  const outcomeIndex = isSplit ? undefined : activity.outcomeIndex ?? 0
+    : isZeroRedeem
+      ? 'Outcome'
+      : (activity.outcome || 'Outcome')
+  const outcomeIndex = isSplit || isZeroRedeem ? undefined : activity.outcomeIndex ?? 0
   const address = activity.proxyWallet || ''
   const displayName = activity.pseudonym || activity.name || address || 'Trader'
   const avatarUrl = activity.profileImageOptimized
@@ -215,7 +222,7 @@ export function mapDataApiActivityToActivityOrder(activity: DataApiActivity): Ac
 
   return {
     id: buildActivityId(activity, slug),
-    type: activity.type?.toLowerCase(),
+    type: isZeroRedeem ? 'loss' : normalizedType,
     user: {
       id: address || 'user',
       username: displayName,

--- a/src/lib/network.ts
+++ b/src/lib/network.ts
@@ -4,7 +4,31 @@ export const AMOY_CHAIN_ID = 80_002
 
 export type DefaultNetworkKey = 'amoy' | 'polygon'
 
-export const DEFAULT_NETWORK_KEY: DefaultNetworkKey = 'amoy'
+export function parseNetworkChainId(value: string | number | null | undefined, fallback = AMOY_CHAIN_ID) {
+  const parsed = typeof value === 'number' ? value : Number(value?.trim() ?? '')
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function getRuntimeChainId() {
+  if (typeof window !== 'undefined') {
+    const runtimeChainId = window.__PUBLIC_RUNTIME_CONFIG__?.chainId
+    if (runtimeChainId !== undefined) {
+      return runtimeChainId
+    }
+  }
+
+  if (typeof process !== 'undefined') {
+    return process.env.CHAIN_ID
+  }
+
+  return undefined
+}
+
+function resolveNetworkKeyByChainId(chainId: string | number | null | undefined): DefaultNetworkKey {
+  return parseNetworkChainId(chainId) === POLYGON_MAINNET_CHAIN_ID ? 'polygon' : 'amoy'
+}
+
+export const DEFAULT_NETWORK_KEY: DefaultNetworkKey = resolveNetworkKeyByChainId(getRuntimeChainId())
 
 const NETWORK_CONFIG = {
   amoy: {

--- a/src/lib/public-runtime-config.shared.ts
+++ b/src/lib/public-runtime-config.shared.ts
@@ -1,3 +1,5 @@
+import { AMOY_CHAIN_ID, parseNetworkChainId } from '@/lib/network'
+
 export interface PublicRuntimeConfig {
   clobUrl: string
   commitSha: string
@@ -7,6 +9,7 @@ export interface PublicRuntimeConfig {
   gammaUrl: string
   geoblockUrl: string
   isVercel: string
+  chainId: number
   polygonRpcUrl: string
   priceReferenceUrl: string
   relayerUrl: string
@@ -28,6 +31,7 @@ export const defaultPublicRuntimeConfig: PublicRuntimeConfig = {
   gammaUrl: 'https://gamma-api.kuest.com',
   geoblockUrl: 'https://geoblock.kuest.com',
   isVercel: 'false',
+  chainId: AMOY_CHAIN_ID,
   polygonRpcUrl: '',
   priceReferenceUrl: 'https://price-reference.kuest.com',
   relayerUrl: 'https://relayer.kuest.com',
@@ -54,6 +58,7 @@ export function resolvePublicRuntimeEnv(env: NodeJS.ProcessEnv): Omit<PublicRunt
     gammaUrl: normalizePublicRuntimeEnvValue(env.GAMMA_URL, defaultPublicRuntimeConfig.gammaUrl),
     geoblockUrl: normalizePublicRuntimeEnvValue(env.GEOBLOCK_URL, defaultPublicRuntimeConfig.geoblockUrl),
     isVercel: env.VERCEL_ENV ? 'true' : 'false',
+    chainId: parseNetworkChainId(env.CHAIN_ID, defaultPublicRuntimeConfig.chainId),
     polygonRpcUrl: normalizePublicRuntimeEnvValue(env.POLYGON_RPC_URL),
     priceReferenceUrl: normalizePublicRuntimeEnvValue(env.PRICE_REFERENCE_URL, defaultPublicRuntimeConfig.priceReferenceUrl),
     relayerUrl: normalizePublicRuntimeEnvValue(env.RELAYER_URL, defaultPublicRuntimeConfig.relayerUrl),

--- a/tests/unit/PublicActivityUtils.test.ts
+++ b/tests/unit/PublicActivityUtils.test.ts
@@ -1,0 +1,78 @@
+import type { ActivityOrder } from '@/types'
+import { describe, expect, it } from 'vitest'
+import {
+  formatActivityShares,
+  normalizeActivityHistoryDisplay,
+  resolveVariant,
+} from '@/app/[locale]/(platform)/profile/_utils/PublicActivityUtils'
+import { MICRO_UNIT } from '@/lib/constants'
+
+function createActivity(overrides: Partial<ActivityOrder> = {}): ActivityOrder {
+  return {
+    id: 'activity-1',
+    type: 'redeem',
+    user: {
+      id: '0xuser',
+      username: '0xuser',
+      address: '0xuser',
+      image: '',
+    },
+    side: 'buy',
+    amount: String(MICRO_UNIT),
+    price: '0',
+    outcome: {
+      index: 0,
+      text: 'Up',
+    },
+    market: {
+      condition_id: '0xcondition',
+      title: 'Bitcoin Up or Down on June 26?',
+      slug: 'bitcoin-up-or-down-on-june-26-2026',
+      icon_url: '',
+      event: {
+        slug: 'bitcoin-up-or-down-on-june-26-2026',
+        show_market_icons: false,
+      },
+    },
+    total_value: MICRO_UNIT,
+    created_at: '2026-06-26T22:06:33.000Z',
+    status: 'completed',
+    tx_hash: '0xtx',
+    ...overrides,
+  }
+}
+
+describe('public activity utils', () => {
+  it('collapses duplicate opposite redeem outcomes into loss and redeem rows', () => {
+    const activities = [
+      createActivity({
+        id: 'redeem-up',
+        outcome: { index: 0, text: 'Up' },
+      }),
+      createActivity({
+        id: 'redeem-down',
+        outcome: { index: 1, text: 'Down' },
+      }),
+    ]
+
+    const normalized = normalizeActivityHistoryDisplay(activities)
+
+    expect(normalized).toHaveLength(2)
+    expect(resolveVariant(normalized[0]!)).toBe('loss')
+    expect(resolveVariant(normalized[1]!)).toBe('redeem')
+    expect(normalized[0]!.outcome.text).toBe('Outcome')
+    expect(normalized[1]!.outcome.text).toBe('Outcome')
+    expect(normalized[0]!.total_value).toBe(0)
+    expect(normalized[1]!.total_value).toBe(MICRO_UNIT)
+    expect(formatActivityShares(normalized[0]!)).toBe('0.0 shares')
+    expect(formatActivityShares(normalized[1]!)).toBeNull()
+  })
+
+  it('hides redeem shares and shows split shares as the original split amount', () => {
+    expect(formatActivityShares(createActivity())).toBeNull()
+    expect(formatActivityShares(createActivity({
+      type: 'split',
+      amount: String(MICRO_UNIT * 2),
+    }))).toBe('1 share')
+  })
+})

--- a/tests/unit/dataApiUser.test.ts
+++ b/tests/unit/dataApiUser.test.ts
@@ -39,4 +39,23 @@ describe('mapDataApiActivityToActivityOrder', () => {
 
     expect(activity.user.username).toBe('doge.trader')
   })
+
+  it('maps zero-value redeem activity as a loss row', () => {
+    const activity = mapDataApiActivityToActivityOrder({
+      proxyWallet: '0xa6a0413f8fa248df51a49bfc759ff190d24fe25b',
+      type: 'REDEEM',
+      conditionId: '0x8d0af56260655c6c6d61949c76196114766112ebce7d32ea6acc43b779732c13',
+      size: 0,
+      usdcSize: 0,
+      price: 0,
+      timestamp: 1779198845,
+      transactionHash: '0xbdedb891c9e999602f9cb3416592fffbee8d0ec8eb4962906e3f92bdea4125d7',
+      outcomeIndex: 999,
+      outcome: '',
+    })
+
+    expect(activity.type).toBe('loss')
+    expect(activity.outcome.text).toBe('Outcome')
+    expect(activity.total_value).toBe(0)
+  })
 })

--- a/tests/unit/publicRuntimeConfig.test.ts
+++ b/tests/unit/publicRuntimeConfig.test.ts
@@ -11,6 +11,7 @@ const RUNTIME_ENV_KEYS_BY_CONFIG_KEY = {
   dataUrl: 'DATA_URL',
   gammaUrl: 'GAMMA_URL',
   geoblockUrl: 'GEOBLOCK_URL',
+  chainId: 'CHAIN_ID',
   polygonRpcUrl: 'POLYGON_RPC_URL',
   priceReferenceUrl: 'PRICE_REFERENCE_URL',
   relayerUrl: 'RELAYER_URL',
@@ -23,7 +24,7 @@ const RUNTIME_ENV_KEYS_BY_CONFIG_KEY = {
 } as const satisfies Record<keyof Omit<typeof defaultPublicRuntimeConfig, 'commitSha' | 'isVercel' | 'siteUrl'>, string>
 
 const KUEST_DEFAULT_CONFIG_KEYS = Object.entries(defaultPublicRuntimeConfig)
-  .filter(([, value]) => value.includes('.kuest.com'))
+  .filter(([, value]) => typeof value === 'string' && value.includes('.kuest.com'))
   .map(([key]) => key as keyof typeof RUNTIME_ENV_KEYS_BY_CONFIG_KEY)
 
 describe('public runtime config resolution', () => {
@@ -55,5 +56,10 @@ describe('public runtime config resolution', () => {
     for (const key of KUEST_DEFAULT_CONFIG_KEYS) {
       expect(config[key]).toBe(`https://override.example/${key}`)
     }
+  })
+
+  it('parses CHAIN_ID from the environment', () => {
+    expect(resolvePublicRuntimeEnv({ CHAIN_ID: '137' }).chainId).toBe(137)
+    expect(resolvePublicRuntimeEnv({ CHAIN_ID: ' ' }).chainId).toBe(defaultPublicRuntimeConfig.chainId)
   })
 })

--- a/tests/unit/viemNetwork.test.ts
+++ b/tests/unit/viemNetwork.test.ts
@@ -8,10 +8,15 @@ async function importViemNetwork() {
 describe('viem-network RPC URL resolution', () => {
   afterEach(() => {
     vi.unstubAllEnvs()
+    vi.unstubAllGlobals()
+    if (typeof window !== 'undefined') {
+      delete (window as Window & { __PUBLIC_RUNTIME_CONFIG__?: unknown }).__PUBLIC_RUNTIME_CONFIG__
+    }
     vi.resetModules()
   })
 
   it('uses the default network RPC when POLYGON_RPC_URL is empty', async () => {
+    vi.stubEnv('CHAIN_ID', '')
     vi.stubEnv('POLYGON_RPC_URL', '')
 
     const { defaultViemNetwork, defaultViemRpcUrl } = await importViemNetwork()
@@ -20,6 +25,7 @@ describe('viem-network RPC URL resolution', () => {
   })
 
   it('uses a valid POLYGON_RPC_URL override', async () => {
+    vi.stubEnv('CHAIN_ID', '')
     vi.stubEnv('POLYGON_RPC_URL', ' https://rpc.example.com/path ')
 
     const { resolveRuntimeViemRpcUrl } = await importViemNetwork()
@@ -27,11 +33,37 @@ describe('viem-network RPC URL resolution', () => {
     expect(resolveRuntimeViemRpcUrl()).toBe('https://rpc.example.com/path')
   })
 
+  it('uses Polygon mainnet when CHAIN_ID is set to 137', async () => {
+    vi.stubEnv('CHAIN_ID', '137')
+    vi.stubEnv('POLYGON_RPC_URL', '')
+
+    const { defaultViemNetwork, defaultViemRpcUrl } = await importViemNetwork()
+
+    expect(defaultViemNetwork.id).toBe(137)
+    expect(defaultViemRpcUrl).toBe(defaultViemNetwork.rpcUrls.default.http[0])
+  })
+
+  it('uses the runtime chain id from the public config when present', async () => {
+    vi.stubEnv('CHAIN_ID', '')
+    vi.stubEnv('POLYGON_RPC_URL', '')
+    ;(window as Window & {
+      __PUBLIC_RUNTIME_CONFIG__?: { chainId?: number }
+    }).__PUBLIC_RUNTIME_CONFIG__ = {
+      chainId: 137,
+    }
+
+    const { defaultViemNetwork, defaultViemRpcUrl } = await importViemNetwork()
+
+    expect(defaultViemNetwork.id).toBe(137)
+    expect(defaultViemRpcUrl).toBe(defaultViemNetwork.rpcUrls.default.http[0])
+  })
+
   it.each([
     'rpc.example.com',
     'ftp://rpc.example.com',
     'ws://rpc.example.com',
   ])('rejects invalid POLYGON_RPC_URL value %s', async (rpcUrl) => {
+    vi.stubEnv('CHAIN_ID', '')
     vi.stubEnv('POLYGON_RPC_URL', rpcUrl)
 
     const { resolveRuntimeViemRpcUrl } = await importViemNetwork()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes redeem activity history by collapsing duplicate outcomes into a clear “Loss” + “Redeem” pair and improving display, filters, and CSV output. Adds dynamic chain ID configuration to switch between Amoy and Polygon mainnet at runtime.

- **Bug Fixes**
  - Collapses opposite `redeem` outcomes into a single `loss` and `redeem` pair with normalized amounts.
  - Maps zero-value redeems from the data API to `loss` and shows outcome as “Outcome”.
  - Share formatting: hides shares for `redeem`, shows `0.0 shares` for `loss`, and halves displayed shares for `split`.
  - CSV export omits token amount for `redeem` and handles `split` amounts correctly.

- **New Features**
  - Adds `CHAIN_ID` to runtime config and `.env` to select Amoy (`80002`, default) or Polygon mainnet (`137`).
  - Default network and viem RPC resolution now derive from `CHAIN_ID` on server or from `window.__PUBLIC_RUNTIME_CONFIG__` in the browser, with safe parsing fallbacks.

<sup>Written for commit 070ec0730bfaa649ea6e144bb0efe47d41486e3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1198?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

