### PR TITLE
fix: vercel prerender

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeClient.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeClient.tsx
@@ -360,6 +360,7 @@ function HomeClientContent({
         <div className="min-w-0 flex-1 space-y-4 lg:space-y-5">
           {hasFeaturedEvents && (
             <HomeFeaturedEventsCarousel
+              currentTimestamp={initialCurrentTimestamp}
               hotTopics={initialFeaturedHotTopics}
               items={initialFeaturedEvents}
               sideCard={initialFeaturedSideCard}

--- a/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
@@ -1,6 +1,9 @@
 import type { SupportedLocale } from '@/i18n/locales'
 import type { Event, HomeFeaturedEventCard, HomeFeaturedHotTopic, HomeFeaturedSideCardSettings } from '@/types'
+import { cacheLife, cacheTag } from 'next/cache'
 import HomeClient from '@/app/[locale]/(platform)/(home)/_components/HomeClient'
+import { HOME_INITIAL_EVENTS_CACHE_LIFE } from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+import { cacheTags } from '@/lib/cache-tags'
 import { listHomeEventsPage } from '@/lib/home-events-page'
 import { getHomeFeaturedSideCard, listHomeFeaturedEvents, listHomeFeaturedHotTopics } from '@/lib/home-featured-events'
 import { DEFAULT_HOME_FEATURED_SETTINGS } from '@/lib/home-featured-settings'
@@ -19,6 +22,13 @@ export default async function HomeContent({
   initialTag,
   initialMainTag,
 }: HomeContentProps) {
+  'use cache'
+  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
+  cacheTag(cacheTags.events('guest'))
+  cacheTag(cacheTags.eventsList)
+  cacheTag(cacheTags.homeFeaturedEvents)
+  cacheTag(cacheTags.settings)
+
   const resolvedLocale = locale as SupportedLocale
   const initialTagSlug = initialTag ?? 'trending'
   const initialMainTagSlug = initialMainTag ?? initialTagSlug

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -50,6 +50,7 @@ import { cn } from '@/lib/utils'
 interface HomeFeaturedEventsCarouselProps {
   items: HomeFeaturedEventCard[]
   hotTopics: HomeFeaturedHotTopic[]
+  currentTimestamp: number | null
   sideCard: HomeFeaturedSideCardSettings
 }
 
@@ -1013,17 +1014,17 @@ function ContextAvatar({ contextItem }: { contextItem: HomeFeaturedContextItem }
   )
 }
 
-function formatContextRelativeTime(value: string | null) {
-  if (!value) {
+function formatContextRelativeTime(value: string | null, currentTimestamp: number | null) {
+  if (!value || currentTimestamp === null) {
     return null
   }
 
   const timestamp = new Date(value).getTime()
-  if (!Number.isFinite(timestamp)) {
+  if (!Number.isFinite(timestamp) || !Number.isFinite(currentTimestamp)) {
     return null
   }
 
-  const diffSeconds = Math.round((timestamp - Date.now()) / 1000)
+  const diffSeconds = Math.round((timestamp - currentTimestamp) / 1000)
   const divisions = [
     { amount: 60, unit: 'second' },
     { amount: 60, unit: 'minute' },
@@ -1051,14 +1052,16 @@ function formatContextRelativeTime(value: string | null) {
 
 function ContextTickerItem({
   contextItem,
+  currentTimestamp,
   index,
   linkedHref,
 }: {
   contextItem: HomeFeaturedContextItem
+  currentTimestamp: number | null
   index: number
   linkedHref: string
 }) {
-  const timeLabel = formatContextRelativeTime(contextItem.publishedAt ?? contextItem.selectedAt)
+  const timeLabel = formatContextRelativeTime(contextItem.publishedAt ?? contextItem.selectedAt, currentTimestamp)
   const isNews = contextItem.type === 'news'
 
   return (
@@ -1096,7 +1099,15 @@ function ContextTickerItem({
   )
 }
 
-function ContextTicker({ item, linkedHref }: { item: HomeFeaturedEventCard, linkedHref: string }) {
+function ContextTicker({
+  currentTimestamp,
+  item,
+  linkedHref,
+}: {
+  currentTimestamp: number | null
+  item: HomeFeaturedEventCard
+  linkedHref: string
+}) {
   if (item.contextItems.length === 0) {
     return null
   }
@@ -1125,6 +1136,7 @@ function ContextTicker({ item, linkedHref }: { item: HomeFeaturedEventCard, link
           <ContextTickerItem
             key={`${contextItem.id}:${index}`}
             contextItem={contextItem}
+            currentTimestamp={currentTimestamp}
             index={index}
             linkedHref={linkedHref}
           />
@@ -1378,11 +1390,13 @@ function FeaturedRightRailAction() {
 
 function FeaturedSlide({
   item,
+  currentTimestamp,
   isActive,
   isNext,
   isChartEnabled,
 }: {
   item: HomeFeaturedEventCard
+  currentTimestamp: number | null
   isActive: boolean
   isNext: boolean
   isChartEnabled: boolean
@@ -1490,7 +1504,7 @@ function FeaturedSlide({
           <div className={featuredDetailsClassName}>
             <FeaturedHeader item={item} showActions={false} />
             {sportsGraphCard && <SportsFeaturedControls card={sportsGraphCard} linkedHref={linkedHref} />}
-            <ContextTicker item={item} linkedHref={linkedHref} />
+            <ContextTicker item={item} currentTimestamp={currentTimestamp} linkedHref={linkedHref} />
           </div>
 
           {chartColumnNode}
@@ -1520,7 +1534,7 @@ function FeaturedSlide({
               ? <StandardActions item={item} linkedHref={linkedHref} />
               : <OutcomeRows outcomes={item.topOutcomes} linkedHref={linkedHref} />}
 
-            <ContextTicker item={item} linkedHref={linkedHref} />
+            <ContextTicker item={item} currentTimestamp={currentTimestamp} linkedHref={linkedHref} />
           </div>
 
           {chartColumnNode}
@@ -1548,7 +1562,7 @@ function FeaturedSlide({
             ? <StandardActions item={item} linkedHref={linkedHref} />
             : <OutcomeRows outcomes={item.topOutcomes} linkedHref={linkedHref} />}
 
-          <ContextTicker item={item} linkedHref={linkedHref} />
+          <ContextTicker item={item} currentTimestamp={currentTimestamp} linkedHref={linkedHref} />
         </div>
 
         {chartColumnNode}
@@ -1558,7 +1572,12 @@ function FeaturedSlide({
   )
 }
 
-export default function HomeFeaturedEventsCarousel({ hotTopics, items, sideCard }: HomeFeaturedEventsCarouselProps) {
+export default function HomeFeaturedEventsCarousel({
+  currentTimestamp,
+  hotTopics,
+  items,
+  sideCard,
+}: HomeFeaturedEventsCarouselProps) {
   const t = useExtracted()
   const sectionRef = useRef<HTMLElement | null>(null)
   const [activeIndex, setActiveIndex] = useState(0)
@@ -1620,6 +1639,7 @@ export default function HomeFeaturedEventsCarousel({ hotTopics, items, sideCard 
               <FeaturedSlide
                 key={item.featuredId}
                 item={item}
+                currentTimestamp={currentTimestamp}
                 isActive={index === activeIndex}
                 isNext={index === nextIndex}
                 isChartEnabled={isChartNearViewport}

--- a/tests/unit/homeContent.test.ts
+++ b/tests/unit/homeContent.test.ts
@@ -8,6 +8,16 @@ vi.mock('@/lib/home-events-page', () => ({
   listHomeEventsPage: (...args: any[]) => mocks.listHomeEventsPage(...args),
 }))
 
+vi.mock('next/cache', async () => {
+  const actual = await vi.importActual<typeof import('next/cache')>('next/cache')
+
+  return {
+    ...actual,
+    cacheLife: vi.fn(),
+    cacheTag: vi.fn(),
+  }
+})
+
 vi.mock('@/app/[locale]/(platform)/(home)/_components/HomeClient', () => ({
   default: () => null,
 }))


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes Vercel prerender on the home page by making the featured carousel’s time labels deterministic and adding explicit cache controls for initial data. Prevents hydration mismatches and ensures predictable ISR.

- **Bug Fixes**
  - HomeContent: opt into caching with 'use cache', set `cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)`, and add `cacheTag` entries for events and settings via `next/cache`.
  - HomeFeaturedEventsCarousel: compute relative times using a passed `currentTimestamp` instead of `Date.now()`; plumbed through from the client to avoid non-deterministic renders.
  - Tests: mock `cacheLife` and `cacheTag` to keep unit tests stable.

<sup>Written for commit edeb589ddc07d5a9702c52979898d0e4cc57232a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

