### PR TITLE
fix: refresh admin settings cache tags

### DIFF
--- a/src/app/[locale]/admin/(general)/page.tsx
+++ b/src/app/[locale]/admin/(general)/page.tsx
@@ -2,9 +2,11 @@
 
 import type { AdminThemeSiteSettingsInitialState } from '@/app/[locale]/admin/theme/_types/theme-form-state'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { cacheTag } from 'next/cache'
 import AdminGeneralSettingsForm from '@/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm'
 import { parseMarketContextSettings } from '@/lib/ai/market-context-config'
 import { fetchOpenRouterModels } from '@/lib/ai/openrouter'
+import { cacheTags } from '@/lib/cache-tags'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { getBlockedCountriesFromSettings } from '@/lib/geoblock-settings'
 import { getGlobalAnnouncementSettingsFromSettings } from '@/lib/global-announcement-settings'
@@ -18,6 +20,8 @@ interface AdminGeneralSettingsPageProps {
 }
 
 export default async function AdminGeneralSettingsPage({ params }: AdminGeneralSettingsPageProps) {
+  cacheTag(cacheTags.settings)
+
   const { locale } = await params
   setRequestLocale(locale)
   const t = await getExtracted()

--- a/src/app/[locale]/admin/market-context/page.tsx
+++ b/src/app/[locale]/admin/market-context/page.tsx
@@ -1,12 +1,16 @@
 'use cache'
 
 import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { cacheTag } from 'next/cache'
 import AdminMarketContextSettingsForm from '@/app/[locale]/admin/market-context/_components/AdminMarketContextSettingsForm'
 import { parseMarketContextSettings } from '@/lib/ai/market-context-config'
 import { MARKET_CONTEXT_VARIABLES } from '@/lib/ai/market-context-template'
+import { cacheTags } from '@/lib/cache-tags'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 
 export default async function AdminMarketContextSettingsPage({ params }: PageProps<'/[locale]/admin/market-context'>) {
+  cacheTag(cacheTags.settings)
+
   const { locale } = await params
   setRequestLocale(locale)
   const t = await getExtracted()

--- a/src/app/[locale]/admin/theme/page.tsx
+++ b/src/app/[locale]/admin/theme/page.tsx
@@ -2,7 +2,9 @@
 
 import type { AdminThemeSiteSettingsInitialState } from '@/app/[locale]/admin/theme/_types/theme-form-state'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { cacheTag } from 'next/cache'
 import AdminThemeSettingsForm from '@/app/[locale]/admin/theme/_components/AdminThemeSettingsForm'
+import { cacheTags } from '@/lib/cache-tags'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { getPublicAssetUrl } from '@/lib/storage'
 import { getThemePresetOptions } from '@/lib/theme'
@@ -10,6 +12,8 @@ import { getThemeSettingsFormState, getThemeSiteSettingsFormState } from '@/lib/
 import { DEFAULT_THEME_SITE_PWA_ICON_192_URL, DEFAULT_THEME_SITE_PWA_ICON_512_URL } from '@/lib/theme-site-identity'
 
 export default async function AdminThemeSettingsPage({ params }: PageProps<'/[locale]/admin/theme'>) {
+  cacheTag(cacheTags.settings)
+
   const { locale } = await params
   setRequestLocale(locale)
   const t = await getExtracted()

--- a/tests/unit/adminSettingsPagesCache.test.tsx
+++ b/tests/unit/adminSettingsPagesCache.test.tsx
@@ -1,0 +1,93 @@
+import * as React from 'react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  cacheTag: vi.fn(),
+  getExtracted: vi.fn(),
+  setRequestLocale: vi.fn(),
+  getSettings: vi.fn(),
+  parseMarketContextSettings: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+  cacheTag: (...args: any[]) => mocks.cacheTag(...args),
+}))
+
+vi.mock('next-intl/server', () => ({
+  getExtracted: (...args: any[]) => mocks.getExtracted(...args),
+  setRequestLocale: (...args: any[]) => mocks.setRequestLocale(...args),
+}))
+
+vi.mock('@/lib/db/queries/settings', () => ({
+  SettingsRepository: {
+    getSettings: (...args: any[]) => mocks.getSettings(...args),
+  },
+}))
+
+vi.mock('@/lib/ai/market-context-config', () => ({
+  parseMarketContextSettings: (...args: any[]) => mocks.parseMarketContextSettings(...args),
+}))
+
+vi.mock('@/lib/ai/openrouter', () => ({
+  fetchOpenRouterModels: vi.fn(),
+}))
+
+vi.mock('@/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', { 'data-testid': 'admin-general-settings-form' }),
+}))
+
+vi.mock('@/app/[locale]/admin/theme/_components/AdminThemeSettingsForm', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', { 'data-testid': 'admin-theme-settings-form' }),
+}))
+
+vi.mock('@/app/[locale]/admin/market-context/_components/AdminMarketContextSettingsForm', () => ({
+  __esModule: true,
+  default: () => React.createElement('div', { 'data-testid': 'admin-market-context-settings-form' }),
+}))
+
+describe('admin settings pages cache tags', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.cacheTag.mockReset()
+    mocks.getExtracted.mockReset()
+    mocks.setRequestLocale.mockReset()
+    mocks.getSettings.mockReset()
+    mocks.parseMarketContextSettings.mockReset()
+
+    mocks.getExtracted.mockResolvedValue((value: string) => value)
+    mocks.getSettings.mockResolvedValue({ data: {}, error: null })
+    mocks.parseMarketContextSettings.mockReturnValue({
+      apiKey: undefined,
+      model: undefined,
+      prompt: 'Prompt',
+      enabled: true,
+    })
+  })
+
+  it('tags cached admin pages that render settings-backed initial state', async () => {
+    const [
+      { default: AdminGeneralSettingsPage },
+      { default: AdminThemeSettingsPage },
+      { default: AdminMarketContextSettingsPage },
+      { cacheTags },
+    ] = await Promise.all([
+      import('@/app/[locale]/admin/(general)/page'),
+      import('@/app/[locale]/admin/theme/page'),
+      import('@/app/[locale]/admin/market-context/page'),
+      import('@/lib/cache-tags'),
+    ])
+
+    const params = Promise.resolve({ locale: 'en' })
+
+    await AdminGeneralSettingsPage({ params })
+    await AdminThemeSettingsPage({ params } as any)
+    await AdminMarketContextSettingsPage({ params } as any)
+
+    expect(mocks.cacheTag).toHaveBeenCalledTimes(3)
+    expect(mocks.cacheTag).toHaveBeenNthCalledWith(1, cacheTags.settings)
+    expect(mocks.cacheTag).toHaveBeenNthCalledWith(2, cacheTags.settings)
+    expect(mocks.cacheTag).toHaveBeenNthCalledWith(3, cacheTags.settings)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stale admin settings pages by tagging them with the settings cache key. Adds `cacheTag(cacheTags.settings)` to the General, Theme, and Market Context pages and a unit test to prevent regressions.

- **Bug Fixes**
  - Tag `/[locale]/admin/(general)`, `/[locale]/admin/theme`, and `/[locale]/admin/market-context` pages with `cacheTag(cacheTags.settings)` so settings edits invalidate cached content.
  - Add `tests/unit/adminSettingsPagesCache.test.tsx` to assert each page calls `cacheTag` with `cacheTags.settings`.

<sup>Written for commit 1ae6b5f45637d4534677fd72e2a7a787c35f66a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1215?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

