### PR TITLE
fix: stabilize live websocket reconnects

### DIFF
--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -71,6 +71,8 @@ const ROW_HEIGHT_ESTIMATE = 64
 const MIN_VISIBLE_ITEMS = 12
 const MAX_VISIBLE_ITEMS = 28
 const DEFAULT_VIEWPORT_HEIGHT = 800
+const WEBSOCKET_PING_INTERVAL_MS = 25000
+const WEBSOCKET_STALE_TIMEOUT_MS = 70000
 
 function clampBaseVisibleCount(viewportHeight: number) {
   const estimate = Math.ceil(viewportHeight / ROW_HEIGHT_ESTIMATE) + 6
@@ -293,6 +295,8 @@ function useLiveActivityStream({
 
     let isActive = true
     let ws: WebSocket | null = null
+    let lastMessageAt = Date.now()
+    let heartbeatHandle: number | null = null
 
     function buildSubscriptionPayload(action: 'subscribe' | 'unsubscribe') {
       return JSON.stringify({
@@ -306,10 +310,46 @@ function useLiveActivityStream({
       })
     }
 
+    function clearHeartbeat() {
+      if (heartbeatHandle != null) {
+        window.clearInterval(heartbeatHandle)
+        heartbeatHandle = null
+      }
+    }
+
+    function startHeartbeat() {
+      clearHeartbeat()
+      heartbeatHandle = window.setInterval(() => {
+        if (!isActive || !ws) {
+          return
+        }
+        if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
+          const staleSocket = ws
+          ws = null
+          closeWebSocketWhenReady(staleSocket)
+          scheduleReconnect()
+          return
+        }
+        if (ws.readyState === WebSocket.OPEN) {
+          try {
+            ws.send('PING')
+          }
+          catch {
+            const staleSocket = ws
+            ws = null
+            closeWebSocketWhenReady(staleSocket)
+            scheduleReconnect()
+          }
+        }
+      }, WEBSOCKET_PING_INTERVAL_MS)
+    }
+
     function handleOpen() {
       if (!ws) {
         return
       }
+      lastMessageAt = Date.now()
+      startHeartbeat()
       ws.send(buildSubscriptionPayload('subscribe'))
     }
 
@@ -317,6 +357,7 @@ function useLiveActivityStream({
       if (!isActive) {
         return
       }
+      lastMessageAt = Date.now()
 
       let payload: LiveActivityMessage | null = null
       try {
@@ -415,9 +456,11 @@ function useLiveActivityStream({
     }
 
     function handleClose() {
+      clearHeartbeat()
       if (!isActive) {
         return
       }
+      ws = null
       scheduleReconnect()
     }
 
@@ -451,6 +494,7 @@ function useLiveActivityStream({
     return function teardownLiveActivityStream() {
       isActive = false
       clearReconnect()
+      clearHeartbeat()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       const socket = ws
       if (socket) {

--- a/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
+++ b/src/app/[locale]/(platform)/activity/_components/ActivityFeed.tsx
@@ -326,6 +326,7 @@ function useLiveActivityStream({
         if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
           const staleSocket = ws
           ws = null
+          clearHeartbeat()
           closeWebSocketWhenReady(staleSocket)
           scheduleReconnect()
           return
@@ -337,6 +338,7 @@ function useLiveActivityStream({
           catch {
             const staleSocket = ws
             ws = null
+            clearHeartbeat()
             closeWebSocketWhenReady(staleSocket)
             scheduleReconnect()
           }
@@ -344,17 +346,17 @@ function useLiveActivityStream({
       }, WEBSOCKET_PING_INTERVAL_MS)
     }
 
-    function handleOpen() {
-      if (!ws) {
+    function handleOpen(socket: WebSocket) {
+      if (socket !== ws) {
         return
       }
       lastMessageAt = Date.now()
       startHeartbeat()
-      ws.send(buildSubscriptionPayload('subscribe'))
+      socket.send(buildSubscriptionPayload('subscribe'))
     }
 
-    function handleMessage(eventMessage: MessageEvent<string>) {
-      if (!isActive) {
+    function handleMessage(socket: WebSocket, eventMessage: MessageEvent<string>) {
+      if (!isActive || socket !== ws) {
         return
       }
       lastMessageAt = Date.now()
@@ -455,7 +457,10 @@ function useLiveActivityStream({
       reconnectController?.scheduleReconnect()
     }
 
-    function handleClose() {
+    function handleClose(socket: WebSocket) {
+      if (socket !== ws) {
+        return
+      }
       clearHeartbeat()
       if (!isActive) {
         return
@@ -472,10 +477,10 @@ function useLiveActivityStream({
         return
       }
       const socket = new WebSocket(wsUrlRef.current)
-      socket.onopen = handleOpen
-      socket.onmessage = handleMessage
+      socket.onopen = () => handleOpen(socket)
+      socket.onmessage = eventMessage => handleMessage(socket, eventMessage)
       socket.onerror = handleError
-      socket.onclose = handleClose
+      socket.onclose = () => handleClose(socket)
       ws = socket
     }
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
@@ -25,6 +25,8 @@ interface TokenMapping {
 }
 
 const MarketChannelContext = createContext<MarketChannelContextValue | null>(null)
+const WEBSOCKET_PING_INTERVAL_MS = 25000
+const WEBSOCKET_STALE_TIMEOUT_MS = 70000
 
 function buildTokenMapping(markets: Market[]): TokenMapping {
   const tokenIds: string[] = []
@@ -265,11 +267,49 @@ function useMarketChannelConnection({
 
     let isActive = true
     let ws: WebSocket | null = null
+    let lastMessageAt = Date.now()
+    let heartbeatHandle: number | null = null
+
+    function clearHeartbeat() {
+      if (heartbeatHandle != null) {
+        window.clearInterval(heartbeatHandle)
+        heartbeatHandle = null
+      }
+    }
+
+    function startHeartbeat() {
+      clearHeartbeat()
+      heartbeatHandle = window.setInterval(() => {
+        if (!isActive || !ws) {
+          return
+        }
+        if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
+          const staleSocket = ws
+          ws = null
+          closeWebSocketWhenReady(staleSocket)
+          scheduleReconnect()
+          return
+        }
+        if (ws.readyState === WebSocket.OPEN) {
+          try {
+            ws.send('PING')
+          }
+          catch {
+            const staleSocket = ws
+            ws = null
+            closeWebSocketWhenReady(staleSocket)
+            scheduleReconnect()
+          }
+        }
+      }, WEBSOCKET_PING_INTERVAL_MS)
+    }
 
     function handleOpen() {
       if (!ws) {
         return
       }
+      lastMessageAt = Date.now()
+      startHeartbeat()
       setConnectionStatus('connecting')
       ws.send(JSON.stringify({
         type: 'market',
@@ -283,6 +323,7 @@ function useMarketChannelConnection({
       if (!isActive) {
         return
       }
+      lastMessageAt = Date.now()
       setConnectionStatus('live')
       let payload: any
       try {
@@ -345,8 +386,10 @@ function useMarketChannelConnection({
     }
 
     function handleClose() {
+      clearHeartbeat()
       if (isActive) {
         setConnectionStatus('offline')
+        ws = null
         scheduleReconnect()
       }
     }
@@ -389,6 +432,7 @@ function useMarketChannelConnection({
     return function teardownMarketChannelConnection() {
       isActive = false
       clearReconnect()
+      clearHeartbeat()
       document.removeEventListener('visibilitychange', handleVisibilityChange)
       const socket = ws
       if (socket) {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider.tsx
@@ -25,7 +25,7 @@ interface TokenMapping {
 }
 
 const MarketChannelContext = createContext<MarketChannelContextValue | null>(null)
-const WEBSOCKET_PING_INTERVAL_MS = 25000
+const WEBSOCKET_PING_INTERVAL_MS = 10000
 const WEBSOCKET_STALE_TIMEOUT_MS = 70000
 
 function buildTokenMapping(markets: Market[]): TokenMapping {
@@ -286,6 +286,7 @@ function useMarketChannelConnection({
         if (Date.now() - lastMessageAt > WEBSOCKET_STALE_TIMEOUT_MS) {
           const staleSocket = ws
           ws = null
+          clearHeartbeat()
           closeWebSocketWhenReady(staleSocket)
           scheduleReconnect()
           return
@@ -297,6 +298,7 @@ function useMarketChannelConnection({
           catch {
             const staleSocket = ws
             ws = null
+            clearHeartbeat()
             closeWebSocketWhenReady(staleSocket)
             scheduleReconnect()
           }
@@ -304,14 +306,14 @@ function useMarketChannelConnection({
       }, WEBSOCKET_PING_INTERVAL_MS)
     }
 
-    function handleOpen() {
-      if (!ws) {
+    function handleOpen(socket: WebSocket) {
+      if (socket !== ws) {
         return
       }
       lastMessageAt = Date.now()
       startHeartbeat()
       setConnectionStatus('connecting')
-      ws.send(JSON.stringify({
+      socket.send(JSON.stringify({
         type: 'market',
         assets_ids: tokenIds,
         markets: [],
@@ -319,8 +321,8 @@ function useMarketChannelConnection({
       }))
     }
 
-    function handleMessage(eventMessage: MessageEvent<string>) {
-      if (!isActive) {
+    function handleMessage(socket: WebSocket, eventMessage: MessageEvent<string>) {
+      if (!isActive || socket !== ws) {
         return
       }
       lastMessageAt = Date.now()
@@ -365,8 +367,8 @@ function useMarketChannelConnection({
       })
     }
 
-    function handleError() {
-      if (isActive) {
+    function handleError(socket: WebSocket) {
+      if (isActive && socket === ws) {
         setConnectionStatus('offline')
       }
     }
@@ -385,7 +387,10 @@ function useMarketChannelConnection({
       reconnectController?.scheduleReconnect()
     }
 
-    function handleClose() {
+    function handleClose(socket: WebSocket) {
+      if (socket !== ws) {
+        return
+      }
       clearHeartbeat()
       if (isActive) {
         setConnectionStatus('offline')
@@ -395,6 +400,7 @@ function useMarketChannelConnection({
     }
 
     function disconnectSocket(socket: WebSocket) {
+      clearHeartbeat()
       socket.onopen = null
       socket.onmessage = null
       socket.onerror = null
@@ -408,10 +414,10 @@ function useMarketChannelConnection({
       }
       setConnectionStatus('connecting')
       const socket = new WebSocket(`${wsUrl}/ws/market`)
-      socket.onopen = handleOpen
-      socket.onmessage = handleMessage
-      socket.onerror = handleError
-      socket.onclose = handleClose
+      socket.onopen = () => handleOpen(socket)
+      socket.onmessage = eventMessage => handleMessage(socket, eventMessage)
+      socket.onerror = () => handleError(socket)
+      socket.onclose = () => handleClose(socket)
       ws = socket
     }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes live WebSocket connections for the activity feed and market channels with heartbeats, stale-socket detection, and guards against stale callbacks. Reduces silent disconnects and prevents old sockets from interfering during reconnects.

- **Bug Fixes**
  - Send heartbeat PINGs and track last message time (25s for `ActivityFeed`, 10s for `EventMarketChannelProvider`).
  - Reconnect when no messages for 70s or when PING send fails.
  - Guard callbacks to ignore events from stale sockets; only act if the socket is current.
  - Clear heartbeat timers on close/unmount; null the socket before reconnecting and start heartbeat on open.

<sup>Written for commit ca631cab48e3e5ac3a91dcb915c3784587675644. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

