### PR TITLE
fix: cache home platform layout data

### DIFF
--- a/src/app/[locale]/(platform)/layout.tsx
+++ b/src/app/[locale]/(platform)/layout.tsx
@@ -21,8 +21,9 @@ async function PlatformLayoutContent({
   children: ReactNode
   locale: SupportedLocale
 }) {
-  setRequestLocale(locale)
-  const t = await getExtracted()
+  'use cache'
+
+  const t = await getExtracted({ locale })
   const { data: mainTags, globalChilds = [] } = await loadPlatformMainTags(locale)
   const tags = buildPlatformNavigationTags({
     mainTags: mainTags ?? [],
@@ -55,6 +56,7 @@ export default async function PlatformLayout({ params, children }: LayoutProps<'
 
   const { locale } = await params
   const resolvedLocale = locale as SupportedLocale
+  setRequestLocale(resolvedLocale)
 
   return (
     <PlatformLayoutContent locale={resolvedLocale}>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Cache the Platform home layout per locale to improve performance and enable prerendering. Added `use cache`, passed `locale` to `getExtracted`, and moved `setRequestLocale` to the top-level layout so caching works correctly for each locale.

<sup>Written for commit b0a5760f9c66ae2e1611a45cb760ed88e1260983. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

