### PR TITLE
fix: wrap platform prerender data

### DIFF
--- a/src/app/[locale]/(platform)/layout.tsx
+++ b/src/app/[locale]/(platform)/layout.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from 'react'
 import type { SupportedLocale } from '@/i18n/locales'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
+import { Suspense } from 'react'
 import AffiliateQueryHandler from '@/app/[locale]/(platform)/_components/AffiliateQueryHandler'
 import Header from '@/app/[locale]/(platform)/_components/Header'
 import MobileBottomNav from '@/app/[locale]/(platform)/_components/MobileBottomNav'
@@ -11,7 +12,7 @@ import PlatformNavigationProvider from '@/app/[locale]/(platform)/_providers/Pla
 import { TradingOnboardingProvider } from '@/app/[locale]/(platform)/_providers/TradingOnboardingProvider'
 import { loadPlatformMainTags } from '@/lib/platform-main-tags'
 import { buildChildParentMap, buildPlatformNavigationTags } from '@/lib/platform-navigation'
-import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
+import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
 import AppKitProvider from '@/providers/AppKitProvider'
 
 async function PlatformLayoutContent({
@@ -55,10 +56,13 @@ export default async function PlatformLayout({ params, children }: LayoutProps<'
 
   const { locale } = await params
   const resolvedLocale = locale as SupportedLocale
-
-  return (
+  const content = (
     <PlatformLayoutContent locale={resolvedLocale}>
       {children}
     </PlatformLayoutContent>
   )
+
+  return shouldPrerenderPublicShell()
+    ? <Suspense fallback={null}>{content}</Suspense>
+    : content
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Wrap the platform layout content in React Suspense during public shell prerendering so deferred data resolves cleanly and the shell renders without blocking.

- **Bug Fixes**
  - Conditionally wrap `PlatformLayoutContent` with `<Suspense fallback={null}>` when `shouldPrerenderPublicShell()` is true.

<sup>Written for commit c7af5527ecf2308676d94892aebeedb8a23e75d7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

