### PR TITLE
fix: missing html dir attr for ar lang

### DIFF
--- a/src/app/[locale]/layout.tsx
+++ b/src/app/[locale]/layout.tsx
@@ -199,6 +199,7 @@ async function PrerenderedLocaleDocument({ locale, children }: LocaleDocumentPro
   return (
     <html
       lang={locale}
+      dir={locale === 'ar' ? 'rtl' : 'ltr'}
       className={openSauceOne.variable}
       data-theme-preset={runtimeData.runtimeTheme.theme.presetId}
       suppressHydrationWarning
@@ -232,6 +233,7 @@ function RuntimeLocaleDocument({ locale, children }: LocaleDocumentProps) {
   return (
     <html
       lang={locale}
+      dir={locale === 'ar' ? 'rtl' : 'ltr'}
       className={openSauceOne.variable}
       suppressHydrationWarning
     >


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set the HTML dir attribute based on locale to enable RTL for Arabic (`ar`), fixing layout and text-direction issues in both prerendered and runtime documents.

<sup>Written for commit 01b94e23ffd6387bd056d400bd12fb7d0c7d0c64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

