### PR TITLE
fix: runtime url in docs playground

### DIFF
--- a/docs/api-reference/index.mdx
+++ b/docs/api-reference/index.mdx
@@ -14,29 +14,29 @@ The <SiteName /> API provides programmatic access this prediction market. The pl
     title="Gamma API"
     description="Public market discovery, comments, profiles, events, tags, series, and search endpoints with Gamma-compatible responses."
   >
-    <code>{process.env.GAMMA_URL ?? 'https://gamma-api.kuest.com'}</code>
+    <code><PublicRuntimeServiceUrl service="gamma" /></code>
   </Card>
 
   <Card
     title="CLOB API"
     description="Order placement, cancellation, user orders, and orderbook/pricing operations."
   >
-    <code>{process.env.CLOB_URL}</code>
+    <code><PublicRuntimeServiceUrl service="clob" /></code>
   </Card>
 
   <Card
     title="Data API"
     description="Positions, user activity, holder data, leaderboards, and market analytics."
   >
-    <code>{process.env.DATA_URL}</code>
+    <code><PublicRuntimeServiceUrl service="data" /></code>
   </Card>
 
   <Card
     title="WebSocket APIs"
     description="Real-time market, user, and sports streams for low-latency updates."
   >
-    <div><code>WS_CLOB_URL</code>: {process.env.WS_CLOB_URL}</div>
-    <div><code>WS_LIVE_DATA_URL</code>: {process.env.WS_LIVE_DATA_URL}</div>
+    <div><code>WS_CLOB_URL</code>: <PublicRuntimeServiceUrl service="wsClob" /></div>
+    <div><code>WS_LIVE_DATA_URL</code>: <PublicRuntimeServiceUrl service="wsLiveData" /></div>
   </Card>
 </Cards>
 

--- a/docs/api-reference/wss/market.mdx
+++ b/docs/api-reference/wss/market.mdx
@@ -9,7 +9,7 @@ Public market stream for order book snapshots and price updates.
 
 ## Endpoint
 
-- Production: <code>{process.env.WS_CLOB_URL}/ws/market</code>
+- Production: <code><PublicRuntimeServiceUrl service="wsClob" path="/ws/market" /></code>
 
 ## Subscription payload
 
@@ -38,8 +38,9 @@ Public market stream for order book snapshots and price updates.
 
 ## WebSocket Playground
 
