### PR TITLE
docs: update clob market maker api docs

### DIFF
--- a/docs/api-reference/markets/get-clob-market-info.mdx
+++ b/docs/api-reference/markets/get-clob-market-info.mdx
@@ -1,0 +1,14 @@
+---
+title: Get CLOB Market Info
+description: "Get CLOB market settings"
+full: true
+_openapi:
+  method: GET
+---
+
+<APIPage
+  document="clob"
+  operations={[
+    { path: '/clob-markets/{condition_id}', method: 'get' }
+  ]}
+/>

--- a/docs/api-reference/markets/meta.json
+++ b/docs/api-reference/markets/meta.json
@@ -10,6 +10,7 @@
     "gamma-get-market-description",
     "gamma-get-market-tags",
     "---CLOB API---",
+    "get-clob-market-info",
     "get-market-by-id",
     "get-market-by-slug",
     "get-prices-history",

--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -108,7 +108,8 @@
           "default": {
             "$ref": "#/components/responses/ErrorResponse"
           }
-        }
+        },
+        "description": "Creates an order. Markets with seconds_delay greater than 0 or itode enabled delay marketable taker orders before matching. Resting and post-only orders are not delayed."
       },
       "delete": {
         "tags": [
@@ -1231,7 +1232,7 @@
         "tags": [
           "Heartbeats"
         ],
-        "summary": "Post a heartbeat",
+        "summary": "Send heartbeat",
         "operationId": "postHeartbeat",
         "parameters": [
           {
@@ -1267,6 +1268,49 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/HeartbeatResponse"
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
+          }
+        },
+        "description": "Keeps your L2 API key heartbeat alive. Send at least every 10 seconds and leave room for retries. If it expires, open orders for that key may be canceled automatically."
+      }
+    },
+    "/heartbeats": {
+      "post": {
+        "tags": [
+          "Heartbeats"
+        ],
+        "summary": "Send heartbeat",
+        "description": "Records a heartbeat and returns an ok status. Send at least every 10 seconds and leave room for retries.",
+        "operationId": "postHeartbeatStatus",
+        "parameters": [
+          {
+            "$ref": "#/components/parameters/KuestAddress"
+          },
+          {
+            "$ref": "#/components/parameters/KuestApiKey"
+          },
+          {
+            "$ref": "#/components/parameters/KuestPassphrase"
+          },
+          {
+            "$ref": "#/components/parameters/KuestTimestamp"
+          },
+          {
+            "$ref": "#/components/parameters/KuestSignatureL2"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Heartbeat accepted.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HeartbeatStatusResponse"
                 }
               }
             }
@@ -1703,14 +1747,14 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": true
+                  "$ref": "#/components/schemas/ClobMarketInfo"
                 }
               }
             }
           }
         },
-        "operationId": "getClobMarketInfo"
+        "operationId": "getClobMarketInfo",
+        "description": "Returns compact CLOB market settings used by trading clients before placing orders."
       }
     },
     "/markets-by-token/{token_id}": {
@@ -2007,9 +2051,10 @@
           "heartbeat_id": {
             "type": "string",
             "nullable": true,
-            "description": "Heartbeat identifier to continue an existing session."
+            "description": "Previous heartbeat id returned by this endpoint. Omit it to start a new session; heartbeatId is also accepted."
           }
-        }
+        },
+        "description": "Heartbeat session payload."
       },
       "HeartbeatResponse": {
         "type": "object",
@@ -2019,7 +2064,7 @@
         "properties": {
           "heartbeat_id": {
             "type": "string",
-            "description": "Current heartbeat identifier."
+            "description": "Heartbeat id to reuse on the next call."
           }
         }
       },
@@ -2519,7 +2564,11 @@
           "tags",
           "assets_ids",
           "outcomes",
