### PR TITLE
fix: load admin settings at request time

### DIFF
--- a/src/app/[locale]/admin/(general)/page.tsx
+++ b/src/app/[locale]/admin/(general)/page.tsx
@@ -1,12 +1,10 @@
-'use cache'
-
 import type { AdminThemeSiteSettingsInitialState } from '@/app/[locale]/admin/theme/_types/theme-form-state'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
-import { cacheTag } from 'next/cache'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
 import AdminGeneralSettingsForm from '@/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm'
 import { parseMarketContextSettings } from '@/lib/ai/market-context-config'
 import { fetchOpenRouterModels } from '@/lib/ai/openrouter'
-import { cacheTags } from '@/lib/cache-tags'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { getBlockedCountriesFromSettings } from '@/lib/geoblock-settings'
 import { getGlobalAnnouncementSettingsFromSettings } from '@/lib/global-announcement-settings'
@@ -19,11 +17,12 @@ interface AdminGeneralSettingsPageProps {
   params: Promise<{ locale: string }>
 }
 
-export default async function AdminGeneralSettingsPage({ params }: AdminGeneralSettingsPageProps) {
-  cacheTag(cacheTags.settings)
+function AdminGeneralSettingsFallback() {
+  return <div className="min-h-96 rounded-lg border bg-background" />
+}
 
-  const { locale } = await params
-  setRequestLocale(locale)
+async function AdminGeneralSettingsContent() {
+  await connection()
   const t = await getExtracted()
 
   const { data: allSettings } = await SettingsRepository.getSettings()
@@ -75,6 +74,29 @@ export default async function AdminGeneralSettingsPage({ params }: AdminGeneralS
   }
 
   return (
+    <AdminGeneralSettingsForm
+      initialThemeSiteSettings={initialThemeSiteSettingsWithImage}
+      initialGlobalAnnouncement={initialGlobalAnnouncement}
+      initialBlockedCountries={initialBlockedCountries}
+      initialTermsOfServicePdfPath={initialTermsOfServicePdfPath}
+      initialTermsOfServicePdfUrl={initialTermsOfServicePdfUrl}
+      openRouterSettings={{
+        defaultModel: defaultOpenRouterModel,
+        isApiKeyConfigured: isOpenRouterApiKeyConfigured,
+        isModelSelectEnabled: isOpenRouterModelSelectEnabled,
+        modelOptions: openRouterModelOptions,
+        modelsError: openRouterModelsError,
+      }}
+    />
+  )
+}
+
+export default async function AdminGeneralSettingsPage({ params }: AdminGeneralSettingsPageProps) {
+  const { locale } = await params
+  setRequestLocale(locale)
+  const t = await getExtracted()
+
+  return (
     <section className="grid gap-4">
       <div className="grid gap-2">
         <h1 className="text-2xl font-semibold">{t('General Settings')}</h1>
@@ -83,20 +105,9 @@ export default async function AdminGeneralSettingsPage({ params }: AdminGeneralS
         </p>
       </div>
 
-      <AdminGeneralSettingsForm
-        initialThemeSiteSettings={initialThemeSiteSettingsWithImage}
-        initialGlobalAnnouncement={initialGlobalAnnouncement}
-        initialBlockedCountries={initialBlockedCountries}
-        initialTermsOfServicePdfPath={initialTermsOfServicePdfPath}
-        initialTermsOfServicePdfUrl={initialTermsOfServicePdfUrl}
-        openRouterSettings={{
-          defaultModel: defaultOpenRouterModel,
-          isApiKeyConfigured: isOpenRouterApiKeyConfigured,
-          isModelSelectEnabled: isOpenRouterModelSelectEnabled,
-          modelOptions: openRouterModelOptions,
-          modelsError: openRouterModelsError,
-        }}
-      />
+      <Suspense fallback={<AdminGeneralSettingsFallback />}>
+        <AdminGeneralSettingsContent />
+      </Suspense>
     </section>
   )
 }

--- a/src/app/[locale]/admin/market-context/page.tsx
+++ b/src/app/[locale]/admin/market-context/page.tsx
@@ -1,34 +1,43 @@
-'use cache'
-
 import { getExtracted, setRequestLocale } from 'next-intl/server'
-import { cacheTag } from 'next/cache'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
 import AdminMarketContextSettingsForm from '@/app/[locale]/admin/market-context/_components/AdminMarketContextSettingsForm'
 import { parseMarketContextSettings } from '@/lib/ai/market-context-config'
 import { MARKET_CONTEXT_VARIABLES } from '@/lib/ai/market-context-template'
-import { cacheTags } from '@/lib/cache-tags'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 
-export default async function AdminMarketContextSettingsPage({ params }: PageProps<'/[locale]/admin/market-context'>) {
-  cacheTag(cacheTags.settings)
+function AdminMarketContextSettingsFallback() {
+  return <div className="min-h-96 rounded-lg border bg-background" />
+}
 
-  const { locale } = await params
-  setRequestLocale(locale)
-  const t = await getExtracted()
-
+async function AdminMarketContextSettingsContent() {
+  await connection()
   const { data: allSettings } = await SettingsRepository.getSettings()
   const parsedSettings = parseMarketContextSettings(allSettings ?? undefined)
   const defaultPrompt = parsedSettings.prompt
   const isEnabled = parsedSettings.enabled
 
   return (
+    <AdminMarketContextSettingsForm
+      defaultPrompt={defaultPrompt}
+      isEnabled={isEnabled}
+      variables={MARKET_CONTEXT_VARIABLES}
+    />
+  )
+}
+
+export default async function AdminMarketContextSettingsPage({ params }: PageProps<'/[locale]/admin/market-context'>) {
+  const { locale } = await params
+  setRequestLocale(locale)
+  const t = await getExtracted()
+
+  return (
     <section className="grid gap-4">
       <h1 className="text-2xl font-semibold">{t('Market Context')}</h1>
 
-      <AdminMarketContextSettingsForm
-        defaultPrompt={defaultPrompt}
-        isEnabled={isEnabled}
-        variables={MARKET_CONTEXT_VARIABLES}
-      />
+      <Suspense fallback={<AdminMarketContextSettingsFallback />}>
+        <AdminMarketContextSettingsContent />
+      </Suspense>
     </section>
   )
 }

--- a/src/app/[locale]/admin/theme/page.tsx
+++ b/src/app/[locale]/admin/theme/page.tsx
@@ -1,23 +1,20 @@
-'use cache'
-
 import type { AdminThemeSiteSettingsInitialState } from '@/app/[locale]/admin/theme/_types/theme-form-state'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
-import { cacheTag } from 'next/cache'
+import { connection } from 'next/server'
+import { Suspense } from 'react'
 import AdminThemeSettingsForm from '@/app/[locale]/admin/theme/_components/AdminThemeSettingsForm'
-import { cacheTags } from '@/lib/cache-tags'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { getPublicAssetUrl } from '@/lib/storage'
 import { getThemePresetOptions } from '@/lib/theme'
 import { getThemeSettingsFormState, getThemeSiteSettingsFormState } from '@/lib/theme-settings'
 import { DEFAULT_THEME_SITE_PWA_ICON_192_URL, DEFAULT_THEME_SITE_PWA_ICON_512_URL } from '@/lib/theme-site-identity'
 
-export default async function AdminThemeSettingsPage({ params }: PageProps<'/[locale]/admin/theme'>) {
-  cacheTag(cacheTags.settings)
+function AdminThemeSettingsFallback() {
+  return <div className="min-h-96 rounded-lg border bg-background" />
+}
 
-  const { locale } = await params
-  setRequestLocale(locale)
-  const t = await getExtracted()
-
+async function AdminThemeSettingsContent() {
+  await connection()
   const { data: allSettings } = await SettingsRepository.getSettings()
 
   const initialThemeSettings = getThemeSettingsFormState(allSettings ?? undefined)
@@ -38,6 +35,20 @@ export default async function AdminThemeSettingsPage({ params }: PageProps<'/[lo
   const presetOptions = getThemePresetOptions()
 
   return (
+    <AdminThemeSettingsForm
+      presetOptions={presetOptions}
+      initialThemeSettings={initialThemeSettings}
+      initialThemeSiteSettings={initialThemeSiteSettingsWithImage}
+    />
+  )
+}
+
+export default async function AdminThemeSettingsPage({ params }: PageProps<'/[locale]/admin/theme'>) {
+  const { locale } = await params
+  setRequestLocale(locale)
+  const t = await getExtracted()
+
+  return (
     <section className="grid gap-4">
       <div className="grid gap-2">
         <h1 className="text-2xl font-semibold">{t('Theme')}</h1>
@@ -46,11 +57,9 @@ export default async function AdminThemeSettingsPage({ params }: PageProps<'/[lo
         </p>
       </div>
 
-      <AdminThemeSettingsForm
-        presetOptions={presetOptions}
-        initialThemeSettings={initialThemeSettings}
-        initialThemeSiteSettings={initialThemeSiteSettingsWithImage}
-      />
+      <Suspense fallback={<AdminThemeSettingsFallback />}>
+        <AdminThemeSettingsContent />
+      </Suspense>
     </section>
   )
 }

--- a/tests/unit/adminSettingsPagesCache.test.tsx
+++ b/tests/unit/adminSettingsPagesCache.test.tsx
@@ -2,15 +2,14 @@ import * as React from 'react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
-  cacheTag: vi.fn(),
+  connection: vi.fn(),
   getExtracted: vi.fn(),
   setRequestLocale: vi.fn(),
   getSettings: vi.fn(),
-  parseMarketContextSettings: vi.fn(),
 }))
 
-vi.mock('next/cache', () => ({
-  cacheTag: (...args: any[]) => mocks.cacheTag(...args),
+vi.mock('next/server', () => ({
+  connection: (...args: any[]) => mocks.connection(...args),
 }))
 
 vi.mock('next-intl/server', () => ({
@@ -22,10 +21,6 @@ vi.mock('@/lib/db/queries/settings', () => ({
   SettingsRepository: {
     getSettings: (...args: any[]) => mocks.getSettings(...args),
   },
-}))
-
-vi.mock('@/lib/ai/market-context-config', () => ({
-  parseMarketContextSettings: (...args: any[]) => mocks.parseMarketContextSettings(...args),
 }))
 
 vi.mock('@/lib/ai/openrouter', () => ({
@@ -47,36 +42,26 @@ vi.mock('@/app/[locale]/admin/market-context/_components/AdminMarketContextSetti
   default: () => React.createElement('div', { 'data-testid': 'admin-market-context-settings-form' }),
 }))
 
-describe('admin settings pages cache tags', () => {
+describe('admin settings pages runtime behavior', () => {
   beforeEach(() => {
     vi.resetModules()
-    mocks.cacheTag.mockReset()
+    mocks.connection.mockReset()
     mocks.getExtracted.mockReset()
     mocks.setRequestLocale.mockReset()
     mocks.getSettings.mockReset()
-    mocks.parseMarketContextSettings.mockReset()
 
     mocks.getExtracted.mockResolvedValue((value: string) => value)
-    mocks.getSettings.mockResolvedValue({ data: {}, error: null })
-    mocks.parseMarketContextSettings.mockReturnValue({
-      apiKey: undefined,
-      model: undefined,
-      prompt: 'Prompt',
-      enabled: true,
-    })
   })
 
-  it('tags cached admin pages that render settings-backed initial state', async () => {
+  it('does not read settings while rendering the page shell', async () => {
     const [
       { default: AdminGeneralSettingsPage },
       { default: AdminThemeSettingsPage },
       { default: AdminMarketContextSettingsPage },
-      { cacheTags },
     ] = await Promise.all([
       import('@/app/[locale]/admin/(general)/page'),
       import('@/app/[locale]/admin/theme/page'),
       import('@/app/[locale]/admin/market-context/page'),
-      import('@/lib/cache-tags'),
     ])
 
     const params = Promise.resolve({ locale: 'en' })
@@ -85,9 +70,7 @@ describe('admin settings pages cache tags', () => {
     await AdminThemeSettingsPage({ params } as any)
     await AdminMarketContextSettingsPage({ params } as any)
 
-    expect(mocks.cacheTag).toHaveBeenCalledTimes(3)
-    expect(mocks.cacheTag).toHaveBeenNthCalledWith(1, cacheTags.settings)
-    expect(mocks.cacheTag).toHaveBeenNthCalledWith(2, cacheTags.settings)
-    expect(mocks.cacheTag).toHaveBeenNthCalledWith(3, cacheTags.settings)
+    expect(mocks.connection).not.toHaveBeenCalled()
+    expect(mocks.getSettings).not.toHaveBeenCalled()
   })
 })

--- a/tests/unit/marketContextSettings.test.ts
+++ b/tests/unit/marketContextSettings.test.ts
@@ -47,6 +47,20 @@ describe('market context settings parser', () => {
     expect(parsed.enabled).toBe(true)
   })
 
+  it('hydrates admin-visible OpenRouter fields from ai settings', async () => {
+    const { parseMarketContextSettings } = await import('@/lib/ai/market-context-config')
+
+    const parsed = parseMarketContextSettings({
+      ai: {
+        openrouter_api_key: setting('enc.v1.openrouter-key'),
+        openrouter_model: setting('openai/gpt-4o-mini'),
+      },
+    })
+
+    expect(parsed.model).toBe('openai/gpt-4o-mini')
+    expect(parsed.apiKey).toBe('openrouter-key')
+  })
+
   it('prioritizes market_context_enabled over legacy openrouter_enabled value', async () => {
     const { parseMarketContextSettings } = await import('@/lib/ai/market-context-config')
 

--- a/tests/unit/themeSettingsSocialLinks.test.ts
+++ b/tests/unit/themeSettingsSocialLinks.test.ts
@@ -117,4 +117,50 @@ describe('themeSettings social links', () => {
       disabledOn: ['portfolio'],
     }])
   })
+
+  it('hydrates admin-visible integration and PWA fields from general settings', () => {
+    const state = getThemeSiteSettingsFormState({
+      general: {
+        site_name: {
+          value: 'Kuest',
+          updated_at: '2026-03-08T00:00:00.000Z',
+        },
+        site_description: {
+          value: 'Prediction markets',
+          updated_at: '2026-03-08T00:00:00.000Z',
+        },
+        site_logo_mode: {
+          value: 'svg',
+          updated_at: '2026-03-08T00:00:00.000Z',
+        },
+        pwa_icon_192_path: {
+          value: 'theme/pwa-192.png',
+          updated_at: '2026-03-08T00:00:00.000Z',
+        },
+        pwa_icon_512_path: {
+          value: 'theme/pwa-512.png',
+          updated_at: '2026-03-08T00:00:00.000Z',
+        },
+        site_google_analytics: {
+          value: 'G-ABC123',
+          updated_at: '2026-03-08T00:00:00.000Z',
+        },
+        lifi_integrator: {
+          value: 'kuest-prod',
+          updated_at: '2026-03-08T00:00:00.000Z',
+        },
+        lifi_api_key: {
+          value: 'enc.v1.lifi-key',
+          updated_at: '2026-03-08T00:00:00.000Z',
+        },
+      },
+    })
+
+    expect(state.pwaIcon192Path).toBe('theme/pwa-192.png')
+    expect(state.pwaIcon512Path).toBe('theme/pwa-512.png')
+    expect(state.googleAnalyticsId).toBe('G-ABC123')
+    expect(state.lifiIntegrator).toBe('kuest-prod')
+    expect(state.lifiApiKey).toBe('')
+    expect(state.lifiApiKeyConfigured).toBe(true)
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Load admin settings at request time to prevent stale data in the admin UI. General, Theme, and Market Context pages now render a fast shell and fetch fresh settings inside a Suspense boundary.

- **Bug Fixes**
  - Moved settings fetch into async content components wrapped in React Suspense with a lightweight fallback; uses `connection()` from `next/server` to run at request time.
  - Removed `use cache` and `cacheTag(cacheTags.settings)` to avoid serving cached settings in admin.
  - Locale is set early via `next-intl/server`; page shell renders without hitting the DB.
  - Updated tests to ensure no settings are read during shell render and to validate hydration of OpenRouter, PWA, and integration fields from settings.

<sup>Written for commit 4c084c80470e94852a8a87c26d29fca3372258e8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/kuestcom/prediction-market/pull/1216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

