### PR TITLE
fix: parses decimal strings into BigInt micro-units and rounds at 6

### DIFF
--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -95,6 +95,10 @@ function roundDecimalToMicroUnits(value: string) {
     microUnits += 1n
   }
 
+  if (microUnits.toString().length > MAX_TO_MICRO_DIGITS) {
+    return null
+  }
+
   return sign === '-' ? -microUnits : microUnits
 }
 

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -28,6 +28,50 @@ const USD_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>([
   ['2-2', usdFormatter],
 ])
 
+const MICRO_DECIMALS = 6
+
+function expandExponentialDecimal(value: string) {
+  const match = value.match(/^([+-]?)(\d+)(?:\.(\d*))?e([+-]?\d+)$/i)
+  if (!match) {
+    return value
+  }
+
+  const [, sign, whole, fraction = '', exponentRaw] = match
+  const exponent = Number.parseInt(exponentRaw, 10)
+  const digits = `${whole}${fraction}`
+  const decimalIndex = whole.length + exponent
+
+  if (decimalIndex <= 0) {
+    return `${sign}0.${'0'.repeat(Math.abs(decimalIndex))}${digits}`
+  }
+
+  if (decimalIndex >= digits.length) {
+    return `${sign}${digits}${'0'.repeat(decimalIndex - digits.length)}`
+  }
+
+  return `${sign}${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`
+}
+
+function roundDecimalToMicroUnits(value: string) {
+  const normalized = expandExponentialDecimal(value.trim())
+  const match = normalized.match(/^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))$/)
+  if (!match) {
+    return null
+  }
+
+  const [, sign, whole = '0', fraction = '', leadingFraction = ''] = match
+  const fractionDigits = fraction || leadingFraction
+  const microFraction = fractionDigits.slice(0, MICRO_DECIMALS).padEnd(MICRO_DECIMALS, '0')
+  const roundDigit = fractionDigits[MICRO_DECIMALS]
+  let microUnits = BigInt(whole || '0') * BigInt(MICRO_UNIT) + BigInt(microFraction || '0')
+
+  if (roundDigit && roundDigit >= '5') {
+    microUnits += 1n
+  }
+
+  return sign === '-' ? -microUnits : microUnits
+}
+
 function getSharesFormatter(min: number, max: number) {
   const key = `${min}-${max}`
   const cached = SHARES_FORMATTER_CACHE.get(key)
@@ -397,11 +441,11 @@ export function toCents(value?: string | number | null) {
 }
 
 export function toMicro(amount: string | number): string {
-  const numeric = Number(amount)
-  if (!Number.isFinite(numeric)) {
+  if (typeof amount === 'number' && !Number.isFinite(amount)) {
     return '0'
   }
-  return Math.round(numeric * MICRO_UNIT).toString()
+
+  return roundDecimalToMicroUnits(String(amount))?.toString() ?? '0'
 }
 
 export function fromMicro(amount: string | number, precision: number = 1): string {

--- a/src/lib/formatters.ts
+++ b/src/lib/formatters.ts
@@ -29,43 +29,69 @@ const USD_FORMATTER_CACHE = new Map<string, Intl.NumberFormat>([
 ])
 
 const MICRO_DECIMALS = 6
+const MAX_TO_MICRO_INPUT_LENGTH = 120
+const MAX_TO_MICRO_DIGITS = 78
 
-function expandExponentialDecimal(value: string) {
-  const match = value.match(/^([+-]?)(\d+)(?:\.(\d*))?e([+-]?\d+)$/i)
-  if (!match) {
-    return value
+function parseBoundedExponent(value: string) {
+  const sign = value.startsWith('-') ? '-' : ''
+  const digits = value.replace(/^[+-]/, '').replace(/^0+/, '') || '0'
+  if (digits.length > String(MAX_TO_MICRO_DIGITS).length) {
+    return null
   }
 
-  const [, sign, whole, fraction = '', exponentRaw] = match
-  const exponent = Number.parseInt(exponentRaw, 10)
-  const digits = `${whole}${fraction}`
-  const decimalIndex = whole.length + exponent
-
-  if (decimalIndex <= 0) {
-    return `${sign}0.${'0'.repeat(Math.abs(decimalIndex))}${digits}`
+  const exponent = Number.parseInt(`${sign}${digits}`, 10)
+  if (!Number.isSafeInteger(exponent) || Math.abs(exponent) > MAX_TO_MICRO_DIGITS) {
+    return null
   }
 
-  if (decimalIndex >= digits.length) {
-    return `${sign}${digits}${'0'.repeat(decimalIndex - digits.length)}`
-  }
-
-  return `${sign}${digits.slice(0, decimalIndex)}.${digits.slice(decimalIndex)}`
+  return exponent
 }
 
 function roundDecimalToMicroUnits(value: string) {
-  const normalized = expandExponentialDecimal(value.trim())
-  const match = normalized.match(/^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))$/)
+  const normalized = value.trim()
+  if (normalized.length > MAX_TO_MICRO_INPUT_LENGTH) {
+    return null
+  }
+
+  const match = normalized.match(/^([+-]?)(?:(\d+)(?:\.(\d*))?|\.(\d+))(?:e([+-]?\d+))?$/i)
   if (!match) {
     return null
   }
 
-  const [, sign, whole = '0', fraction = '', leadingFraction = ''] = match
+  const [, sign, whole = '0', fraction = '', leadingFraction = '', exponentRaw] = match
   const fractionDigits = fraction || leadingFraction
-  const microFraction = fractionDigits.slice(0, MICRO_DECIMALS).padEnd(MICRO_DECIMALS, '0')
-  const roundDigit = fractionDigits[MICRO_DECIMALS]
-  let microUnits = BigInt(whole || '0') * BigInt(MICRO_UNIT) + BigInt(microFraction || '0')
+  const exponent = exponentRaw ? parseBoundedExponent(exponentRaw) : 0
+  if (exponent === null) {
+    return null
+  }
 
-  if (roundDigit && roundDigit >= '5') {
+  const digits = `${whole || '0'}${fractionDigits}`.replace(/^0+/, '') || '0'
+  if (digits === '0') {
+    return 0n
+  }
+
+  const scale = exponent + MICRO_DECIMALS - fractionDigits.length
+  if (scale >= 0) {
+    if (digits.length + scale > MAX_TO_MICRO_DIGITS) {
+      return null
+    }
+
+    const microUnits = BigInt(digits) * 10n ** BigInt(scale)
+    return sign === '-' ? -microUnits : microUnits
+  }
+
+  const divisorExponent = Math.abs(scale)
+  if (divisorExponent > digits.length + 1) {
+    return 0n
+  }
+
+  const integer = BigInt(digits)
+  const divisor = 10n ** BigInt(divisorExponent)
+  const quotient = integer / divisor
+  const remainder = integer % divisor
+  let microUnits = quotient
+
+  if (remainder * 2n >= divisor) {
     microUnits += 1n
   }
 

--- a/tests/unit/formattersMoney.test.ts
+++ b/tests/unit/formattersMoney.test.ts
@@ -9,6 +9,11 @@ describe('money/price formatters', () => {
     expect(toMicro(0.0000005)).toBe('1')
     expect(toMicro('12.3456789')).toBe('12345679')
     expect(toMicro('0.07483805618869868')).toBe('74838')
+    expect(toMicro('.5e-6')).toBe('1')
+    expect(toMicro('.4e-6')).toBe('0')
+    expect(toMicro('1.25e2')).toBe('125000000')
+    expect(toMicro('1e000001')).toBe('10000000')
+    expect(toMicro('1e1000000000')).toBe('0')
   })
 
   it('fromMicro formats with precision', () => {

--- a/tests/unit/formattersMoney.test.ts
+++ b/tests/unit/formattersMoney.test.ts
@@ -8,6 +8,7 @@ describe('money/price formatters', () => {
     expect(toMicro(0.0000004)).toBe('0')
     expect(toMicro(0.0000005)).toBe('1')
     expect(toMicro('12.3456789')).toBe('12345679')
+    expect(toMicro('0.07483805618869868')).toBe('74838')
   })
 
   it('fromMicro formats with precision', () => {

--- a/tests/unit/formattersMoney.test.ts
+++ b/tests/unit/formattersMoney.test.ts
@@ -14,6 +14,7 @@ describe('money/price formatters', () => {
     expect(toMicro('1.25e2')).toBe('125000000')
     expect(toMicro('1e000001')).toBe('10000000')
     expect(toMicro('1e1000000000')).toBe('0')
+    expect(toMicro(`${'9'.repeat(80)}.0000000`)).toBe('0')
   })
 
   it('fromMicro formats with precision', () => {

--- a/tests/unit/orderHelpers.test.ts
+++ b/tests/unit/orderHelpers.test.ts
@@ -47,6 +47,20 @@ describe('calculateOrderAmounts', () => {
     expect(result.makerAmount).toBe(130000n)
     expect(result.takerAmount).toBe(10000000n)
   })
+
+  it('computes market buy amounts when derived prices have more than 15 significant digits', () => {
+    const result = calculateOrderAmounts({
+      orderType: ORDER_TYPE.MARKET,
+      side: ORDER_SIDE.BUY,
+      amount: '1',
+      limitPrice: '0',
+      limitShares: '0',
+      marketPriceCents: 7.483805618869868,
+    })
+
+    expect(result.makerAmount).toBe(1000000n)
+    expect(result.takerAmount).toBe(13362195n)
+  })
 })
 
 describe('buildOrderPayload', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes money conversion by parsing decimal and exponent notation into BigInt micro-units, with 6-decimal rounding and output-length validation to prevent overflow and float precision bugs in price and order calculations.

- **Bug Fixes**
  - Rewrote `toMicro` to use BigInt-based `roundDecimalToMicroUnits`; non-finite numbers return `0`.
  - Adds strict bounds on input length, digit count, exponent, and validates resulting micro-unit length; invalid inputs return `0`.
  - Corrects market buy amounts for high-significant-digit prices and adds tests for long decimals, exponent notation, and overflow cases.

<sup>Written for commit 5646ac8f85af0a7c621be3575ae9b42ce614274f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