-          "event"
+          "event",
+          "itode",
+          "taker_order_delay_ms",
+          "order_age_seconds",
+          "blockaid_check_enabled"
         ],
         "properties": {
           "enable_order_book": {
@@ -2593,16 +2642,19 @@
             "nullable": true
           },
           "seconds_delay": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Extra market delay in seconds. When greater than 0, marketable orders wait this amount before matching."
           },
           "fpmm": {
             "type": "string"
           },
           "maker_base_fee": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Maker base fee in basis points."
           },
           "taker_base_fee": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Taker base fee in basis points."
           },
           "notifications_enabled": {
             "type": "boolean"
@@ -2659,6 +2711,22 @@
             "nullable": true,
             "additionalProperties": true,
             "description": "Raw metadata payload when available."
+          },
+          "itode": {
+            "type": "boolean",
+            "description": "Whether the short taker delay is enabled for marketable orders."
+          },
+          "taker_order_delay_ms": {
+            "type": "integer",
+            "description": "Configured taker delay in milliseconds, usually 250 when itode is true and seconds_delay is 0."
+          },
+          "order_age_seconds": {
+            "type": "integer",
+            "description": "Order age setting in seconds exposed to trading clients."
+          },
+          "blockaid_check_enabled": {
+            "type": "boolean",
+            "description": "Whether additional order risk checks are enabled for the market."
           }
         }
       },
@@ -2777,7 +2845,11 @@
           "rewards",
           "is_50_50_outcome",
           "tokens",
-          "tags"
+          "tags",
+          "itode",
+          "taker_order_delay_ms",
+          "order_age_seconds",
+          "blockaid_check_enabled"
         ],
         "properties": {
           "enable_order_book": {
@@ -2830,16 +2902,19 @@
             "nullable": true
           },
           "seconds_delay": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Extra market delay in seconds. When greater than 0, marketable orders wait this amount before matching."
           },
           "fpmm": {
             "type": "string"
           },
           "maker_base_fee": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Maker base fee in basis points."
           },
           "taker_base_fee": {
-            "type": "integer"
+            "type": "integer",
+            "description": "Taker base fee in basis points."
           },
           "notifications_enabled": {
             "type": "boolean"
@@ -2876,6 +2951,22 @@
             "items": {
               "type": "string"
             }
+          },
+          "itode": {
+            "type": "boolean",
+            "description": "Whether the short taker delay is enabled for marketable orders."
+          },
+          "taker_order_delay_ms": {
+            "type": "integer",
+            "description": "Configured taker delay in milliseconds, usually 250 when itode is true and seconds_delay is 0."
+          },
+          "order_age_seconds": {
+            "type": "integer",
+            "description": "Order age setting in seconds exposed to trading clients."
+          },
+          "blockaid_check_enabled": {
+            "type": "boolean",
+            "description": "Whether additional order risk checks are enabled for the market."
           }
         }
       },
@@ -3171,7 +3262,7 @@
           },
           "status": {
             "type": "string",
-            "description": "Placement status (e.g. live or error)."
+            "description": "Final placement status, such as matched, live, unmatched, or error. On delayed taker orders, the status is returned after the delay completes."
           }
         }
       },
@@ -4256,6 +4347,137 @@
           "base_fee"
         ],
         "additionalProperties": false
+      },
+      "ClobMarketToken": {
+        "type": "object",
+        "required": [
+          "t",
+          "o"
+        ],
+        "properties": {
+          "t": {
+            "type": "string",
+            "description": "Token id for this outcome."
+          },
+          "o": {
+            "type": "string",
+            "description": "Outcome label."
+          }
+        }
+      },
+      "ClobMarketFeeDetails": {
+        "type": "object",
+        "required": [
+          "r",
+          "e",
+          "to"
+        ],
+        "properties": {
+          "r": {
+            "type": "number",
+            "description": "Fee rate as a decimal fraction."
+          },
+          "e": {
+            "type": "integer",
+            "description": "Fee exponent."
+          },
+          "to": {
+            "type": "boolean",
+            "description": "Whether the fee applies to taker orders."
+          }
+        }
+      },
+      "ClobMarketInfo": {
+        "type": "object",
+        "required": [
+          "c",
+          "nr",
+          "t",
+          "mts",
+          "mos",
+          "fd",
+          "mbf",
+          "tbf",
+          "rfqe",
+          "ibce",
+          "oas",
+          "r"
+        ],
+        "properties": {
+          "gst": {
+            "type": "string",
+            "nullable": true,
+            "description": "Scheduled start time when available."
+          },
+          "r": {
+            "$ref": "#/components/schemas/SamplingMarketRewards"
+          },
+          "c": {
+            "type": "string",
+            "description": "Condition id."
+          },
+          "nr": {
+            "type": "boolean",
+            "description": "Whether the market is negative risk."
+          },
+          "t": {
+            "type": "array",
+            "description": "Outcome tokens for the market.",
+            "items": {
+              "$ref": "#/components/schemas/ClobMarketToken"
+            }
+          },
+          "mts": {
+            "type": "number",
+            "description": "Minimum tick size."
+          },
+          "mos": {
+            "type": "integer",
+            "description": "Minimum order size."
+          },
+          "fd": {
+            "$ref": "#/components/schemas/ClobMarketFeeDetails"
+          },
+          "mbf": {
+            "type": "integer",
+            "description": "Maker base fee in basis points."
+          },
+          "tbf": {
+            "type": "integer",
+            "description": "Taker base fee in basis points."
+          },
+          "rfqe": {
+            "type": "boolean",
+            "description": "Whether RFQ is enabled."
+          },
+          "itode": {
+            "type": "boolean",
+            "description": "When present and true, marketable taker orders wait briefly, usually around 250 ms, before matching."
+          },
+          "ibce": {
+            "type": "boolean",
+            "description": "Whether additional order risk checks are enabled for the market."
+          },
+          "oas": {
+            "type": "integer",
+            "description": "Order age setting in seconds."
+          }
+        }
+      },
+      "HeartbeatStatusResponse": {
+        "type": "object",
+        "required": [
+          "status"
+        ],
+        "properties": {
+          "status": {
+            "type": "string",
+            "enum": [
+              "ok"
+            ],
+            "description": "Heartbeat accepted."
+          }
+        }
       }
     }
   }

