### PR TITLE
docs: document markets by token endpoint

### DIFF
--- a/docs/api-reference/markets/get-market-by-token-id.mdx
+++ b/docs/api-reference/markets/get-market-by-token-id.mdx
@@ -1,0 +1,14 @@
+---
+title: Get Market By Token Id
+description: "Get market identifiers for a token"
+full: true
+_openapi:
+  method: GET
+---
+
+<APIPage
+  document="clob"
+  operations={[
+    { path: '/markets-by-token/{token_id}', method: 'get' }
+  ]}
+/>

--- a/docs/api-reference/markets/meta.json
+++ b/docs/api-reference/markets/meta.json
@@ -11,6 +11,7 @@
     "gamma-get-market-tags",
     "---CLOB API---",
     "get-clob-market-info",
+    "get-market-by-token-id",
     "get-market-by-id",
     "get-market-by-slug",
     "get-prices-history",

--- a/docs/api-reference/schemas/openapi-clob.json
+++ b/docs/api-reference/schemas/openapi-clob.json
@@ -1776,15 +1776,20 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "Parent market identifiers for the token.",
             "content": {
               "application/json": {
                 "schema": {
-                  "type": "object",
-                  "additionalProperties": true
+                  "$ref": "#/components/schemas/MarketByTokenResponse"
                 }
               }
             }
+          },
+          "404": {
+            "$ref": "#/components/responses/ErrorResponse"
+          },
+          "default": {
+            "$ref": "#/components/responses/ErrorResponse"
           }
         },
         "operationId": "getMarketByTokenId"
@@ -4384,6 +4389,28 @@
           "to": {
             "type": "boolean",
             "description": "Whether the fee applies to taker orders."
+          }
+        }
+      },
+      "MarketByTokenResponse": {
+        "type": "object",
+        "required": [
+          "condition_id",
+          "primary_token_id",
+          "secondary_token_id"
+        ],
+        "properties": {
+          "condition_id": {
+            "type": "string",
+            "description": "Condition id for the parent market."
+          },
+          "primary_token_id": {
+            "type": "string",
+            "description": "First token id for the market."
+          },
+          "secondary_token_id": {
+            "type": "string",
+            "description": "Second token id for the market."
           }
         }
       },


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds an API docs page for getting a market by token ID and defines a typed response for the endpoint in the `clob` OpenAPI schema to make outputs and errors explicit.

- New Features
  - New page: Get Market By Token Id for `GET /markets-by-token/{token_id}`.
  - OpenAPI: added `MarketByTokenResponse` with `condition_id`, `primary_token_id`, `secondary_token_id`.
  - Responses: `200` returns `MarketByTokenResponse`; added `404` and `default` error responses.
  - Navigation: added the page to `markets` `meta.json`.

<sup>Written for commit 1002d99db990eb7f91d68c41f8b8d0e8a3add1c5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

