### PR TITLE
feat: add language flags

### DIFF
--- a/src/app/[locale]/admin/locales/_components/AdminLocalesSettingsForm.tsx
+++ b/src/app/[locale]/admin/locales/_components/AdminLocalesSettingsForm.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button'
 import { InputError } from '@/components/ui/input-error'
 import { Label } from '@/components/ui/label'
 import { Switch } from '@/components/ui/switch'
-import { DEFAULT_LOCALE, LOCALE_LABELS } from '@/i18n/locales'
+import { DEFAULT_LOCALE, getFlaggedLocaleLabel } from '@/i18n/locales'
 
 const initialState = {
   error: null,
@@ -120,7 +120,7 @@ function AdminLocalesSettingsFormInner({
           return (
             <div key={locale} className="flex items-center justify-between gap-4">
               <div className="grid gap-1">
-                <Label htmlFor={switchId} className="text-sm font-medium">{LOCALE_LABELS[locale]}</Label>
+                <Label htmlFor={switchId} className="text-sm font-medium">{getFlaggedLocaleLabel(locale)}</Label>
                 <span className="text-xs text-muted-foreground">
                   {isDefault ? t('Default locale') : locale.toUpperCase()}
                 </span>

--- a/src/components/LocaleSwitcherMenuItem.tsx
+++ b/src/components/LocaleSwitcherMenuItem.tsx
@@ -12,7 +12,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuSubTrigger,
 } from '@/components/ui/dropdown-menu'
-import { LOCALE_LABELS, LOOP_LABELS, normalizeEnabledLocales, SUPPORTED_LOCALES } from '@/i18n/locales'
+import { getFlaggedLocaleLabel, LOCALE_LABELS, LOOP_LABELS, normalizeEnabledLocales, SUPPORTED_LOCALES } from '@/i18n/locales'
 import { stripLocalePrefix, withLocalePrefix } from '@/lib/locale-path'
 
 function useLocaleCarousel() {
@@ -21,7 +21,7 @@ function useLocaleCarousel() {
   const [carouselState, setCarouselState] = useState({ index: 0, isSliding: true })
   const displayLocales = enabledLocales ?? SUPPORTED_LOCALES
   const localeLabels = displayLocales.map(
-    option => LOOP_LABELS[option] ?? option.toUpperCase(),
+    option => getFlaggedLocaleLabel(option, LOOP_LABELS[option] ?? option.toUpperCase()),
   )
   const loopedLabels = [
     ...localeLabels,
@@ -152,7 +152,7 @@ export default function LocaleSwitcherMenuItem() {
                 className="group flex items-center gap-1.5 pr-7 pl-2 text-sm font-semibold [&>span:first-child]:hidden"
               >
                 <span className="flex-1 font-medium">
-                  {LOCALE_LABELS[option] ?? option.toUpperCase()}
+                  {getFlaggedLocaleLabel(option, LOCALE_LABELS[option] ?? option.toUpperCase())}
                 </span>
                 <CheckIcon className="ml-auto size-4 text-primary opacity-0 group-data-[state=checked]:opacity-100" />
               </DropdownMenuRadioItem>

--- a/src/i18n/locales.ts
+++ b/src/i18n/locales.ts
@@ -17,6 +17,20 @@ export const LOCALE_LABELS: Record<SupportedLocale, string> = {
   zh: '中文',
 }
 
+const LOCALE_FLAGS: Record<SupportedLocale, string> = {
+  en: '🇺🇸',
+  de: '🇩🇪',
+  es: '🇪🇸',
+  pt: '🇧🇷',
+  fr: '🇫🇷',
+  zh: '🇨🇳',
+}
+
+export function getFlaggedLocaleLabel(locale: SupportedLocale, label = LOCALE_LABELS[locale] ?? locale.toUpperCase()) {
+  const flag = LOCALE_FLAGS[locale]
+  return flag ? `${flag} ${label}` : label
+}
+
 export const LOOP_LABELS: Record<SupportedLocale, string> = {
   en: 'Language',
   de: 'Sprache',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add country flags to locale labels so users can scan and pick languages faster. Updates admin locale settings and the locale switcher to show “flag + label”.

- **New Features**
  - Added `LOCALE_FLAGS` and `getFlaggedLocaleLabel(locale, label?)` to prefix flags to labels with safe fallbacks.
  - Switched `AdminLocalesSettingsForm` and `LocaleSwitcherMenuItem` (carousel and radio items) to use flagged labels.
  - Falls back to existing labels or `LOCALE_LABELS`/uppercase when a flag isn’t available.

<sup>Written for commit d3ef4ae0336fdb29108ca5aeb863cf25d2dd2ae2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1206?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

