### PR TITLE
feat: implement authentication check for market context generation

### DIFF
--- a/src/app/api/market-context/route.ts
+++ b/src/app/api/market-context/route.ts
@@ -1,3 +1,4 @@
+import { UserRepository } from '@/lib/db/queries/user'
 import { MarketContextRequestSchema, resolveMarketContextRequest } from '@/lib/market-context-service'
 
 export async function POST(request: Request) {
@@ -8,6 +9,16 @@ export async function POST(request: Request) {
       { error: parsedPayload.error.issues[0]?.message ?? 'Invalid request.' },
       { status: 400 },
     )
+  }
+
+  if (!parsedPayload.data.readOnly) {
+    const currentUser = await UserRepository.getCurrentUser({ minimal: true })
+    if (!currentUser) {
+      return Response.json(
+        { error: 'Authentication required to generate market context.' },
+        { status: 401 },
+      )
+    }
   }
 
   const result = await resolveMarketContextRequest(parsedPayload.data)

--- a/src/app/api/market-context/route.ts
+++ b/src/app/api/market-context/route.ts
@@ -1,5 +1,100 @@
+import type { MarketContextResponse } from '@/lib/market-context-service'
+import { Buffer } from 'node:buffer'
+import crypto from 'node:crypto'
+import { cookies } from 'next/headers'
 import { UserRepository } from '@/lib/db/queries/user'
 import { MarketContextRequestSchema, resolveMarketContextRequest } from '@/lib/market-context-service'
+
+const MARKET_CONTEXT_GENERATION_LIMIT = 5
+const MARKET_CONTEXT_GENERATION_WINDOW_MS = 24 * 60 * 60 * 1000
+const MARKET_CONTEXT_GENERATION_COOKIE_NAME = 'market_context_generation_quota'
+
+interface MarketContextGenerationQuota {
+  subject: string
+  count: number
+  windowStart: number
+}
+
+function resolveQuotaSecret() {
+  return process.env.BETTER_AUTH_SECRET
+    || process.env.CRON_SECRET
+    || 'market-context-generation-local-secret'
+}
+
+function signQuotaValue(encodedPayload: string) {
+  return crypto
+    .createHmac('sha256', resolveQuotaSecret())
+    .update(encodedPayload)
+    .digest('base64url')
+}
+
+function encodeQuotaCookie(payload: MarketContextGenerationQuota) {
+  const encodedPayload = Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')
+  return `${encodedPayload}.${signQuotaValue(encodedPayload)}`
+}
+
+function parseQuotaCookie(rawValue: string | undefined, subject: string, nowMs: number) {
+  if (!rawValue) {
+    return null
+  }
+
+  const [encodedPayload, signature] = rawValue.split('.')
+  if (!encodedPayload || !signature || signQuotaValue(encodedPayload) !== signature) {
+    return null
+  }
+
+  try {
+    const payload = JSON.parse(Buffer.from(encodedPayload, 'base64url').toString('utf8')) as MarketContextGenerationQuota
+    if (
+      payload.subject !== subject
+      || !Number.isInteger(payload.count)
+      || !Number.isInteger(payload.windowStart)
+      || payload.windowStart + MARKET_CONTEXT_GENERATION_WINDOW_MS <= nowMs
+    ) {
+      return null
+    }
+
+    return payload
+  }
+  catch {
+    return null
+  }
+}
+
+async function consumeMarketContextGenerationQuota(userId: string | undefined): Promise<MarketContextResponse | null> {
+  const subject = userId ? `user:${userId}` : 'anonymous'
+  const nowMs = Date.now()
+  const cookieStore = await cookies()
+  const existingQuota = parseQuotaCookie(
+    cookieStore.get(MARKET_CONTEXT_GENERATION_COOKIE_NAME)?.value,
+    subject,
+    nowMs,
+  ) ?? {
+    subject,
+    count: 0,
+    windowStart: nowMs,
+  }
+
+  if (existingQuota.count >= MARKET_CONTEXT_GENERATION_LIMIT) {
+    return {
+      error: 'Market context generation limit reached. Try again later.',
+      status: 429,
+    }
+  }
+
+  cookieStore.set(MARKET_CONTEXT_GENERATION_COOKIE_NAME, encodeQuotaCookie({
+    ...existingQuota,
+    count: existingQuota.count + 1,
+  }), {
+    httpOnly: true,
+    maxAge: Math.ceil(MARKET_CONTEXT_GENERATION_WINDOW_MS / 1000),
+    path: '/',
+    sameSite: 'lax',
+    secure: process.env.NODE_ENV === 'production',
+  })
+
+  return null
+}
 
 export async function POST(request: Request) {
   const payload = await request.json().catch(() => null)
@@ -11,17 +106,13 @@ export async function POST(request: Request) {
     )
   }
 
