### PR TITLE
fix: market buy max fee buffer

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_actions/store-order.ts
@@ -108,6 +108,10 @@ const CLOB_ERROR_PATTERNS: Array<{ pattern: RegExp, messageKey: ClobErrorMessage
     messageKey: 'insufficientBalance',
   },
   {
+    pattern: /\b(collateral|position) (balance|allowance) \d+ below required \d+\b/i,
+    messageKey: 'insufficientBalance',
+  },
+  {
     pattern: /\b(order .* expired|expiration must be in the future|expiration must be non-negative|expiration is required)\b/i,
     messageKey: 'invalidExpirationRefreshPrices',
   },

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -70,7 +70,12 @@ import { calculateMarketFill, normalizeBookLevels } from '@/lib/order-panel-util
 import { buildOrderPayload, submitOrder } from '@/lib/orders'
 import { resolveOrderExpirationTimestamp } from '@/lib/orders/expiration'
 import { signOrderPayload } from '@/lib/orders/signing'
-import { MIN_LIMIT_ORDER_SHARES, validateOrder } from '@/lib/orders/validation'
+import {
+  calculateBuyOrderFundingRequirement,
+  calculateMaxBuyOrderAmount,
+  MIN_LIMIT_ORDER_SHARES,
+  validateOrder,
+} from '@/lib/orders/validation'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import { cn } from '@/lib/utils'
 import { isUserRejectedRequestError, normalizeAddress } from '@/lib/wallet'
