### PR TITLE
fix: resolve leaderboard metadata site url at runtime

### DIFF
--- a/src/app/[locale]/(platform)/leaderboard/[[...filters]]/page.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/[[...filters]]/page.tsx
@@ -1,5 +1,3 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
@@ -12,6 +10,7 @@ import {
   PERIOD_OPTIONS,
 } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardFilters'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -52,6 +51,8 @@ function buildLeaderboardOgImageUrl({
 }
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/leaderboard/[[...filters]]'>): Promise<Metadata> {
+  await deferPublicShellPrerenderIfNeeded()
+
   const { locale, filters } = await params
   setRequestLocale(locale)
 
@@ -119,6 +120,19 @@ export async function generateStaticParams() {
 
 export default async function LeaderboardPage({ params }: PageProps<'/[locale]/leaderboard/[[...filters]]'>) {
   const { locale, filters } = await params
+
+  return <LeaderboardPageContent locale={locale as SupportedLocale} filters={filters} />
+}
+
+async function LeaderboardPageContent({
+  locale,
+  filters,
+}: {
+  locale: SupportedLocale
+  filters?: string[]
+}) {
+  'use cache'
+
   setRequestLocale(locale)
 
   const initialFilters = parseLeaderboardFilters(filters)

--- a/tests/unit/leaderboardMetadata.test.ts
+++ b/tests/unit/leaderboardMetadata.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  calls: [] as string[],
+  deferPublicShellPrerenderIfNeeded: vi.fn(),
+  getExtracted: vi.fn(),
+  loadRuntimeThemeState: vi.fn(),
+  resolveSiteUrl: vi.fn(),
+  setRequestLocale: vi.fn(),
+}))
+
+vi.mock('next-intl/server', () => ({
+  getExtracted: (...args: any[]) => mocks.getExtracted(...args),
+  setRequestLocale: (...args: any[]) => mocks.setRequestLocale(...args),
+}))
+
+vi.mock('@/app/[locale]/(platform)/leaderboard/_components/LeaderboardClient', () => ({
+  default: () => null,
+}))
+
+vi.mock('@/lib/public-shell-rendering', () => ({
+  deferPublicShellPrerenderIfNeeded: (...args: any[]) => mocks.deferPublicShellPrerenderIfNeeded(...args),
+}))
+
+vi.mock('@/lib/site-url', () => ({
+  default: (...args: any[]) => mocks.resolveSiteUrl(...args),
+}))
+
+vi.mock('@/lib/theme-settings', () => ({
+  loadRuntimeThemeState: (...args: any[]) => mocks.loadRuntimeThemeState(...args),
+}))
+
+describe('leaderboard metadata', () => {
+  beforeEach(() => {
+    mocks.calls.length = 0
+    mocks.deferPublicShellPrerenderIfNeeded.mockReset()
+    mocks.getExtracted.mockReset()
+    mocks.loadRuntimeThemeState.mockReset()
+    mocks.resolveSiteUrl.mockReset()
+    mocks.setRequestLocale.mockReset()
+
+    mocks.deferPublicShellPrerenderIfNeeded.mockImplementation(async () => {
+      mocks.calls.push('defer')
+    })
+    mocks.getExtracted.mockResolvedValue((key: string, values?: Record<string, string>) => {
+      if (key === 'See top traders and biggest wins on {siteName}') {
+        return `See top traders and biggest wins on ${values?.siteName ?? ''}`
+      }
+
+      return key
+    })
+    mocks.loadRuntimeThemeState.mockResolvedValue({ site: { name: 'Kuest' } })
+    mocks.resolveSiteUrl.mockImplementation(() => {
+      mocks.calls.push('resolve-site-url')
+      return 'https://demo.kuest.com'
+    })
+  })
+
+  it('defers prerendering before resolving absolute social URLs', async () => {
+    const { generateMetadata } = await import('@/app/[locale]/(platform)/leaderboard/[[...filters]]/page')
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({
+        locale: 'en',
+        filters: ['sports', 'weekly', 'volume'],
+      }),
+    } as any)
+
+    const serializedMetadata = JSON.stringify(metadata)
+    const firstResolveIndex = mocks.calls.indexOf('resolve-site-url')
+
+    expect(mocks.calls.indexOf('defer')).toBeGreaterThanOrEqual(0)
+    expect(firstResolveIndex).toBeGreaterThan(mocks.calls.indexOf('defer'))
+    expect(metadata.openGraph?.url).toBe('https://demo.kuest.com/leaderboard/sports/weekly/volume')
+    expect(serializedMetadata).toContain('https://demo.kuest.com/api/og/leaderboard')
+    expect(serializedMetadata).not.toContain('localhost:3000')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Resolve leaderboard metadata URLs at runtime to generate correct absolute OG and canonical URLs across environments. Prevents localhost URLs from leaking into social previews.

- **Bug Fixes**
  - Call `deferPublicShellPrerenderIfNeeded()` in `generateMetadata` before resolving the site URL.
  - Build absolute URLs with `resolveSiteUrl` at runtime for `openGraph.url` and OG image.
  - Move `'use cache'` to `LeaderboardPageContent` so metadata executes dynamically.
  - Add unit test `leaderboardMetadata.test.ts` to verify prerender deferral order and final URLs.

<sup>Written for commit 0b03d82d2d21736759719f263813c37c07f11640. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1203?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

