### PR TITLE
fix: improve featured sports controls

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -689,8 +689,9 @@ function resolveSpreadLineForButton(
   const team2 = card.teams[1]
   const marketMatchesTeam1 = doesLineMarketTextMatchTeam(market, team1)
   const marketMatchesTeam2 = doesLineMarketTextMatchTeam(market, team2)
+  const marketMatchesSingleTeam = marketMatchesTeam1 !== marketMatchesTeam2
 
-  if (marketLine !== null && (marketMatchesTeam1 || marketMatchesTeam2)) {
+  if (marketLine !== null && marketMatchesSingleTeam) {
     if (button.tone === 'team1') {
       return marketMatchesTeam1 ? marketLine : -marketLine
     }

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -2,15 +2,19 @@
 
 import type { IconName } from 'lucide-react/dynamic'
 import type { CSSProperties } from 'react'
-import type { SportsGamesMarketType } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-types'
-import type { SportsGamesCard } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
+import type {
+  LinePickerMarketType,
+  SportsGamesMarketType,
+  SportsLinePickerOption,
+} from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-types'
+import type { SportsGamesButton, SportsGamesCard } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 import type {
   HomeFeaturedContextItem,
   HomeFeaturedEventCard,
   HomeFeaturedHotTopic,
   HomeFeaturedOutcomeSummary,
   HomeFeaturedSideCardSettings,
-  HomeFeaturedSportsMarketGroup,
+  Market,
 } from '@/types'
 import {
   ChevronLeftIcon,
@@ -26,6 +30,7 @@ import EventBookmark from '@/app/[locale]/(platform)/event/[slug]/_components/Ev
 import EventChart from '@/app/[locale]/(platform)/event/[slug]/_components/EventChart'
 import EventMarketChannelProvider from '@/app/[locale]/(platform)/event/[slug]/_components/EventMarketChannelProvider'
 import { shouldUseLiveSeriesChart } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartEligibility'
+import { buildLinePickerOptions } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils'
 import {
   buildSportsGamesCards,
   resolveSportsGamesCardCollapsedMarketType,
@@ -51,6 +56,15 @@ interface HomeFeaturedEventsCarouselProps {
 const HOME_FEATURED_CHART_HEIGHT = 292
 const HOME_FEATURED_CHART_HEIGHT_OFFSET = 20
 const HOME_FEATURED_LIVE_CHART_WIDTH_OFFSET = 24
+type FeaturedSportsButtonTone = 'home' | 'away' | 'draw' | 'neutral'
+interface FeaturedSportsButtonMarket {
+  key: string
+  conditionId: string
+  label: string
+  tone: FeaturedSportsButtonTone
+  color: string | null
+}
+
 const HomeSportsGameGraph = dynamic(
   () => import('@/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameGraph'),
   { ssr: false, loading: () => <div className="min-h-60 w-full md:min-h-[260px] lg:min-h-[280px]" /> },
@@ -133,17 +147,21 @@ function isNegativeOutcomeLabel(label: string) {
   return /\b(?:no|down|below|lower|under)\b/.test(normalized)
 }
 
-function resolveSportsButtonAppearance(market: HomeFeaturedSportsMarketGroup['markets'][number]) {
+function resolveNeutralSportsButtonAppearance() {
+  return {
+    className: `
+      border border-button-outline-border bg-transparent text-muted-foreground
+      hover:bg-secondary/80 hover:text-foreground
+    `,
+    style: undefined,
+    backgroundClassName: undefined,
+    backgroundStyle: undefined,
+  }
+}
+
+function resolveSportsButtonAppearance(market: FeaturedSportsButtonMarket) {
   if (market.tone === 'draw') {
-    return {
-      className: `
-        border border-button-outline-border bg-transparent text-muted-foreground
-        hover:bg-secondary/80 hover:text-foreground
-      `,
-      style: undefined,
-      backgroundClassName: undefined,
-      backgroundStyle: undefined,
-    }
+    return resolveNeutralSportsButtonAppearance()
   }
 
   if (market.tone === 'neutral') {
@@ -166,10 +184,8 @@ function resolveSportsButtonAppearance(market: HomeFeaturedSportsMarketGroup['ma
     }
 
     return {
-      className: 'border border-button-outline-border bg-transparent text-muted-foreground hover:bg-secondary/80',
-      style: undefined,
-      backgroundClassName: undefined,
-      backgroundStyle: undefined,
+      ...resolveNeutralSportsButtonAppearance(),
+      className: 'border border-button-outline-border bg-transparent text-muted-foreground hover:bg-secondary/80 hover:text-foreground',
     }
   }
 
@@ -298,6 +314,52 @@ function FeaturedBreadcrumb({ items }: { items: Array<{ label: string, href: str
   )
 }
 
+function normalizeFeaturedSportsTitle(value: string) {
+  return value
+    .replace(/\s+-\s+more markets\s*$/i, '')
+    .replace(/\bvs\.\s*/i, 'vs ')
+    .replace(/\s+/g, ' ')
+    .trim()
+}
+
+function resolveFeaturedDisplayTitle(item: HomeFeaturedEventCard) {
+  if (item.kind === 'sports') {
+    const teams = item.event.sports_teams ?? []
+    const [homeTeam, awayTeam] = teams
+    if (homeTeam?.name && awayTeam?.name) {
+      return `${homeTeam.name} vs ${awayTeam.name}`
+    }
+
+    return normalizeFeaturedSportsTitle(item.event.title)
+  }
+
+  return item.event.title
+}
+
+function FeaturedHeaderActions({
+  event,
+  className,
+}: {
+  event: HomeFeaturedEventCard['event']
+  className?: string
+}) {
+  const t = useExtracted()
+  const eventHref = resolveEventPagePath(event)
+
+  return (
+    <div className={cn('flex shrink-0 items-center gap-2', className)}>
+      <Button type="button" variant="ghost" size="icon" asChild aria-label={t('Open market')}>
+        <AppLink intentPrefetch href={eventHref}>
+          <ExternalLinkIcon className="size-4" />
+        </AppLink>
+      </Button>
+      <div className="flex size-10 items-center justify-center">
+        <EventBookmark event={event} refreshStatusOnMount={false} />
+      </div>
+    </div>
+  )
+}
+
 function FeaturedHeader({
   item,
   showActions = true,
@@ -305,10 +367,10 @@ function FeaturedHeader({
   item: HomeFeaturedEventCard
   showActions?: boolean
 }) {
-  const t = useExtracted()
   const event = item.event
   const eventHref = resolveEventPagePath(event)
   const breadcrumbItems = resolveFeaturedBreadcrumbItems(item)
+  const displayTitle = resolveFeaturedDisplayTitle(item)
 
   return (
     <div className="flex min-w-0 items-start justify-between gap-3">
@@ -321,7 +383,7 @@ function FeaturedHeader({
           >
             <EventIconImage
               src={event.icon_url || item.primaryMarkets[0]?.icon_url || '/images/pwa/default-icon-192.png'}
-              alt={event.title}
+              alt={displayTitle}
               sizes="48px"
               containerClassName="size-full rounded-lg"
             />
@@ -338,23 +400,12 @@ function FeaturedHeader({
               md:text-xl
             "
           >
-            {event.title}
+            {displayTitle}
           </AppLink>
         </div>
       </div>
 
-      {showActions && (
-        <div className="flex shrink-0 items-center gap-2">
-          <Button type="button" variant="ghost" size="icon" asChild aria-label={t('Open market')}>
-            <AppLink intentPrefetch href={eventHref}>
-              <ExternalLinkIcon className="size-4" />
-            </AppLink>
-          </Button>
-          <div className="flex size-10 items-center justify-center">
-            <EventBookmark event={event} refreshStatusOnMount={false} />
-          </div>
-        </div>
-      )}
+      {showActions && <FeaturedHeaderActions event={event} />}
     </div>
   )
 }
@@ -438,62 +489,24 @@ function StandardActions({ item, linkedHref }: { item: HomeFeaturedEventCard, li
   )
 }
 
-function isSportsMoneylineGroup(group: HomeFeaturedSportsMarketGroup) {
-  return normalizeText(group.label) === 'moneyline'
-}
-
-function resolveSportsLineValueLabel(label: string) {
-  const normalizedLabel = label.replace(/[\u2212\u2013\u2014]/g, '-')
-  const valueText = normalizedLabel.match(/\bo\/u\s*([+-]?\d+(?:\.\d+)?)/i)?.[1]
-    ?? normalizedLabel.match(/\(([+-]?\d+(?:\.\d+)?)\)/)?.[1]
-    ?? normalizedLabel.match(/[+-]\d+(?:\.\d+)?/)?.[0]
-    ?? normalizedLabel.match(/\d+(?:\.\d+)?/)?.[0]
-
-  if (!valueText) {
-    return null
-  }
-
-  const value = Number(valueText)
-  if (!Number.isFinite(value)) {
-    return valueText
-  }
-
-  return String(Math.abs(value))
-}
-
-function resolveSportsLineSummary(markets: HomeFeaturedSportsMarketGroup['markets']) {
-  const labels: string[] = []
-  const seenLabels = new Set<string>()
-
-  for (const market of markets) {
-    const label = resolveSportsLineValueLabel(market.label)
-    if (!label || seenLabels.has(label)) {
-      continue
-    }
-
-    labels.push(label)
-    seenLabels.add(label)
-  }
-
-  return labels
-}
-
 function SportsMarketButton({
   groupLabel,
   market,
   linkedHref,
   className,
+  forceNeutral = false,
 }: {
   groupLabel: string
-  market: HomeFeaturedSportsMarketGroup['markets'][number]
+  market: FeaturedSportsButtonMarket
   linkedHref: string
   className?: string
+  forceNeutral?: boolean
 }) {
-  const appearance = resolveSportsButtonAppearance(market)
+  const appearance = forceNeutral ? resolveNeutralSportsButtonAppearance() : resolveSportsButtonAppearance(market)
 
   return (
     <AppLink
-      key={`${groupLabel}:${market.conditionId}:${market.label}`}
+      key={`${groupLabel}:${market.key}`}
       intentPrefetch
       href={linkedHref}
       className={cn(
@@ -529,126 +542,385 @@ function SportsMarketButton({
 }
 
 function SportsMoneylineButtons({
-  group,
+  card,
   linkedHref,
 }: {
-  group: HomeFeaturedSportsMarketGroup | undefined
+  card: SportsGamesCard
   linkedHref: string
 }) {
-  if (!group || group.markets.length === 0) {
+  const moneylineButtons = card.buttons
+    .filter(button => button.marketType === 'moneyline')
+    .sort(compareSportsButtonsByTone)
+
+  if (moneylineButtons.length === 0) {
     return null
   }
 
   return (
     <div
       className="grid gap-2"
-      style={{ gridTemplateColumns: `repeat(${Math.min(group.markets.length, 3)}, minmax(0, 1fr))` }}
+      style={{ gridTemplateColumns: `repeat(${Math.min(moneylineButtons.length, 3)}, minmax(0, 1fr))` }}
     >
-      {group.markets.slice(0, 3).map(market => (
+      {moneylineButtons.slice(0, 3).map(button => (
         <SportsMarketButton
-          key={`${group.label}:${market.conditionId}:${market.label}`}
-          groupLabel={group.label}
-          market={market}
+          key={button.key}
+          groupLabel="Moneyline"
+          market={toFeaturedSportsButtonMarket(
+            button,
+            resolveMoneylineButtonLabel(card, button),
+          )}
           linkedHref={linkedHref}
-          className="h-14 text-sm md:h-16 md:text-base"
+          className="h-14 text-sm md:text-base"
         />
       ))}
     </div>
   )
 }
 
-function SportsLineMarketCarousel({
-  group,
-  linkedHref,
-}: {
-  group: HomeFeaturedSportsMarketGroup
-  linkedHref: string
-}) {
-  const [pageIndex, setPageIndex] = useState(0)
+const SPORTS_BUTTON_TONE_ORDER: Record<SportsGamesButton['tone'], number> = {
+  team1: 0,
+  draw: 1,
+  team2: 2,
+  over: 3,
+  under: 4,
+  neutral: 5,
+}
 
-  if (group.markets.length === 0) {
+function compareSportsButtonsByTone(left: SportsGamesButton, right: SportsGamesButton) {
+  const toneComparison = SPORTS_BUTTON_TONE_ORDER[left.tone] - SPORTS_BUTTON_TONE_ORDER[right.tone]
+  if (toneComparison !== 0) {
+    return toneComparison
+  }
+
+  return left.key.localeCompare(right.key)
+}
+
+function resolveMoneylineButtonLabel(card: SportsGamesCard, button: SportsGamesButton) {
+  if (button.tone === 'team1') {
+    return card.teams[0]?.name ?? button.label
+  }
+  if (button.tone === 'team2') {
+    return card.teams[1]?.name ?? button.label
+  }
+  if (button.tone === 'draw') {
+    return 'Draw'
+  }
+
+  return button.label
+}
+
+function resolveFeaturedSportsButtonTone(button: SportsGamesButton): FeaturedSportsButtonTone {
+  if (button.tone === 'team1') {
+    return 'home'
+  }
+  if (button.tone === 'team2') {
+    return 'away'
+  }
+  if (button.tone === 'draw') {
+    return 'draw'
+  }
+
+  return 'neutral'
+}
+
+function toFeaturedSportsButtonMarket(button: SportsGamesButton, label = button.label): FeaturedSportsButtonMarket {
+  return {
+    key: button.key,
+    conditionId: button.conditionId,
+    label,
+    tone: resolveFeaturedSportsButtonTone(button),
+    color: button.color,
+  }
+}
+
+function extractSignedLineValue(value: string | null | undefined) {
+  const match = value?.replace(/[\u2212\u2013\u2014]/g, '-').match(/([+-]\s*\d+(?:\.\d+)?)/)
+  const rawValue = match?.[1]?.replace(/\s+/g, '')
+  if (!rawValue) {
     return null
   }
 
-  const marketsPerPage = 2
-  const pageCount = Math.max(1, Math.ceil(group.markets.length / marketsPerPage))
-  const normalizedPageIndex = Math.min(pageIndex, pageCount - 1)
-  const pageStartIndex = normalizedPageIndex * marketsPerPage
-  const visibleMarkets = group.markets.slice(pageStartIndex, pageStartIndex + marketsPerPage)
-  const lineLabels = resolveSportsLineSummary(visibleMarkets)
-  const canPickPrevious = normalizedPageIndex > 0
-  const canPickNext = normalizedPageIndex < pageCount - 1
+  const numericValue = Number(rawValue)
+  return Number.isFinite(numericValue) ? numericValue : null
+}
+
+function formatSignedSportsLine(value: number) {
+  const rounded = Math.round(value * 10) / 10
+  const display = Number.isInteger(rounded) ? `${rounded.toFixed(1)}` : `${rounded}`
+  return value > 0 ? `+${display}` : display
+}
+
+function doesLineMarketTextMatchTeam(market: Market | null | undefined, team: SportsGamesCard['teams'][number] | null | undefined) {
+  if (!market || !team) {
+    return false
+  }
+
+  const marketText = normalizeText([
+    market.sports_group_item_title,
+    market.short_title,
+    market.title,
+    market.slug,
+  ].filter(Boolean).join(' '))
+  const teamName = normalizeText(team.name)
+  const teamAbbreviation = normalizeText(team.abbreviation)
+
+  return Boolean(
+    (teamName && marketText.includes(teamName))
+    || (teamAbbreviation && new Set(marketText.split(' ')).has(teamAbbreviation)),
+  )
+}
+
+function resolveMarketSignedLine(market: Market | null | undefined) {
+  return extractSignedLineValue([
+    market?.sports_group_item_title,
+    market?.short_title,
+    market?.title,
+  ].filter(Boolean).join(' '))
+}
+
+function resolveSpreadLineForButton(
+  card: SportsGamesCard,
+  option: SportsLinePickerOption,
+  button: SportsGamesButton,
+  market: Market | null | undefined,
+) {
+  const marketLine = resolveMarketSignedLine(market)
+  const team1 = card.teams[0]
+  const team2 = card.teams[1]
+  const marketMatchesTeam1 = doesLineMarketTextMatchTeam(market, team1)
+  const marketMatchesTeam2 = doesLineMarketTextMatchTeam(market, team2)
+
+  if (marketLine !== null && (marketMatchesTeam1 || marketMatchesTeam2)) {
+    if (button.tone === 'team1') {
+      return marketMatchesTeam1 ? marketLine : -marketLine
+    }
+    if (button.tone === 'team2') {
+      return marketMatchesTeam2 ? marketLine : -marketLine
+    }
+  }
+
+  const buttonLine = extractSignedLineValue(button.label)
+  if (buttonLine !== null) {
+    return buttonLine
+  }
+
+  if (button.tone === 'team1') {
+    return -option.lineValue
+  }
+  if (button.tone === 'team2') {
+    return option.lineValue
+  }
+
+  return option.lineValue
+}
+
+function resolveLineButtonLabel(
+  card: SportsGamesCard,
+  option: SportsLinePickerOption,
+  button: SportsGamesButton,
+  market: Market | null | undefined,
+  marketType: LinePickerMarketType,
+) {
+  if (marketType === 'total') {
+    return button.tone === 'under' ? `U ${option.label}` : `O ${option.label}`
+  }
+
+  const teamName = button.tone === 'team1'
+    ? card.teams[0]?.name
+    : button.tone === 'team2'
+      ? card.teams[1]?.name
+      : null
+  const line = resolveSpreadLineForButton(card, option, button, market)
+
+  return teamName ? `${teamName} ${formatSignedSportsLine(line)}` : button.label
+}
+
+function isFeaturedLineMarket(market: Market | null | undefined, marketType: LinePickerMarketType) {
+  if (!market) {
+    return false
+  }
+
+  const normalizedType = normalizeText(market.sports_market_type)
+  const normalizedText = normalizeText([
+    market.sports_group_item_title,
+    market.short_title,
+    market.title,
+  ].filter(Boolean).join(' '))
+
+  if (marketType === 'spread') {
+    return normalizedType.includes('spread') || normalizedType.includes('handicap')
+  }
+
+  const isTeamOrSegmentTotal = normalizedType.includes('team')
+    || normalizedText.includes('team total')
+    || normalizedText.includes('half')
+    || normalizedText.includes('quarter')
+    || normalizedText.includes('period')
+
+  return !isTeamOrSegmentTotal
+    && (normalizedType === 'totals' || normalizedType.includes(' total') || normalizedType.includes('over under'))
+}
+
+function scoreSpreadLineOption(card: SportsGamesCard, option: SportsLinePickerOption, market: Market | null | undefined) {
+  const team1 = card.teams[0]
+  const marketLine = resolveMarketSignedLine(market)
+  if (marketLine !== null && doesLineMarketTextMatchTeam(market, team1) && marketLine < 0) {
+    return 3
+  }
+
+  const team1ButtonLine = option.buttons
+    .filter(button => button.tone === 'team1')
+    .map(button => extractSignedLineValue(button.label))
+    .find((line): line is number => line !== null)
+  if (team1ButtonLine != null && team1ButtonLine < 0) {
+    return 2
+  }
+
+  return 1
+}
+
+function resolveFeaturedLinePickerOptions(card: SportsGamesCard, marketType: LinePickerMarketType) {
+  const marketByConditionId = new Map(card.detailMarkets.map(market => [market.condition_id, market] as const))
+  const filteredOptions = buildLinePickerOptions(card, marketType)
+    .filter(option => isFeaturedLineMarket(marketByConditionId.get(option.conditionId), marketType))
+
+  const byLineValue = new Map<number, SportsLinePickerOption>()
+  for (const option of filteredOptions) {
+    const existing = byLineValue.get(option.lineValue)
+    if (!existing) {
+      byLineValue.set(option.lineValue, option)
+      continue
+    }
+
+    const optionScore = scoreSpreadLineOption(card, option, marketByConditionId.get(option.conditionId))
+    const existingScore = scoreSpreadLineOption(card, existing, marketByConditionId.get(existing.conditionId))
+    if (
+      marketType === 'spread'
+      && optionScore > existingScore
+    ) {
+      byLineValue.set(option.lineValue, option)
+    }
+  }
+
+  return Array.from(byLineValue.values()).sort((left, right) => left.lineValue - right.lineValue)
+}
+
+function LinePickerArrowButton({
+  direction,
+  disabled,
+  onClick,
+}: {
+  direction: 'previous' | 'next'
+  disabled: boolean
+  onClick: () => void
+}) {
+  const Icon = direction === 'previous' ? ChevronLeftIcon : ChevronRightIcon
 
   return (
-    <div className="grid gap-2">
-      <div className="flex min-h-8 items-center justify-between gap-3">
-        <span className="min-w-0 truncate text-base font-semibold">{group.label}</span>
-        <div className="flex min-w-0 items-center gap-2">
-          {pageCount > 1 && (
-            <button
-              type="button"
-              onClick={() => setPageIndex(current => Math.max(0, current - 1))}
-              disabled={!canPickPrevious}
-              className={cn(
-                `
-                  inline-flex size-7 shrink-0 items-center justify-center rounded-sm text-muted-foreground
-                  transition-colors
-                  focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none
-                `,
-                canPickPrevious
-                  ? 'cursor-pointer hover:bg-muted/70 hover:text-foreground'
-                  : 'cursor-not-allowed opacity-40',
-              )}
-              aria-label="Previous line"
-            >
-              <ChevronLeftIcon className="size-4.5" />
-            </button>
-          )}
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      className={cn(
+        `
+          inline-flex size-7 shrink-0 items-center justify-center rounded-sm text-muted-foreground transition-colors
+          focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none
+        `,
+        disabled
+          ? 'cursor-not-allowed opacity-35'
+          : 'cursor-pointer hover:bg-muted/70 hover:text-foreground',
+      )}
+      aria-label={direction === 'previous' ? 'Previous line' : 'Next line'}
+    >
+      <Icon className="size-4.5" />
+    </button>
+  )
+}
 
-          {lineLabels.length > 0 && (
-            <span className="flex min-w-0 items-center gap-4 text-sm font-semibold tabular-nums">
-              {lineLabels.map((lineLabel, index) => (
-                <span
-                  key={`${group.label}:${lineLabel}:${index}`}
-                  className={cn(index === 0 ? 'text-foreground' : 'text-muted-foreground')}
-                >
-                  {lineLabel}
-                </span>
-              ))}
+function SportsFeaturedLineMarketCarousel({
+  card,
+  marketType,
+  label,
+  linkedHref,
+}: {
+  card: SportsGamesCard
+  marketType: LinePickerMarketType
+  label: string
+  linkedHref: string
+}) {
+  const options = useMemo(
+    () => resolveFeaturedLinePickerOptions(card, marketType),
+    [card, marketType],
+  )
+  const [selectedIndex, setSelectedIndex] = useState(0)
+  const activeIndex = options.length === 0 ? 0 : Math.min(selectedIndex, options.length - 1)
+  const activeOption = options[activeIndex]
+  const marketByConditionId = useMemo(
+    () => new Map(card.detailMarkets.map(market => [market.condition_id, market] as const)),
+    [card.detailMarkets],
+  )
+
+  if (!activeOption) {
+    return null
+  }
+
+  const canPickPrevious = activeIndex > 0
+  const canPickNext = activeIndex < options.length - 1
+  const visibleOptions = [
+    activeIndex > 0 ? options[activeIndex - 1] : null,
+    activeOption,
+    activeIndex < options.length - 1 ? options[activeIndex + 1] : null,
+  ]
+  const activeMarket = marketByConditionId.get(activeOption.conditionId) ?? null
+  const visibleButtons = [...activeOption.buttons]
+    .sort(compareSportsButtonsByTone)
+    .slice(0, 2)
+
+  return (
+    <div className="grid gap-2.5">
+      <div className="grid min-h-8 grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
+        <span className="min-w-0 truncate text-base font-semibold">{label}</span>
+        <div className="
+          grid grid-cols-[1.75rem_2.5rem_2.5rem_2.5rem_1.75rem] items-center gap-1 text-sm font-semibold tabular-nums
+        "
+        >
+          <LinePickerArrowButton
+            direction="previous"
+            disabled={!canPickPrevious}
+            onClick={() => setSelectedIndex(Math.max(0, activeIndex - 1))}
+          />
+          {visibleOptions.map((option, index) => (
+            <span
+              key={option ? `${marketType}:${option.conditionId}` : `${marketType}:empty:${index}`}
+              aria-hidden={!option}
+              className={cn(
+                'inline-flex h-7 min-w-0 items-center justify-center text-center',
+                index === 1 ? 'text-foreground' : 'text-muted-foreground',
+              )}
+            >
+              {option?.label ?? ''}
             </span>
-          )}
-
-          {pageCount > 1 && (
-            <button
-              type="button"
-              onClick={() => setPageIndex(current => Math.min(pageCount - 1, current + 1))}
-              disabled={!canPickNext}
-              className={cn(
-                `
-                  inline-flex size-7 shrink-0 items-center justify-center rounded-sm text-muted-foreground
-                  transition-colors
-                  focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none
-                `,
-                canPickNext
-                  ? 'cursor-pointer hover:bg-muted/70 hover:text-foreground'
-                  : 'cursor-not-allowed opacity-40',
-              )}
-              aria-label="Next line"
-            >
-              <ChevronRightIcon className="size-4.5" />
-            </button>
-          )}
+          ))}
+          <LinePickerArrowButton
+            direction="next"
+            disabled={!canPickNext}
+            onClick={() => setSelectedIndex(Math.min(options.length - 1, activeIndex + 1))}
+          />
         </div>
       </div>
 
-      <div className={cn('grid gap-2', visibleMarkets.length === 1 ? 'grid-cols-1' : 'grid-cols-2')}>
-        {visibleMarkets.map(market => (
+      <div className="grid grid-cols-2 gap-2">
+        {visibleButtons.map(button => (
           <SportsMarketButton
-            key={`${group.label}:${market.conditionId}:${market.label}`}
-            groupLabel={group.label}
-            market={market}
+            key={button.key}
+            groupLabel={label}
+            market={toFeaturedSportsButtonMarket(
+              button,
+              resolveLineButtonLabel(card, activeOption, button, activeMarket, marketType),
+            )}
             linkedHref={linkedHref}
-            className="h-12 text-sm md:h-[52px]"
+            className="h-10 text-sm"
+            forceNeutral
           />
         ))}
       </div>
@@ -656,22 +928,36 @@ function SportsLineMarketCarousel({
   )
 }
 
-function SportsGroups({ groups, linkedHref }: { groups: HomeFeaturedSportsMarketGroup[], linkedHref: string }) {
-  const secondaryGroups = groups.filter(group => !isSportsMoneylineGroup(group))
+function SportsFeaturedControls({ card, linkedHref }: { card: SportsGamesCard, linkedHref: string }) {
+  const hasMoneyline = card.buttons.some(button => button.marketType === 'moneyline')
+  const hasSpread = resolveFeaturedLinePickerOptions(card, 'spread').length > 0
+  const hasTotal = resolveFeaturedLinePickerOptions(card, 'total').length > 0
+  const hasSecondaryMarkets = hasSpread || hasTotal
 
-  if (secondaryGroups.length === 0) {
+  if (!hasMoneyline && !hasSecondaryMarkets) {
     return null
   }
 
   return (
     <div className="grid gap-4">
-      {secondaryGroups.map(group => (
-        <SportsLineMarketCarousel
-          key={group.label}
-          group={group}
+      {hasMoneyline && <SportsMoneylineButtons card={card} linkedHref={linkedHref} />}
+      {hasMoneyline && hasSecondaryMarkets && <div className="border-t border-border/60" />}
+      {hasSpread && (
+        <SportsFeaturedLineMarketCarousel
+          card={card}
+          marketType="spread"
+          label="Spread"
           linkedHref={linkedHref}
         />
-      ))}
+      )}
+      {hasTotal && (
+        <SportsFeaturedLineMarketCarousel
+          card={card}
+          marketType="total"
+          label="Total"
+          linkedHref={linkedHref}
+        />
+      )}
     </div>
   )
 }
@@ -1108,12 +1394,6 @@ function FeaturedSlide({
     ? Math.max(1, chartContainerWidth - HOME_FEATURED_LIVE_CHART_WIDTH_OFFSET)
     : undefined
   const hasContextItems = item.contextItems.length > 0
-  const sportsMoneylineGroup = item.kind === 'sports'
-    ? item.sportsMarketGroups.find(isSportsMoneylineGroup)
-    : undefined
-  const sportsSecondaryGroups = item.kind === 'sports'
-    ? item.sportsMarketGroups.filter(group => !isSportsMoneylineGroup(group))
-    : []
   const featuredDetailsClassName = cn(
     'flex min-h-0 min-w-0 flex-col gap-3',
     !hasContextItems && item.kind !== 'sports' && 'justify-center',
@@ -1174,12 +1454,39 @@ function FeaturedSlide({
   )
   const chartColumnNode = item.kind === 'sports'
     ? (
-        <div className="grid min-h-0 content-start gap-3">
+        <div className="grid min-h-0 content-start gap-3 pr-16">
           <SportsScoreboard item={item} />
           {chartNode}
         </div>
       )
     : chartNode
+
+  if (item.kind === 'sports') {
+    return (
+      <article className="
+        relative flex h-full min-w-full flex-col gap-4 overflow-hidden p-4 pb-[64px]
+        md:p-5 md:pb-[68px]
+      "
+      >
+        <FeaturedHeaderActions event={item.event} className="absolute top-4 right-4 z-30 md:top-5 md:right-5" />
+        <div className="
+          grid min-h-0 flex-1 grid-cols-1 gap-4
+          md:grid-cols-[minmax(260px,0.8fr)_minmax(320px,1fr)] md:gap-5
+          lg:grid-cols-[minmax(320px,0.8fr)_minmax(420px,1fr)] lg:gap-6
+        "
+        >
+          <div className={featuredDetailsClassName}>
+            <FeaturedHeader item={item} showActions={false} />
+            {sportsGraphCard && <SportsFeaturedControls card={sportsGraphCard} linkedHref={linkedHref} />}
+            <ContextTicker item={item} linkedHref={linkedHref} />
+          </div>
+
+          {chartColumnNode}
+        </div>
+        <FeaturedFooter item={item} />
+      </article>
+    )
+  }
 
   if (shouldRenderLiveSeriesChart) {
     return (
@@ -1197,16 +1504,9 @@ function FeaturedSlide({
           <div className={featuredDetailsClassName}>
             <FeaturedHeader item={item} showActions={false} />
 
-            {item.kind === 'sports'
-              ? (
-                  <>
-                    <SportsMoneylineButtons group={sportsMoneylineGroup} linkedHref={linkedHref} />
-                    <SportsGroups groups={sportsSecondaryGroups} linkedHref={linkedHref} />
-                  </>
-                )
-              : item.kind === 'standard'
-                ? <StandardActions item={item} linkedHref={linkedHref} />
-                : <OutcomeRows outcomes={item.topOutcomes} linkedHref={linkedHref} />}
+            {item.kind === 'standard'
+              ? <StandardActions item={item} linkedHref={linkedHref} />
+              : <OutcomeRows outcomes={item.topOutcomes} linkedHref={linkedHref} />}
 
             <ContextTicker item={item} linkedHref={linkedHref} />
           </div>
@@ -1232,16 +1532,9 @@ function FeaturedSlide({
       "
       >
         <div className={featuredDetailsClassName}>
-          {item.kind === 'sports'
-            ? (
-                <>
-                  <SportsMoneylineButtons group={sportsMoneylineGroup} linkedHref={linkedHref} />
-                  <SportsGroups groups={sportsSecondaryGroups} linkedHref={linkedHref} />
-                </>
-              )
-            : item.kind === 'standard'
-              ? <StandardActions item={item} linkedHref={linkedHref} />
-              : <OutcomeRows outcomes={item.topOutcomes} linkedHref={linkedHref} />}
+          {item.kind === 'standard'
+            ? <StandardActions item={item} linkedHref={linkedHref} />
+            : <OutcomeRows outcomes={item.topOutcomes} linkedHref={linkedHref} />}
 
           <ContextTicker item={item} linkedHref={linkedHref} />
         </div>

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -1330,7 +1330,7 @@ function FeaturedRightRail({
                 {topic.label}
               </span>
               <span className="text-sm text-muted-foreground">
-                {`${formatDollarValueLabel(topic.volume24h, { maximumFractionDigits: 0 })} 24h`}
+                {`${formatDollarValueLabel(topic.volume24h, { maximumFractionDigits: 0 })} Vol`}
               </span>
               <ChevronRightIcon className="size-4 text-muted-foreground" />
             </AppLink>
@@ -1454,7 +1454,7 @@ function FeaturedSlide({
   )
   const chartColumnNode = item.kind === 'sports'
     ? (
-        <div className="grid min-h-0 content-start gap-3 pr-16">
+        <div className="grid min-h-0 content-start gap-3">
           <SportsScoreboard item={item} />
           {chartNode}
         </div>
@@ -1468,7 +1468,6 @@ function FeaturedSlide({
         md:p-5 md:pb-[68px]
       "
       >
-        <FeaturedHeaderActions event={item.event} className="absolute top-4 right-4 z-30 md:top-5 md:right-5" />
         <div className="
           grid min-h-0 flex-1 grid-cols-1 gap-4
           md:grid-cols-[minmax(260px,0.8fr)_minmax(320px,1fr)] md:gap-5

--- a/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/[...slugParts]/page.tsx
@@ -181,6 +181,7 @@ async function renderEsportsSubcategoryGamesPage(params: {
     locale: locale as SupportedLocale,
     sportsSportSlug: context.canonicalSportSlug,
     sportsSection: 'games',
+    excludeSportsAuxiliary: true,
     status: 'active',
   })
   const subcategoryEvents = (activeEvents ?? []).filter(event =>

--- a/src/app/[locale]/(platform)/esports/[sport]/games/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/games/page.tsx
@@ -96,6 +96,7 @@ export default async function EsportsGamesBySportPage({
     locale: locale as SupportedLocale,
     sportsSportSlug: canonicalSportSlug,
     sportsSection: 'games' as const,
+    excludeSportsAuxiliary: true,
   }
 
   const { data: activeEvents } = await EventRepository.listEvents({

--- a/src/app/[locale]/(platform)/esports/[sport]/games/week/[week]/page.tsx
+++ b/src/app/[locale]/(platform)/esports/[sport]/games/week/[week]/page.tsx
@@ -121,6 +121,7 @@ export default async function EsportsGamesBySportWeekPage({
     locale: locale as SupportedLocale,
     sportsSportSlug: canonicalSportSlug,
     sportsSection: 'games' as const,
+    excludeSportsAuxiliary: true,
   }
 
   const { data: activeEvents } = await EventRepository.listEvents({

--- a/src/app/[locale]/(platform)/esports/live/page.tsx
+++ b/src/app/[locale]/(platform)/esports/live/page.tsx
@@ -37,6 +37,7 @@ export default async function EsportsLivePage({ params }: PageProps<'/[locale]/e
       status: 'active',
       locale: locale as SupportedLocale,
       sportsSection: 'games',
+      excludeSportsAuxiliary: true,
     }),
     SportsMenuRepository.getLayoutData('esports'),
   ])

--- a/src/app/[locale]/(platform)/esports/soon/page.tsx
+++ b/src/app/[locale]/(platform)/esports/soon/page.tsx
@@ -25,6 +25,7 @@ export default async function EsportsSoonPage({ params }: { params: Promise<{ lo
       status: 'active',
       locale: locale as SupportedLocale,
       sportsSection: 'games',
+      excludeSportsAuxiliary: true,
     }),
     SportsMenuRepository.getLayoutData('esports'),
   ])

--- a/src/app/[locale]/(platform)/sports/[sport]/games/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/games/page.tsx
@@ -95,6 +95,7 @@ export default async function SportsGamesBySportPage({
     locale: locale as SupportedLocale,
     sportsSportSlug: canonicalSportSlug,
     sportsSection: 'games' as const,
+    excludeSportsAuxiliary: true,
   }
 
   const { data: activeEvents } = await EventRepository.listEvents({

--- a/src/app/[locale]/(platform)/sports/[sport]/games/week/[week]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/games/week/[week]/page.tsx
@@ -121,6 +121,7 @@ export default async function SportsGamesBySportWeekPage({
     locale: locale as SupportedLocale,
     sportsSportSlug: canonicalSportSlug,
     sportsSection: 'games' as const,
+    excludeSportsAuxiliary: true,
   }
 
   const { data: activeEvents } = await EventRepository.listEvents({

--- a/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
@@ -3,6 +3,11 @@ import type { Event, Market, Outcome, SportsTeam } from '@/types'
 import { resolveEventPagePath } from '@/lib/events-routing'
 import { resolveOutcomeSelectionPriceCents } from '@/lib/market-pricing'
 import {
+  mergeSportsEventGroupMarkets,
+  resolveSportsMarketsVolume,
+  sumFiniteSportsValues,
+} from '@/lib/sports-event-market-utils'
+import {
   isSportsMoreMarketsSlug,
   SPORTS_EVENT_MARKET_VIEW_LABELS,
   SPORTS_EVENT_MARKET_VIEW_ORDER,
@@ -1641,35 +1646,6 @@ function resolveEventGroupKey(event: Event) {
   return stripSportsAuxiliaryEventSuffix(event.sports_event_slug?.trim() || event.slug)
 }
 
-function mergeMarkets(events: Event[]) {
-  const byConditionId = new Map<string, Market>()
-
-  for (const event of events) {
-    for (const market of event.markets ?? []) {
-      if (!market?.condition_id || byConditionId.has(market.condition_id)) {
-        continue
-      }
-      byConditionId.set(market.condition_id, market)
-    }
-  }
-
-  return Array.from(byConditionId.values())
-}
-
-function sumFiniteValues(values: Array<number | null | undefined>): number {
-  return values.reduce<number>((sum, value) => {
-    const numericValue = Number(value)
-    if (!Number.isFinite(numericValue)) {
-      return sum
-    }
-    return sum + numericValue
-  }, 0)
-}
-
-function resolveMarketsVolume(markets: Market[]) {
-  return sumFiniteValues(markets.map(market => Number(market.volume ?? 0)))
-}
-
 function resolveWeek(events: Event[], fallback: number | null) {
   if (fallback !== null) {
     return fallback
@@ -1790,7 +1766,7 @@ function buildSportsGamesCard(
     ?? eventsGroup.find(event => (event.sports_teams?.length ?? 0) > 0)
     ?? primaryEvent
 
-  const mergedMarkets = mergeMarkets(eventsGroup)
+  const mergedMarkets = mergeSportsEventGroupMarkets(eventsGroup)
     .filter(market => options?.marketFilter ? options.marketFilter(market) : true)
   const eventForDisplay: Event = {
     ...primaryEvent,
@@ -1821,7 +1797,7 @@ function buildSportsGamesCard(
   const mergedMarketsCount = mergedMarkets.length
   const marketsCount = mergedMarketsCount > 0 ? mergedMarketsCount : mergedMarkets.length
 
-  const volume = resolveMarketsVolume(mergedMarkets)
+  const volume = resolveSportsMarketsVolume(mergedMarkets)
 
   return {
     id: primaryEvent.id,
@@ -1891,9 +1867,9 @@ export function buildSportsGamesCardGroups(events: Event[]): SportsGamesCardGrou
         return null
       }
 
-      const aggregatedMarkets = mergeMarkets(allGroupEvents)
-      const aggregatedMarketsCount = sumFiniteValues(allGroupEvents.map(event => event.total_markets_count))
-      const aggregatedVolume = resolveMarketsVolume(aggregatedMarkets)
+      const aggregatedMarkets = mergeSportsEventGroupMarkets(allGroupEvents)
+      const aggregatedMarketsCount = sumFiniteSportsValues(allGroupEvents.map(event => event.total_markets_count))
+      const aggregatedVolume = resolveSportsMarketsVolume(aggregatedMarkets)
       const primaryCard = {
         ...primaryMarketView.card,
         volume: aggregatedVolume,

--- a/src/app/[locale]/(platform)/sports/live/page.tsx
+++ b/src/app/[locale]/(platform)/sports/live/page.tsx
@@ -37,6 +37,7 @@ export default async function SportsLivePage({ params }: PageProps<'/[locale]/sp
       status: 'active',
       locale: locale as SupportedLocale,
       sportsSection: 'games',
+      excludeSportsAuxiliary: true,
     }),
     SportsMenuRepository.getLayoutData('sports'),
   ])

--- a/src/app/[locale]/(platform)/sports/soon/page.tsx
+++ b/src/app/[locale]/(platform)/sports/soon/page.tsx
@@ -25,6 +25,7 @@ export default async function SportsSoonPage({ params }: PageProps<'/[locale]/sp
       status: 'active',
       locale: locale as SupportedLocale,
       sportsSection: 'games',
+      excludeSportsAuxiliary: true,
     }),
     SportsMenuRepository.getLayoutData('sports'),
   ])

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -335,20 +335,40 @@ export async function listHomeFeaturedHotTopics(
   cacheTag(cacheTags.mainTags(locale))
 
   const volume24h = sql<number>`COALESCE(SUM(${markets.volume_24h}), 0)::double precision`
+  const fallbackVolume = sql<number>`
+    COALESCE(
+      NULLIF(SUM(${markets.volume}), 0),
+      COUNT(${markets.condition_id})::double precision,
+      0
+    )::double precision
+  `
   const localizedName = sql<string>`COALESCE(${tag_translations.name}, ${tags.name})`
   interface HotTopicVolumeRow {
     slug: string
     label: string
     volume24h: number
+    fallbackVolume: number
   }
 
-  function mergeHotTopicRows(rows: HotTopicVolumeRow[]) {
-    const topicsBySlug = new Map<string, HomeFeaturedHotTopic>()
+  function mergeHotTopicRows(rows: HotTopicVolumeRow[], includeFallbackVolume: boolean) {
+    const topicsBySlug = new Map<string, HomeFeaturedHotTopic & { score: number }>()
 
     for (const row of rows) {
       const slug = row.slug.trim()
-      const volume = Number(row.volume24h ?? 0)
-      if (!slug || volume <= 0) {
+      const volume24hValue = Number(row.volume24h ?? 0)
+      const fallbackVolumeValue = Number(row.fallbackVolume ?? 0)
+      const displayVolume = volume24hValue > 0
+        ? volume24hValue
+        : includeFallbackVolume
+          ? fallbackVolumeValue
+          : 0
+      const score = volume24hValue > 0
+        ? volume24hValue
+        : includeFallbackVolume
+          ? fallbackVolumeValue
+          : 0
+
+      if (!slug || score <= 0) {
         continue
       }
 
@@ -357,13 +377,37 @@ export async function listHomeFeaturedHotTopics(
         label: existing?.label ?? row.label,
         slug,
         href: resolveHotTopicHref(slug),
-        volume24h: (existing?.volume24h ?? 0) + volume,
+        volume24h: (existing?.volume24h ?? 0) + displayVolume,
+        score: (existing?.score ?? 0) + score,
       })
     }
 
     return Array.from(topicsBySlug.values())
-      .sort((left, right) => right.volume24h - left.volume24h)
+      .sort((left, right) => right.score - left.score)
       .slice(0, FEATURED_HOT_TOPICS_TARGET_COUNT)
+      .map(({ score: _score, ...topic }) => topic)
+  }
+
+  function appendMissingHotTopics(
+    primaryTopics: HomeFeaturedHotTopic[],
+    fallbackTopics: HomeFeaturedHotTopic[],
+  ) {
+    const nextTopics = [...primaryTopics]
+    const seenSlugs = new Set(primaryTopics.map(topic => topic.slug))
+
+    for (const topic of fallbackTopics) {
+      if (seenSlugs.has(topic.slug)) {
+        continue
+      }
+
+      nextTopics.push(topic)
+      seenSlugs.add(topic.slug)
+      if (nextTopics.length >= FEATURED_HOT_TOPICS_TARGET_COUNT) {
+        break
+      }
+    }
+
+    return nextTopics.slice(0, FEATURED_HOT_TOPICS_TARGET_COUNT)
   }
 
   const { data, error } = await runQuery(async () => {
@@ -372,6 +416,7 @@ export async function listHomeFeaturedHotTopics(
         slug: tags.slug,
         label: localizedName,
         volume24h,
+        fallbackVolume,
       })
       .from(tags)
       .innerJoin(event_tags, eq(event_tags.tag_id, tags.id))
@@ -399,6 +444,7 @@ export async function listHomeFeaturedHotTopics(
           slug: tags.slug,
           label: localizedName,
           volume24h,
+          fallbackVolume,
         })
         .from(tags)
         .innerJoin(event_tags, eq(event_tags.tag_id, tags.id))
@@ -423,7 +469,7 @@ export async function listHomeFeaturedHotTopics(
 
     const recentResolvedCutoff = new Date(Date.now() - FEATURED_HOT_TOPICS_RECENT_RESOLVED_WINDOW_MS)
     const recentResolvedRows = await listResolvedHotTopicRows(recentResolvedCutoff)
-    const primaryTopics = mergeHotTopicRows([...activeRows, ...recentResolvedRows])
+    const primaryTopics = mergeHotTopicRows([...activeRows, ...recentResolvedRows], false)
 
     if (primaryTopics.length >= FEATURED_HOT_TOPICS_TARGET_COUNT) {
       return { data: primaryTopics, error: null }
@@ -431,8 +477,9 @@ export async function listHomeFeaturedHotTopics(
 
     const fallbackResolvedCutoff = new Date(Date.now() - FEATURED_HOT_TOPICS_FALLBACK_RESOLVED_WINDOW_MS)
     const fallbackResolvedRows = await listResolvedHotTopicRows(fallbackResolvedCutoff)
+    const fallbackTopics = mergeHotTopicRows([...activeRows, ...fallbackResolvedRows], true)
 
-    return { data: mergeHotTopicRows([...activeRows, ...fallbackResolvedRows]), error: null }
+    return { data: appendMissingHotTopics(primaryTopics, fallbackTopics), error: null }
   })
 
   if (error || !data) {
@@ -471,7 +518,7 @@ function buildHomeFeaturedSideCard(input: {
     return {
       ...configured,
       title: `${topTopic.label} leads volume`,
-      text: `${formatDollarValueLabel(topTopic.volume24h, { maximumFractionDigits: 0 })} traded in the last 24h across active and recently settled markets.`,
+      text: `${formatDollarValueLabel(topTopic.volume24h, { maximumFractionDigits: 0 })} tracked across active and recently settled markets.`,
       ctaLabel: configured.ctaLabel || 'Explore topic',
       ctaHref: configured.ctaHref || topTopic.href,
       icon: 'trending-up',

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -30,6 +30,11 @@ import { formatDollarValueLabel } from '@/lib/formatters'
 import { getHomeFeaturedSettingsFromSettings } from '@/lib/home-featured-settings'
 import { resolveDisplayPrice } from '@/lib/market-chance'
 import { resolvePublicRuntimeEnv } from '@/lib/public-runtime-config.shared'
+import {
+  mergeSportsEventGroupMarkets,
+  resolveSportsMarketsVolume,
+  sumFiniteSportsValues,
+} from '@/lib/sports-event-market-utils'
 import { buildHomeSportsMoneylineModel, resolveHomeSportsButtonChance } from '@/lib/sports-home-card'
 
 const CHART_COLORS = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)']
@@ -259,39 +264,16 @@ function buildSportsMarketGroups(event: Event): HomeFeaturedSportsMarketGroup[] 
   return groups.slice(0, 3)
 }
 
-function mergeFeaturedSportsGroupMarkets(eventsGroup: Event[]) {
-  const marketsByConditionId = new Map<string, Market>()
-
-  for (const event of eventsGroup) {
-    for (const market of event.markets ?? []) {
-      if (!market.condition_id || marketsByConditionId.has(market.condition_id)) {
-        continue
-      }
-
-      marketsByConditionId.set(market.condition_id, market)
-    }
-  }
-
-  return Array.from(marketsByConditionId.values())
-}
-
-function sumFiniteNumbers(values: Array<number | null | undefined>): number {
-  return values.reduce<number>((sum, value) => {
-    const numericValue = Number(value)
-    return Number.isFinite(numericValue) ? sum + numericValue : sum
-  }, 0)
-}
-
 function resolveMergedFeaturedSportsEvent(baseEvent: Event, eventsGroup: Event[]) {
   const displayEvent = eventsGroup.find(event => event.sports_parent_event_id == null)
     ?? eventsGroup.find(event => (event.sports_teams?.length ?? 0) >= 2)
     ?? baseEvent
-  const mergedMarkets = mergeFeaturedSportsGroupMarkets(eventsGroup)
+  const mergedMarkets = mergeSportsEventGroupMarkets(eventsGroup)
   if (mergedMarkets.length === 0) {
     return baseEvent
   }
 
-  const totalMarketsCount = sumFiniteNumbers(eventsGroup.map(event => event.total_markets_count))
+  const totalMarketsCount = sumFiniteSportsValues(eventsGroup.map(event => event.total_markets_count))
   const activeMarketsCount = mergedMarkets.filter(
     market => market.is_active && !market.is_resolved && !market.condition?.resolved,
   ).length
@@ -299,7 +281,7 @@ function resolveMergedFeaturedSportsEvent(baseEvent: Event, eventsGroup: Event[]
   return {
     ...displayEvent,
     markets: mergedMarkets,
-    volume: sumFiniteNumbers(mergedMarkets.map(market => market.volume)),
+    volume: resolveSportsMarketsVolume(mergedMarkets),
     active_markets_count: activeMarketsCount,
     total_markets_count: totalMarketsCount > 0 ? totalMarketsCount : mergedMarkets.length,
   }
@@ -357,18 +339,13 @@ export async function listHomeFeaturedHotTopics(
       const slug = row.slug.trim()
       const volume24hValue = Number(row.volume24h ?? 0)
       const fallbackVolumeValue = Number(row.fallbackVolume ?? 0)
-      const displayVolume = volume24hValue > 0
-        ? volume24hValue
-        : includeFallbackVolume
-          ? fallbackVolumeValue
-          : 0
-      const score = volume24hValue > 0
+      const topicScore = volume24hValue > 0
         ? volume24hValue
         : includeFallbackVolume
           ? fallbackVolumeValue
           : 0
 
-      if (!slug || score <= 0) {
+      if (!slug || topicScore <= 0) {
         continue
       }
 
@@ -377,8 +354,8 @@ export async function listHomeFeaturedHotTopics(
         label: existing?.label ?? row.label,
         slug,
         href: resolveHotTopicHref(slug),
-        volume24h: (existing?.volume24h ?? 0) + displayVolume,
-        score: (existing?.score ?? 0) + score,
+        volume24h: (existing?.volume24h ?? 0) + Math.max(0, volume24hValue),
+        score: (existing?.score ?? 0) + topicScore,
       })
     }
 

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -259,6 +259,69 @@ function buildSportsMarketGroups(event: Event): HomeFeaturedSportsMarketGroup[] 
   return groups.slice(0, 3)
 }
 
+function mergeFeaturedSportsGroupMarkets(eventsGroup: Event[]) {
+  const marketsByConditionId = new Map<string, Market>()
+
+  for (const event of eventsGroup) {
+    for (const market of event.markets ?? []) {
+      if (!market.condition_id || marketsByConditionId.has(market.condition_id)) {
+        continue
+      }
+
+      marketsByConditionId.set(market.condition_id, market)
+    }
+  }
+
+  return Array.from(marketsByConditionId.values())
+}
+
+function sumFiniteNumbers(values: Array<number | null | undefined>): number {
+  return values.reduce<number>((sum, value) => {
+    const numericValue = Number(value)
+    return Number.isFinite(numericValue) ? sum + numericValue : sum
+  }, 0)
+}
+
+function resolveMergedFeaturedSportsEvent(baseEvent: Event, eventsGroup: Event[]) {
+  const displayEvent = eventsGroup.find(event => event.sports_parent_event_id == null)
+    ?? eventsGroup.find(event => (event.sports_teams?.length ?? 0) >= 2)
+    ?? baseEvent
+  const mergedMarkets = mergeFeaturedSportsGroupMarkets(eventsGroup)
+  if (mergedMarkets.length === 0) {
+    return baseEvent
+  }
+
+  const totalMarketsCount = sumFiniteNumbers(eventsGroup.map(event => event.total_markets_count))
+  const activeMarketsCount = mergedMarkets.filter(
+    market => market.is_active && !market.is_resolved && !market.condition?.resolved,
+  ).length
+
+  return {
+    ...displayEvent,
+    markets: mergedMarkets,
+    volume: sumFiniteNumbers(mergedMarkets.map(market => market.volume)),
+    active_markets_count: activeMarketsCount,
+    total_markets_count: totalMarketsCount > 0 ? totalMarketsCount : mergedMarkets.length,
+  }
+}
+
+async function resolveFeaturedSportsEventPayload(event: Event, locale: SupportedLocale) {
+  if (!isSportsEvent(event)) {
+    return event
+  }
+
+  const { data: sportsEventsGroup, error } = await EventRepository.getSportsEventGroupBySlug(event.slug, '', locale)
+  if (error) {
+    console.warn('Failed to load featured sports event group:', error)
+    return event
+  }
+  if (!sportsEventsGroup || sportsEventsGroup.length <= 1) {
+    return event
+  }
+
+  return resolveMergedFeaturedSportsEvent(event, sportsEventsGroup)
+}
+
 function resolveHotTopicHref(slug: string) {
   return `/${slug.trim().toLowerCase()}`
 }
@@ -657,7 +720,7 @@ export async function listHomeFeaturedEvents(locale: SupportedLocale = DEFAULT_L
 
   const events = await Promise.all(targets.map(async (target) => {
     const { data } = await EventRepository.getEventBySlug(target.eventSlug, '', locale)
-    return data ? { target, event: data } : null
+    return data ? { target, event: await resolveFeaturedSportsEventPayload(data, locale) } : null
   }))
   const resolvedEvents = events.filter((entry): entry is NonNullable<typeof entry> => entry !== null)
   if (resolvedEvents.length === 0) {

--- a/src/lib/sports-event-market-utils.ts
+++ b/src/lib/sports-event-market-utils.ts
@@ -1,0 +1,28 @@
+import type { Event, Market } from '@/types'
+
+export function mergeSportsEventGroupMarkets(eventsGroup: Array<Pick<Event, 'markets'>>) {
+  const marketsByConditionId = new Map<string, Market>()
+
+  for (const event of eventsGroup) {
+    for (const market of event.markets ?? []) {
+      if (!market.condition_id || marketsByConditionId.has(market.condition_id)) {
+        continue
+      }
+
+      marketsByConditionId.set(market.condition_id, market)
+    }
+  }
+
+  return Array.from(marketsByConditionId.values())
+}
+
+export function sumFiniteSportsValues(values: Array<number | null | undefined>): number {
+  return values.reduce<number>((sum, value) => {
+    const numericValue = Number(value)
+    return Number.isFinite(numericValue) ? sum + numericValue : sum
+  }, 0)
+}
+
+export function resolveSportsMarketsVolume(markets: Array<Pick<Market, 'volume'>>) {
+  return sumFiniteSportsValues(markets.map(market => market.volume))
+}

--- a/src/lib/sports-event-market-utils.ts
+++ b/src/lib/sports-event-market-utils.ts
@@ -5,7 +5,7 @@ export function mergeSportsEventGroupMarkets(eventsGroup: Array<Pick<Event, 'mar
 
   for (const event of eventsGroup) {
     for (const market of event.markets ?? []) {
-      if (!market.condition_id || marketsByConditionId.has(market.condition_id)) {
+      if (!market?.condition_id || marketsByConditionId.has(market.condition_id)) {
         continue
       }
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Rebuilt the featured sports controls in the home carousel with team-based moneyline buttons and a compact Spread/Total line picker that shows adjacent lines and clearer signed values. Restored Featured Hot Topics with smarter fallback scoring; sports lists now show primary games only.

- **New Features**
  - Moneyline buttons use team names with consistent home/draw/away order and styling.
  - Added Spread and Total controls with a compact line picker that shows previous/current/next; team-aware signed spreads and O/U labels; excludes team/segment totals.
  - Cleaner titles (“Team A vs Team B”), improved alt text, and header actions pinned top-right.

- **Bug Fixes**
  - Merged markets across sports event groups and recomputed active/total counts and volume for featured cards.
  - Sports and esports Games/Live/Soon pages exclude auxiliary events so list cards stay on primary games.
  - Restored Featured Hot Topics using fallback scoring when 24h volume is missing; fills remaining slots with recent items; right rail shows “Vol” and side card copy updated.

<sup>Written for commit 4d95b7314a33e7d068419eddce3db2db583f89aa. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

