### PR TITLE
fix: stabilize sports route navigation

### DIFF
--- a/src/app/[locale]/(platform)/esports/page.tsx
+++ b/src/app/[locale]/(platform)/esports/page.tsx
@@ -3,9 +3,7 @@
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
-import { notFound } from 'next/navigation'
 import { redirect } from '@/i18n/navigation'
-import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
 export const metadata: Metadata = {
   title: 'Esports',
@@ -14,13 +12,9 @@ export const metadata: Metadata = {
 export default async function EsportsPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params
   setRequestLocale(locale)
-  const { data: landingHref } = await SportsMenuRepository.getLandingHref('esports')
-  if (!landingHref) {
-    notFound()
-  }
 
   redirect({
-    href: landingHref,
+    href: '/esports/live',
     locale: locale as SupportedLocale,
   })
 }

--- a/src/app/[locale]/(platform)/esports/page.tsx
+++ b/src/app/[locale]/(platform)/esports/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { redirect } from '@/i18n/navigation'
+import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
 export const metadata: Metadata = {
   title: 'Esports',
@@ -12,9 +13,10 @@ export const metadata: Metadata = {
 export default async function EsportsPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params
   setRequestLocale(locale)
+  const { data: landingHref } = await SportsMenuRepository.getLandingHref('esports')
 
   redirect({
-    href: '/esports/live',
+    href: landingHref?.trim() || '/esports/live',
     locale: locale as SupportedLocale,
   })
 }

--- a/src/app/[locale]/(platform)/sports/page.tsx
+++ b/src/app/[locale]/(platform)/sports/page.tsx
@@ -4,6 +4,7 @@ import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
 import { redirect } from '@/i18n/navigation'
+import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
 export const metadata: Metadata = {
   title: 'Sports',
@@ -12,9 +13,10 @@ export const metadata: Metadata = {
 export default async function SportsPage({ params }: PageProps<'/[locale]/sports'>) {
   const { locale } = await params
   setRequestLocale(locale)
+  const { data: landingHref } = await SportsMenuRepository.getLandingHref('sports')
 
   redirect({
-    href: '/sports/live',
+    href: landingHref?.trim() || '/sports/live',
     locale: locale as SupportedLocale,
   })
 }

--- a/src/app/[locale]/(platform)/sports/page.tsx
+++ b/src/app/[locale]/(platform)/sports/page.tsx
@@ -3,9 +3,7 @@
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
-import { notFound } from 'next/navigation'
 import { redirect } from '@/i18n/navigation'
-import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
 export const metadata: Metadata = {
   title: 'Sports',
@@ -14,13 +12,9 @@ export const metadata: Metadata = {
 export default async function SportsPage({ params }: PageProps<'/[locale]/sports'>) {
   const { locale } = await params
   setRequestLocale(locale)
-  const { data: landingHref } = await SportsMenuRepository.getLandingHref('sports')
-  if (!landingHref) {
-    notFound()
-  }
 
   redirect({
-    href: landingHref,
+    href: '/sports/live',
     locale: locale as SupportedLocale,
   })
 }

--- a/src/lib/db/queries/sports-menu.ts
+++ b/src/lib/db/queries/sports-menu.ts
@@ -217,7 +217,7 @@ const getCachedActiveSportsCountRows = unstable_cache(
   ['sports-menu-active-count-rows-v4'],
   {
     revalidate: 900,
-    tags: [cacheTags.sportsMenu],
+    tags: [cacheTags.sportsMenu, cacheTags.eventsList],
   },
 )
 
@@ -353,6 +353,7 @@ async function getCachedMenuEntries(vertical: SportsVertical): Promise<QueryResu
 async function getCachedLayoutData(vertical: SportsVertical): Promise<QueryResult<SportsMenuLayoutData>> {
   'use cache'
   cacheTag(cacheTags.sportsMenu)
+  cacheTag(cacheTags.eventsList)
 
   return runQuery(async () => {
     const [rows, activeCountRows] = await Promise.all([


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stabilizes sports and esports navigation by resolving landing links and falling back to `/sports/live` and `/esports/live`. Also improves menu freshness by revalidating when events change.

- **Bug Fixes**
  - Root pages now redirect to the resolved landing href (trimmed) or fallback to `/sports/live` and `/esports/live`; removed `notFound` while keeping `SportsMenuRepository` lookup.
  - Added `cacheTags.eventsList` to sports menu caching (active counts and layout) to revalidate when events update.

<sup>Written for commit 173e01ffbcb40850f0272a3f6fa755fc3bf8c8a6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