@@ -962,6 +967,7 @@ export default function EventOrderPanelForm({
   const claimedConditionIds = claimedConditionIdsByEvent[event.id] ?? {}
 
   const availableBalanceForOrders = Math.max(0, balance.raw)
+  const maxBuyAmountForOrders = calculateMaxBuyOrderAmount(availableBalanceForOrders)
   const formattedBalanceText = Number.isFinite(balance.raw)
     ? balance.raw.toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     : '0.00'
@@ -1073,7 +1079,7 @@ export default function EventOrderPanelForm({
   const shouldShowDepositCta = isInteractiveWalletReady
     && state.side === ORDER_SIDE.BUY
     && state.type === ORDER_TYPE.MARKET
-    && Math.max(effectiveMarketBuyCost, amountNumber) > balance.raw
+    && calculateBuyOrderFundingRequirement(Math.max(effectiveMarketBuyCost, amountNumber)) > availableBalanceForOrders
 
   const avgBuyPriceDollars = typeof currentBuyPriceCents === 'number' && Number.isFinite(currentBuyPriceCents)
     ? currentBuyPriceCents / 100
@@ -1879,6 +1885,7 @@ export default function EventOrderPanelForm({
                   amount={state.amount}
                   amountNumber={amountNumber}
                   availableShares={selectedShares}
+                  maxBuyAmount={maxBuyAmountForOrders}
                   availableYesTokenShares={availableYesTokenShares}
                   availableNoTokenShares={availableNoTokenShares}
                   availableYesPositionShares={availableYesPositionShares}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -71,8 +71,6 @@ import { buildOrderPayload, submitOrder } from '@/lib/orders'
 import { resolveOrderExpirationTimestamp } from '@/lib/orders/expiration'
 import { signOrderPayload } from '@/lib/orders/signing'
 import {
-  calculateBuyOrderFundingRequirement,
-  calculateMaxBuyOrderAmount,
   MIN_LIMIT_ORDER_SHARES,
   validateOrder,
 } from '@/lib/orders/validation'
@@ -967,7 +965,6 @@ export default function EventOrderPanelForm({
   const claimedConditionIds = claimedConditionIdsByEvent[event.id] ?? {}
 
   const availableBalanceForOrders = Math.max(0, balance.raw)
-  const maxBuyAmountForOrders = calculateMaxBuyOrderAmount(availableBalanceForOrders)
   const formattedBalanceText = Number.isFinite(balance.raw)
     ? balance.raw.toLocaleString(locale, { minimumFractionDigits: 2, maximumFractionDigits: 2 })
     : '0.00'
@@ -1079,7 +1076,7 @@ export default function EventOrderPanelForm({
   const shouldShowDepositCta = isInteractiveWalletReady
     && state.side === ORDER_SIDE.BUY
     && state.type === ORDER_TYPE.MARKET
-    && calculateBuyOrderFundingRequirement(Math.max(effectiveMarketBuyCost, amountNumber)) > availableBalanceForOrders
+    && Math.max(effectiveMarketBuyCost, amountNumber) > availableBalanceForOrders
 
   const avgBuyPriceDollars = typeof currentBuyPriceCents === 'number' && Number.isFinite(currentBuyPriceCents)
     ? currentBuyPriceCents / 100
@@ -1885,7 +1882,6 @@ export default function EventOrderPanelForm({
                   amount={state.amount}
                   amountNumber={amountNumber}
                   availableShares={selectedShares}
-                  maxBuyAmount={maxBuyAmountForOrders}
                   availableYesTokenShares={availableYesTokenShares}
                   availableNoTokenShares={availableNoTokenShares}
                   availableYesPositionShares={availableYesPositionShares}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput.tsx
@@ -22,7 +22,6 @@ interface EventOrderPanelInputProps {
   amountNumber: number
   availableShares: number
   balance: BalanceSummary
-  maxBuyAmount?: number
   isBalanceLoading?: boolean
   inputRef: RefObject<HTMLInputElement | null>
   onAmountChange: (value: string) => void
@@ -31,14 +30,6 @@ interface EventOrderPanelInputProps {
 
 const BUY_CHIPS = ['+$1', '+$5', '+$10', '+$100']
 
-function normalizeMaxBuyAmount(value: number | undefined) {
-  if (typeof value !== 'number' || !Number.isFinite(value)) {
-    return null
-  }
-
-  return Math.max(0, value)
-}
-
 export default function EventOrderPanelInput({
   isMobile,
   side,
@@ -46,7 +37,6 @@ export default function EventOrderPanelInput({
   amountNumber,
   availableShares,
   balance,
-  maxBuyAmount,
   isBalanceLoading = false,
   inputRef,
   onAmountChange,
@@ -54,7 +44,6 @@ export default function EventOrderPanelInput({
 }: EventOrderPanelInputProps) {
   const t = useExtracted()
   const areValuesHidden = usePortfolioValueVisibility(state => state.isHidden)
-  const normalizedMaxBuyAmount = normalizeMaxBuyAmount(maxBuyAmount)
 
   function focusInput() {
     inputRef?.current?.focus()
@@ -99,8 +88,7 @@ export default function EventOrderPanelInput({
       return
     }
 
-    const maxBuyValue = normalizedMaxBuyAmount ?? MAX_AMOUNT_INPUT
-    const limitedValue = Math.min(nextValue, maxBuyValue, MAX_AMOUNT_INPUT)
+    const limitedValue = Math.min(nextValue, MAX_AMOUNT_INPUT)
     onAmountChange(formatAmountInputValue(limitedValue))
   }
 
@@ -114,9 +102,7 @@ export default function EventOrderPanelInput({
       return
     }
 
-    const maxBalance = normalizedMaxBuyAmount !== null
-      ? normalizedMaxBuyAmount
-      : Number.isFinite(balance.raw) ? balance.raw : 0
+    const maxBalance = Number.isFinite(balance.raw) ? balance.raw : 0
     const limitedBalance = Math.min(maxBalance, MAX_AMOUNT_INPUT)
     onAmountChange(formatAmountInputValue(limitedBalance, { roundingMode: 'floor' }))
     focusInput()
@@ -163,8 +149,7 @@ export default function EventOrderPanelInput({
           const chipValue = Number.parseInt(chip.substring(2), 10)
           const newValue = amountNumber + chipValue
 
-          const maxBuyValue = normalizedMaxBuyAmount ?? MAX_AMOUNT_INPUT
-          const limitedValue = Math.min(newValue, maxBuyValue, MAX_AMOUNT_INPUT)
+          const limitedValue = Math.min(newValue, MAX_AMOUNT_INPUT)
           onAmountChange(formatAmountInputValue(limitedValue))
           focusInput()
         }}
@@ -304,10 +289,7 @@ export default function EventOrderPanelInput({
               onAmountChange(formatAmountInputValue(availableShares, { roundingMode: 'floor' }))
             }
             else {
-              const maxBalance = normalizedMaxBuyAmount !== null
-                ? normalizedMaxBuyAmount
-                : balance.raw
-              const limitedBalance = Math.min(maxBalance, MAX_AMOUNT_INPUT)
+              const limitedBalance = Math.min(balance.raw, MAX_AMOUNT_INPUT)
               onAmountChange(formatAmountInputValue(limitedBalance, { roundingMode: 'floor' }))
             }
             focusInput()

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelInput.tsx
@@ -22,6 +22,7 @@ interface EventOrderPanelInputProps {
   amountNumber: number
   availableShares: number
   balance: BalanceSummary
+  maxBuyAmount?: number
   isBalanceLoading?: boolean
   inputRef: RefObject<HTMLInputElement | null>
   onAmountChange: (value: string) => void
@@ -30,6 +31,14 @@ interface EventOrderPanelInputProps {
 
 const BUY_CHIPS = ['+$1', '+$5', '+$10', '+$100']
 
+function normalizeMaxBuyAmount(value: number | undefined) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return null
+  }
+
+  return Math.max(0, value)
+}
+
 export default function EventOrderPanelInput({
   isMobile,
   side,
@@ -37,6 +46,7 @@ export default function EventOrderPanelInput({
   amountNumber,
   availableShares,
   balance,
+  maxBuyAmount,
   isBalanceLoading = false,
   inputRef,
   onAmountChange,
@@ -44,6 +54,7 @@ export default function EventOrderPanelInput({
 }: EventOrderPanelInputProps) {
   const t = useExtracted()
   const areValuesHidden = usePortfolioValueVisibility(state => state.isHidden)
+  const normalizedMaxBuyAmount = normalizeMaxBuyAmount(maxBuyAmount)
 
   function focusInput() {
     inputRef?.current?.focus()
@@ -88,7 +99,8 @@ export default function EventOrderPanelInput({
       return
     }
 
-    const limitedValue = Math.min(nextValue, MAX_AMOUNT_INPUT)
+    const maxBuyValue = normalizedMaxBuyAmount ?? MAX_AMOUNT_INPUT
+    const limitedValue = Math.min(nextValue, maxBuyValue, MAX_AMOUNT_INPUT)
     onAmountChange(formatAmountInputValue(limitedValue))
   }
 
@@ -102,7 +114,9 @@ export default function EventOrderPanelInput({
       return
     }
 
-    const maxBalance = Number.isFinite(balance.raw) ? balance.raw : 0
+    const maxBalance = normalizedMaxBuyAmount !== null
+      ? normalizedMaxBuyAmount
+      : Number.isFinite(balance.raw) ? balance.raw : 0
     const limitedBalance = Math.min(maxBalance, MAX_AMOUNT_INPUT)
     onAmountChange(formatAmountInputValue(limitedBalance, { roundingMode: 'floor' }))
     focusInput()
@@ -149,7 +163,8 @@ export default function EventOrderPanelInput({
           const chipValue = Number.parseInt(chip.substring(2), 10)
           const newValue = amountNumber + chipValue
 
-          const limitedValue = Math.min(newValue, MAX_AMOUNT_INPUT)
+          const maxBuyValue = normalizedMaxBuyAmount ?? MAX_AMOUNT_INPUT
+          const limitedValue = Math.min(newValue, maxBuyValue, MAX_AMOUNT_INPUT)
           onAmountChange(formatAmountInputValue(limitedValue))
           focusInput()
         }}
@@ -289,7 +304,9 @@ export default function EventOrderPanelInput({
               onAmountChange(formatAmountInputValue(availableShares, { roundingMode: 'floor' }))
             }
             else {
-              const maxBalance = balance.raw
+              const maxBalance = normalizedMaxBuyAmount !== null
+                ? normalizedMaxBuyAmount
+                : balance.raw
               const limitedBalance = Math.min(maxBalance, MAX_AMOUNT_INPUT)
               onAmountChange(formatAmountInputValue(limitedBalance, { roundingMode: 'floor' }))
             }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOrderInput.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOrderInput.tsx
@@ -22,6 +22,7 @@ interface EventOrderPanelOrderInputProps {
   amount: string
   amountNumber: number
   availableShares: number
+  maxBuyAmount: number
   availableYesTokenShares: number
   availableNoTokenShares: number
   availableYesPositionShares: number
@@ -79,6 +80,7 @@ export default function EventOrderPanelOrderInput({
   amount,
   amountNumber,
   availableShares,
+  maxBuyAmount,
   availableYesTokenShares,
   availableNoTokenShares,
   availableYesPositionShares,
@@ -174,6 +176,7 @@ export default function EventOrderPanelOrderInput({
                 amountNumber={amountNumber}
                 availableShares={availableShares}
                 balance={balance}
+                maxBuyAmount={maxBuyAmount}
                 isBalanceLoading={isBalanceLoading}
                 inputRef={inputRef}
                 onAmountChange={onAmountChange}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOrderInput.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOrderInput.tsx
@@ -22,7 +22,6 @@ interface EventOrderPanelOrderInputProps {
   amount: string
   amountNumber: number
   availableShares: number
-  maxBuyAmount: number
   availableYesTokenShares: number
   availableNoTokenShares: number
   availableYesPositionShares: number
@@ -80,7 +79,6 @@ export default function EventOrderPanelOrderInput({
   amount,
   amountNumber,
   availableShares,
-  maxBuyAmount,
   availableYesTokenShares,
   availableNoTokenShares,
   availableYesPositionShares,
@@ -176,7 +174,6 @@ export default function EventOrderPanelOrderInput({
                 amountNumber={amountNumber}
                 availableShares={availableShares}
                 balance={balance}
-                maxBuyAmount={maxBuyAmount}
                 isBalanceLoading={isBalanceLoading}
                 inputRef={inputRef}
                 onAmountChange={onAmountChange}

--- a/src/lib/orders/validation.ts
+++ b/src/lib/orders/validation.ts
@@ -18,6 +18,27 @@ export type OrderValidationError
     | 'INSUFFICIENT_SHARES'
 
 export const MIN_LIMIT_ORDER_SHARES = 0.01
+const BUY_ORDER_FUNDING_BUFFER_BPS = 200
+
+const BPS_DENOMINATOR = 10_000
+
+function normalizeFundingValue(value: number) {
+  return Number.isFinite(value) ? Math.max(0, value) : 0
+}
+
+export function calculateBuyOrderFundingRequirement(amount: number) {
+  const normalizedAmount = normalizeFundingValue(amount)
+  return normalizedAmount * (BPS_DENOMINATOR + BUY_ORDER_FUNDING_BUFFER_BPS) / BPS_DENOMINATOR
+}
+
+export function calculateMaxBuyOrderAmount(availableBalance: number) {
+  const normalizedBalance = normalizeFundingValue(availableBalance)
+  if (normalizedBalance <= 0) {
+    return 0
+  }
+
+  return normalizedBalance * BPS_DENOMINATOR / (BPS_DENOMINATOR + BUY_ORDER_FUNDING_BUFFER_BPS)
+}
 
 interface ValidateOrderArgs {
   isLoading: boolean
@@ -111,7 +132,8 @@ export function validateOrder({
 
     if (side === ORDER_SIDE.BUY) {
       const estimatedCost = (limitPriceValue / 100) * limitSharesValue
-      if (!Number.isFinite(estimatedCost) || estimatedCost > availableBalance) {
+      const fundingRequired = calculateBuyOrderFundingRequirement(estimatedCost)
+      if (!Number.isFinite(estimatedCost) || fundingRequired > availableBalance) {
         return { ok: false, reason: 'INSUFFICIENT_BALANCE' }
       }
     }
@@ -130,7 +152,10 @@ export function validateOrder({
     return { ok: false, reason: 'MARKET_MIN_AMOUNT' }
   }
 
-  if (side === ORDER_SIDE.BUY && amountNumber > availableBalance) {
+  const marketBuyFundingRequired = side === ORDER_SIDE.BUY
+    ? calculateBuyOrderFundingRequirement(amountNumber)
+    : 0
+  if (side === ORDER_SIDE.BUY && marketBuyFundingRequired > availableBalance) {
     return { ok: false, reason: 'INSUFFICIENT_BALANCE' }
   }
 

--- a/src/lib/orders/validation.ts
+++ b/src/lib/orders/validation.ts
@@ -31,15 +31,6 @@ export function calculateBuyOrderFundingRequirement(amount: number) {
   return normalizedAmount * (BPS_DENOMINATOR + BUY_ORDER_FUNDING_BUFFER_BPS) / BPS_DENOMINATOR
 }
 
-export function calculateMaxBuyOrderAmount(availableBalance: number) {
-  const normalizedBalance = normalizeFundingValue(availableBalance)
-  if (normalizedBalance <= 0) {
-    return 0
-  }
-
-  return normalizedBalance * BPS_DENOMINATOR / (BPS_DENOMINATOR + BUY_ORDER_FUNDING_BUFFER_BPS)
-}
-
 interface ValidateOrderArgs {
   isLoading: boolean
   isConnected: boolean
@@ -152,10 +143,7 @@ export function validateOrder({
     return { ok: false, reason: 'MARKET_MIN_AMOUNT' }
   }
 
-  const marketBuyFundingRequired = side === ORDER_SIDE.BUY
-    ? calculateBuyOrderFundingRequirement(amountNumber)
-    : 0
-  if (side === ORDER_SIDE.BUY && marketBuyFundingRequired > availableBalance) {
+  if (side === ORDER_SIDE.BUY && amountNumber > availableBalance) {
     return { ok: false, reason: 'INSUFFICIENT_BALANCE' }
   }
 

--- a/tests/unit/orderValidation.test.ts
+++ b/tests/unit/orderValidation.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 import { ORDER_SIDE } from '@/lib/constants'
-import { MIN_LIMIT_ORDER_SHARES, validateOrder } from '@/lib/orders/validation'
+import {
+  calculateBuyOrderFundingRequirement,
+  calculateMaxBuyOrderAmount,
+  MIN_LIMIT_ORDER_SHARES,
+  validateOrder,
+} from '@/lib/orders/validation'
 
 function baseArgs(overrides: Partial<Parameters<typeof validateOrder>[0]> = {}) {
   return {
@@ -23,6 +28,11 @@ function baseArgs(overrides: Partial<Parameters<typeof validateOrder>[0]> = {}) 
 }
 
 describe('validateOrder', () => {
+  it('calculates buy funding requirements with the trading fee buffer', () => {
+    expect(calculateBuyOrderFundingRequirement(9.98)).toBeCloseTo(10.1796)
+    expect(calculateMaxBuyOrderAmount(9.98)).toBeCloseTo(9.7843137)
+  })
+
   it('rejects when loading or disconnected', () => {
     expect(validateOrder(baseArgs({ isLoading: true }))).toEqual({ ok: false, reason: 'IS_LOADING' })
     expect(validateOrder(baseArgs({ isConnected: false }))).toEqual({ ok: false, reason: 'NOT_CONNECTED' })
@@ -39,7 +49,7 @@ describe('validateOrder', () => {
 
     expect(validateOrder(baseArgs({
       side: ORDER_SIDE.BUY,
-      amountNumber: 200,
+      amountNumber: 100,
       availableBalance: 100,
     }))).toEqual({ ok: false, reason: 'INSUFFICIENT_BALANCE' })
 
@@ -73,8 +83,8 @@ describe('validateOrder', () => {
       isLimitOrder: true,
       side: ORDER_SIDE.BUY,
       limitPrice: '80', // cents
-      limitShares: '200',
-      availableBalance: 100, // estimated cost = 0.8 * 200 = 160
+      limitShares: '125',
+      availableBalance: 100, // estimated cost = 100, plus fee buffer
     }))).toEqual({ ok: false, reason: 'INSUFFICIENT_BALANCE' })
 
     expect(validateOrder(baseArgs({

--- a/tests/unit/orderValidation.test.ts
+++ b/tests/unit/orderValidation.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest'
 import { ORDER_SIDE } from '@/lib/constants'
 import {
   calculateBuyOrderFundingRequirement,
-  calculateMaxBuyOrderAmount,
   MIN_LIMIT_ORDER_SHARES,
   validateOrder,
 } from '@/lib/orders/validation'
@@ -30,7 +29,6 @@ function baseArgs(overrides: Partial<Parameters<typeof validateOrder>[0]> = {}) 
 describe('validateOrder', () => {
   it('calculates buy funding requirements with the trading fee buffer', () => {
     expect(calculateBuyOrderFundingRequirement(9.98)).toBeCloseTo(10.1796)
-    expect(calculateMaxBuyOrderAmount(9.98)).toBeCloseTo(9.7843137)
   })
 
   it('rejects when loading or disconnected', () => {
@@ -49,9 +47,15 @@ describe('validateOrder', () => {
 
     expect(validateOrder(baseArgs({
       side: ORDER_SIDE.BUY,
-      amountNumber: 100,
+      amountNumber: 100.01,
       availableBalance: 100,
     }))).toEqual({ ok: false, reason: 'INSUFFICIENT_BALANCE' })
+
+    expect(validateOrder(baseArgs({
+      side: ORDER_SIDE.BUY,
+      amountNumber: 100,
+      availableBalance: 100,
+    }))).toEqual({ ok: true })
 
     expect(validateOrder(baseArgs({
       side: ORDER_SIDE.SELL,

--- a/tests/unit/storeOrderAction.test.ts
+++ b/tests/unit/storeOrderAction.test.ts
@@ -185,6 +185,40 @@ describe('storeOrderAction', () => {
     })
   })
 
+  it('returns friendly error for CLOB collateral balance precheck failures', async () => {
+    process.env.CLOB_URL = 'https://clob.local'
+    const depositWallet = address('01')
+    mocks.getCurrentUser.mockResolvedValueOnce({
+      id: 'user-1',
+      address: address('aa'),
+      deposit_wallet_address: depositWallet,
+      settings: {},
+    })
+    mocks.getUserTradingAuthSecrets.mockResolvedValueOnce({
+      clob: { key: 'k', passphrase: 'p', secret: 's' },
+    })
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      status: 422,
+      statusText: 'Unprocessable Entity',
+      ok: false,
+      text: async () => JSON.stringify({
+        error: 'collateral balance 9980000 below required 10179600',
+      }),
+    })
+    globalThis.fetch = fetchMock as any
+
+    const { storeOrderAction } = await import('@/app/[locale]/(platform)/event/[slug]/_actions/store-order')
+    const result = await storeOrderAction(basePayload({
+      maker: depositWallet,
+      signer: depositWallet,
+      type: 'MARKET',
+    }))
+
+    expect(result).toEqual({
+      error: 'Insufficient available balance for this order.',
+    })
+  })
+
   it('submits to CLOB, updates tags, and schedules local order creation', async () => {
     process.env.CLOB_URL = 'https://clob.local'
     const depositWallet = address('01')


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a 2% fee buffer to buy orders and fix market-buy max-spend so users don’t hit post-fee “insufficient balance” errors. Also map CLOB collateral precheck failures to a clear, friendly message.

- **Bug Fixes**
  - Apply a 2% funding buffer in buy-order validation via calculateBuyOrderFundingRequirement.
  - Use availableBalanceForOrders to decide the deposit CTA for market buys, preserving correct max-spend behavior.
  - Map CLOB “(collateral|position) balance/allowance … below required …” to the insufficient balance error.
  - Update unit tests for the buffer logic and new error mapping.

<sup>Written for commit 9cfecd6c306dbe8fbefaf2f1eea357a04e6b6f5b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

