### PR TITLE
fix: restore admin version commit sha

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -27,8 +27,11 @@ RUN mkdir -p /tmp/runtime-node_modules \
 FROM node:24-bookworm-slim AS runner
 WORKDIR /app
 
+ARG COMMIT_SHA=unknown
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
+ENV COMMIT_SHA=$COMMIT_SHA
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 ENV PNPM_HOME=/pnpm

--- a/next.config.ts
+++ b/next.config.ts
@@ -2,9 +2,11 @@ import type { NextConfig } from 'next'
 import { withSentryConfig } from '@sentry/nextjs'
 import { createMDX } from 'fumadocs-mdx/next'
 import createNextIntlPlugin from 'next-intl/plugin'
+import { resolveCommitSha } from '@/lib/git'
 import { getOptimizedImageHostPatterns } from '@/lib/image/image-optimization'
 
 const optimizedImageHostPatterns = getOptimizedImageHostPatterns(process.env)
+const commitSha = resolveCommitSha()
 
 const config: NextConfig = {
   output: process.env.VERCEL_ENV ? undefined : 'standalone',
@@ -76,6 +78,9 @@ const config: NextConfig = {
         destination: '/:locale/profile/:username',
       },
     ]
+  },
+  env: {
+    COMMIT_SHA: commitSha,
   },
 }
 

--- a/src/lib/git.ts
+++ b/src/lib/git.ts
@@ -1,5 +1,9 @@
 import { execSync } from 'node:child_process'
 
+const BUILD_COMMIT_SHA = process.env.COMMIT_SHA
+const BUILD_VERCEL_GIT_COMMIT_MESSAGE = process.env.VERCEL_GIT_COMMIT_MESSAGE
+const BUILD_VERCEL_GIT_COMMIT_SHA = process.env.VERCEL_GIT_COMMIT_SHA
+
 function toShortSha(value: string | undefined): string | undefined {
   const trimmed = value?.trim()
   return trimmed ? trimmed.slice(0, 7) : undefined
@@ -33,12 +37,15 @@ function readGitShortSha(): string | undefined {
   }
 }
 
