### PR TITLE
fix: homepage ssr

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
@@ -1,6 +1,9 @@
 import type { SupportedLocale } from '@/i18n/locales'
 import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
-import { getHomeInitialCurrentTimestamp } from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+import {
+  getCachedHomeInitialCurrentTimestamp,
+  getHomeInitialCurrentTimestamp,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
 import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
 
 interface HomeInitialContentProps {
@@ -32,28 +35,38 @@ async function HomeInitialContentBody({
 
 async function RuntimeHomeInitialContent(props: HomeInitialContentProps) {
   await deferPublicShellPrerenderIfNeeded()
+  const currentTimestamp = getHomeInitialCurrentTimestamp()
 
   return (
     <HomeInitialContentBody
       {...props}
-      currentTimestamp={getHomeInitialCurrentTimestamp()}
+      currentTimestamp={currentTimestamp}
     />
   )
 }
 
-export default function HomeInitialContent({
+export default async function HomeInitialContent({
   deferRuntimePrerender = true,
   ...props
 }: HomeInitialContentProps) {
   if (shouldPrerenderPublicShell()) {
-    return <HomeInitialContentBody {...props} />
-  }
+    const currentTimestamp = await getCachedHomeInitialCurrentTimestamp()
 
-  if (!deferRuntimePrerender) {
     return (
       <HomeInitialContentBody
         {...props}
-        currentTimestamp={getHomeInitialCurrentTimestamp()}
+        currentTimestamp={currentTimestamp}
+      />
+    )
+  }
+
+  if (!deferRuntimePrerender) {
+    const currentTimestamp = getHomeInitialCurrentTimestamp()
+
+    return (
+      <HomeInitialContentBody
+        {...props}
+        currentTimestamp={currentTimestamp}
       />
     )
   }

--- a/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
+++ b/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
@@ -1,3 +1,5 @@
+import { cacheLife } from 'next/cache'
+
 export const HOME_INITIAL_EVENTS_CACHE_LIFE = {
   stale: 900,
   revalidate: 900,
@@ -8,4 +10,11 @@ const HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS = 900_000
 
 export function getHomeInitialCurrentTimestamp() {
   return Math.floor(Date.now() / HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS) * HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS
+}
+
+export async function getCachedHomeInitialCurrentTimestamp() {
+  'use cache'
+  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
+
+  return getHomeInitialCurrentTimestamp()
 }

--- a/src/app/[locale]/(platform)/layout.tsx
+++ b/src/app/[locale]/(platform)/layout.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from 'react'
 import type { SupportedLocale } from '@/i18n/locales'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
-import { Suspense } from 'react'
 import AffiliateQueryHandler from '@/app/[locale]/(platform)/_components/AffiliateQueryHandler'
 import Header from '@/app/[locale]/(platform)/_components/Header'
 import MobileBottomNav from '@/app/[locale]/(platform)/_components/MobileBottomNav'
@@ -12,7 +11,7 @@ import PlatformNavigationProvider from '@/app/[locale]/(platform)/_providers/Pla
 import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { loadPlatformMainTags } from '@/lib/platform-main-tags'
 import { buildChildParentMap, buildPlatformNavigationTags } from '@/lib/platform-navigation'
-import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
+import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 import AppKitProvider from '@/providers/AppKitProvider'
 
 async function PlatformLayoutContent({
@@ -56,13 +55,10 @@ export default async function PlatformLayout({ params, children }: LayoutProps<'
 
   const { locale } = await params
   const resolvedLocale = locale as SupportedLocale
-  const content = (
+
+  return (
     <PlatformLayoutContent locale={resolvedLocale}>
       {children}
     </PlatformLayoutContent>
   )
-
-  return shouldPrerenderPublicShell()
-    ? <Suspense fallback={null}>{content}</Suspense>
-    : content
 }

--- a/tests/unit/homeInitialEventsCache.test.ts
+++ b/tests/unit/homeInitialEventsCache.test.ts
@@ -1,8 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+
 import {
+  getCachedHomeInitialCurrentTimestamp,
   getHomeInitialCurrentTimestamp,
   HOME_INITIAL_EVENTS_CACHE_LIFE,
 } from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+
+vi.mock('next/cache', () => ({
+  cacheLife: vi.fn(),
+}))
 
 describe('homeInitialEventsCache', () => {
   afterEach(() => {
@@ -17,10 +23,17 @@ describe('homeInitialEventsCache', () => {
     })
   })
 
-  it('normalizes the seed timestamp to the current fifteen-minute window', () => {
+  it('normalizes the runtime timestamp to the current fifteen-minute window', () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-05-11T12:34:56.789Z'))
 
     expect(getHomeInitialCurrentTimestamp()).toBe(Date.parse('2026-05-11T12:30:00.000Z'))
+  })
+
+  it('normalizes the cached prerender timestamp to the current fifteen-minute window', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-11T12:34:56.789Z'))
+
+    await expect(getCachedHomeInitialCurrentTimestamp()).resolves.toBe(Date.parse('2026-05-11T12:30:00.000Z'))
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fix homepage SSR by using a cached, bucketed timestamp during prerender and removing the layout Suspense wrapper. This prevents hydration mismatches and stabilizes the initial render.

- **Bug Fixes**
  - Added getCachedHomeInitialCurrentTimestamp with `next/cache` and 15‑minute cache life.
  - Use cached timestamp when prerendering; use runtime timestamp otherwise.
  - Removed Suspense wrapper from platform layout to avoid unnecessary streaming.
  - Expanded unit tests to cover cached prerender path and mocked `next/cache`.

<sup>Written for commit 4bff7c6df7bc6bdc237e393449e2df416cc3d4d9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

