### PR TITLE
fix: support home public prerender

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
@@ -10,13 +10,16 @@ interface HomeInitialContentProps {
   locale: SupportedLocale
 }
 
+interface HomeInitialContentBodyProps extends HomeInitialContentProps {
+  currentTimestamp?: number | null
+}
+
 async function HomeInitialContentBody({
+  currentTimestamp = null,
   initialMainTag,
   initialTag,
   locale,
-}: HomeInitialContentProps) {
-  const currentTimestamp = getHomeInitialCurrentTimestamp()
-
+}: HomeInitialContentBodyProps) {
   return (
     <HomeContent
       locale={locale}
@@ -30,15 +33,29 @@ async function HomeInitialContentBody({
 async function RuntimeHomeInitialContent(props: HomeInitialContentProps) {
   await deferPublicShellPrerenderIfNeeded()
 
-  return <HomeInitialContentBody {...props} />
+  return (
+    <HomeInitialContentBody
+      {...props}
+      currentTimestamp={getHomeInitialCurrentTimestamp()}
+    />
+  )
 }
 
 export default function HomeInitialContent({
   deferRuntimePrerender = true,
   ...props
 }: HomeInitialContentProps) {
-  if (shouldPrerenderPublicShell() || !deferRuntimePrerender) {
+  if (shouldPrerenderPublicShell()) {
     return <HomeInitialContentBody {...props} />
+  }
+
+  if (!deferRuntimePrerender) {
+    return (
+      <HomeInitialContentBody
+        {...props}
+        currentTimestamp={getHomeInitialCurrentTimestamp()}
+      />
+    )
   }
 
   return <RuntimeHomeInitialContent {...props} />

--- a/src/app/[locale]/(platform)/layout.tsx
+++ b/src/app/[locale]/(platform)/layout.tsx
@@ -1,5 +1,7 @@
+import type { ReactNode } from 'react'
 import type { SupportedLocale } from '@/i18n/locales'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { Suspense } from 'react'
 import AffiliateQueryHandler from '@/app/[locale]/(platform)/_components/AffiliateQueryHandler'
 import Header from '@/app/[locale]/(platform)/_components/Header'
 import MobileBottomNav from '@/app/[locale]/(platform)/_components/MobileBottomNav'
@@ -10,17 +12,19 @@ import PlatformNavigationProvider from '@/app/[locale]/(platform)/_providers/Pla
 import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { loadPlatformMainTags } from '@/lib/platform-main-tags'
 import { buildChildParentMap, buildPlatformNavigationTags } from '@/lib/platform-navigation'
-import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
+import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
 import AppKitProvider from '@/providers/AppKitProvider'
 
-export default async function PlatformLayout({ params, children }: LayoutProps<'/[locale]'>) {
-  await deferPublicShellPrerenderIfNeeded()
-
-  const { locale } = await params
-  const resolvedLocale = locale as SupportedLocale
-  setRequestLocale(resolvedLocale)
+async function PlatformLayoutContent({
+  children,
+  locale,
+}: {
+  children: ReactNode
+  locale: SupportedLocale
+}) {
+  setRequestLocale(locale)
   const t = await getExtracted()
-  const { data: mainTags, globalChilds = [] } = await loadPlatformMainTags(resolvedLocale)
+  const { data: mainTags, globalChilds = [] } = await loadPlatformMainTags(locale)
   const tags = buildPlatformNavigationTags({
     mainTags: mainTags ?? [],
     globalChilds,
@@ -45,4 +49,20 @@ export default async function PlatformLayout({ params, children }: LayoutProps<'
       </TradingOnboardingProvider>
     </AppKitProvider>
   )
+}
+
+export default async function PlatformLayout({ params, children }: LayoutProps<'/[locale]'>) {
+  await deferPublicShellPrerenderIfNeeded()
+
+  const { locale } = await params
+  const resolvedLocale = locale as SupportedLocale
+  const content = (
+    <PlatformLayoutContent locale={resolvedLocale}>
+      {children}
+    </PlatformLayoutContent>
+  )
+
+  return shouldPrerenderPublicShell()
+    ? <Suspense fallback={null}>{content}</Suspense>
+    : content
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes public shell prerender for the home page and layout. Removes the runtime-only timestamp during prerender and uses Suspense so the shell can render safely.

- **Bug Fixes**
  - Home: Don’t compute the current timestamp during public prerender; pass it only at runtime or when `deferRuntimePrerender` is false. Prevents hydration mismatches and enables static prerender.
  - Layout: Defer public shell prerender and wrap content with `Suspense` only when prerendering, so the shell renders without blocking.

- **Refactors**
  - Extracted `PlatformLayoutContent` to run locale setup and tag loading after prerender deferral.

<sup>Written for commit 5b410bca8e3f22d41150b4a5574cf4931aab7f41. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