-export function resolveCommitSha() {
+export function resolveCommitSha(env: NodeJS.ProcessEnv = process.env) {
   return (
-    parseSyncCommitUpstreamShortSha(process.env.VERCEL_GIT_COMMIT_MESSAGE)
+    parseSyncCommitUpstreamShortSha(env.VERCEL_GIT_COMMIT_MESSAGE)
+    ?? parseSyncCommitUpstreamShortSha(BUILD_VERCEL_GIT_COMMIT_MESSAGE)
     ?? readGitSyncCommitUpstreamShortSha()
-    ?? toShortSha(process.env.COMMIT_SHA)
-    ?? toShortSha(process.env.VERCEL_GIT_COMMIT_SHA)
+    ?? toShortSha(env.COMMIT_SHA)
+    ?? toShortSha(BUILD_COMMIT_SHA)
+    ?? toShortSha(env.VERCEL_GIT_COMMIT_SHA)
+    ?? toShortSha(BUILD_VERCEL_GIT_COMMIT_SHA)
     ?? readGitShortSha()
     ?? 'unknown'
   )

--- a/src/lib/public-runtime-config.server.ts
+++ b/src/lib/public-runtime-config.server.ts
@@ -8,7 +8,7 @@ export type { PublicRuntimeConfig } from '@/lib/public-runtime-config.shared'
 export function getPublicRuntimeConfig(env: NodeJS.ProcessEnv = process.env): PublicRuntimeConfig {
   return {
     ...resolvePublicRuntimeEnv(env),
-    commitSha: resolveCommitSha(),
+    commitSha: resolveCommitSha(env),
     siteUrl: resolveSiteUrl(env),
   }
 }

--- a/tests/unit/git.test.ts
+++ b/tests/unit/git.test.ts
@@ -1,0 +1,87 @@
+import { Buffer } from 'node:buffer'
+import { beforeEach, describe, expect, it } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  execSync: vi.fn(),
+}))
+
+vi.mock('node:child_process', () => ({
+  default: {
+    execSync: mocks.execSync,
+  },
+  execSync: mocks.execSync,
+}))
+
+function mockGitCommands({
+  commitMessage = 'Regular commit message',
+  shortSha = '7654321',
+}: {
+  commitMessage?: string
+  shortSha?: string
+} = {}) {
+  mocks.execSync.mockImplementation((command: string) => {
+    if (command === 'git log -1 --pretty=%B') {
+      return Buffer.from(commitMessage)
+    }
+
+    if (command === 'git rev-parse --short HEAD') {
+      return Buffer.from(`${shortSha}\n`)
+    }
+
+    throw new Error(`Unexpected command: ${command}`)
+  })
+}
+
+async function importGitWithBuildEnv({
+  commitSha = '',
+  vercelCommitMessage = '',
+  vercelCommitSha = '',
+}: {
+  commitSha?: string
+  vercelCommitMessage?: string
+  vercelCommitSha?: string
+} = {}) {
+  vi.resetModules()
+  vi.stubEnv('COMMIT_SHA', commitSha)
+  vi.stubEnv('VERCEL_GIT_COMMIT_MESSAGE', vercelCommitMessage)
+  vi.stubEnv('VERCEL_GIT_COMMIT_SHA', vercelCommitSha)
+
+  return import('@/lib/git')
+}
+
+describe('resolveCommitSha', () => {
+  beforeEach(() => {
+    mocks.execSync.mockReset()
+    vi.unstubAllEnvs()
+  })
+
+  it('uses the upstream SHA from a sync commit message', async () => {
+    const { resolveCommitSha } = await importGitWithBuildEnv()
+
+    expect(resolveCommitSha({
+      VERCEL_GIT_COMMIT_MESSAGE: 'Sync fork\n\nUpstream: abcdef1234567890',
+    })).toBe('abcdef1')
+    expect(mocks.execSync).not.toHaveBeenCalled()
+  })
+
+  it('uses COMMIT_SHA from the supplied runtime environment', async () => {
+    mockGitCommands()
+    const { resolveCommitSha } = await importGitWithBuildEnv()
+
+    expect(resolveCommitSha({ COMMIT_SHA: '1234567890abcdef' })).toBe('1234567')
+  })
+
+  it('keeps the build-time COMMIT_SHA as a runtime fallback', async () => {
+    mockGitCommands()
+    const { resolveCommitSha } = await importGitWithBuildEnv({ commitSha: 'fedcba9876543210' })
+
+    expect(resolveCommitSha({})).toBe('fedcba9')
+  })
+
+  it('falls back to the local git short SHA', async () => {
+    mockGitCommands({ shortSha: '7654321' })
+    const { resolveCommitSha } = await importGitWithBuildEnv()
+
+    expect(resolveCommitSha({})).toBe('7654321')
+  })
+})

--- a/tests/unit/publicRuntimeConfig.test.ts
+++ b/tests/unit/publicRuntimeConfig.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { getPublicRuntimeConfig } from '@/lib/public-runtime-config.server'
 import {
   defaultPublicRuntimeConfig,
   resolvePublicRuntimeEnv,
@@ -61,5 +62,14 @@ describe('public runtime config resolution', () => {
   it('parses CHAIN_ID from the environment', () => {
     expect(resolvePublicRuntimeEnv({ CHAIN_ID: '137' }).chainId).toBe(137)
     expect(resolvePublicRuntimeEnv({ CHAIN_ID: ' ' }).chainId).toBe(defaultPublicRuntimeConfig.chainId)
+  })
+
+  it('resolves commit SHA from the runtime config environment', () => {
+    const config = getPublicRuntimeConfig({
+      SITE_URL: 'https://kuest.test',
+      VERCEL_GIT_COMMIT_MESSAGE: 'Sync fork\n\nUpstream: abcdef1234567890',
+    })
+
+    expect(config.commitSha).toBe('abcdef1')
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restores the admin version commit SHA by resolving it reliably at build and runtime. Fixes cases where the value was missing or incorrect in production.

- **Bug Fixes**
  - Added `resolveCommitSha(env)` with a stable order: upstream SHA from sync commits → runtime env → build-time env → local git → `unknown`.
  - Passed `env` into `getPublicRuntimeConfig` so runtime values win when available.
  - Injected `COMMIT_SHA` at build time via Docker (`ARG`/`ENV`) and exposed it in `next.config.ts` (`env.COMMIT_SHA`).
  - Added unit tests for resolution paths and runtime config integration.

<sup>Written for commit caa06c781f5a1f038d605b59e0a79c1f7a808e7b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1205?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

