### PR TITLE
fix: restore home sports and hot topics

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
@@ -53,10 +53,24 @@ export default async function HomeContent({
   const featuredEventsPromise = shouldLoadFeaturedEvents
     ? (async () => {
         try {
-          const featuredEvents = await listHomeFeaturedEvents(resolvedLocale)
-          const featuredHotTopics = featuredEvents.length > 0
-            ? await listHomeFeaturedHotTopics(resolvedLocale)
+          const [featuredEventsResult, featuredHotTopicsResult] = await Promise.allSettled([
+            listHomeFeaturedEvents(resolvedLocale),
+            listHomeFeaturedHotTopics(resolvedLocale),
+          ])
+          const featuredEvents = featuredEventsResult.status === 'fulfilled'
+            ? featuredEventsResult.value
             : []
+          const featuredHotTopics = featuredHotTopicsResult.status === 'fulfilled'
+            ? featuredHotTopicsResult.value
+            : []
+
+          if (featuredEventsResult.status === 'rejected') {
+            console.error('Failed to load home featured markets', featuredEventsResult.reason)
+          }
+          if (featuredHotTopicsResult.status === 'rejected') {
+            console.error('Failed to load home featured hot topics', featuredHotTopicsResult.reason)
+          }
+
           const featuredSideCard = featuredEvents.length > 0
             ? await getHomeFeaturedSideCard(featuredEvents, featuredHotTopics)
             : DEFAULT_HOME_FEATURED_SETTINGS.sideCard

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -159,6 +159,18 @@ function resolveNeutralSportsButtonAppearance() {
   }
 }
 
+function resolveFilledNeutralSportsButtonAppearance() {
+  return {
+    className: `
+      border border-border bg-border text-foreground
+      hover:brightness-95
+    `,
+    style: undefined,
+    backgroundClassName: undefined,
+    backgroundStyle: undefined,
+  }
+}
+
 function resolveSportsButtonAppearance(market: FeaturedSportsButtonMarket) {
   if (market.tone === 'draw') {
     return resolveNeutralSportsButtonAppearance()
@@ -502,7 +514,7 @@ function SportsMarketButton({
   className?: string
   forceNeutral?: boolean
 }) {
-  const appearance = forceNeutral ? resolveNeutralSportsButtonAppearance() : resolveSportsButtonAppearance(market)
+  const appearance = forceNeutral ? resolveFilledNeutralSportsButtonAppearance() : resolveSportsButtonAppearance(market)
 
   return (
     <AppLink

--- a/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
@@ -1,12 +1,6 @@
 import type { SupportedLocale } from '@/i18n/locales'
-import { cacheLife, cacheTag } from 'next/cache'
 import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
-import {
-  getHomeInitialCurrentTimestamp,
-  HOME_INITIAL_EVENTS_CACHE_LIFE,
-} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
-import { cacheTags } from '@/lib/cache-tags'
-import { hasDatabaseEnv } from '@/lib/db/env'
+import { getHomeInitialCurrentTimestamp } from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
 import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
 
 interface HomeInitialContentProps {
@@ -33,21 +27,10 @@ async function HomeInitialContentBody({
   )
 }
 
-async function CachedHomeInitialContent(props: HomeInitialContentProps) {
-  'use cache'
-  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
-  cacheTag(cacheTags.homeFeaturedEvents)
-  cacheTag(cacheTags.settings)
-
-  return <HomeInitialContentBody {...props} />
-}
-
 async function RuntimeHomeInitialContent(props: HomeInitialContentProps) {
   await deferPublicShellPrerenderIfNeeded()
 
-  return hasDatabaseEnv()
-    ? <CachedHomeInitialContent {...props} />
-    : <HomeInitialContentBody {...props} />
+  return <HomeInitialContentBody {...props} />
 }
 
 export default function HomeInitialContent({
@@ -55,9 +38,7 @@ export default function HomeInitialContent({
   ...props
 }: HomeInitialContentProps) {
   if (shouldPrerenderPublicShell() || !deferRuntimePrerender) {
-    return hasDatabaseEnv()
-      ? <CachedHomeInitialContent {...props} />
-      : <HomeInitialContentBody {...props} />
+    return <HomeInitialContentBody {...props} />
   }
 
   return <RuntimeHomeInitialContent {...props} />

--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -1,6 +1,7 @@
 import { and, eq, inArray, lt, ne, or } from 'drizzle-orm'
 import { revalidateTag } from 'next/cache'
 import { NextResponse } from 'next/server'
+import { SUPPORTED_LOCALES } from '@/i18n/locales'
 import {
   loadAllowedMarketCreatorWallets,
   refreshAllowedMarketCreatorSiteSources,
@@ -34,6 +35,24 @@ const SYNC_RUNNING_STALE_MS = 15 * 60 * 1000
 const PNL_PAGE_SIZE = 200
 const SPORTS_LOGO_STORAGE_PREFIX = 'sports/team-logos'
 const sportsLogoStorageCache = new Map<string, string>()
+const MAIN_CATEGORY_TAGS = [
+  { name: 'Politics', slug: 'politics', displayOrder: 1 },
+  { name: 'Sports', slug: 'sports', displayOrder: 2 },
+  { name: 'Crypto', slug: 'crypto', displayOrder: 3 },
+  { name: 'Esports', slug: 'esports', displayOrder: 4 },
+  { name: 'Finance', slug: 'finance', displayOrder: 5 },
+  { name: 'Geopolitics', slug: 'geopolitics', displayOrder: 6 },
+  { name: 'Tech', slug: 'tech', displayOrder: 7 },
+  { name: 'Culture', slug: 'culture', displayOrder: 8 },
+  { name: 'World', slug: 'world', displayOrder: 9 },
+  { name: 'Economy', slug: 'economy', displayOrder: 10 },
+  { name: 'Weather', slug: 'weather', displayOrder: 11 },
+  { name: 'Elections', slug: 'elections', displayOrder: 12 },
+  { name: 'Mentions', slug: 'mentions', displayOrder: 13 },
+] as const
+const MAIN_CATEGORY_TAG_BY_SLUG = new Map<string, typeof MAIN_CATEGORY_TAGS[number]>(
+  MAIN_CATEGORY_TAGS.map(tag => [tag.slug, tag]),
+)
 
 interface SyncCursor {
   conditionId: string
@@ -113,6 +132,12 @@ interface SyncOptions {
 
 interface SyncRuntimeState {
   eventTagSlugsByEventId: Map<string, Set<string>>
+}
+
+interface NormalizedEventTag {
+  name: string
+  isMainCategory: boolean
+  displayOrder: number | null
 }
 
 interface ProcessMarketResult {
@@ -906,7 +931,11 @@ async function processEvent(
   const sportsLive = normalizeOptionalBooleanField(sportsEventData?.live)
   const sportsEnded = normalizeOptionalBooleanField(sportsEventData?.ended)
   const sportsTags = normalizeStringArrayField(sportsEventData?.tags)
-  const normalizedEventTags = normalizeIncomingTags(eventData.tags)
+  const normalizedEventTags = normalizeIncomingTags([
+    ...(Array.isArray(eventData.tags) ? eventData.tags : []),
+    ...(sportsEventData ? ['Sports'] : []),
+    ...(sportsTags ?? []),
+  ])
   const normalizedSportsTeams = normalizeSportsTeamsField(sportsEventData?.teams)
   const sportsAssets = await normalizeSportsTeamAssets(normalizedSportsTeams)
   const sportsTeams = sportsAssets.teams
@@ -1032,12 +1061,10 @@ async function processEvent(
       }
     }
 
-    if (
-      normalizedEventTags.size > 0
-    ) {
+    if (normalizedEventTags.size > 0) {
       const existingEventTagSlugs = await loadEventTagSlugs(existingEvent.id, runtimeState)
-      if (hasMissingTags(existingEventTagSlugs, normalizedEventTags)) {
-        await processNormalizedTags(existingEvent.id, normalizedEventTags)
+      const normalizedTagsChanged = await processNormalizedTags(existingEvent.id, normalizedEventTags)
+      if (normalizedTagsChanged) {
         eventChanged = true
         listAffectingChange = true
 
@@ -1510,8 +1537,13 @@ async function invalidateEventCaches(
   const uniqueEventIds = Array.from(new Set(eventIds.filter(Boolean)))
   const listTagInvalidated = options.includeList === true
   const sitemapTagInvalidated = options.includeSitemap === true
+  const homeFeaturedTagInvalidated = listTagInvalidated
   if (listTagInvalidated) {
     revalidateTag(cacheTags.eventsList, 'max')
+    revalidateTag(cacheTags.homeFeaturedEvents, 'max')
+    for (const locale of SUPPORTED_LOCALES) {
+      revalidateTag(cacheTags.mainTags(locale), 'max')
+    }
   }
   if (sitemapTagInvalidated) {
     revalidateTag(cacheTags.sitemap, 'max')
@@ -1521,6 +1553,8 @@ async function invalidateEventCaches(
     return {
       listTagInvalidated,
       sitemapTagInvalidated,
+      homeFeaturedTagInvalidated,
+      mainTagsInvalidations: listTagInvalidated ? SUPPORTED_LOCALES.length : 0,
       eventTagInvalidations: 0,
       uniqueEventIdsCount: 0,
     }
@@ -1544,6 +1578,8 @@ async function invalidateEventCaches(
   return {
     listTagInvalidated,
     sitemapTagInvalidated,
+    homeFeaturedTagInvalidated,
+    mainTagsInvalidations: listTagInvalidated ? SUPPORTED_LOCALES.length : 0,
     eventTagInvalidations,
     uniqueEventIdsCount: uniqueEventIds.length,
   }
@@ -1585,13 +1621,9 @@ async function processOutcomes(conditionId: string, outcomes: any[]) {
 }
 
 function normalizeIncomingTags(tagNames: any[] | null | undefined) {
-  const normalizedTagBySlug = new Map<string, string>()
+  const normalizedTagBySlug = new Map<string, NormalizedEventTag>()
 
-  if (!Array.isArray(tagNames)) {
-    return normalizedTagBySlug
-  }
-
-  for (const tagName of tagNames) {
+  for (const tagName of tagNames ?? []) {
     if (typeof tagName !== 'string') {
       console.warn(`Skipping invalid tag:`, tagName)
       continue
@@ -1607,9 +1639,13 @@ function normalizeIncomingTags(tagNames: any[] | null | undefined) {
       continue
     }
 
-    if (!normalizedTagBySlug.has(slug)) {
-      normalizedTagBySlug.set(slug, truncatedName)
-    }
+    const mainCategory = MAIN_CATEGORY_TAG_BY_SLUG.get(slug)
+    const existing = normalizedTagBySlug.get(slug)
+    normalizedTagBySlug.set(slug, {
+      name: mainCategory?.name ?? existing?.name ?? truncatedName,
+      isMainCategory: Boolean(existing?.isMainCategory || mainCategory),
+      displayOrder: mainCategory?.displayOrder ?? existing?.displayOrder ?? null,
+    })
   }
 
   return normalizedTagBySlug
@@ -1645,37 +1681,28 @@ async function loadEventTagSlugs(eventId: string, runtimeState: SyncRuntimeState
   return eventTagSlugs
 }
 
-function hasMissingTags(existingTagSlugs: Set<string>, normalizedTagBySlug: Map<string, string>) {
-  for (const slug of normalizedTagBySlug.keys()) {
-    if (!existingTagSlugs.has(slug)) {
-      return true
-    }
-  }
-
-  return false
-}
-
-async function processNormalizedTags(eventId: string, normalizedTagBySlug: Map<string, string>) {
+async function processNormalizedTags(eventId: string, normalizedTagBySlug: Map<string, NormalizedEventTag>) {
   if (normalizedTagBySlug.size === 0) {
-    return
+    return false
   }
 
   const slugs = Array.from(normalizedTagBySlug.keys())
   const tagIdBySlug = new Map<string, number>()
 
-  let existingTags: Array<{ id: number, slug: string }> = []
+  let existingTags: Array<{ id: number, slug: string, is_main_category: boolean | null }> = []
   try {
     existingTags = await db
       .select({
         id: tagsTable.id,
         slug: tagsTable.slug,
+        is_main_category: tagsTable.is_main_category,
       })
       .from(tagsTable)
       .where(inArray(tagsTable.slug, slugs))
   }
   catch (existingTagsError) {
     console.error(`Failed to load existing tags for event ${eventId}:`, existingTagsError)
-    return
+    return false
   }
 
   for (const tag of existingTags) {
@@ -1684,11 +1711,40 @@ async function processNormalizedTags(eventId: string, normalizedTagBySlug: Map<s
     }
   }
 
+  let changed = false
+  for (const tag of existingTags) {
+    const normalizedTag = normalizedTagBySlug.get(tag.slug)
+    if (!normalizedTag?.isMainCategory || tag.is_main_category === true) {
+      continue
+    }
+
+    try {
+      await db
+        .update(tagsTable)
+        .set({
+          name: normalizedTag.name,
+          is_main_category: true,
+          is_hidden: false,
+          hide_events: false,
+          display_order: normalizedTag.displayOrder ?? 0,
+        })
+        .where(eq(tagsTable.slug, tag.slug))
+      changed = true
+    }
+    catch (updateTagError) {
+      console.error(`Failed to promote main tag ${tag.slug} for event ${eventId}:`, updateTagError)
+    }
+  }
+
   const rowsToInsert = slugs
     .filter(slug => !tagIdBySlug.has(slug))
     .map(slug => ({
-      name: normalizedTagBySlug.get(slug)!,
+      name: normalizedTagBySlug.get(slug)!.name,
       slug,
+      is_main_category: normalizedTagBySlug.get(slug)!.isMainCategory,
+      is_hidden: false,
+      hide_events: false,
+      display_order: normalizedTagBySlug.get(slug)!.displayOrder ?? 0,
     }))
 
   if (rowsToInsert.length > 0) {
@@ -1707,8 +1763,9 @@ async function processNormalizedTags(eventId: string, normalizedTagBySlug: Map<s
     }
     catch (upsertTagsError) {
       console.error(`Failed to create tags for event ${eventId}:`, upsertTagsError)
-      return
+      return changed
     }
+    changed = insertedTags.length > 0 || changed
 
     for (const tag of insertedTags) {
       if (typeof tag.slug === 'string' && typeof tag.id === 'number') {
@@ -1734,7 +1791,7 @@ async function processNormalizedTags(eventId: string, normalizedTagBySlug: Map<s
       }
       catch (refreshedTagsError) {
         console.error(`Failed to refresh tags for event ${eventId}:`, refreshedTagsError)
-        return
+        return changed
       }
     }
   }
@@ -1748,19 +1805,25 @@ async function processNormalizedTags(eventId: string, normalizedTagBySlug: Map<s
     }))
 
   if (eventTagRows.length === 0) {
-    return
+    return changed
   }
 
   try {
-    await db
+    const insertedEventTagRows = await db
       .insert(eventTagsTable)
       .values(eventTagRows)
       .onConflictDoNothing({
         target: [eventTagsTable.event_id, eventTagsTable.tag_id],
       })
+      .returning({
+        event_id: eventTagsTable.event_id,
+      })
+
+    return changed || insertedEventTagRows.length > 0
   }
   catch (eventTagsError) {
     console.error(`Failed to upsert event_tags for event ${eventId}:`, eventTagsError)
+    return changed
   }
 }
 function resolveImageMeta(contentType: string | null, bytes: Uint8Array | null) {

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -603,7 +603,7 @@ function buildExcludeSportsAuxiliaryCondition() {
       SELECT 1
       FROM ${event_sports} sports_aux
       WHERE sports_aux.event_id = ${events.id}
-        AND sports_aux.sports_parent_event_id IS NOT NULL
+        AND sports_aux.sports_parent_event_id > 0
     )
   `
 }

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -596,6 +596,18 @@ function buildSportsVolumeGroupKeySql() {
   `
 }
 
+function buildExcludeSportsAuxiliaryCondition() {
+  return sql`
+    ${events.slug} !~* ${SPORTS_AUXILIARY_SLUG_SQL_REGEX}
+    AND NOT EXISTS (
+      SELECT 1
+      FROM ${event_sports} sports_aux
+      WHERE sports_aux.event_id = ${events.id}
+        AND sports_aux.sports_parent_event_id IS NOT NULL
+    )
+  `
+}
+
 async function hydrateSportsAuxiliaryEventContext(
   eventResult: DrizzleEventResult,
 ): Promise<DrizzleEventResult> {
@@ -1324,7 +1336,7 @@ async function buildEventListQueryContext({
   whereConditions.push(eq(events.is_hidden, false))
 
   if (excludeSportsAuxiliary) {
-    whereConditions.push(sql`${events.slug} !~* ${SPORTS_AUXILIARY_SLUG_SQL_REGEX}`)
+    whereConditions.push(buildExcludeSportsAuxiliaryCondition())
   }
 
   if (search) {
@@ -1581,7 +1593,7 @@ export const EventRepository = {
       whereConditions.push(eq(events.is_hidden, false))
 
       if (excludeSportsAuxiliary) {
-        whereConditions.push(sql`${events.slug} !~* ${SPORTS_AUXILIARY_SLUG_SQL_REGEX}`)
+        whereConditions.push(buildExcludeSportsAuxiliaryCondition())
       }
 
       if (search) {

--- a/src/lib/home-events-page.ts
+++ b/src/lib/home-events-page.ts
@@ -163,6 +163,7 @@ async function loadHomeEventCandidates({
       locale,
       sportsSportSlug,
       sportsSection,
+      excludeSportsAuxiliary: true,
     })
 
     if (error) {

--- a/src/lib/home-events.ts
+++ b/src/lib/home-events.ts
@@ -28,6 +28,8 @@ interface HomeVisibleEventCandidate {
   slug: string
   status: 'draft' | 'active' | 'resolved' | 'archived'
   series_slug?: string | null
+  sports_event_slug?: string | null
+  sports_parent_event_id?: number | string | null
   end_date?: string | null
   created_at: string
   updated_at: string
@@ -39,6 +41,21 @@ interface HomeVisibleEventCandidate {
 function normalizeSeriesSlug(value: string | null | undefined) {
   const normalized = value?.trim().toLowerCase()
   return normalized || null
+}
+
+function hasSportsParentEventId(value: HomeVisibleEventCandidate['sports_parent_event_id']) {
+  if (value === null || value === undefined || value === '') {
+    return false
+  }
+
+  const numericValue = Number(value)
+  return Number.isFinite(numericValue) && numericValue > 0
+}
+
+function isSportsAuxiliaryHomeEvent(event: HomeVisibleEventCandidate) {
+  return hasSportsParentEventId(event.sports_parent_event_id)
+    || isSportsAuxiliaryEventSlug(event.slug)
+    || isSportsAuxiliaryEventSlug(event.sports_event_slug)
 }
 
 function toTimestamp(value: string | null | undefined) {
@@ -165,7 +182,7 @@ export function filterHomeEvents<T extends HomeVisibleEventCandidate>(
   } = options
 
   const eventsMatchingTagFilters = events.filter((event) => {
-    if (isSportsAuxiliaryEventSlug(event.slug)) {
+    if (isSportsAuxiliaryHomeEvent(event)) {
       return false
     }
 

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -13,9 +13,7 @@ import type {
   Market,
 } from '@/types'
 import { and, desc, eq, sql } from 'drizzle-orm'
-import { cacheLife, cacheTag } from 'next/cache'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
-import { cacheTags } from '@/lib/cache-tags'
 import { buildCommunityApiUrl } from '@/lib/community-url'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { EventRepository } from '@/lib/db/queries/event'
@@ -42,11 +40,6 @@ const FEATURED_COMMENTS_LIMIT = 8
 const FEATURED_CONTEXT_ITEMS_PER_EVENT = 6
 const MIN_COMMENTS_FOR_SERIES = 3
 const CONTEXT_ITEM_TTL_MS = 30 * 60 * 1000
-const FEATURED_HOT_TOPICS_CACHE_LIFE = {
-  stale: 900,
-  revalidate: 900,
-  expire: 31_536_000,
-} as const
 const FEATURED_HOT_TOPICS_TARGET_COUNT = 5
 const FEATURED_HOT_TOPICS_RECENT_RESOLVED_WINDOW_MS = 36 * 60 * 60 * 1000
 const FEATURED_HOT_TOPICS_FALLBACK_RESOLVED_WINDOW_MS = 7 * 24 * 60 * 60 * 1000
@@ -311,11 +304,6 @@ function resolveHotTopicHref(slug: string) {
 export async function listHomeFeaturedHotTopics(
   locale: SupportedLocale = DEFAULT_LOCALE,
 ): Promise<HomeFeaturedHotTopic[]> {
-  'use cache'
-  cacheLife(FEATURED_HOT_TOPICS_CACHE_LIFE)
-  cacheTag(cacheTags.eventsList)
-  cacheTag(cacheTags.mainTags(locale))
-
   const volume24h = sql<number>`COALESCE(SUM(${markets.volume_24h}), 0)::double precision`
   const fallbackVolume = sql<number>`
     COALESCE(

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -404,6 +404,8 @@ export async function listHomeFeaturedHotTopics(
       .orderBy(desc(volume24h))
 
     async function listResolvedHotTopicRows(cutoff: Date) {
+      const cutoffIso = cutoff.toISOString()
+
       return db
         .select({
           slug: tags.slug,
@@ -425,7 +427,7 @@ export async function listHomeFeaturedHotTopics(
           eq(events.status, 'resolved'),
           eq(events.is_hidden, false),
           eq(markets.is_resolved, true),
-          sql`COALESCE(${events.resolved_at}, ${events.end_date}) >= ${cutoff}`,
+          sql`COALESCE(${events.resolved_at}, ${events.end_date}) >= ${cutoffIso}::timestamptz`,
           buildPublicEventListVisibilityCondition(events.id),
         ))
         .groupBy(tags.id, tags.slug, tags.name, tag_translations.name)

--- a/src/lib/sports-event-slugs.ts
+++ b/src/lib/sports-event-slugs.ts
@@ -16,11 +16,14 @@ export const SPORTS_EVENT_MARKET_VIEW_ORDER: SportsEventMarketViewKey[] = [
 
 const MORE_MARKETS_SUFFIX_REGEX = /-more-markets(?:-\d+)?$/i
 const EXACT_SCORE_SUFFIX_REGEX = /-exact-score$/i
+const FIRST_TO_SCORE_SUFFIX_REGEX = /-first-to-score$/i
 const GOALSCORERS_SUFFIX_REGEX = /-goalscorers?$/i
 const HALFTIME_RESULT_SUFFIX_REGEX = /-halftime-result$/i
-const SPORTS_AUXILIARY_SUFFIX_REGEX = /(?:-more-markets(?:-\d+)?|-exact-score|-goalscorers?|-halftime-result)$/i
+const SECOND_HALF_RESULT_SUFFIX_REGEX = /-second-half-result$/i
+const TOTAL_CORNERS_SUFFIX_REGEX = /-total-corners$/i
+const SPORTS_AUXILIARY_SUFFIX_REGEX = /(?:-more-markets(?:-\d+)?|-exact-score|-first-to-score|-goalscorers?|-halftime-result|-second-half-result|-total-corners)$/i
 
-export const SPORTS_AUXILIARY_SLUG_SQL_REGEX = '(-more-markets(?:-[0-9]+)?|-exact-score|-goalscorers?|-halftime-result)$'
+export const SPORTS_AUXILIARY_SLUG_SQL_REGEX = '(-more-markets(?:-[0-9]+)?|-exact-score|-first-to-score|-goalscorers?|-halftime-result|-second-half-result|-total-corners)$'
 
 export function isSportsMoreMarketsSlug(slug: string | null | undefined) {
   return MORE_MARKETS_SUFFIX_REGEX.test(slug?.trim() ?? '')
@@ -47,6 +50,14 @@ export function resolveSportsEventMarketViewKey(slug: string | null | undefined)
 
   if (HALFTIME_RESULT_SUFFIX_REGEX.test(normalizedSlug)) {
     return 'halftimeResult'
+  }
+
+  if (
+    FIRST_TO_SCORE_SUFFIX_REGEX.test(normalizedSlug)
+    || SECOND_HALF_RESULT_SUFFIX_REGEX.test(normalizedSlug)
+    || TOTAL_CORNERS_SUFFIX_REGEX.test(normalizedSlug)
+  ) {
+    return 'gameLines'
   }
 
   return 'gameLines'

--- a/src/lib/sports-home-card.ts
+++ b/src/lib/sports-home-card.ts
@@ -41,6 +41,13 @@ function getNormalizedEventTagTokens(event: Event) {
     tagTokens.add(normalizedMainTag)
   }
 
+  for (const tag of event.sports_tags ?? []) {
+    const normalizedTag = normalizeText(tag)
+    if (normalizedTag) {
+      tagTokens.add(normalizedTag)
+    }
+  }
+
   return tagTokens
 }
 
@@ -75,6 +82,17 @@ function isDrawMarket(market: Market) {
   return normalizeText(marketDisplayText(market)).includes('draw')
 }
 
+function isExplicitNonMoneylineMarket(market: Market) {
+  const normalizedType = normalizeText(market.sports_market_type)
+  const normalizedDisplayText = normalizeText(marketDisplayText(market))
+  const combinedText = `${normalizedType} ${normalizedDisplayText}`
+
+  return /\b(?:first|last|anytime|both)\s+teams?\s+to\s+score\b/.test(combinedText)
+    || /\b(?:team|player)\s+to\s+score\b/.test(combinedText)
+    || /\b(?:exact|correct)\s+score\b/.test(combinedText)
+    || /\b(?:total|totals|spread|spreads|handicap|over\s+under|btts)\b/.test(combinedText)
+}
+
 function doesMarketMatchTeam(market: Market, team: HomeSportsTeam | null) {
   if (!team || isDrawMarket(market)) {
     return false
@@ -93,6 +111,10 @@ function resolveYesOutcome(market: Market) {
 function toMarketType(market: Market) {
   const normalizedType = normalizeText(market.sports_market_type)
   const normalizedDisplayText = normalizeText(marketDisplayText(market))
+  if (isExplicitNonMoneylineMarket(market)) {
+    return null
+  }
+
   if (
     normalizedType.includes('moneyline')
     || normalizedType.includes('match winner')
@@ -193,7 +215,7 @@ function findMoneylineMarkets(event: Event) {
       return true
     }
 
-    return isDrawMarket(market)
+    return isDrawMarket(market) && !isExplicitNonMoneylineMarket(market)
   })
 }
 

--- a/tests/unit/homeEvents.test.ts
+++ b/tests/unit/homeEvents.test.ts
@@ -126,6 +126,53 @@ describe('home-events', () => {
     )).toEqual([soonerActiveEvent, resolvedEvent])
   })
 
+  it('filters sports child market rows before choosing the newest series entry', () => {
+    const moneylineEvent = {
+      id: 'moneyline-event',
+      slug: 'fifwc-bra-nor-2026-07-05',
+      sports_event_slug: 'fifwc-bra-nor-2026-07-05',
+      sports_parent_event_id: null,
+      series_slug: 'soccer-fifwc',
+      status: 'active' as const,
+      end_date: '2026-07-05T20:00:00.000Z',
+      created_at: '2026-07-05T10:53:16.000Z',
+      updated_at: '2026-07-05T10:53:16.000Z',
+      markets: [{ is_resolved: false }],
+    }
+    const firstToScoreEvent = {
+      id: 'first-to-score-event',
+      slug: 'fifwc-bra-nor-2026-07-05-first-to-score',
+      sports_event_slug: 'fifwc-bra-nor-2026-07-05-first-to-score',
+      sports_parent_event_id: 654615,
+      series_slug: 'soccer-fifwc',
+      status: 'active' as const,
+      end_date: '2026-07-05T20:00:00.000Z',
+      created_at: '2026-07-05T12:44:24.000Z',
+      updated_at: '2026-07-05T12:44:24.000Z',
+      markets: [{ is_resolved: false }],
+    }
+    const totalCornersEvent = {
+      id: 'total-corners-event',
+      slug: 'fifwc-bra-nor-2026-07-05-total-corners',
+      sports_event_slug: 'fifwc-bra-nor-2026-07-05-total-corners',
+      sports_parent_event_id: null,
+      series_slug: 'soccer-fifwc',
+      status: 'active' as const,
+      end_date: '2026-07-05T20:00:00.000Z',
+      created_at: '2026-07-05T12:45:24.000Z',
+      updated_at: '2026-07-05T12:45:24.000Z',
+      markets: [{ is_resolved: false }],
+    }
+
+    expect(filterHomeEvents(
+      [firstToScoreEvent, totalCornersEvent, moneylineEvent],
+      {
+        currentTimestamp: Date.parse('2026-07-05T14:00:00.000Z'),
+        status: 'active',
+      },
+    )).toEqual([moneylineEvent])
+  })
+
   it('prefers the current active series event over an overdue unresolved entry', () => {
     const overdueEvent = {
       id: 'overdue-event',

--- a/tests/unit/homeEvents.test.ts
+++ b/tests/unit/homeEvents.test.ts
@@ -163,14 +163,26 @@ describe('home-events', () => {
       updated_at: '2026-07-05T12:45:24.000Z',
       markets: [{ is_resolved: false }],
     }
+    const zeroParentEvent = {
+      id: 'zero-parent-event',
+      slug: 'nba-bos-nyk-2026-07-05',
+      sports_event_slug: 'nba-bos-nyk-2026-07-05',
+      sports_parent_event_id: 0,
+      series_slug: 'basketball-nba',
+      status: 'active' as const,
+      end_date: '2026-07-05T23:00:00.000Z',
+      created_at: '2026-07-05T12:45:24.000Z',
+      updated_at: '2026-07-05T12:45:24.000Z',
+      markets: [{ is_resolved: false }],
+    }
 
     expect(filterHomeEvents(
-      [firstToScoreEvent, totalCornersEvent, moneylineEvent],
+      [firstToScoreEvent, totalCornersEvent, zeroParentEvent, moneylineEvent],
       {
         currentTimestamp: Date.parse('2026-07-05T14:00:00.000Z'),
         status: 'active',
       },
-    )).toEqual([moneylineEvent])
+    )).toEqual([zeroParentEvent, moneylineEvent])
   })
 
   it('prefers the current active series event over an overdue unresolved entry', () => {

--- a/tests/unit/homeEventsPage.test.ts
+++ b/tests/unit/homeEventsPage.test.ts
@@ -194,14 +194,17 @@ describe('listHomeEventsPage', () => {
     expect(mocks.filterHomeEvents).toHaveBeenCalledTimes(1)
     expect(mocks.listEvents).toHaveBeenCalledTimes(3)
     expect(mocks.listEvents).toHaveBeenNthCalledWith(1, expect.objectContaining({
+      excludeSportsAuxiliary: true,
       limit: queryBatchSize,
       offset: 0,
     }))
     expect(mocks.listEvents).toHaveBeenNthCalledWith(2, expect.objectContaining({
+      excludeSportsAuxiliary: true,
       limit: queryBatchSize,
       offset: queryBatchSize,
     }))
     expect(mocks.listEvents).toHaveBeenNthCalledWith(3, expect.objectContaining({
+      excludeSportsAuxiliary: true,
       limit: queryBatchSize,
       offset: queryBatchSize * 2,
     }))
@@ -228,6 +231,7 @@ describe('listHomeEventsPage', () => {
     })
 
     expect(mocks.listEvents).toHaveBeenCalledWith(expect.objectContaining({
+      excludeSportsAuxiliary: true,
       limit: queryBatchSize,
       sortBy: 'volume_24h',
     }))

--- a/tests/unit/sportsHomeCard.test.ts
+++ b/tests/unit/sportsHomeCard.test.ts
@@ -69,6 +69,113 @@ describe('sportsHomeCard', () => {
     expect(model?.drawButton).toBeUndefined()
   })
 
+  it('uses sports tags to detect games sports cards when event tags are incomplete', () => {
+    const event = {
+      sports_sport_slug: 'soccer',
+      sports_tags: ['games', 'world-cup'],
+      tags: [],
+      sports_teams: [
+        {
+          name: 'Brazil',
+          abbreviation: 'BRA',
+          host_status: 'home',
+        },
+        {
+          name: 'Norway',
+          abbreviation: 'NOR',
+          host_status: 'away',
+        },
+      ],
+      markets: [
+        {
+          condition_id: 'match-winner-condition',
+          sports_market_type: null,
+          sports_group_item_title: null,
+          short_title: 'Match Winner',
+          title: 'Match Winner',
+          outcomes: [
+            {
+              outcome_index: 0,
+              outcome_text: 'Brazil',
+            },
+            {
+              outcome_index: 1,
+              outcome_text: 'Norway',
+            },
+          ],
+        },
+      ],
+    } as any
+
+    const model = buildHomeSportsMoneylineModel(event)
+
+    expect(model).not.toBeNull()
+    expect(model?.team1Button.conditionId).toBe('match-winner-condition')
+    expect(model?.team2Button.conditionId).toBe('match-winner-condition')
+  })
+
+  it('does not treat first-team-to-score markets as moneyline markets', () => {
+    const event = {
+      sports_sport_slug: 'soccer',
+      sports_tags: ['games'],
+      tags: [],
+      sports_teams: [
+        {
+          name: 'Brazil',
+          abbreviation: 'BRA',
+          host_status: 'home',
+        },
+        {
+          name: 'Norway',
+          abbreviation: 'NOR',
+          host_status: 'away',
+        },
+      ],
+      markets: [
+        {
+          condition_id: 'first-team-to-score-condition',
+          sports_market_type: 'moneyline',
+          sports_group_item_title: 'Brazil vs. Norway - First Team to Score',
+          short_title: 'First Team to Score',
+          title: 'Brazil vs. Norway - First Team to Score',
+          outcomes: [
+            {
+              outcome_index: 0,
+              outcome_text: 'Brazil',
+            },
+            {
+              outcome_index: 1,
+              outcome_text: 'Norway',
+            },
+          ],
+        },
+        {
+          condition_id: 'match-winner-condition',
+          sports_market_type: null,
+          sports_group_item_title: null,
+          short_title: 'Match Winner',
+          title: 'Match Winner',
+          outcomes: [
+            {
+              outcome_index: 0,
+              outcome_text: 'Brazil',
+            },
+            {
+              outcome_index: 1,
+              outcome_text: 'Norway',
+            },
+          ],
+        },
+      ],
+    } as any
+
+    const model = buildHomeSportsMoneylineModel(event)
+
+    expect(model).not.toBeNull()
+    expect(model?.team1Button.conditionId).toBe('match-winner-condition')
+    expect(model?.team2Button.conditionId).toBe('match-winner-condition')
+  })
+
   it('preserves draw button support for separated neg-risk moneyline markets', () => {
     const event = {
       sports_sport_slug: 'soccer',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restore sports moneyline cards and Hot Topics on the home page. Moneyline buttons render correctly, hot topics load reliably, and auxiliary sports markets are excluded from home lists while zero‑parent sports events are kept.

- **Bug Fixes**
  - Sports cards: detect true moneyline/match‑winner markets; ignore first/last/anytime/team/player‑to‑score, totals/spread/handicap/over‑under/BTTS/correct‑score; fall back to `sports_tags` when event `tags` are missing; use a filled neutral button style when neutral is forced.
  - Home events: exclude auxiliary/child sports entries by slug or `sports_parent_event_id > 0` (e.g., -first-to-score, -second-half-result, -total-corners, -exact-score, -goalscorers, -halftime-result, -more-markets); prefer the real series entry when selecting the newest; preserve zero‑parent sports events.
  - Hot Topics/tags: add "Sports" and incoming sports tags to events; promote main‑category tags (name/order/unhide); fix resolved‑window filtering; revalidate per‑locale main‑tags, home‑featured, and events‑list caches after sync; remove stale caching in featured hot topics and initial home content; load featured events and hot topics in parallel with isolated error handling.
  - Tests: added unit tests for moneyline detection, `sports_tags` fallback, excluding first‑team‑to‑score markets and other auxiliaries, and filtering child sports rows while preserving zero‑parent rows during series selection.

<sup>Written for commit 41a36973b6b322606be427cb0fef03e7e84f7434. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

