### PR TITLE
fix: avoid pathname read during prerender

### DIFF
--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -5,7 +5,6 @@ import type { TradingOnboardingContextValue } from '@/app/[locale]/(platform)/_p
 import type { CommunityProfile } from '@/lib/community-profile'
 import type { User } from '@/types'
 import { useExtracted } from 'next-intl'
-import { usePathname } from 'next/navigation'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { createPublicClient, erc20Abi, erc1155Abi, http } from 'viem'
 import { useSignMessage, useSignTypedData } from 'wagmi'
@@ -379,7 +378,6 @@ function TradingOnboardingProviderContent({
   const t = useExtracted()
   const signatureRejectedMessage = t('You rejected the signature request.')
   const walletConnectorReconnectMessage = t('Your wallet connection expired. Reconnect your wallet and try again.')
-  const pathname = usePathname()
   const affiliateMetadata = useAffiliateOrderMetadata()
   const { open: openAppKit } = useAppKit()
   const refreshSessionUserState = useSessionRefresher()
@@ -471,10 +469,9 @@ function TradingOnboardingProviderContent({
     hasDepositWalletAddress: status.hasDepositWalletAddress,
   })
 
-  const isEventRoute = pathname.includes('/event/')
   const nextModal = resolveNextOnboardingModal({
     ...status,
-    allowTradingAuthPrompt: isEventRoute,
+    allowTradingAuthPrompt: false,
   })
 
   useEffect(function syncNextOnboardingModal() {
@@ -530,7 +527,6 @@ function TradingOnboardingProviderContent({
 
     const allowTradingAuthPrompt = Boolean(options?.allowTradingAuthPrompt)
       || Boolean(options?.forceTradingAuth)
-      || isEventRoute
     setShouldContinueTradingAuthPrompt(allowTradingAuthPrompt)
 
     const forcedStatus = options?.forceTradingAuth
@@ -541,7 +537,7 @@ function TradingOnboardingProviderContent({
       allowTradingAuthPrompt,
     })
     setActiveModal(modal)
-  }, [isEventRoute, openAppKit, refreshSessionUserState, status, user])
+  }, [openAppKit, refreshSessionUserState, status, user])
 
   const openFundModalIfBalanceEmpty = useCallback(async () => {
     if (!user?.deposit_wallet_address) {
@@ -676,7 +672,7 @@ function TradingOnboardingProviderContent({
       })
       void refreshSessionUserState()
       setDismissedModal(null)
-      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt || isEventRoute
+      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt
       const nextModal = status.needsEmail
         ? 'email'
         : resolveNextOnboardingModal({
@@ -707,7 +703,6 @@ function TradingOnboardingProviderContent({
     t,
     user?.address,
     user?.deposit_wallet_address,
-    isEventRoute,
   ])
 
   const handleEmailSubmit = useCallback(async (email: string) => {
@@ -735,7 +730,7 @@ function TradingOnboardingProviderContent({
       })
       void refreshSessionUserState()
       setDismissedModal(null)
-      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt || isEventRoute
+      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt
       const nextModal = resolveNextOnboardingModal({
         ...status,
         needsEmail: false,
@@ -749,7 +744,7 @@ function TradingOnboardingProviderContent({
     finally {
       setIsEmailSubmitting(false)
     }
-  }, [isEmailSubmitting, refreshSessionUserState, shouldContinueTradingAuthPrompt, status, isEventRoute])
+  }, [isEmailSubmitting, refreshSessionUserState, shouldContinueTradingAuthPrompt, status])
 
   const handleEmailSkip = useCallback(async () => {
     if (isEmailSubmitting) {
@@ -775,7 +770,7 @@ function TradingOnboardingProviderContent({
       })
       void refreshSessionUserState()
       setDismissedModal(null)
-      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt || isEventRoute
+      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt
       const nextModal = resolveNextOnboardingModal({
         ...status,
         needsEmail: false,
@@ -789,7 +784,7 @@ function TradingOnboardingProviderContent({
     finally {
       setIsEmailSubmitting(false)
     }
-  }, [isEmailSubmitting, refreshSessionUserState, shouldContinueTradingAuthPrompt, status, isEventRoute])
+  }, [isEmailSubmitting, refreshSessionUserState, shouldContinueTradingAuthPrompt, status])
 
   const enableTradingAuthForCurrentUser = useCallback(async () => {
     if (!user?.address) {

--- a/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
+++ b/src/app/[locale]/(platform)/_providers/TradingOnboardingProvider.tsx
@@ -5,7 +5,8 @@ import type { TradingOnboardingContextValue } from '@/app/[locale]/(platform)/_p
 import type { CommunityProfile } from '@/lib/community-profile'
 import type { User } from '@/types'
 import { useExtracted } from 'next-intl'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { usePathname } from 'next/navigation'
+import { Suspense, useCallback, useEffect, useMemo, useState } from 'react'
 import { createPublicClient, erc20Abi, erc1155Abi, http } from 'viem'
 import { useSignMessage, useSignTypedData } from 'wagmi'
 import { markApprovalStateWithoutTransactionAction } from '@/app/[locale]/(platform)/_actions/approve-tokens'
@@ -346,6 +347,20 @@ function openFundModalAfterTradingReady({
   }
 }
 
+function TradingAuthRoutePromptSync({
+  onRoutePromptChange,
+}: {
+  onRoutePromptChange: (allowTradingAuthPrompt: boolean) => void
+}) {
+  const pathname = usePathname()
+
+  useEffect(function syncRouteTradingAuthPrompt() {
+    onRoutePromptChange(pathname.includes('/event/'))
+  }, [onRoutePromptChange, pathname])
+
+  return null
+}
+
 function TradingOnboardingProviderContent({
   children,
   user,
@@ -368,6 +383,7 @@ function TradingOnboardingProviderContent({
   const [autoRedeemStep, setAutoRedeemStep] = useState<ApprovalsStep>('idle')
   const [requiresTradingAuthRefresh, setRequiresTradingAuthRefresh] = useState(false)
   const [shouldContinueTradingAuthPrompt, setShouldContinueTradingAuthPrompt] = useState(false)
+  const [allowsRouteTradingAuthPrompt, setAllowsRouteTradingAuthPrompt] = useState(false)
   const [communityUsernameHint, setCommunityUsernameHint] = useState<{
     address: string
     username: string
@@ -471,7 +487,7 @@ function TradingOnboardingProviderContent({
 
   const nextModal = resolveNextOnboardingModal({
     ...status,
-    allowTradingAuthPrompt: false,
+    allowTradingAuthPrompt: allowsRouteTradingAuthPrompt,
   })
 
   useEffect(function syncNextOnboardingModal() {
@@ -527,6 +543,7 @@ function TradingOnboardingProviderContent({
 
     const allowTradingAuthPrompt = Boolean(options?.allowTradingAuthPrompt)
       || Boolean(options?.forceTradingAuth)
+      || allowsRouteTradingAuthPrompt
     setShouldContinueTradingAuthPrompt(allowTradingAuthPrompt)
 
     const forcedStatus = options?.forceTradingAuth
@@ -537,7 +554,7 @@ function TradingOnboardingProviderContent({
       allowTradingAuthPrompt,
     })
     setActiveModal(modal)
-  }, [openAppKit, refreshSessionUserState, status, user])
+  }, [allowsRouteTradingAuthPrompt, openAppKit, refreshSessionUserState, status, user])
 
   const openFundModalIfBalanceEmpty = useCallback(async () => {
     if (!user?.deposit_wallet_address) {
@@ -672,7 +689,7 @@ function TradingOnboardingProviderContent({
       })
       void refreshSessionUserState()
       setDismissedModal(null)
-      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt
+      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt || allowsRouteTradingAuthPrompt
       const nextModal = status.needsEmail
         ? 'email'
         : resolveNextOnboardingModal({
@@ -703,6 +720,7 @@ function TradingOnboardingProviderContent({
     t,
     user?.address,
     user?.deposit_wallet_address,
+    allowsRouteTradingAuthPrompt,
   ])
 
   const handleEmailSubmit = useCallback(async (email: string) => {
@@ -730,7 +748,7 @@ function TradingOnboardingProviderContent({
       })
       void refreshSessionUserState()
       setDismissedModal(null)
-      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt
+      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt || allowsRouteTradingAuthPrompt
       const nextModal = resolveNextOnboardingModal({
         ...status,
         needsEmail: false,
@@ -744,7 +762,7 @@ function TradingOnboardingProviderContent({
     finally {
       setIsEmailSubmitting(false)
     }
-  }, [isEmailSubmitting, refreshSessionUserState, shouldContinueTradingAuthPrompt, status])
+  }, [allowsRouteTradingAuthPrompt, isEmailSubmitting, refreshSessionUserState, shouldContinueTradingAuthPrompt, status])
 
   const handleEmailSkip = useCallback(async () => {
     if (isEmailSubmitting) {
@@ -770,7 +788,7 @@ function TradingOnboardingProviderContent({
       })
       void refreshSessionUserState()
       setDismissedModal(null)
-      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt
+      const allowTradingAuthPrompt = shouldContinueTradingAuthPrompt || allowsRouteTradingAuthPrompt
       const nextModal = resolveNextOnboardingModal({
         ...status,
         needsEmail: false,
@@ -784,7 +802,7 @@ function TradingOnboardingProviderContent({
     finally {
       setIsEmailSubmitting(false)
     }
-  }, [isEmailSubmitting, refreshSessionUserState, shouldContinueTradingAuthPrompt, status])
+  }, [allowsRouteTradingAuthPrompt, isEmailSubmitting, refreshSessionUserState, shouldContinueTradingAuthPrompt, status])
 
   const enableTradingAuthForCurrentUser = useCallback(async () => {
     if (!user?.address) {
@@ -1374,6 +1392,10 @@ function TradingOnboardingProviderContent({
 
   return (
     <TradingOnboardingContext value={contextValue}>
+      <Suspense fallback={null}>
+        <TradingAuthRoutePromptSync onRoutePromptChange={setAllowsRouteTradingAuthPrompt} />
+      </Suspense>
+
       {children}
 
       <TradingOnboardingDialogs

--- a/tests/unit/TradingOnboardingProvider.test.tsx
+++ b/tests/unit/TradingOnboardingProvider.test.tsx
@@ -13,7 +13,6 @@ const mocks = vi.hoisted(() => ({
   openAppKit: vi.fn(),
   signAndSubmitDepositWalletCalls: vi.fn(),
   signTypedDataAsync: vi.fn(),
-  usePathname: vi.fn(() => '/'),
 }))
 
 const PENDING_DEPOSIT_WALLET_MESSAGE = 'Your trading wallet is still being set up on-chain. Check back shortly.'
@@ -21,10 +20,6 @@ const WALLET_RECONNECT_MESSAGE = 'Your wallet connection expired. Reconnect your
 
 vi.mock('next-intl', () => ({
   useExtracted: () => (message: string) => message,
-}))
-
-vi.mock('next/navigation', () => ({
-  usePathname: mocks.usePathname,
 }))
 
 vi.mock('wagmi', () => ({
@@ -118,7 +113,6 @@ describe('tradingOnboardingProvider', () => {
     mocks.openAppKit.mockClear()
     mocks.signAndSubmitDepositWalletCalls.mockReset()
     mocks.signTypedDataAsync.mockReset()
-    mocks.usePathname.mockReturnValue('/')
   })
 
   afterEach(() => {

--- a/tests/unit/TradingOnboardingProvider.test.tsx
+++ b/tests/unit/TradingOnboardingProvider.test.tsx
@@ -13,6 +13,7 @@ const mocks = vi.hoisted(() => ({
   openAppKit: vi.fn(),
   signAndSubmitDepositWalletCalls: vi.fn(),
   signTypedDataAsync: vi.fn(),
+  usePathname: vi.fn(() => '/'),
 }))
 
 const PENDING_DEPOSIT_WALLET_MESSAGE = 'Your trading wallet is still being set up on-chain. Check back shortly.'
@@ -20,6 +21,10 @@ const WALLET_RECONNECT_MESSAGE = 'Your wallet connection expired. Reconnect your
 
 vi.mock('next-intl', () => ({
   useExtracted: () => (message: string) => message,
+}))
+
+vi.mock('next/navigation', () => ({
+  usePathname: mocks.usePathname,
 }))
 
 vi.mock('wagmi', () => ({
@@ -113,6 +118,7 @@ describe('tradingOnboardingProvider', () => {
     mocks.openAppKit.mockClear()
     mocks.signAndSubmitDepositWalletCalls.mockReset()
     mocks.signTypedDataAsync.mockReset()
+    mocks.usePathname.mockReturnValue('/')
   })
 
   afterEach(() => {
@@ -197,6 +203,27 @@ describe('tradingOnboardingProvider', () => {
     expect(mocks.createDepositWalletAction).toHaveBeenCalledTimes(2)
     expect(screen.getByTestId('active-modal')).toHaveTextContent('enable')
     expect(screen.getByTestId('active-modal')).not.toHaveTextContent('enable-status')
+  })
+
+  it('auto-prompts trading auth on event routes', async () => {
+    mocks.usePathname.mockReturnValue('/event/test-market')
+
+    useUser.setState(createUser({
+      deposit_wallet_address: '0xbc040c5a56d757986475005f8cde8e41fe3e2486',
+      deposit_wallet_status: 'deployed',
+      email: 'user@example.com',
+      username: 'user',
+    }))
+
+    render(
+      <TradingOnboardingProvider>
+        <div />
+      </TradingOnboardingProvider>,
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('active-modal')).toHaveTextContent('enable-status')
+    })
   })
 
   it('opens AppKit instead of exposing wagmi connector errors during enable trading', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes prerender crashes by deferring route checks to the client while keeping the auto-prompt for trading authorization on event routes.

- **Bug Fixes**
  - Moved `usePathname` into a new `TradingAuthRoutePromptSync` component rendered under `Suspense` to avoid reading the pathname during prerender.
  - Replaced direct `isEventRoute` reads with an `allowsRouteTradingAuthPrompt` state updated via callback; updated modal resolution and handlers to use it.
  - Added a unit test to confirm trading auth auto-prompts on `/event/...` routes.

<sup>Written for commit fc47617102fc5e947c3b5de1c816c8d21e96e606. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