-<WebSocketPlayground
-  endpoint={`${process.env.WS_CLOB_URL}/ws/market`}
+<PublicRuntimeWebSocketPlayground
+  service="wsClob"
+  path="/ws/market"
   defaultMessage={`{
   "type": "market",
   "assets_ids": ["<asset_id>"],

--- a/docs/api-reference/wss/sports.mdx
+++ b/docs/api-reference/wss/sports.mdx
@@ -9,7 +9,7 @@ Live data stream for activity events, comment updates, and crypto prices.
 
 ## Endpoint
 
-- Production: <code>{process.env.WS_LIVE_DATA_URL}</code>
+- Production: <code><PublicRuntimeServiceUrl service="wsLiveData" /></code>
 
 ## Heartbeats
 
@@ -49,8 +49,8 @@ Send any variant of `PING` (`ping`, `PiNg`, `PING`). The server replies with `PO
 
 ## WebSocket Playground
 
-<WebSocketPlayground
-  endpoint={process.env.WS_LIVE_DATA_URL}
+<PublicRuntimeWebSocketPlayground
+  service="wsLiveData"
   defaultMessage={`{
   "action": "subscribe",
   "subscriptions": [

--- a/docs/api-reference/wss/user.mdx
+++ b/docs/api-reference/wss/user.mdx
@@ -9,7 +9,7 @@ Authenticated stream for order and trade updates scoped to your API credentials.
 
 ## Endpoint
 
-- Production: <code>{process.env.WS_CLOB_URL}/ws/user</code>
+- Production: <code><PublicRuntimeServiceUrl service="wsClob" path="/ws/user" /></code>
 
 ## Required auth object
 
@@ -34,8 +34,9 @@ Authenticated stream for order and trade updates scoped to your API credentials.
 
 ## WebSocket Playground
 
-<WebSocketPlayground
-  endpoint={`${process.env.WS_CLOB_URL}/ws/user`}
+<PublicRuntimeWebSocketPlayground
+  service="wsClob"
+  path="/ws/user"
   defaultMessage={`{
   "type": "user",
   "markets": ["<condition_id>"],

--- a/src/app/[locale]/docs/[[...slug]]/page.tsx
+++ b/src/app/[locale]/docs/[[...slug]]/page.tsx
@@ -14,6 +14,10 @@ import { FeeCalculationExample } from '@/app/[locale]/docs/_components/FeeCalcul
 import { GammaAPIPage } from '@/app/[locale]/docs/_components/GammaAPIPage'
 import { ViewOptions } from '@/app/[locale]/docs/_components/LLMPageActions'
 import { PlatformShareDisplay } from '@/app/[locale]/docs/_components/PlatformShareDisplay'
+import {
+  PublicRuntimeServiceUrl,
+  PublicRuntimeWebSocketPlayground,
+} from '@/app/[locale]/docs/_components/PublicRuntimeServiceUrl'
 import { SiteName } from '@/app/[locale]/docs/_components/SiteName'
 import { TradingFeeDisplay } from '@/app/[locale]/docs/_components/TradingFeeDisplay'
 import { WebSocketPlayground } from '@/app/[locale]/docs/_components/WebSocketPlayground'
@@ -33,6 +37,8 @@ function getMDXComponents(components?: MDXComponents): MDXComponents {
     PlatformShareDisplay,
     FeeCalculationExample,
     WebSocketPlayground,
+    PublicRuntimeServiceUrl,
+    PublicRuntimeWebSocketPlayground,
     DiscordLink,
     SiteName,
     ...components,

--- a/src/app/[locale]/docs/_components/PublicRuntimeServiceUrl.tsx
+++ b/src/app/[locale]/docs/_components/PublicRuntimeServiceUrl.tsx
@@ -1,0 +1,58 @@
+import { WebSocketPlayground } from '@/app/[locale]/docs/_components/WebSocketPlayground'
+import { resolvePublicRuntimeEnv } from '@/lib/public-runtime-config.shared'
+
+const publicRuntimeServiceUrlSelectors = {
+  clob: (config: ReturnType<typeof resolvePublicRuntimeEnv>) => config.clobUrl,
+  data: (config: ReturnType<typeof resolvePublicRuntimeEnv>) => config.dataUrl,
+  gamma: (config: ReturnType<typeof resolvePublicRuntimeEnv>) => config.gammaUrl,
+  wsClob: (config: ReturnType<typeof resolvePublicRuntimeEnv>) => config.wsClobUrl,
+  wsLiveData: (config: ReturnType<typeof resolvePublicRuntimeEnv>) => config.wsLiveDataUrl,
+}
+
+type PublicRuntimeService = keyof typeof publicRuntimeServiceUrlSelectors
+type PublicRuntimeWebSocketService = Extract<PublicRuntimeService, 'wsClob' | 'wsLiveData'>
+
+interface PublicRuntimeServiceUrlProps {
+  service: PublicRuntimeService
+  path?: string
+}
+
+interface PublicRuntimeWebSocketPlaygroundProps {
+  service: PublicRuntimeWebSocketService
+  path?: string
+  defaultMessage?: string
+  authQueryKey?: string
+  maxLogs?: number
+  className?: string
+}
+
+function resolvePublicRuntimeServiceUrl(service: PublicRuntimeService, path = '') {
+  const config = resolvePublicRuntimeEnv(process.env)
+  return `${publicRuntimeServiceUrlSelectors[service](config)}${path}`
+}
+
+export function PublicRuntimeServiceUrl({
+  service,
+  path,
+}: PublicRuntimeServiceUrlProps) {
+  return <>{resolvePublicRuntimeServiceUrl(service, path)}</>
+}
+
+export function PublicRuntimeWebSocketPlayground({
+  service,
+  path,
+  defaultMessage,
+  authQueryKey,
+  maxLogs,
+  className,
+}: PublicRuntimeWebSocketPlaygroundProps) {
+  return (
+    <WebSocketPlayground
+      endpoint={resolvePublicRuntimeServiceUrl(service, path)}
+      defaultMessage={defaultMessage}
+      authQueryKey={authQueryKey}
+      maxLogs={maxLogs}
+      className={className}
+    />
+  )
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes broken service URLs in the docs and WebSocket Playground by resolving endpoints from the public runtime config at render time. Adds small helpers to display URLs and wire the Playground correctly across environments.

- **Bug Fixes**
  - Added `PublicRuntimeServiceUrl` and `PublicRuntimeWebSocketPlayground` using `resolvePublicRuntimeEnv`.
  - Replaced `process.env` references in MDX for Gamma, CLOB, Data, and WebSocket endpoints (market, user, sports).
  - Ensures correct URLs in preview/prod and avoids server-only env usage in the docs.

<sup>Written for commit ce5090dbdcf9043a6309cb7633ac940b3e97807f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

