### PR TITLE
fix: home featured news refresh

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -587,7 +587,7 @@ function ContextTickerItem({
   linkedHref: string
 }) {
   const timeLabel = formatContextRelativeTime(contextItem.publishedAt ?? contextItem.selectedAt)
-  const sourceLabel = timeLabel ? `${contextItem.source} · ${timeLabel}` : contextItem.source
+  const isNews = contextItem.type === 'news'
 
   return (
     <AppLink
@@ -596,12 +596,27 @@ function ContextTickerItem({
       href={linkedHref}
       className="flex h-14 min-w-0 items-center gap-2"
     >
-      <ContextAvatar contextItem={contextItem} />
+      {!isNews && <ContextAvatar contextItem={contextItem} />}
       <span className="grid min-w-0 gap-0.5">
-        <span className="truncate text-xs font-medium text-foreground">
-          {sourceLabel}
+        <span className="flex min-w-0 items-center gap-1.5 text-xs font-medium text-muted-foreground">
+          {isNews && contextItem.faviconUrl && (
+            <EventIconImage
+              src={contextItem.faviconUrl}
+              alt={contextItem.source}
+              sizes="14px"
+              containerClassName="size-3.5 shrink-0 rounded-[3px] bg-muted"
+              imageClassName="rounded-[3px]"
+            />
+          )}
+          <span className="truncate">{contextItem.source}</span>
+          {timeLabel && (
+            <>
+              <span className="shrink-0 text-muted-foreground/70">·</span>
+              <span className="shrink-0">{timeLabel}</span>
+            </>
+          )}
         </span>
-        <span className="line-clamp-2 text-xs/snug text-muted-foreground">
+        <span className="line-clamp-2 text-xs/snug text-foreground">
           {contextItem.title}
         </span>
       </span>

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -596,7 +596,7 @@ function ContextTickerItem({
       href={linkedHref}
       className="flex h-14 min-w-0 items-center gap-2"
     >
-      {!isNews && <ContextAvatar contextItem={contextItem} />}
+      {(!isNews || !contextItem.faviconUrl) && <ContextAvatar contextItem={contextItem} />}
       <span className="grid min-w-0 gap-0.5">
         <span className="flex min-w-0 items-center gap-1.5 text-xs font-medium text-muted-foreground">
           {isNews && contextItem.faviconUrl && (

--- a/src/app/[locale]/admin/(general)/_components/HomeFeaturedMarketsSection.tsx
+++ b/src/app/[locale]/admin/(general)/_components/HomeFeaturedMarketsSection.tsx
@@ -1339,7 +1339,7 @@ export default function HomeFeaturedMarketsSection({
 
       <HomeFeaturedContextDialog
         key={manageContextItem
-          ? `${buildFeaturedKey(manageContextItem)}:${manageContextItem.eventId ?? ''}:${manageContextItem.slug ?? ''}`
+          ? `${buildFeaturedKey(manageContextItem)}:${manageContextItem.slug ?? ''}`
           : 'home-featured-context-dialog'}
         open={manageContextIndex != null}
         disabled={disabled}

--- a/src/app/[locale]/admin/(general)/_components/HomeFeaturedMarketsSection.tsx
+++ b/src/app/[locale]/admin/(general)/_components/HomeFeaturedMarketsSection.tsx
@@ -1338,7 +1338,9 @@ export default function HomeFeaturedMarketsSection({
       />
 
       <HomeFeaturedContextDialog
-        key={manageContextItem ? buildFeaturedKey(manageContextItem) : 'home-featured-context-dialog'}
+        key={manageContextItem
+          ? `${buildFeaturedKey(manageContextItem)}:${manageContextItem.eventId ?? ''}:${manageContextItem.slug ?? ''}`
+          : 'home-featured-context-dialog'}
         open={manageContextIndex != null}
         disabled={disabled}
         item={manageContextItem}

--- a/src/app/[locale]/admin/api/home-featured-events/context-news/route.ts
+++ b/src/app/[locale]/admin/api/home-featured-events/context-news/route.ts
@@ -4,7 +4,11 @@ import { parseOpenRouterProviderSettings } from '@/lib/ai/market-context-config'
 import { requestOpenRouterCompletion, sanitizeForPrompt } from '@/lib/ai/openrouter'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 import { UserRepository } from '@/lib/db/queries/user'
-import { fetchHomeFeaturedNewsMetadata } from '@/lib/home-featured-context-metadata'
+import {
+  assertHomeFeaturedNewsMetadataUrlAllowed,
+  fetchHomeFeaturedNewsMetadata,
+} from '@/lib/home-featured-context-metadata'
+import { buildHomeFeaturedNewsSearchPromptLines } from '@/lib/home-featured-news-search-prompt'
 
 const RequestSchema = z.object({
   title: z.string().min(3).max(240),
@@ -37,45 +41,26 @@ function parseAiNewsResults(value: string): AiNewsResult[] {
   }
 }
 
-function buildNewsSearchPromptLines() {
-  const currentDate = new Date().toISOString().slice(0, 10)
-
-  return [
-    `Current date: ${currentDate}. Prefer articles published today or in the last 48 hours when the event is time-sensitive.`,
-    'Use broad live web search first. Source hints are preferred publications/domains, not a whitelist; if they have no relevant article, use another reputable source.',
-    'For sports matchups, search exact and close variants such as "Team A vs Team B", "Team A v Team B", lineups, injuries, preview, prediction, live, result, and the league/tournament name.',
-  ]
-}
-
-function normalizeAiNewsUrl(rawUrl: string | null | undefined) {
-  if (!rawUrl?.trim()) {
+async function buildAiNewsMetadataFallback(item: AiNewsResult) {
+  if (!item.url?.trim()) {
     return null
   }
 
   try {
-    const url = new URL(rawUrl.trim())
-    return ['http:', 'https:'].includes(url.protocol) ? url : null
+    const url = await assertHomeFeaturedNewsMetadataUrlAllowed(item.url)
+    const source = item.source?.trim() || url.hostname.replace(/^www\./, '')
+    const title = item.title?.trim() || source
+
+    return {
+      title,
+      source,
+      url: url.toString(),
+      faviconUrl: item.faviconUrl?.trim() || new URL('/favicon.ico', url.origin).toString(),
+      publishedAt: item.publishedAt ?? null,
+    }
   }
   catch {
     return null
-  }
-}
-
-function buildAiNewsMetadataFallback(item: AiNewsResult) {
-  const url = normalizeAiNewsUrl(item.url)
-  if (!url) {
-    return null
-  }
-
-  const source = item.source?.trim() || url.hostname.replace(/^www\./, '')
-  const title = item.title?.trim() || source
-
-  return {
-    title,
-    source,
-    url: url.toString(),
-    faviconUrl: item.faviconUrl?.trim() || new URL('/favicon.ico', url.origin).toString(),
-    publishedAt: item.publishedAt ?? null,
   }
 }
 
@@ -103,7 +88,7 @@ export async function POST(request: Request) {
       'Use live web search. Return JSON only with this shape: {"news":[{"title":"article headline","source":"publisher","url":"https://...","publishedAt":"2026-07-04T12:00:00Z"}]}',
       'Critical relevance rules:',
       '- The phrase "prediction market" describes our product only. Do not search for or return articles about prediction markets, betting, exchanges, Polymarket, Kalshi, regulation, or the app itself unless the event title is explicitly about those things.',
-      ...buildNewsSearchPromptLines().map(line => `- ${line}`),
+      ...buildHomeFeaturedNewsSearchPromptLines().map(line => `- ${line}`),
       '- Search for the event title, named entities, and close real-world variants. For yes/no markets, look for reporting that helps understand the likelihood of the event outcome.',
       '- Treat source hints as publication/domain hints. If a hint is an RSS feed, homepage, sitemap, section URL, or article URL, infer the publication/domain and search broadly within or around that source.',
       '- Prefer directly relevant article pages published recently. Avoid homepages, RSS feeds, search pages, tag pages, and social profile pages.',
@@ -149,7 +134,7 @@ export async function POST(request: Request) {
             }
           }
           catch {
-            const fallback = buildAiNewsMetadataFallback(item)
+            const fallback = await buildAiNewsMetadataFallback(item)
             if (fallback) {
               return fallback
             }

--- a/src/app/[locale]/admin/api/home-featured-events/context-news/route.ts
+++ b/src/app/[locale]/admin/api/home-featured-events/context-news/route.ts
@@ -17,6 +17,7 @@ interface AiNewsResult {
   source?: string
   url?: string
   publishedAt?: string | null
+  faviconUrl?: string | null
 }
 
 function parseAiNewsResults(value: string): AiNewsResult[] {
@@ -33,6 +34,48 @@ function parseAiNewsResults(value: string): AiNewsResult[] {
   }
   catch {
     return []
+  }
+}
+
+function buildNewsSearchPromptLines() {
+  const currentDate = new Date().toISOString().slice(0, 10)
+
+  return [
+    `Current date: ${currentDate}. Prefer articles published today or in the last 48 hours when the event is time-sensitive.`,
+    'Use broad live web search first. Source hints are preferred publications/domains, not a whitelist; if they have no relevant article, use another reputable source.',
+    'For sports matchups, search exact and close variants such as "Team A vs Team B", "Team A v Team B", lineups, injuries, preview, prediction, live, result, and the league/tournament name.',
+  ]
+}
+
+function normalizeAiNewsUrl(rawUrl: string | null | undefined) {
+  if (!rawUrl?.trim()) {
+    return null
+  }
+
+  try {
+    const url = new URL(rawUrl.trim())
+    return ['http:', 'https:'].includes(url.protocol) ? url : null
+  }
+  catch {
+    return null
+  }
+}
+
+function buildAiNewsMetadataFallback(item: AiNewsResult) {
+  const url = normalizeAiNewsUrl(item.url)
+  if (!url) {
+    return null
+  }
+
+  const source = item.source?.trim() || url.hostname.replace(/^www\./, '')
+  const title = item.title?.trim() || source
+
+  return {
+    title,
+    source,
+    url: url.toString(),
+    faviconUrl: item.faviconUrl?.trim() || new URL('/favicon.ico', url.origin).toString(),
+    publishedAt: item.publishedAt ?? null,
   }
 }
 
@@ -60,8 +103,9 @@ export async function POST(request: Request) {
       'Use live web search. Return JSON only with this shape: {"news":[{"title":"article headline","source":"publisher","url":"https://...","publishedAt":"2026-07-04T12:00:00Z"}]}',
       'Critical relevance rules:',
       '- The phrase "prediction market" describes our product only. Do not search for or return articles about prediction markets, betting, exchanges, Polymarket, Kalshi, regulation, or the app itself unless the event title is explicitly about those things.',
+      ...buildNewsSearchPromptLines().map(line => `- ${line}`),
       '- Search for the event title, named entities, and close real-world variants. For yes/no markets, look for reporting that helps understand the likelihood of the event outcome.',
-      '- Treat source hints as publication/domain hints. If a hint is an RSS feed, homepage, sitemap, or section URL, infer the publication/domain and search broadly within or around that source.',
+      '- Treat source hints as publication/domain hints. If a hint is an RSS feed, homepage, sitemap, section URL, or article URL, infer the publication/domain and search broadly within or around that source.',
       '- Prefer directly relevant article pages published recently. Avoid homepages, RSS feeds, search pages, tag pages, and social profile pages.',
       '- Before returning a result, verify it is about the event topic itself and not generic prediction-market industry news.',
       '- Do not invent URLs. Return at most 6 results.',
@@ -85,6 +129,7 @@ export async function POST(request: Request) {
       temperature: 0.1,
       maxTokens: 900,
       webSearch: true,
+      webSearchContextSize: 'high',
     })
 
     const rawResults = parseAiNewsResults(content)
@@ -94,12 +139,22 @@ export async function POST(request: Request) {
         .filter(item => item.url?.trim())
         .slice(0, 6)
         .map(async (item) => {
-          const metadata = await fetchHomeFeaturedNewsMetadata(item.url!)
-          return {
-            ...metadata,
-            title: item.title?.trim() || metadata.title,
-            source: item.source?.trim() || metadata.source,
-            publishedAt: item.publishedAt ?? metadata.publishedAt,
+          try {
+            const metadata = await fetchHomeFeaturedNewsMetadata(item.url!)
+            return {
+              ...metadata,
+              title: item.title?.trim() || metadata.title,
+              source: item.source?.trim() || metadata.source,
+              publishedAt: item.publishedAt ?? metadata.publishedAt,
+            }
+          }
+          catch {
+            const fallback = buildAiNewsMetadataFallback(item)
+            if (fallback) {
+              return fallback
+            }
+
+            throw new Error('Could not fetch URL metadata.')
           }
         }),
     )

--- a/src/lib/ai/openrouter.ts
+++ b/src/lib/ai/openrouter.ts
@@ -41,6 +41,7 @@ interface RequestCompletionOptions {
   model?: string
   apiKey?: string
   webSearch?: boolean
+  webSearchContextSize?: 'low' | 'medium' | 'high'
 }
 
 async function buildOpenRouterHeaders(apiKey: string) {
@@ -78,7 +79,7 @@ export async function requestOpenRouterCompletion(messages: OpenRouterMessage[],
     ...(options?.webSearch
       ? {
           web_search_options: {
-            search_context_size: 'medium',
+            search_context_size: options.webSearchContextSize ?? 'medium',
           },
         }
       : {}),

--- a/src/lib/db/queries/home-featured-events.ts
+++ b/src/lib/db/queries/home-featured-events.ts
@@ -90,6 +90,13 @@ const VALID_TARGET_TYPES: HomeFeaturedTargetType[] = ['event', 'series']
 const VALID_SOURCES: HomeFeaturedSource[] = ['manual', 'ai']
 const MANUAL_CONTEXT_EXPIRY_MS = 365 * 24 * 60 * 60 * 1000
 type HomeFeaturedTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
+interface AdminFeaturedEventRow {
+  id: string
+  target_type: string
+  event_id: string | null
+  series_slug: string | null
+}
+type SeriesTargetMap = Map<string, ResolvedSeriesTarget>
 
 function normalizeContextMode(value: string | null | undefined): HomeFeaturedContextMode {
   return VALID_CONTEXT_MODES.includes(value as HomeFeaturedContextMode)
@@ -437,6 +444,22 @@ function mapContextRow(row: typeof home_featured_event_context_items.$inferSelec
   }
 }
 
+function resolveAdminFeaturedEventTarget(row: AdminFeaturedEventRow, seriesTargetBySlug: SeriesTargetMap) {
+  const targetType = normalizeTargetType(row.target_type)
+  const resolvedSeriesEvent = targetType === 'series'
+    ? seriesTargetBySlug.get(row.series_slug?.trim() ?? '') ?? null
+    : null
+  const eventId = targetType === 'series'
+    ? resolvedSeriesEvent?.id ?? row.event_id ?? null
+    : row.event_id ?? null
+
+  return {
+    targetType,
+    resolvedSeriesEvent,
+    eventId,
+  }
+}
+
 export const HomeFeaturedEventsRepository = {
   async listAdminFeaturedEvents(locale?: string): Promise<QueryResult<HomeFeaturedEventAdminItem[]>> {
     return runQuery(async () => {
@@ -471,13 +494,7 @@ export const HomeFeaturedEventsRepository = {
       )
       const eventIdsByFeaturedId = new Map<string, string>()
       for (const row of rows) {
-        const targetType = normalizeTargetType(row.target_type)
-        const resolvedSeriesEvent = targetType === 'series'
-          ? seriesTargetBySlug.get(row.series_slug?.trim() ?? '') ?? null
-          : null
-        const eventId = targetType === 'series'
-          ? resolvedSeriesEvent?.id ?? row.event_id ?? null
-          : row.event_id ?? null
+        const { eventId } = resolveAdminFeaturedEventTarget(row, seriesTargetBySlug)
 
         if (eventId) {
           eventIdsByFeaturedId.set(row.id, eventId)
@@ -494,13 +511,7 @@ export const HomeFeaturedEventsRepository = {
       const contextItemsByFeaturedId = contextResult.data ?? new Map<string, HomeFeaturedContextItem[]>()
 
       const items: HomeFeaturedEventAdminItem[] = rows.map((row) => {
-        const targetType = normalizeTargetType(row.target_type)
-        const resolvedSeriesEvent = targetType === 'series'
-          ? seriesTargetBySlug.get(row.series_slug?.trim() ?? '') ?? null
-          : null
-        const eventId = targetType === 'series'
-          ? resolvedSeriesEvent?.id ?? row.event_id ?? null
-          : row.event_id ?? null
+        const { eventId, resolvedSeriesEvent, targetType } = resolveAdminFeaturedEventTarget(row, seriesTargetBySlug)
 
         return {
           id: row.id,

--- a/src/lib/db/queries/home-featured-events.ts
+++ b/src/lib/db/queries/home-featured-events.ts
@@ -469,8 +469,23 @@ export const HomeFeaturedEventsRepository = {
           return targetType === 'series' && seriesSlug ? [seriesSlug] : []
         }),
       )
+      const eventIdsByFeaturedId = new Map<string, string>()
+      for (const row of rows) {
+        const targetType = normalizeTargetType(row.target_type)
+        const resolvedSeriesEvent = targetType === 'series'
+          ? seriesTargetBySlug.get(row.series_slug?.trim() ?? '') ?? null
+          : null
+        const eventId = targetType === 'series'
+          ? resolvedSeriesEvent?.id ?? row.event_id ?? null
+          : row.event_id ?? null
+
+        if (eventId) {
+          eventIdsByFeaturedId.set(row.id, eventId)
+        }
+      }
+
       const contextResult = locale
-        ? await HomeFeaturedEventsRepository.listContextItems(rows.map(row => row.id), locale)
+        ? await HomeFeaturedEventsRepository.listContextItems(rows.map(row => row.id), locale, { eventIdsByFeaturedId })
         : { data: new Map<string, HomeFeaturedContextItem[]>(), error: null }
       if (contextResult.error) {
         return { data: null, error: contextResult.error }
@@ -610,7 +625,10 @@ export const HomeFeaturedEventsRepository = {
   async listContextItems(
     featuredEventIds: string[],
     locale: string,
-    options: { includeDefaultFallback?: boolean } = {},
+    options: {
+      includeDefaultFallback?: boolean
+      eventIdsByFeaturedId?: Map<string, string | null | undefined>
+    } = {},
   ): Promise<QueryResult<Map<string, HomeFeaturedContextItem[]>>> {
     if (featuredEventIds.length === 0) {
       return { data: new Map(), error: null }
@@ -621,12 +639,21 @@ export const HomeFeaturedEventsRepository = {
       const contextLocales = options.includeDefaultFallback && locale !== DEFAULT_LOCALE
         ? [locale, DEFAULT_LOCALE]
         : [locale]
+      const eventIdsByFeaturedId = options.eventIdsByFeaturedId
+      const allowedEventIds = Array.from(new Set(
+        Array.from(eventIdsByFeaturedId?.values() ?? [])
+          .map(eventId => eventId?.trim())
+          .filter((eventId): eventId is string => Boolean(eventId)),
+      ))
       const rows = await db
         .select()
         .from(home_featured_event_context_items)
         .where(and(
           inArray(home_featured_event_context_items.featured_event_id, featuredEventIds),
           inArray(home_featured_event_context_items.locale, contextLocales),
+          ...(allowedEventIds.length > 0
+            ? [inArray(home_featured_event_context_items.event_id, allowedEventIds)]
+            : []),
           gt(home_featured_event_context_items.expires_at, now),
         ))
         .orderBy(
@@ -640,6 +667,11 @@ export const HomeFeaturedEventsRepository = {
 
       const itemsByFeaturedId = new Map<string, HomeFeaturedContextItem[]>()
       for (const row of rows) {
+        const expectedEventId = eventIdsByFeaturedId?.get(row.featured_event_id)?.trim()
+        if (expectedEventId && row.event_id !== expectedEventId) {
+          continue
+        }
+
         const items = itemsByFeaturedId.get(row.featured_event_id) ?? []
         if (items.length < 3) {
           items.push(mapContextRow(row))

--- a/src/lib/home-featured-ai.ts
+++ b/src/lib/home-featured-ai.ts
@@ -6,6 +6,7 @@ import { requestOpenRouterCompletion, sanitizeForPrompt } from '@/lib/ai/openrou
 import { EventRepository } from '@/lib/db/queries/event'
 import { HomeFeaturedEventsRepository } from '@/lib/db/queries/home-featured-events'
 import { SettingsRepository } from '@/lib/db/queries/settings'
+import { buildHomeFeaturedNewsSearchPromptLines } from '@/lib/home-featured-news-search-prompt'
 import { getHomeFeaturedSettingsFromSettings } from '@/lib/home-featured-settings'
 
 interface NewsHeadline {
@@ -401,16 +402,6 @@ function eventToPromptCandidate(event: Event) {
   }
 }
 
-function buildNewsSearchPromptLines() {
-  const currentDate = new Date().toISOString().slice(0, 10)
-
-  return [
-    `Current date: ${currentDate}. Prefer articles published today or in the last 48 hours when the event is time-sensitive.`,
-    'Use broad live web search first. Source hints are preferred publications/domains, not a whitelist; if they have no relevant article, use another reputable source.',
-    'For sports matchups, search exact and close variants such as "Team A vs Team B", "Team A v Team B", lineups, injuries, preview, prediction, live, result, and the league/tournament name.',
-  ]
-}
-
 function normalizeNewsIdentity(value: Pick<NewsHeadline, 'source' | 'title'>) {
   return `${value.source}:${value.title}`.replace(/\s+/g, ' ').trim().toLowerCase()
 }
@@ -704,7 +695,7 @@ export async function regenerateHomeFeaturedEvents(
         'Return JSON only with this shape: {"markets":[{"slug":"event-slug","news":[{"title":"headline","source":"source","url":"https://...","publishedAt":null,"score":0.8}]}]}',
         `Pick at most ${slotsToFill} markets. Prefer recent volume, clear public interest, sports live/today when relevant, and news relevance.`,
         'Use live web search when available to understand the current news cycle for each candidate.',
-        ...buildNewsSearchPromptLines(),
+        ...buildHomeFeaturedNewsSearchPromptLines(),
         'The phrase "prediction market" describes our product only. Do not search for or return articles about prediction markets, betting, exchanges, Polymarket, Kalshi, regulation, or the app itself unless the candidate event title is explicitly about those things.',
         'Search for each candidate event title, named entities, and close real-world variants. For yes/no markets, prefer reporting that helps understand the likelihood of the event outcome.',
         'Treat the provided source URLs as publication/domain hints. If a source is an RSS feed, homepage, sitemap, section URL, or article URL, infer the publication domain and search broadly for recent relevant articles about the candidate event title on or around that publication.',
@@ -825,7 +816,7 @@ export async function regenerateHomeFeaturedEvents(
       'Return JSON only with this shape: {"markets":[{"slug":"event-slug","news":[{"title":"headline","source":"source","url":"https://...","publishedAt":null,"score":0.8}]}]}',
       'Return every market slug that has at least one directly relevant headline. Use no more than 3 headlines per market.',
       'Use live web search when available to find recent article URLs for markets whose provided headlines are weak or too generic.',
-      ...buildNewsSearchPromptLines(),
+      ...buildHomeFeaturedNewsSearchPromptLines(),
       'The phrase "prediction market" describes our product only. Do not search for or return articles about prediction markets, betting, exchanges, Polymarket, Kalshi, regulation, or the app itself unless the market title is explicitly about those things.',
       'Search for each market title, named entities, and close real-world variants. For yes/no markets, prefer reporting that helps understand the likelihood of the event outcome.',
       'Treat the configured source URLs as publication/domain hints, not only literal RSS feeds. Search for the event title and the main market terms broadly, then prefer those sources when they have a relevant article.',

--- a/src/lib/home-featured-ai.ts
+++ b/src/lib/home-featured-ai.ts
@@ -57,7 +57,7 @@ function extractXmlTagValue(item: string, tag: string) {
 function extractHeadlinesFromXml(source: string, sourceUrl: string, body: string): NewsHeadline[] {
   const items = Array.from(body.matchAll(/<item[\s\S]*?<\/item>|<entry[\s\S]*?<\/entry>/gi))
     .map(match => match[0])
-    .slice(0, 12)
+    .slice(0, 18)
 
   if (items.length === 0) {
     const title = extractXmlTagValue(body, 'title')
@@ -254,7 +254,7 @@ function extractHeadlinesFromHtml(source: string, sourceUrl: string, body: strin
       url: resolveHtmlLink(sourceUrl, match[1]),
       publishedAt: null,
     })
-    if (headlines.length >= 32) {
+    if (headlines.length >= 50) {
       break
     }
   }
@@ -272,7 +272,7 @@ function extractHeadlinesFromHtml(source: string, sourceUrl: string, body: strin
   }
 
   if (headlines.length > 0) {
-    return headlines.slice(0, 24)
+    return headlines.slice(0, 36)
   }
 
   const title = decodeBasicEntities(stripTags(
@@ -371,7 +371,7 @@ async function collectNewsHeadlines(sources: string[]) {
     headlines.push(headline)
   }
 
-  return headlines.slice(0, 40)
+  return headlines.slice(0, 80)
 }
 
 function eventToPromptCandidate(event: Event) {
@@ -387,7 +387,28 @@ function eventToPromptCandidate(event: Event) {
     recurrence: event.series_recurrence,
     seriesSlug: event.series_slug,
     sportsLive: event.sports_live,
+    sports: {
+      sport: event.sports_sport_slug,
+      league: event.sports_league_slug,
+      teams: (event.sports_teams ?? []).map(team => team.name).filter(Boolean),
+    },
+    marketTerms: event.markets.slice(0, 8).map(market => ({
+      title: market.title,
+      shortTitle: market.short_title,
+      question: market.question,
+      outcomes: market.outcomes.map(outcome => outcome.outcome_text).filter(Boolean),
+    })),
   }
+}
+
+function buildNewsSearchPromptLines() {
+  const currentDate = new Date().toISOString().slice(0, 10)
+
+  return [
+    `Current date: ${currentDate}. Prefer articles published today or in the last 48 hours when the event is time-sensitive.`,
+    'Use broad live web search first. Source hints are preferred publications/domains, not a whitelist; if they have no relevant article, use another reputable source.',
+    'For sports matchups, search exact and close variants such as "Team A vs Team B", "Team A v Team B", lineups, injuries, preview, prediction, live, result, and the league/tournament name.',
+  ]
 }
 
 function normalizeNewsIdentity(value: Pick<NewsHeadline, 'source' | 'title'>) {
@@ -683,9 +704,10 @@ export async function regenerateHomeFeaturedEvents(
         'Return JSON only with this shape: {"markets":[{"slug":"event-slug","news":[{"title":"headline","source":"source","url":"https://...","publishedAt":null,"score":0.8}]}]}',
         `Pick at most ${slotsToFill} markets. Prefer recent volume, clear public interest, sports live/today when relevant, and news relevance.`,
         'Use live web search when available to understand the current news cycle for each candidate.',
+        ...buildNewsSearchPromptLines(),
         'The phrase "prediction market" describes our product only. Do not search for or return articles about prediction markets, betting, exchanges, Polymarket, Kalshi, regulation, or the app itself unless the candidate event title is explicitly about those things.',
         'Search for each candidate event title, named entities, and close real-world variants. For yes/no markets, prefer reporting that helps understand the likelihood of the event outcome.',
-        'Treat the provided source URLs as publication/domain hints. If a source is an RSS feed, homepage, sitemap, or section URL, infer the publication domain and search broadly for recent relevant articles about the candidate event title on or around that publication.',
+        'Treat the provided source URLs as publication/domain hints. If a source is an RSS feed, homepage, sitemap, section URL, or article URL, infer the publication domain and search broadly for recent relevant articles about the candidate event title on or around that publication.',
         'Before attaching news, verify it is about the event topic itself and not generic prediction-market industry news.',
         'Do not invent market slugs or article URLs. Only use candidate slugs. Prefer article URLs over homepages, feeds, search pages, or tag pages.',
         `Candidates: ${JSON.stringify(filteredCandidates.map(eventToPromptCandidate))}`,
@@ -709,6 +731,7 @@ export async function regenerateHomeFeaturedEvents(
           temperature: 0.2,
           maxTokens: 900,
           webSearch: true,
+          webSearchContextSize: 'high',
         })
 
         const parsed = safeJsonFromText(content)
@@ -802,9 +825,10 @@ export async function regenerateHomeFeaturedEvents(
       'Return JSON only with this shape: {"markets":[{"slug":"event-slug","news":[{"title":"headline","source":"source","url":"https://...","publishedAt":null,"score":0.8}]}]}',
       'Return every market slug that has at least one directly relevant headline. Use no more than 3 headlines per market.',
       'Use live web search when available to find recent article URLs for markets whose provided headlines are weak or too generic.',
+      ...buildNewsSearchPromptLines(),
       'The phrase "prediction market" describes our product only. Do not search for or return articles about prediction markets, betting, exchanges, Polymarket, Kalshi, regulation, or the app itself unless the market title is explicitly about those things.',
       'Search for each market title, named entities, and close real-world variants. For yes/no markets, prefer reporting that helps understand the likelihood of the event outcome.',
-      'Treat the configured source URLs as publication/domain hints, not only literal RSS feeds. Search for the event title and the main market terms on or around those sources.',
+      'Treat the configured source URLs as publication/domain hints, not only literal RSS feeds. Search for the event title and the main market terms broadly, then prefer those sources when they have a relevant article.',
       'Before attaching news, verify it is about the market topic itself and not generic prediction-market industry news.',
       'Do not invent market slugs or URLs. Prefer specific article URLs over homepages, feeds, search pages, or tag pages.',
       `Markets: ${JSON.stringify(displayedEvents.map(entry => eventToPromptCandidate(entry.event)))}`,
@@ -828,6 +852,7 @@ export async function regenerateHomeFeaturedEvents(
         temperature: 0.1,
         maxTokens: 1200,
         webSearch: true,
+        webSearchContextSize: 'high',
       })
 
       const parsed = safeJsonFromText(content)

--- a/src/lib/home-featured-context-metadata.ts
+++ b/src/lib/home-featured-context-metadata.ts
@@ -1,5 +1,6 @@
 import type { ClientRequest, RequestOptions as HttpRequestOptions, IncomingMessage } from 'node:http'
 import type { RequestOptions as HttpsRequestOptions } from 'node:https'
+import type { LookupFunction } from 'node:net'
 import type { Readable } from 'node:stream'
 import { Buffer } from 'node:buffer'
 import { lookup } from 'node:dns/promises'
@@ -22,12 +23,18 @@ interface MetadataResponsePayload {
   statusCode: number
 }
 
+interface ResolvedHostAddress {
+  address: string
+  family: 4 | 6
+}
+
 const MAX_METADATA_REDIRECTS = 5
 const MAX_METADATA_BODY_BYTES = 1_000_000
 const METADATA_REQUEST_TIMEOUT_MS = 12_000
 const METADATA_REQUEST_HEADERS = {
   'Accept-Encoding': 'gzip, deflate, br',
   'Accept': 'text/html,application/xhtml+xml',
+  'Accept-Language': 'en-US,en;q=0.9,pt-BR;q=0.8,pt;q=0.7',
   'User-Agent': 'Mozilla/5.0 (compatible; KuestBot/1.0; +https://kuest.com)',
 }
 const blockedNetworkRanges = new BlockList()
@@ -212,7 +219,7 @@ function assertFetchableHttpUrl(url: URL) {
   }
 }
 
-async function resolveAllowedHostAddress(hostname: string) {
+async function resolveAllowedHostAddresses(hostname: string): Promise<ResolvedHostAddress[]> {
   try {
     const normalizedHostname = normalizeHostname(hostname)
     if (isIP(normalizedHostname)) {
@@ -220,10 +227,10 @@ async function resolveAllowedHostAddress(hostname: string) {
         throw new HomeFeaturedNewsMetadataUrlError('URL host is not allowed.')
       }
 
-      return {
+      return [{
         address: normalizedHostname,
         family: isIP(normalizedHostname) as 4 | 6,
-      }
+      }]
     }
 
     const addresses = await lookup(normalizedHostname, { all: true, verbatim: false })
@@ -231,15 +238,17 @@ async function resolveAllowedHostAddress(hostname: string) {
       throw new HomeFeaturedNewsMetadataUrlError('URL host is not allowed.')
     }
 
-    const selectedAddress = addresses[0]
-    if (!selectedAddress || (selectedAddress.family !== 4 && selectedAddress.family !== 6)) {
+    const allowedAddresses = addresses
+      .filter((address): address is ResolvedHostAddress => address.family === 4 || address.family === 6)
+      .map(address => ({
+        address: address.address,
+        family: address.family,
+      }))
+    if (allowedAddresses.length === 0) {
       throw new HomeFeaturedNewsMetadataUrlError('URL host is not allowed.')
     }
 
-    return {
-      address: selectedAddress.address,
-      family: selectedAddress.family,
-    }
+    return allowedAddresses
   }
   catch (error) {
     if (error instanceof HomeFeaturedNewsMetadataUrlError) {
@@ -247,6 +256,36 @@ async function resolveAllowedHostAddress(hostname: string) {
     }
 
     throw new HomeFeaturedNewsMetadataUrlError('Could not resolve URL host.')
+  }
+}
+
+function createMetadataLookup(): LookupFunction {
+  return (hostname, options, callback) => {
+    const wantsAllAddresses = Boolean(options && typeof options === 'object' && (options as { all?: boolean }).all)
+
+    resolveAllowedHostAddresses(hostname)
+      .then((addresses) => {
+        if (wantsAllAddresses) {
+          callback(null, addresses)
+          return
+        }
+
+        const selectedAddress = addresses[0]
+        if (!selectedAddress) {
+          callback(new HomeFeaturedNewsMetadataUrlError('URL host is not allowed.'), '', 0)
+          return
+        }
+
+        callback(null, selectedAddress.address, selectedAddress.family)
+      })
+      .catch((error) => {
+        if (wantsAllAddresses) {
+          callback(error as NodeJS.ErrnoException, [])
+          return
+        }
+
+        callback(error as NodeJS.ErrnoException, '', 0)
+      })
   }
 }
 
@@ -404,11 +443,7 @@ function requestMetadataUrl(url: URL) {
         ...METADATA_REQUEST_HEADERS,
         Host: url.host,
       },
-      lookup: (hostname, _options, callback) => {
-        resolveAllowedHostAddress(hostname)
-          .then(address => callback(null, address.address, address.family))
-          .catch(error => callback(error as NodeJS.ErrnoException, '', 0))
-      },
+      lookup: createMetadataLookup(),
     }
 
     function handleResponse(response: IncomingMessage) {

--- a/src/lib/home-featured-context-metadata.ts
+++ b/src/lib/home-featured-context-metadata.ts
@@ -495,6 +495,14 @@ async function fetchMetadataResponse(initialUrl: URL) {
   throw new Error('Too many redirects while fetching URL metadata.')
 }
 
+export async function assertHomeFeaturedNewsMetadataUrlAllowed(rawUrl: string) {
+  const url = new URL(rawUrl)
+  assertFetchableHttpUrl(url)
+  await resolveAllowedHostAddresses(url.hostname)
+
+  return url
+}
+
 export async function fetchHomeFeaturedNewsMetadata(rawUrl: string): Promise<HomeFeaturedNewsMetadata> {
   const initialUrl = new URL(rawUrl)
   const { response, url } = await fetchMetadataResponse(initialUrl)

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -620,7 +620,10 @@ export async function listHomeFeaturedEvents(locale: SupportedLocale = DEFAULT_L
   const contextResult = await HomeFeaturedEventsRepository.listContextItems(
     resolvedEvents.map(entry => entry.target.featuredId),
     locale,
-    { includeDefaultFallback: true },
+    {
+      includeDefaultFallback: true,
+      eventIdsByFeaturedId: new Map(resolvedEvents.map(entry => [entry.target.featuredId, entry.target.eventId])),
+    },
   )
   const newsItemsByFeaturedId = contextResult.data ?? new Map()
   const commentsByEventSlug = new Map<string, { hasEnoughSeriesComments: boolean, items: HomeFeaturedContextItem[] }>()

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -42,6 +42,7 @@ const FEATURED_HOT_TOPICS_CACHE_LIFE = {
   revalidate: 900,
   expire: 31_536_000,
 } as const
+const FEATURED_HOT_TOPICS_RECENT_RESOLVED_WINDOW_MS = 36 * 60 * 60 * 1000
 
 function isNegRiskEvent(event: Event) {
   return Boolean(event.neg_risk || event.enable_neg_risk || event.neg_risk_augmented || event.neg_risk_market_id)
@@ -268,9 +269,38 @@ export async function listHomeFeaturedHotTopics(
 
   const volume24h = sql<number>`COALESCE(SUM(${markets.volume_24h}), 0)::double precision`
   const localizedName = sql<string>`COALESCE(${tag_translations.name}, ${tags.name})`
+  interface HotTopicVolumeRow {
+    slug: string
+    label: string
+    volume24h: number
+  }
+
+  function mergeHotTopicRows(rows: HotTopicVolumeRow[]) {
+    const topicsBySlug = new Map<string, HomeFeaturedHotTopic>()
+
+    for (const row of rows) {
+      const slug = row.slug.trim()
+      const volume = Number(row.volume24h ?? 0)
+      if (!slug || volume <= 0) {
+        continue
+      }
+
+      const existing = topicsBySlug.get(slug)
+      topicsBySlug.set(slug, {
+        label: existing?.label ?? row.label,
+        slug,
+        href: resolveHotTopicHref(slug),
+        volume24h: (existing?.volume24h ?? 0) + volume,
+      })
+    }
+
+    return Array.from(topicsBySlug.values())
+      .sort((left, right) => right.volume24h - left.volume24h)
+      .slice(0, 5)
+  }
 
   const { data, error } = await runQuery(async () => {
-    const result = await db
+    const activeRows = await db
       .select({
         slug: tags.slug,
         label: localizedName,
@@ -295,9 +325,35 @@ export async function listHomeFeaturedHotTopics(
       ))
       .groupBy(tags.id, tags.slug, tags.name, tag_translations.name)
       .orderBy(desc(volume24h))
-      .limit(5)
 
-    return { data: result, error: null }
+    const recentResolvedCutoff = new Date(Date.now() - FEATURED_HOT_TOPICS_RECENT_RESOLVED_WINDOW_MS)
+    const recentResolvedRows = await db
+      .select({
+        slug: tags.slug,
+        label: localizedName,
+        volume24h,
+      })
+      .from(tags)
+      .innerJoin(event_tags, eq(event_tags.tag_id, tags.id))
+      .innerJoin(events, eq(events.id, event_tags.event_id))
+      .innerJoin(markets, eq(markets.event_id, events.id))
+      .leftJoin(tag_translations, and(
+        eq(tag_translations.tag_id, tags.id),
+        eq(tag_translations.locale, locale),
+      ))
+      .where(and(
+        eq(tags.is_main_category, true),
+        eq(tags.is_hidden, false),
+        eq(events.status, 'resolved'),
+        eq(events.is_hidden, false),
+        eq(markets.is_resolved, true),
+        sql`COALESCE(${events.resolved_at}, ${events.end_date}) >= ${recentResolvedCutoff}`,
+        buildPublicEventListVisibilityCondition(events.id),
+      ))
+      .groupBy(tags.id, tags.slug, tags.name, tag_translations.name)
+      .orderBy(desc(volume24h))
+
+    return { data: mergeHotTopicRows([...activeRows, ...recentResolvedRows]), error: null }
   })
 
   if (error || !data) {
@@ -306,13 +362,6 @@ export async function listHomeFeaturedHotTopics(
   }
 
   return data
-    .map(row => ({
-      label: row.label,
-      slug: row.slug,
-      href: resolveHotTopicHref(row.slug),
-      volume24h: Number(row.volume24h ?? 0),
-    }))
-    .filter(topic => topic.slug.trim() && topic.volume24h > 0)
 }
 
 function buildHomeFeaturedSideCard(input: {

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -392,7 +392,7 @@ function buildHomeFeaturedSideCard(input: {
     return {
       ...configured,
       title: `${topTopic.label} leads volume`,
-      text: `${formatDollarValueLabel(topTopic.volume24h, { maximumFractionDigits: 0 })} traded in the last 24h across active markets.`,
+      text: `${formatDollarValueLabel(topTopic.volume24h, { maximumFractionDigits: 0 })} traded in the last 24h across active and recently settled markets.`,
       ctaLabel: configured.ctaLabel || 'Explore topic',
       ctaHref: configured.ctaHref || topTopic.href,
       icon: 'trending-up',

--- a/src/lib/home-featured-news-search-prompt.ts
+++ b/src/lib/home-featured-news-search-prompt.ts
@@ -1,0 +1,9 @@
+export function buildHomeFeaturedNewsSearchPromptLines() {
+  const currentDate = new Date().toISOString().slice(0, 10)
+
+  return [
+    `Current date: ${currentDate}. Prefer articles published today or in the last 48 hours when the event is time-sensitive.`,
+    'Use broad live web search first. Source hints are preferred publications/domains, not a whitelist; if they have no relevant article, use another reputable source.',
+    'For sports matchups, search exact and close variants such as "Team A vs Team B", "Team A v Team B", lineups, injuries, preview, prediction, live, result, and the league/tournament name.',
+  ]
+}

--- a/tests/unit/homeFeaturedContextMetadata.test.ts
+++ b/tests/unit/homeFeaturedContextMetadata.test.ts
@@ -144,7 +144,9 @@ describe('fetchHomeFeaturedNewsMetadata', () => {
   })
 
   it('rejects direct private IP destinations before request', async () => {
-    const { fetchHomeFeaturedNewsMetadata } = await import('@/lib/home-featured-context-metadata')
+    const { assertHomeFeaturedNewsMetadataUrlAllowed, fetchHomeFeaturedNewsMetadata } = await import('@/lib/home-featured-context-metadata')
+
+    await expect(assertHomeFeaturedNewsMetadataUrlAllowed('http://127.0.0.1/admin')).rejects.toThrow('URL host is not allowed.')
     await expect(fetchHomeFeaturedNewsMetadata('http://127.0.0.1/admin')).rejects.toThrow('URL host is not allowed.')
 
     expect(mocks.httpRequest).not.toHaveBeenCalled()

--- a/tests/unit/homeFeaturedContextMetadata.test.ts
+++ b/tests/unit/homeFeaturedContextMetadata.test.ts
@@ -37,7 +37,7 @@ interface MockResponsePayload {
   status?: number
 }
 
-function createRequestMock(responses: MockResponsePayload[]) {
+function createRequestMock(responses: MockResponsePayload[], lookupOptions: Record<string, unknown> = {}) {
   return vi.fn((options: any, callback: (response: any) => void) => {
     const request = new EventEmitter() as any
     request.destroy = vi.fn((error?: Error) => {
@@ -63,9 +63,17 @@ function createRequestMock(responses: MockResponsePayload[]) {
       }
 
       if (typeof options.lookup === 'function') {
-        options.lookup(String(options.hostname), {}, (error: Error | null) => {
+        options.lookup(String(options.hostname), lookupOptions, (error: Error | null, addressResult: unknown, familyResult: unknown) => {
           if (error) {
             request.emit('error', error)
+            return
+          }
+          if (lookupOptions.all && !Array.isArray(addressResult)) {
+            request.emit('error', new Error('Expected lookup to return all addresses.'))
+            return
+          }
+          if (!lookupOptions.all && (typeof addressResult !== 'string' || (familyResult !== 4 && familyResult !== 6))) {
+            request.emit('error', new Error('Expected lookup to return one address.'))
             return
           }
 
@@ -119,6 +127,20 @@ describe('fetchHomeFeaturedNewsMetadata', () => {
     expect(mocks.httpsRequest).toHaveBeenCalledTimes(2)
     expect(mocks.lookup).toHaveBeenCalledWith('short.example', { all: true, verbatim: false })
     expect(mocks.lookup).toHaveBeenCalledWith('final.example', { all: true, verbatim: false })
+  })
+
+  it('supports request lookup callbacks that ask for all addresses', async () => {
+    mocks.lookup.mockResolvedValue([{ address: '93.184.216.34', family: 4 }])
+    mocks.httpsRequest.mockImplementation(createRequestMock([{
+      status: 200,
+      body: '<html><head><title>All Addresses Story</title></head></html>',
+    }], { all: true }))
+
+    const { fetchHomeFeaturedNewsMetadata } = await import('@/lib/home-featured-context-metadata')
+    const metadata = await fetchHomeFeaturedNewsMetadata('https://news.example/article')
+
+    expect(metadata.title).toBe('All Addresses Story')
+    expect(metadata.source).toBe('news.example')
   })
 
   it('rejects direct private IP destinations before request', async () => {

--- a/tests/unit/homeFeaturedContextNewsRoute.test.ts
+++ b/tests/unit/homeFeaturedContextNewsRoute.test.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  assertHomeFeaturedNewsMetadataUrlAllowed: vi.fn(),
+  fetchHomeFeaturedNewsMetadata: vi.fn(),
+  getCurrentUser: vi.fn(),
+  getSettings: vi.fn(),
+  parseOpenRouterProviderSettings: vi.fn(),
+  requestOpenRouterCompletion: vi.fn(),
+}))
+
+vi.mock('@/lib/db/queries/user', () => ({
+  UserRepository: {
+    getCurrentUser: (...args: unknown[]) => mocks.getCurrentUser(...args),
+  },
+}))
+
+vi.mock('@/lib/db/queries/settings', () => ({
+  SettingsRepository: {
+    getSettings: (...args: unknown[]) => mocks.getSettings(...args),
+  },
+}))
+
+vi.mock('@/lib/ai/market-context-config', () => ({
+  parseOpenRouterProviderSettings: (...args: unknown[]) => mocks.parseOpenRouterProviderSettings(...args),
+}))
+
+vi.mock('@/lib/ai/openrouter', () => ({
+  requestOpenRouterCompletion: (...args: unknown[]) => mocks.requestOpenRouterCompletion(...args),
+  sanitizeForPrompt: (value: string) => value,
+}))
+
+vi.mock('@/lib/home-featured-context-metadata', () => ({
+  assertHomeFeaturedNewsMetadataUrlAllowed: (...args: unknown[]) =>
+    mocks.assertHomeFeaturedNewsMetadataUrlAllowed(...args),
+  fetchHomeFeaturedNewsMetadata: (...args: unknown[]) => mocks.fetchHomeFeaturedNewsMetadata(...args),
+}))
+
+describe('home featured context news route', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.assertHomeFeaturedNewsMetadataUrlAllowed.mockReset()
+    mocks.fetchHomeFeaturedNewsMetadata.mockReset()
+    mocks.getCurrentUser.mockReset()
+    mocks.getSettings.mockReset()
+    mocks.parseOpenRouterProviderSettings.mockReset()
+    mocks.requestOpenRouterCompletion.mockReset()
+  })
+
+  it('does not return AI fallback URLs when the metadata host validation rejects them', async () => {
+    mocks.getCurrentUser.mockResolvedValue({ id: 'admin-1', is_admin: true })
+    mocks.getSettings.mockResolvedValue({ data: {}, error: null })
+    mocks.parseOpenRouterProviderSettings.mockReturnValue({ apiKey: 'openrouter-key', model: 'openai/gpt-4o-mini' })
+    mocks.requestOpenRouterCompletion.mockResolvedValue(JSON.stringify({
+      news: [{
+        title: 'Blocked Story',
+        source: 'Blocked',
+        url: 'http://127.0.0.1/admin',
+        publishedAt: null,
+      }],
+    }))
+    mocks.fetchHomeFeaturedNewsMetadata.mockRejectedValue(new Error('Could not fetch URL metadata.'))
+    mocks.assertHomeFeaturedNewsMetadataUrlAllowed.mockRejectedValue(new Error('URL host is not allowed.'))
+
+    const { POST } = await import('@/app/[locale]/admin/api/home-featured-events/context-news/route')
+    const response = await POST(new Request('https://example.com/admin/api/home-featured-events/context-news', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Brazil vs Norway',
+        slug: 'brazil-vs-norway',
+        newsSources: '',
+      }),
+    }))
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ items: [] })
+    expect(mocks.assertHomeFeaturedNewsMetadataUrlAllowed).toHaveBeenCalledWith('http://127.0.0.1/admin')
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stale/mismatched news in Home Featured and improves the freshness of attached articles. Hot Topics now include recently resolved events for better coverage.

- **Bug Fixes**
  - Load context items only for the exact event ID and skip mismatches; re-mount the admin “Manage context” dialog when the selected item changes to avoid stale state.
  - More resilient metadata fetch with DNS lookups that support all addresses, stricter SSRF checks, Accept-Language header, and a safe, allowed-host fallback using returned title/source/url/favicon when scraping fails.
  - News ticker: show publisher favicon for news items and correct source/time label.

- **New Features**
  - Higher-quality live web search with `webSearchContextSize: 'high'`, improved prompts for time-sensitive/sports events, and larger headline pools.
  - Hot Topics now merge active volume with recently resolved events (last 36h) and surface the top 5.

<sup>Written for commit 01cff5d8b609c13eb519462bb377459bc5932f10. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

