### PR TITLE
fix: sports sidebar rendering

### DIFF
--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -1570,7 +1570,7 @@ async function invalidateEventCaches(
   let eventTagInvalidations = 0
   for (const row of rows) {
     if (row.slug) {
-      revalidateTag(cacheTags.event(row.slug), 'max')
+      revalidateTag(cacheTags.event(row.slug), { expire: 0 })
       eventTagInvalidations += 1
     }
   }

--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -1474,13 +1474,12 @@ async function updateEventStatusesFromMarketsBatch(eventIds: string[]) {
     const bucket = countsByEventId.get(eventId)!
     bucket.total += 1
 
-    const isActiveMarket = market.is_active === true
-      || (market.is_active == null && market.is_resolved === false)
+    const isActiveMarket = market.is_active || (market.is_active == null && !market.is_resolved)
     if (isActiveMarket) {
       bucket.active += 1
     }
 
-    const isUnresolvedMarket = market.is_resolved === false || market.is_resolved == null
+    const isUnresolvedMarket = !market.is_resolved
     if (isUnresolvedMarket) {
       bucket.unresolved += 1
     }
@@ -1570,7 +1569,7 @@ async function invalidateEventCaches(
   let eventTagInvalidations = 0
   for (const row of rows) {
     if (row.slug) {
-      revalidateTag(cacheTags.event(row.slug), { expire: 0 })
+      revalidateTag(cacheTags.event(row.slug), 'max')
       eventTagInvalidations += 1
     }
   }

--- a/src/lib/db/queries/sports-menu.ts
+++ b/src/lib/db/queries/sports-menu.ts
@@ -149,29 +149,42 @@ function buildGroupQueryCandidates(childRows: SportsMenuItemRow[]) {
   return Array.from(queryCandidates)
 }
 
+class EmptySportsMenuRowsError extends Error {
+  constructor() {
+    super('sports_menu_items returned no enabled rows.')
+    this.name = 'EmptySportsMenuRowsError'
+  }
+}
+
+function isEmptySportsMenuRowsError(error: unknown) {
+  return error instanceof EmptySportsMenuRowsError
+}
+
+async function fetchSportsMenuRows(): Promise<SportsMenuItemRow[]> {
+  return db
+    .select({
+      id: sports_menu_items.id,
+      item_type: sports_menu_items.item_type,
+      label: sports_menu_items.label,
+      href: sports_menu_items.href,
+      icon_url: sports_menu_items.icon_url,
+      parent_id: sports_menu_items.parent_id,
+      menu_slug: sports_menu_items.menu_slug,
+      h1_title: sports_menu_items.h1_title,
+      mapped_tags: sports_menu_items.mapped_tags,
+      url_aliases: sports_menu_items.url_aliases,
+      games_enabled: sports_menu_items.games_enabled,
+      props_enabled: sports_menu_items.props_enabled,
+      sort_order: sports_menu_items.sort_order,
+    })
+    .from(sports_menu_items)
+    .where(eq(sports_menu_items.enabled, true))
+    .orderBy(asc(sports_menu_items.sort_order), asc(sports_menu_items.id))
+}
+
 const getCachedSportsMenuRows = unstable_cache(
   async (): Promise<SportsMenuItemRow[]> => {
-    const rows = await db
-      .select({
-        id: sports_menu_items.id,
-        item_type: sports_menu_items.item_type,
-        label: sports_menu_items.label,
-        href: sports_menu_items.href,
-        icon_url: sports_menu_items.icon_url,
-        parent_id: sports_menu_items.parent_id,
-        menu_slug: sports_menu_items.menu_slug,
-        h1_title: sports_menu_items.h1_title,
-        mapped_tags: sports_menu_items.mapped_tags,
-        url_aliases: sports_menu_items.url_aliases,
-        games_enabled: sports_menu_items.games_enabled,
-        props_enabled: sports_menu_items.props_enabled,
-        sort_order: sports_menu_items.sort_order,
-      })
-      .from(sports_menu_items)
-      .where(eq(sports_menu_items.enabled, true))
-      .orderBy(asc(sports_menu_items.sort_order), asc(sports_menu_items.id))
-
-    return rows
+    return fetchSportsMenuRows()
   },
   ['sports-menu-items-v2'],
   {
@@ -179,6 +192,24 @@ const getCachedSportsMenuRows = unstable_cache(
     tags: [cacheTags.sportsMenu],
   },
 )
+
+async function getSportsMenuRowsWithFreshEmptyFallback() {
+  const cachedRows = await getCachedSportsMenuRows()
+  if (cachedRows.length > 0) {
+    return cachedRows
+  }
+
+  return fetchSportsMenuRows()
+}
+
+async function getRequiredSportsMenuRows() {
+  const rows = await getSportsMenuRowsWithFreshEmptyFallback()
+  if (rows.length === 0) {
+    throw new EmptySportsMenuRowsError()
+  }
+
+  return rows
+}
 
 const getCachedActiveSportsCountRows = unstable_cache(
   async (): Promise<SportsMenuActiveCountRow[]> => {
@@ -326,7 +357,7 @@ function buildQueryResult<T>(data: T): QueryResult<T> {
 }
 
 async function getCachedSportsSlugResolverFromDb() {
-  const rows = await getCachedSportsMenuRows()
+  const rows = await getSportsMenuRowsWithFreshEmptyFallback()
   const mappingEntries = toMappingEntries(rows)
   return buildSportsSlugResolver(mappingEntries)
 }
@@ -343,9 +374,9 @@ async function getCachedMenuEntries(vertical: SportsVertical): Promise<QueryResu
   'use cache'
   cacheTag(cacheTags.sportsMenu)
 
-  return runQuery(async () => {
-    const rows = await getCachedSportsMenuRows()
+  const rows = await getRequiredSportsMenuRows()
 
+  return runQuery(async () => {
     return buildQueryResult(buildSportsSidebarEntries(rows, vertical))
   })
 }
@@ -355,11 +386,12 @@ async function getCachedLayoutData(vertical: SportsVertical): Promise<QueryResul
   cacheTag(cacheTags.sportsMenu)
   cacheTag(cacheTags.eventsList)
 
+  const [rows, activeCountRows] = await Promise.all([
+    getRequiredSportsMenuRows(),
+    getCachedActiveSportsCountRows(),
+  ])
+
   return runQuery(async () => {
-    const [rows, activeCountRows] = await Promise.all([
-      getCachedSportsMenuRows(),
-      getCachedActiveSportsCountRows(),
-    ])
     const resolver = buildSportsSlugResolver(toMappingEntries(rows))
     const menuEntries = buildSportsSidebarEntries(rows, vertical)
     const countsBySlug = buildSportsMenuCountsBySlug(resolver, activeCountRows, menuEntries)
@@ -378,8 +410,10 @@ async function getCachedCanonicalSlugByAlias(alias: string): Promise<QueryResult
   'use cache'
   cacheTag(cacheTags.sportsMenu)
 
+  const rows = await getRequiredSportsMenuRows()
+
   return runQuery(async () => {
-    const resolver = await getCachedSportsSlugResolverFromDb()
+    const resolver = buildSportsSlugResolver(toMappingEntries(rows))
 
     return buildQueryResult(resolveCanonicalSportsSlugAlias(resolver, alias))
   })
@@ -389,8 +423,9 @@ async function getCachedLandingHref(vertical: SportsVertical): Promise<QueryResu
   'use cache'
   cacheTag(cacheTags.sportsMenu)
 
+  const rows = await getRequiredSportsMenuRows()
+
   return runQuery(async () => {
-    const rows = await getCachedSportsMenuRows()
     const menuEntries = buildSportsSidebarEntries(rows, vertical)
 
     return buildQueryResult(findDefaultLandingHref(menuEntries))
@@ -401,8 +436,64 @@ async function getCachedFuturesHref(vertical: SportsVertical): Promise<QueryResu
   'use cache'
   cacheTag(cacheTags.sportsMenu)
 
+  const rows = await getRequiredSportsMenuRows()
+
   return runQuery(async () => {
-    const rows = await getCachedSportsMenuRows()
+    const menuEntries = buildSportsSidebarEntries(rows, vertical)
+
+    return buildQueryResult(findDefaultFuturesHref(menuEntries))
+  })
+}
+
+async function getFreshMenuEntries(vertical: SportsVertical): Promise<QueryResult<SportsMenuEntry[]>> {
+  return runQuery(async () => {
+    const rows = await fetchSportsMenuRows()
+
+    return buildQueryResult(buildSportsSidebarEntries(rows, vertical))
+  })
+}
+
+async function getFreshLayoutData(vertical: SportsVertical): Promise<QueryResult<SportsMenuLayoutData>> {
+  return runQuery(async () => {
+    const [rows, activeCountRows] = await Promise.all([
+      fetchSportsMenuRows(),
+      getCachedActiveSportsCountRows(),
+    ])
+    const resolver = buildSportsSlugResolver(toMappingEntries(rows))
+    const menuEntries = buildSportsSidebarEntries(rows, vertical)
+    const countsBySlug = buildSportsMenuCountsBySlug(resolver, activeCountRows, menuEntries)
+
+    return buildQueryResult({
+      menuEntries,
+      countsBySlug,
+      canonicalSlugByAliasKey: Object.fromEntries(resolver.canonicalByAliasKey),
+      h1TitleBySlug: Object.fromEntries(resolver.h1TitleBySlug),
+      sectionsBySlug: Object.fromEntries(resolver.sectionsBySlug),
+    })
+  })
+}
+
+async function getFreshCanonicalSlugByAlias(alias: string): Promise<QueryResult<string | null>> {
+  return runQuery(async () => {
+    const rows = await fetchSportsMenuRows()
+    const resolver = buildSportsSlugResolver(toMappingEntries(rows))
+
+    return buildQueryResult(resolveCanonicalSportsSlugAlias(resolver, alias))
+  })
+}
+
+async function getFreshLandingHref(vertical: SportsVertical): Promise<QueryResult<string | null>> {
+  return runQuery(async () => {
+    const rows = await fetchSportsMenuRows()
+    const menuEntries = buildSportsSidebarEntries(rows, vertical)
+
+    return buildQueryResult(findDefaultLandingHref(menuEntries))
+  })
+}
+
+async function getFreshFuturesHref(vertical: SportsVertical): Promise<QueryResult<string | null>> {
+  return runQuery(async () => {
+    const rows = await fetchSportsMenuRows()
     const menuEntries = buildSportsSidebarEntries(rows, vertical)
 
     return buildQueryResult(findDefaultFuturesHref(menuEntries))
@@ -415,7 +506,16 @@ export const SportsMenuRepository = {
       return buildQueryResult([])
     }
 
-    return getCachedMenuEntries(vertical)
+    try {
+      return await getCachedMenuEntries(vertical)
+    }
+    catch (error) {
+      if (isEmptySportsMenuRowsError(error)) {
+        return getFreshMenuEntries(vertical)
+      }
+
+      throw error
+    }
   },
 
   async getLayoutData(vertical: SportsVertical = 'sports'): Promise<QueryResult<SportsMenuLayoutData>> {
@@ -423,7 +523,16 @@ export const SportsMenuRepository = {
       return buildQueryResult(buildEmptySportsMenuLayoutData())
     }
 
-    return getCachedLayoutData(vertical)
+    try {
+      return await getCachedLayoutData(vertical)
+    }
+    catch (error) {
+      if (isEmptySportsMenuRowsError(error)) {
+        return getFreshLayoutData(vertical)
+      }
+
+      throw error
+    }
   },
 
   async resolveCanonicalSlugByAlias(alias: string): Promise<QueryResult<string | null>> {
@@ -431,7 +540,16 @@ export const SportsMenuRepository = {
       return buildQueryResult(null)
     }
 
-    return getCachedCanonicalSlugByAlias(alias)
+    try {
+      return await getCachedCanonicalSlugByAlias(alias)
+    }
+    catch (error) {
+      if (isEmptySportsMenuRowsError(error)) {
+        return getFreshCanonicalSlugByAlias(alias)
+      }
+
+      throw error
+    }
   },
 
   async getLandingHref(vertical: SportsVertical = 'sports'): Promise<QueryResult<string | null>> {
@@ -439,7 +557,16 @@ export const SportsMenuRepository = {
       return buildQueryResult(null)
     }
 
-    return getCachedLandingHref(vertical)
+    try {
+      return await getCachedLandingHref(vertical)
+    }
+    catch (error) {
+      if (isEmptySportsMenuRowsError(error)) {
+        return getFreshLandingHref(vertical)
+      }
+
+      throw error
+    }
   },
 
   async getFuturesHref(vertical: SportsVertical = 'sports'): Promise<QueryResult<string | null>> {
@@ -447,6 +574,15 @@ export const SportsMenuRepository = {
       return buildQueryResult(null)
     }
 
-    return getCachedFuturesHref(vertical)
+    try {
+      return await getCachedFuturesHref(vertical)
+    }
+    catch (error) {
+      if (isEmptySportsMenuRowsError(error)) {
+        return getFreshFuturesHref(vertical)
+      }
+
+      throw error
+    }
   },
 }

--- a/src/lib/sports-menu-counts.ts
+++ b/src/lib/sports-menu-counts.ts
@@ -6,6 +6,7 @@ import {
   resolveSportsSidebarMenuSlugCountKey,
   SPORTS_SIDEBAR_FUTURE_COUNT_KEY,
   SPORTS_SIDEBAR_LIVE_COUNT_KEY,
+  SPORTS_SIDEBAR_SOON_COUNT_KEY,
 } from '@/lib/sports-sidebar-counts'
 import { resolveCanonicalSportsSportSlug } from '@/lib/sports-slug-mapping'
 
@@ -277,7 +278,9 @@ export function buildSportsMenuCountsBySlug(
       })
     }
 
-    if (isCountRowLiveNow(row, nowMs)) {
+    const isGamesRow = rowSection === 'games'
+
+    if (isGamesRow && isCountRowLiveNow(row, nowMs)) {
       incrementCountForGroup({
         countsBySlug,
         seenGroupKeysByCountKey,
@@ -287,6 +290,15 @@ export function buildSportsMenuCountsBySlug(
     }
 
     if (isCountRowFuture(row, nowMs)) {
+      if (isGamesRow) {
+        incrementCountForGroup({
+          countsBySlug,
+          seenGroupKeysByCountKey,
+          countKey: SPORTS_SIDEBAR_SOON_COUNT_KEY,
+          groupKey: rowGroupKey,
+        })
+      }
+
       incrementCountForGroup({
         countsBySlug,
         seenGroupKeysByCountKey,

--- a/src/lib/sports-sidebar-counts.ts
+++ b/src/lib/sports-sidebar-counts.ts
@@ -2,6 +2,7 @@ import type { SportsVertical } from '@/lib/sports-vertical'
 import { getSportsVerticalConfig } from '@/lib/sports-vertical'
 
 export const SPORTS_SIDEBAR_LIVE_COUNT_KEY = '__live__'
+export const SPORTS_SIDEBAR_SOON_COUNT_KEY = '__soon__'
 export const SPORTS_SIDEBAR_FUTURE_COUNT_KEY = '__future__'
 const SPORTS_SIDEBAR_SECTION_DELIMITER = '::'
 
@@ -70,10 +71,11 @@ export function resolveSportsSidebarCountKey(input: {
     return SPORTS_SIDEBAR_LIVE_COUNT_KEY
   }
 
-  if (
-    isSportsSidebarSoonHref(input.href, input.vertical)
-    || isSportsSidebarFutureHref(input.href, input.vertical)
-  ) {
+  if (isSportsSidebarSoonHref(input.href, input.vertical)) {
+    return SPORTS_SIDEBAR_SOON_COUNT_KEY
+  }
+
+  if (isSportsSidebarFutureHref(input.href, input.vertical)) {
     return SPORTS_SIDEBAR_FUTURE_COUNT_KEY
   }
 

--- a/tests/unit/sportsMenuCounts.test.ts
+++ b/tests/unit/sportsMenuCounts.test.ts
@@ -5,6 +5,7 @@ import {
   resolveSportsSidebarCountKey,
   SPORTS_SIDEBAR_FUTURE_COUNT_KEY,
   SPORTS_SIDEBAR_LIVE_COUNT_KEY,
+  SPORTS_SIDEBAR_SOON_COUNT_KEY,
 } from '@/lib/sports-sidebar-counts'
 import { buildSportsSlugResolver } from '@/lib/sports-slug-mapping'
 
@@ -25,11 +26,11 @@ function buildLinkEntry(params: {
 }
 
 describe('buildSportsMenuCountsBySlug', () => {
-  it('maps sports soon and legacy futures links to the same future sidebar bucket', () => {
+  it('maps sports soon and futures links to separate sidebar buckets', () => {
     expect(resolveSportsSidebarCountKey({
       href: '/sports/soon',
       vertical: 'sports',
-    })).toBe(SPORTS_SIDEBAR_FUTURE_COUNT_KEY)
+    })).toBe(SPORTS_SIDEBAR_SOON_COUNT_KEY)
 
     expect(resolveSportsSidebarCountKey({
       href: '/sports/futures/nba',
@@ -119,6 +120,7 @@ describe('buildSportsMenuCountsBySlug', () => {
       'league-of-legends::games': 1,
       'counter-strike::games': 1,
       [SPORTS_SIDEBAR_LIVE_COUNT_KEY]: 1,
+      [SPORTS_SIDEBAR_SOON_COUNT_KEY]: 1,
       [SPORTS_SIDEBAR_FUTURE_COUNT_KEY]: 1,
     })
   })
@@ -183,8 +185,63 @@ describe('buildSportsMenuCountsBySlug', () => {
 
     expect(counts).toMatchObject({
       'league-of-legends::games': 1,
+      [SPORTS_SIDEBAR_SOON_COUNT_KEY]: 1,
       [SPORTS_SIDEBAR_FUTURE_COUNT_KEY]: 1,
     })
+  })
+
+  it('keeps props out of the live and upcoming games buckets', () => {
+    const resolver = buildSportsSlugResolver([
+      {
+        menuSlug: 'basketball',
+        h1Title: 'Basketball',
+        sections: {
+          gamesEnabled: true,
+          propsEnabled: true,
+        },
+      },
+    ])
+
+    const menuEntries: SportsMenuEntry[] = [
+      buildLinkEntry({ id: 'live', label: 'Live', href: '/sports/live' }),
+      buildLinkEntry({ id: 'upcoming', label: 'Upcoming', href: '/sports/soon' }),
+      buildLinkEntry({
+        id: 'basketball-props',
+        label: 'Basketball Props',
+        href: '/sports/basketball/props',
+        menuSlug: 'basketball',
+      }),
+    ]
+
+    const counts = buildSportsMenuCountsBySlug(
+      resolver,
+      [
+        {
+          slug: 'basketball',
+          series_slug: null,
+          event_slug: 'basketball-player-points',
+          sports_event_id: 'basketball-player-points',
+          sports_event_slug: 'basketball-player-points',
+          parent_event_id: null,
+          tags: ['Sports', 'Props', 'Basketball'],
+          is_hidden: false,
+          sports_live: false,
+          sports_ended: false,
+          sports_start_time: new Date('2026-04-02T15:00:00.000Z'),
+          start_date: new Date('2026-04-02T15:00:00.000Z'),
+          end_date: new Date('2026-04-02T17:00:00.000Z'),
+        },
+      ],
+      menuEntries,
+      new Date('2026-04-02T12:00:00.000Z').getTime(),
+    )
+
+    expect(counts).toMatchObject({
+      'basketball::props': 1,
+      [SPORTS_SIDEBAR_FUTURE_COUNT_KEY]: 1,
+    })
+    expect(counts[SPORTS_SIDEBAR_LIVE_COUNT_KEY]).toBeUndefined()
+    expect(counts[SPORTS_SIDEBAR_SOON_COUNT_KEY]).toBeUndefined()
   })
 
   it('ignores slugs that are not present in the current vertical menu', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes cases where the sports sidebar rendered empty by falling back to fresh DB rows when the cache is empty. Also corrects sidebar counts by separating “Soon” from “Futures” and keeping props out of live/upcoming.

- **Bug Fixes**
  - Added a fallback to fetch fresh `sports_menu_items` when cached rows are empty; introduced an `EmptySportsMenuRowsError` and fresh query paths for menu, layout, canonical slug, and default hrefs.
  - Introduced a separate `__soon__` bucket; `/sports/soon` maps to “Soon” and `/sports/futures/*` to “Futures”.
  - Only “games” contribute to Live and Soon counts; props are excluded from these buckets.

<sup>Written for commit 84e8bbb8ee07103ebf2e299f3ccfe0d022d44eb4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