--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -2051,7 +2051,7 @@
           "heartbeat_id": {
             "type": "string",
             "nullable": true,
-            "description": "Previous heartbeat id returned by this endpoint. Omit it to start a new session; heartbeatId is also accepted."
+            "description": "Previous heartbeat id returned by this endpoint. Omit it to start a new session."
           }
         },
         "description": "Heartbeat session payload."

--- a/docs/api-reference/trade/send-heartbeat.mdx
+++ b/docs/api-reference/trade/send-heartbeat.mdx
@@ -1,6 +1,6 @@
 ---
 title: Send Heartbeat
-description: "Post a heartbeat"
+description: "Keep your trading session alive"
 full: true
 _openapi:
   method: POST
@@ -9,6 +9,7 @@ _openapi:
 <APIPage
   document="clob"
   operations={[
-    { path: '/v1/heartbeats', method: 'post' }
+    { path: '/v1/heartbeats', method: 'post' },
+    { path: '/heartbeats', method: 'post' }
   ]}
 />

--- a/docs/api-reference/wss/market.mdx
+++ b/docs/api-reference/wss/market.mdx
@@ -32,6 +32,8 @@ Public market stream for order book snapshots and price updates.
 
 - Numeric values are returned as strings.
 - `book.hash` is a summary hash of the order book payload.
+- Live events include `sequence`, `stream_id`, and `server_ts_ms`; refetch a
+  snapshot if you reconnect or detect a missed event.
 - Use one connection for multiple token subscriptions when possible.
 
 ## WebSocket Playground

--- a/docs/api-reference/wss/user.mdx
+++ b/docs/api-reference/wss/user.mdx
@@ -28,6 +28,8 @@ Authenticated stream for order and trade updates scoped to your API credentials.
 
 - Numeric fields are strings.
 - `owner`, `trade_owner`, and `order_owner` are normalized to the caller API key.
+- Live events include `sequence`, `stream_id`, and `server_ts_ms`; refetch your
+  active orders if you reconnect or detect a missed event.
 - Reuse the same L2 credentials used for private REST endpoints.
 
 ## WebSocket Playground


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Updates the CLOB market maker API docs with a new market settings endpoint, a lightweight heartbeat route, and clearer guidance on taker delays and WebSocket event fields. Clarifies the heartbeat request schema, including `heartbeat_id` reuse, and expands market schemas with delay and risk flags used by trading clients.

- **New Features**
  - Added “Get CLOB Market Info” for `GET /clob-markets/{condition_id}` returning `ClobMarketInfo` (tokens, fees, min tick/size, RFQ, taker delay flags).
  - Added `POST /heartbeats` and updated “Send Heartbeat” to include both `/v1/heartbeats` and `/heartbeats` with clearer keep-alive guidance.
  - OpenAPI: clarified heartbeat request/response (`heartbeat_id` reuse, payload description), added `itode`, `taker_order_delay_ms`, `order_age_seconds`, `blockaid_check_enabled`, and clarified placement status and taker delay behavior.
  - WebSocket docs note `sequence`, `stream_id`, and `server_ts_ms` with reconnect/snapshot guidance.

<sup>Written for commit cac2b845f2d9378662c693d81fe2cffc35c300e4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