-  if (!parsedPayload.data.readOnly) {
-    const currentUser = await UserRepository.getCurrentUser({ minimal: true })
-    if (!currentUser) {
-      return Response.json(
-        { error: 'Authentication required to generate market context.' },
-        { status: 401 },
-      )
-    }
-  }
+  const currentUser = parsedPayload.data.readOnly
+    ? null
+    : await UserRepository.getCurrentUser({ minimal: true })
+  const result = await resolveMarketContextRequest(parsedPayload.data, {
+    beforeGenerate: () => consumeMarketContextGenerationQuota(currentUser?.id),
+  })
+  const { status = 200, ...responseBody } = result
 
-  const result = await resolveMarketContextRequest(parsedPayload.data)
-
-  return Response.json(result)
+  return Response.json(responseBody, { status })
 }

--- a/src/lib/market-context-service.ts
+++ b/src/lib/market-context-service.ts
@@ -22,6 +22,11 @@ export interface MarketContextResponse {
   expiresAt?: string | null
   updatedAt?: string | null
   cached?: boolean
+  status?: number
+}
+
+interface MarketContextRequestOptions {
+  beforeGenerate?: () => MarketContextResponse | null | Promise<MarketContextResponse | null>
 }
 
 function resolveSupportedLocale(locale: string | null | undefined): SupportedLocale {
@@ -34,7 +39,10 @@ function resolveSupportedLocale(locale: string | null | undefined): SupportedLoc
   return DEFAULT_LOCALE
 }
 
