### PR TITLE
fix: featured market save crash

### DIFF
--- a/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
+++ b/src/app/[locale]/admin/(general)/_components/AdminGeneralSettingsForm.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { InputError } from '@/components/ui/input-error'
 import { serializeCustomJavascriptCodes } from '@/lib/custom-javascript-code'
+import { serializeHomeFeaturedEventsForSave } from '@/lib/home-featured-payload'
 import { DEFAULT_HOME_FEATURED_SETTINGS } from '@/lib/home-featured-settings'
 import { sanitizeSvg } from '@/lib/utils'
 import BrandIdentitySection from './BrandIdentitySection'
@@ -251,24 +252,7 @@ function AdminGeneralSettingsFormInner({
   )
   const blockedCountriesValue = useMemo(() => formatBlockedCountriesValue(blockedCountries), [blockedCountries])
   const serializedHomeFeaturedEvents = useMemo(
-    () => JSON.stringify(homeFeaturedEvents.map((event, index) => ({
-      targetType: event.targetType,
-      eventId: event.eventId,
-      seriesSlug: event.seriesSlug,
-      enabled: event.enabled,
-      rank: index,
-      source: event.source,
-      startsAt: event.startsAt,
-      endsAt: event.endsAt,
-      contextMode: event.contextMode,
-      autoRolloverEnabled: event.autoRolloverEnabled,
-      contextLocale: locale,
-      contextEventId: event.eventId,
-      contextItems: (event.contextItems ?? []).map(contextItem => ({
-        ...contextItem,
-        locale,
-      })),
-    }))),
+    () => JSON.stringify(serializeHomeFeaturedEventsForSave(homeFeaturedEvents, locale)),
     [homeFeaturedEvents, locale],
   )
   const customJavascriptCodeDisablePageOptions = useMemo(() => ([

--- a/src/app/[locale]/admin/(general)/_components/HomeFeaturedMarketsSection.tsx
+++ b/src/app/[locale]/admin/(general)/_components/HomeFeaturedMarketsSection.tsx
@@ -23,7 +23,6 @@ import {
 } from 'lucide-react'
 import { DynamicIcon } from 'lucide-react/dynamic'
 import { useExtracted } from 'next-intl'
-import Image from 'next/image'
 import { useEffect, useMemo, useRef, useState, useTransition } from 'react'
 import { toast } from 'sonner'
 import { Button } from '@/components/ui/button'
@@ -47,6 +46,7 @@ import {
 import { Switch } from '@/components/ui/switch'
 import { Textarea } from '@/components/ui/textarea'
 import { formatDollarValueLabel } from '@/lib/formatters'
+import { serializeHomeFeaturedEventsForSave } from '@/lib/home-featured-payload'
 import {
   HOME_FEATURED_SIDE_CARD_ICONS,
   HOME_FEATURED_SIDE_CARD_LIMITS,
@@ -164,25 +164,52 @@ function moveItem<T>(items: T[], index: number, direction: -1 | 1) {
   return next
 }
 
-function serializeFeaturedEventsForSave(items: HomeFeaturedEventAdminItem[], locale: string) {
-  return items.map((event, index) => ({
-    targetType: event.targetType,
-    eventId: event.eventId,
-    seriesSlug: event.seriesSlug,
-    enabled: event.enabled,
-    rank: index,
-    source: event.source,
-    startsAt: event.startsAt,
-    endsAt: event.endsAt,
-    contextMode: event.contextMode,
-    autoRolloverEnabled: event.autoRolloverEnabled,
-    contextLocale: locale,
-    contextEventId: event.eventId,
-    contextItems: (event.contextItems ?? []).map(contextItem => ({
-      ...contextItem,
-      locale,
-    })),
-  }))
+function normalizePreviewImageSrc(src: string | null | undefined) {
+  const normalizedSrc = src?.trim()
+  if (!normalizedSrc) {
+    return null
+  }
+  if (normalizedSrc.startsWith('/') && !normalizedSrc.startsWith('//')) {
+    return normalizedSrc
+  }
+  if (normalizedSrc.startsWith('data:image/') || normalizedSrc.startsWith('blob:')) {
+    return normalizedSrc
+  }
+
+  try {
+    const url = new URL(normalizedSrc.startsWith('//') ? `https:${normalizedSrc}` : normalizedSrc)
+    return url.protocol === 'http:' || url.protocol === 'https:' ? url.toString() : null
+  }
+  catch {
+    return null
+  }
+}
+
+function AdminPreviewImage({
+  src,
+  alt,
+  className,
+}: {
+  src: string | null | undefined
+  alt: string
+  className: string
+}) {
+  const normalizedSrc = normalizePreviewImageSrc(src)
+  if (!normalizedSrc) {
+    return null
+  }
+
+  return (
+    // eslint-disable-next-line next/no-img-element
+    <img
+      src={normalizedSrc}
+      alt={alt}
+      loading="lazy"
+      decoding="async"
+      referrerPolicy="no-referrer"
+      className={className}
+    />
+  )
 }
 
 function buildManualNewsContextItem(item: {
@@ -357,15 +384,7 @@ function HomeFeaturedSelectionDialog({
                   `)}
                 >
                   <div className="size-10 overflow-hidden rounded-lg bg-muted">
-                    {candidate.icon_url && (
-                      <Image
-                        src={candidate.icon_url}
-                        alt=""
-                        width={40}
-                        height={40}
-                        className="size-10 object-cover"
-                      />
-                    )}
+                    <AdminPreviewImage src={candidate.icon_url} alt="" className="size-10 object-cover" />
                   </div>
                   <div className="min-w-0 flex-1">
                     <p className="truncate text-sm font-medium">{candidate.title}</p>
@@ -873,15 +892,7 @@ function HomeFeaturedContextDialog({
                         "
                       >
                         <div className="size-8 overflow-hidden rounded-md bg-muted">
-                          {contextItem.faviconUrl && (
-                            <Image
-                              src={contextItem.faviconUrl}
-                              alt=""
-                              width={32}
-                              height={32}
-                              className="size-8 object-cover"
-                            />
-                          )}
+                          <AdminPreviewImage src={contextItem.faviconUrl} alt="" className="size-8 object-cover" />
                         </div>
                         <div className="min-w-0">
                           <p className="truncate text-sm font-medium">{contextItem.title}</p>
@@ -951,15 +962,7 @@ function FeaturedEventRow({
     "
     >
       <div className="size-10 overflow-hidden rounded-lg bg-muted">
-        {item.iconUrl && (
-          <Image
-            src={item.iconUrl}
-            alt=""
-            width={40}
-            height={40}
-            className="size-10 object-cover"
-          />
-        )}
+        <AdminPreviewImage src={item.iconUrl} alt="" className="size-10 object-cover" />
       </div>
 
       <div className="min-w-0">
@@ -1128,7 +1131,7 @@ export default function HomeFeaturedMarketsSection({
               includeNewEvents,
               sideCard,
             },
-            featuredEvents: serializeFeaturedEventsForSave(featuredEvents, locale),
+            featuredEvents: serializeHomeFeaturedEventsForSave(featuredEvents, locale),
           }),
         })
         const payload = await response.json().catch(() => null) as unknown

--- a/src/lib/home-featured-payload.ts
+++ b/src/lib/home-featured-payload.ts
@@ -1,0 +1,47 @@
+import type { HomeFeaturedContextItem, HomeFeaturedEventAdminItem } from '@/types'
+
+function normalizeOptionalString(value: string | null | undefined) {
+  const normalized = value?.trim()
+  return normalized || null
+}
+
+function serializeContextItemsForSave(items: HomeFeaturedContextItem[] | null | undefined, locale: string) {
+  return (items ?? []).map(contextItem => ({
+    id: contextItem.id,
+    type: contextItem.type,
+    source: contextItem.source,
+    title: contextItem.title,
+    avatarUrl: contextItem.avatarUrl,
+    faviconUrl: contextItem.faviconUrl,
+    url: contextItem.url,
+    publishedAt: contextItem.publishedAt,
+    selectedAt: contextItem.selectedAt,
+    expiresAt: contextItem.expiresAt,
+    relevanceScore: contextItem.relevanceScore,
+    isManual: contextItem.isManual,
+    locale,
+  }))
+}
+
+export function serializeHomeFeaturedEventsForSave(items: HomeFeaturedEventAdminItem[], locale: string) {
+  return items.map((event, index) => {
+    const eventId = normalizeOptionalString(event.eventId)
+    const seriesSlug = normalizeOptionalString(event.seriesSlug)
+
+    return {
+      targetType: event.targetType,
+      eventId,
+      seriesSlug,
+      enabled: event.enabled,
+      rank: index,
+      source: event.source,
+      startsAt: event.startsAt,
+      endsAt: event.endsAt,
+      contextMode: event.contextMode,
+      autoRolloverEnabled: event.autoRolloverEnabled,
+      contextLocale: locale,
+      contextEventId: eventId,
+      contextItems: serializeContextItemsForSave(event.contextItems, locale),
+    }
+  })
+}

--- a/tests/unit/updateGeneralSettingsAction.test.ts
+++ b/tests/unit/updateGeneralSettingsAction.test.ts
@@ -216,6 +216,83 @@ describe('updateGeneralSettingsAction', () => {
     }
   })
 
+  it('saves featured market context payloads without dropping the resolved event id', async () => {
+    mocks.getCurrentUser.mockResolvedValueOnce({ id: 'admin-1', is_admin: true })
+
+    const { updateGeneralSettingsAction } = await import('@/app/[locale]/admin/(general)/_actions/update-general-settings')
+    const formData = new FormData()
+    formData.set('site_name', 'Kuest')
+    formData.set('site_description', 'Prediction market')
+    formData.set('logo_mode', 'svg')
+    formData.set('logo_svg', '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"/></svg>')
+    formData.set('logo_image_path', '')
+    formData.set('home_featured_enabled', 'true')
+    formData.set('home_featured_use_ai', 'false')
+    formData.set('home_featured_max_cards', '6')
+    formData.set('home_featured_default_context_mode', 'auto')
+    formData.set('home_featured_news_sources', '')
+    formData.set('home_featured_comment_blacklist', '')
+    formData.set('home_featured_min_volume_24h', '0')
+    formData.set('home_featured_include_sports_today', 'true')
+    formData.set('home_featured_include_new_events', 'true')
+    formData.set('home_featured_side_card_title', 'Market pulse')
+    formData.set('home_featured_side_card_text', 'Fast movers across active markets.')
+    formData.set('home_featured_side_card_cta_label', '')
+    formData.set('home_featured_side_card_cta_href', '')
+    formData.set('home_featured_side_card_icon', 'trending-up')
+    formData.set('home_featured_side_card_use_ai', 'false')
+    formData.set('home_featured_events_json', JSON.stringify([{
+      targetType: 'series',
+      eventId: '01HZY8N77WMQ2GZ8J3KQ6M4P9A',
+      seriesSlug: 'nba-finals',
+      enabled: true,
+      rank: 0,
+      source: 'manual',
+      startsAt: null,
+      endsAt: null,
+      contextMode: 'auto',
+      autoRolloverEnabled: true,
+      contextLocale: 'pt',
+      contextEventId: '01HZY8N77WMQ2GZ8J3KQ6M4P9A',
+      contextItems: [{
+        type: 'news',
+        source: 'Example News',
+        title: 'Preview article',
+        url: 'https://news.example/article',
+        faviconUrl: 'https://news.example/favicon.ico',
+        publishedAt: '2026-07-05T12:00:00.000Z',
+        relevanceScore: 1,
+        expiresAt: '2027-07-05T12:00:00.000Z',
+        isManual: true,
+        locale: 'pt',
+      }],
+    }]))
+
+    const result = await updateGeneralSettingsAction({ error: null }, formData)
+    expect(result).toEqual({ error: null })
+    expect(mocks.replaceFeaturedEventsWithSettings).toHaveBeenCalledTimes(1)
+
+    const [featuredEventsPayload] = mocks.replaceFeaturedEventsWithSettings.mock.calls[0]
+    expect(featuredEventsPayload[0]).toMatchObject({
+      targetType: 'series',
+      eventId: null,
+      seriesSlug: 'nba-finals',
+      contextEventId: '01HZY8N77WMQ2GZ8J3KQ6M4P9A',
+      contextLocale: 'pt',
+    })
+    expect(featuredEventsPayload[0].contextItems[0]).toMatchObject({
+      locale: 'pt',
+      itemType: 'news',
+      source: 'Example News',
+      title: 'Preview article',
+      url: 'https://news.example/article',
+      faviconUrl: 'https://news.example/favicon.ico',
+      isManual: true,
+    })
+    expect(featuredEventsPayload[0].contextItems[0].publishedAt).toBeInstanceOf(Date)
+    expect(featuredEventsPayload[0].contextItems[0].expiresAt).toBeInstanceOf(Date)
+  })
+
   it('saves image-mode settings when an image path already exists', async () => {
     mocks.getCurrentUser.mockResolvedValueOnce({ id: 'admin-1', is_admin: true })
     mocks.updateSettings.mockResolvedValueOnce({ data: [], error: null })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the Admin “Featured Markets” save crash by hardening payload serialization and making image previews more robust. Adds a unit test to prevent regressions.

- **Bug Fixes**
  - Normalize featured event payloads via `serializeHomeFeaturedEventsForSave` (preserves `contextEventId`, nulls empty `eventId`/`seriesSlug`, keeps locale on context items) to avoid backend errors when saving.
  - Replace `next/image` with a safe admin preview `<img>` that supports relative, http(s), data, and blob URLs, ignoring invalid sources.

- **Refactors**
  - Extract shared serializer to `src/lib/home-featured-payload.ts` and use it in `AdminGeneralSettingsForm` and `HomeFeaturedMarketsSection` to remove duplicate logic.

<sup>Written for commit 4179ce260075ee4e086b511ca4a7284d00198627. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