-export async function resolveMarketContextRequest(input: unknown): Promise<MarketContextResponse> {
+export async function resolveMarketContextRequest(
+  input: unknown,
+  options: MarketContextRequestOptions = {},
+): Promise<MarketContextResponse> {
   const parsed = MarketContextRequestSchema.safeParse(input)
 
   if (!parsed.success) {
@@ -83,6 +91,11 @@ export async function resolveMarketContextRequest(input: unknown): Promise<Marke
     const settings = await loadMarketContextSettings()
     if (!settings.enabled || !settings.apiKey) {
       return { error: 'Market context generation is not configured.' }
+    }
+
+    const generationGate = await options.beforeGenerate?.()
+    if (generationGate) {
+      return generationGate
     }
 
     const context = await generateMarketContext(event, market, settings, resolvedLocale)

--- a/src/lib/openapi-proxy.ts
+++ b/src/lib/openapi-proxy.ts
@@ -78,6 +78,8 @@ async function proxy(request: Request): Promise<Response> {
 
   const requestHeaders = new Headers(request.headers)
   requestHeaders.delete('content-length')
+  requestHeaders.delete('cookie')
+  requestHeaders.delete('cookie2')
   requestHeaders.delete('host')
   requestHeaders.delete('origin')
   requestHeaders.set('accept-encoding', 'identity')
@@ -97,6 +99,7 @@ async function proxy(request: Request): Promise<Response> {
 
     responseHeaders.delete('content-encoding')
     responseHeaders.delete('content-length')
+    responseHeaders.delete('set-cookie')
     responseHeaders.delete('transfer-encoding')
     responseHeaders.set('X-Forwarded-Host', upstreamResponse.url)
     responseHeaders.forEach((_value, key) => {

--- a/tests/unit/marketContextRoute.test.ts
+++ b/tests/unit/marketContextRoute.test.ts
@@ -1,8 +1,15 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  getCurrentUser: vi.fn(),
   safeParse: vi.fn(),
   resolveMarketContextRequest: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/user', () => ({
+  UserRepository: {
+    getCurrentUser: (...args: any[]) => mocks.getCurrentUser(...args),
+  },
 }))
 
 vi.mock('@/lib/market-context-service', () => ({
@@ -16,6 +23,7 @@ const { POST } = await import('@/app/api/market-context/route')
 
 describe('market context route', () => {
   beforeEach(() => {
+    mocks.getCurrentUser.mockReset()
     mocks.safeParse.mockReset()
     mocks.resolveMarketContextRequest.mockReset()
   })
@@ -37,7 +45,7 @@ describe('market context route', () => {
     expect(mocks.resolveMarketContextRequest).not.toHaveBeenCalled()
   })
 
-  it('delegates validated payloads to the service', async () => {
+  it('delegates read-only payloads to the service without requiring a session', async () => {
     const payload = {
       slug: 'event-slug',
       marketConditionId: 'condition-1',
@@ -71,6 +79,74 @@ describe('market context route', () => {
       updatedAt: null,
       cached: false,
     })
+    expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload)
+    expect(mocks.getCurrentUser).not.toHaveBeenCalled()
+  })
+
+  it('rejects generation requests when unauthenticated', async () => {
+    const payload = {
+      slug: 'event-slug',
+      marketConditionId: 'condition-1',
+      locale: 'pt',
+    }
+
+    mocks.safeParse.mockReturnValue({
+      success: true,
+      data: payload,
+    })
+    mocks.getCurrentUser.mockResolvedValueOnce(null)
+
+    const response = await POST(new Request('https://example.com/api/market-context', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }))
+
+    expect(response.status).toBe(401)
+    await expect(response.json()).resolves.toEqual({
+      error: 'Authentication required to generate market context.',
+    })
+    expect(mocks.getCurrentUser).toHaveBeenCalledWith({ minimal: true })
+    expect(mocks.resolveMarketContextRequest).not.toHaveBeenCalled()
+  })
+
+  it('delegates generation requests for authenticated users', async () => {
+    const payload = {
+      slug: 'event-slug',
+      marketConditionId: 'condition-1',
+      locale: 'pt',
+    }
+
+    mocks.safeParse.mockReturnValue({
+      success: true,
+      data: payload,
+    })
+    mocks.getCurrentUser.mockResolvedValueOnce({ id: 'user-1' })
+    mocks.resolveMarketContextRequest.mockResolvedValue({
+      context: 'generated context',
+      expiresAt: '2026-06-27T15:00:00.000Z',
+      updatedAt: '2026-06-27T14:30:00.000Z',
+      cached: false,
+    })
+
+    const response = await POST(new Request('https://example.com/api/market-context', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      context: 'generated context',
+      expiresAt: '2026-06-27T15:00:00.000Z',
+      updatedAt: '2026-06-27T14:30:00.000Z',
+      cached: false,
+    })
+    expect(mocks.getCurrentUser).toHaveBeenCalledWith({ minimal: true })
     expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload)
   })
 })

--- a/tests/unit/marketContextRoute.test.ts
+++ b/tests/unit/marketContextRoute.test.ts
@@ -1,9 +1,18 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
+  cookieGet: vi.fn(),
+  cookieSet: vi.fn(),
   getCurrentUser: vi.fn(),
   safeParse: vi.fn(),
   resolveMarketContextRequest: vi.fn(),
+}))
+
+vi.mock('next/headers', () => ({
+  cookies: vi.fn(async () => ({
+    get: (...args: any[]) => mocks.cookieGet(...args),
+    set: (...args: any[]) => mocks.cookieSet(...args),
+  })),
 }))
 
 vi.mock('@/lib/db/queries/user', () => ({
@@ -23,9 +32,24 @@ const { POST } = await import('@/app/api/market-context/route')
 
 describe('market context route', () => {
   beforeEach(() => {
+    mocks.cookieGet.mockReset()
+    mocks.cookieSet.mockReset()
     mocks.getCurrentUser.mockReset()
     mocks.safeParse.mockReset()
     mocks.resolveMarketContextRequest.mockReset()
+    mocks.resolveMarketContextRequest.mockImplementation(async (_payload, options) => {
+      const generationGate = await options?.beforeGenerate?.()
+      if (generationGate) {
+        return generationGate
+      }
+
+      return {
+        context: 'generated context',
+        expiresAt: '2026-06-27T15:00:00.000Z',
+        updatedAt: '2026-06-27T14:30:00.000Z',
+        cached: false,
+      }
+    })
   })
 
   it('returns 400 for schema-invalid payloads', async () => {
@@ -79,11 +103,12 @@ describe('market context route', () => {
       updatedAt: null,
       cached: false,
     })
-    expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload)
+    expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload, expect.any(Object))
     expect(mocks.getCurrentUser).not.toHaveBeenCalled()
+    expect(mocks.cookieSet).not.toHaveBeenCalled()
   })
 
-  it('rejects generation requests when unauthenticated', async () => {
+  it('allows anonymous generation while under the quota', async () => {
     const payload = {
       slug: 'event-slug',
       marketConditionId: 'condition-1',
@@ -104,12 +129,25 @@ describe('market context route', () => {
       body: JSON.stringify(payload),
     }))
 
-    expect(response.status).toBe(401)
+    expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({
-      error: 'Authentication required to generate market context.',
+      context: 'generated context',
+      expiresAt: '2026-06-27T15:00:00.000Z',
+      updatedAt: '2026-06-27T14:30:00.000Z',
+      cached: false,
     })
     expect(mocks.getCurrentUser).toHaveBeenCalledWith({ minimal: true })
-    expect(mocks.resolveMarketContextRequest).not.toHaveBeenCalled()
+    expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload, expect.any(Object))
+    expect(mocks.cookieSet).toHaveBeenCalledWith(
+      'market_context_generation_quota',
+      expect.any(String),
+      expect.objectContaining({
+        httpOnly: true,
+        maxAge: 86400,
+        path: '/',
+        sameSite: 'lax',
+      }),
+    )
   })
 
   it('delegates generation requests for authenticated users', async () => {
@@ -124,12 +162,6 @@ describe('market context route', () => {
       data: payload,
     })
     mocks.getCurrentUser.mockResolvedValueOnce({ id: 'user-1' })
-    mocks.resolveMarketContextRequest.mockResolvedValue({
-      context: 'generated context',
-      expiresAt: '2026-06-27T15:00:00.000Z',
-      updatedAt: '2026-06-27T14:30:00.000Z',
-      cached: false,
-    })
 
     const response = await POST(new Request('https://example.com/api/market-context', {
       method: 'POST',
@@ -147,6 +179,60 @@ describe('market context route', () => {
       cached: false,
     })
     expect(mocks.getCurrentUser).toHaveBeenCalledWith({ minimal: true })
-    expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload)
+    expect(mocks.resolveMarketContextRequest).toHaveBeenCalledWith(payload, expect.any(Object))
+    expect(mocks.cookieSet).toHaveBeenCalledWith(
+      'market_context_generation_quota',
+      expect.any(String),
+      expect.objectContaining({
+        httpOnly: true,
+        maxAge: 86400,
+        path: '/',
+        sameSite: 'lax',
+      }),
+    )
+  })
+
+  it('blocks generation after five attempts in the quota window', async () => {
+    const payload = {
+      slug: 'event-slug',
+      marketConditionId: 'condition-1',
+      locale: 'pt',
+    }
+    let quotaCookie: string | undefined
+
+    mocks.safeParse.mockReturnValue({
+      success: true,
+      data: payload,
+    })
+    mocks.getCurrentUser.mockResolvedValue(null)
+    mocks.cookieGet.mockImplementation(() => quotaCookie ? { value: quotaCookie } : undefined)
+    mocks.cookieSet.mockImplementation((_name, value) => {
+      quotaCookie = value
+    })
+
+    for (let index = 0; index < 5; index += 1) {
+      const response = await POST(new Request('https://example.com/api/market-context', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      }))
+
+      expect(response.status).toBe(200)
+    }
+
+    const limitedResponse = await POST(new Request('https://example.com/api/market-context', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    }))
+
+    expect(limitedResponse.status).toBe(429)
+    await expect(limitedResponse.json()).resolves.toEqual({
+      error: 'Market context generation limit reached. Try again later.',
+    })
   })
 })

--- a/tests/unit/openapiProxy.test.ts
+++ b/tests/unit/openapiProxy.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+}))
+
+vi.mock('@/lib/openapi-servers', () => ({
+  OPENAPI_SERVER_URLS: {
+    dataApi: 'https://data-api.kuest.com',
+  },
+}))
+
+vi.mock('@/lib/site-url', () => ({
+  default: vi.fn(() => 'https://prediction.example'),
+}))
+
+const { GET } = await import('@/lib/openapi-proxy')
+
+describe('openapi proxy', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    mocks.fetch.mockReset()
+  })
+
+  it('does not forward app cookies to upstream docs APIs', async () => {
+    mocks.fetch.mockResolvedValueOnce(new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: {
+        'access-control-allow-origin': '*',
+        'content-type': 'application/json',
+        'set-cookie': 'upstream=session',
+      },
+    }))
+    vi.stubGlobal('fetch', mocks.fetch)
+
+    const response = await GET(new Request('https://prediction.example/docs/api/proxy?url=https%3A%2F%2Fdata-api.kuest.com%2Fv1%2Fevents', {
+      method: 'GET',
+      headers: {
+        authorization: 'Bearer docs-token',
+        cookie: 'better-auth.session_token=secret; l2-auth-context=secret',
+        cookie2: 'legacy=secret',
+      },
+    }))
+
+    expect(mocks.fetch).toHaveBeenCalledTimes(1)
+
+    const fetchInit = mocks.fetch.mock.calls[0]?.[1] as RequestInit
+    const upstreamHeaders = new Headers(fetchInit.headers)
+
+    expect(upstreamHeaders.get('cookie')).toBeNull()
+    expect(upstreamHeaders.get('cookie2')).toBeNull()
+    expect(upstreamHeaders.get('authorization')).toBe('Bearer docs-token')
+    expect(response.headers.get('set-cookie')).toBeNull()
+    expect(response.headers.get('access-control-allow-origin')).toBeNull()
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a signed, cookie-based quota (5 per 24h) for market context generation and stop cookie leaks via the OpenAPI proxy. Generation now works for authenticated and anonymous users under the quota; read-only requests are unchanged.

- New Features
  - `POST /api/market-context`: per-subject quota (user or anonymous) with 429 when exceeded.
  - Market context service: added `beforeGenerate` hook and optional `status` in responses.

- Bug Fixes
  - `openapi-proxy`: strip `cookie`/`cookie2` from upstream requests and remove `set-cookie` from upstream responses.
  - Added unit tests for quota enforcement, auth paths, and proxy header sanitization.

<sup>Written for commit e6cc91d96d202b200dc6bb0881a76e5421b13db9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1202?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

