### PR TITLE
fix: require sports game context in admin

### DIFF
--- a/src/app/[locale]/(platform)/settings/_actions/update-profile.ts
+++ b/src/app/[locale]/(platform)/settings/_actions/update-profile.ts
@@ -1,16 +1,10 @@
 'use server'
 
-import { Buffer } from 'node:buffer'
 import { revalidatePath } from 'next/cache'
-import sharp from 'sharp'
 import { z } from 'zod'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { UserRepository } from '@/lib/db/queries/user'
-import { validateOutboundImageUrl } from '@/lib/og-image-security'
-import { uploadPublicAsset } from '@/lib/storage'
-
-const MAX_FILE_SIZE = 2 * 1024 * 1024
-const ACCEPTED_IMAGE_TYPES = ['image/jpeg', 'image/jpg', 'image/png', 'image/webp']
+import { normalizeOutboundImageUrl } from '@/lib/og-image-security'
 
 export interface ActionState {
   error?: string
@@ -41,23 +35,6 @@ const UpdateUserSchema = z.object({
     .regex(/^[A-Z0-9.-]+$/i, 'Only letters, numbers, dots and hyphens are allowed')
     .regex(/^(?![.-])/, 'Cannot start with a dot or hyphen')
     .regex(/(?<![.-])$/, 'Cannot end with a dot or hyphen'),
-  image: z
-    .instanceof(File)
-    .optional()
-    .refine((file) => {
-      if (!file || file.size === 0) {
-        return true
-      }
-
-      return file.size <= MAX_FILE_SIZE
-    }, { error: 'Image must be less than 2MB' })
-    .refine((file) => {
-      if (!file || file.size === 0) {
-        return true
-      }
-
-      return ACCEPTED_IMAGE_TYPES.includes(file.type)
-    }, { error: 'Only JPG, PNG, and WebP images are allowed' }),
   avatar_url: z.url().refine((value) => {
     const protocol = new URL(value).protocol
     return protocol === 'http:' || protocol === 'https:'
@@ -71,7 +48,6 @@ export async function updateUserAction(formData: FormData): Promise<ActionState>
       return { error: 'Unauthenticated.' }
     }
 
-    const imageFile = formData.get('image') as File
     const emailRaw = formData.get('email')
     const avatarUrlRaw = formData.get('avatar_url')
     const avatarUrl = typeof avatarUrlRaw === 'string' && avatarUrlRaw.trim().length > 0
@@ -81,7 +57,6 @@ export async function updateUserAction(formData: FormData): Promise<ActionState>
     const rawData = {
       email: typeof emailRaw === 'string' ? emailRaw : undefined,
       username: formData.get('username') as string,
-      image: imageFile && imageFile.size > 0 ? imageFile : undefined,
       avatar_url: avatarUrl,
     }
 
@@ -97,7 +72,11 @@ export async function updateUserAction(formData: FormData): Promise<ActionState>
       return { errors }
     }
 
-    if (validated.data.avatar_url && !(await validateOutboundImageUrl(validated.data.avatar_url))) {
+    const normalizedAvatarUrl = validated.data.avatar_url
+      ? normalizeOutboundImageUrl(validated.data.avatar_url)
+      : undefined
+
+    if (validated.data.avatar_url && !normalizedAvatarUrl) {
       return {
         errors: {
           avatar_url: 'Avatar URL must point to a public HTTP(S) image host.',
@@ -113,11 +92,8 @@ export async function updateUserAction(formData: FormData): Promise<ActionState>
       updateData.email = validated.data.email
     }
 
-    if (validated.data.avatar_url) {
-      updateData.image = validated.data.avatar_url
-    }
-    else if (validated.data.image && validated.data.image.size > 0) {
-      updateData.image = await uploadImage(user, validated.data.image)
+    if (normalizedAvatarUrl) {
+      updateData.image = normalizedAvatarUrl
     }
 
     const { error } = await UserRepository.updateUserProfileById(user.id, updateData)
@@ -131,26 +107,4 @@ export async function updateUserAction(formData: FormData): Promise<ActionState>
   catch {
     return { error: DEFAULT_ERROR_MESSAGE }
   }
-}
-
-async function uploadImage(user: any, image: File) {
-  const fileName = `users/avatars/${user.id}-${Date.now()}.jpg`
-
-  const buffer = Buffer.from(await image.arrayBuffer())
-
-  const resizedBuffer = await sharp(buffer)
-    .resize(100, 100, { fit: 'cover' })
-    .jpeg({ quality: 90 })
-    .toBuffer()
-
-  const { error } = await uploadPublicAsset(fileName, resizedBuffer, {
-    contentType: 'image/jpeg',
-    cacheControl: '31536000',
-  })
-
-  if (error) {
-    return user.image?.startsWith('http') ? null : user.image
-  }
-
-  return fileName
 }

--- a/src/app/[locale]/(platform)/settings/_actions/update-profile.ts
+++ b/src/app/[locale]/(platform)/settings/_actions/update-profile.ts
@@ -4,7 +4,7 @@ import { revalidatePath } from 'next/cache'
 import { z } from 'zod'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { UserRepository } from '@/lib/db/queries/user'
-import { normalizeOutboundImageUrl } from '@/lib/og-image-security'
+import { normalizeOutboundImageUrl, validateOutboundImageUrl } from '@/lib/og-image-security'
 
 export interface ActionState {
   error?: string
@@ -76,7 +76,10 @@ export async function updateUserAction(formData: FormData): Promise<ActionState>
       ? normalizeOutboundImageUrl(validated.data.avatar_url)
       : undefined
 
-    if (validated.data.avatar_url && !normalizedAvatarUrl) {
+    if (
+      validated.data.avatar_url
+      && (!normalizedAvatarUrl || !(await validateOutboundImageUrl(normalizedAvatarUrl)))
+    ) {
       return {
         errors: {
           avatar_url: 'Avatar URL must point to a public HTTP(S) image host.',

--- a/src/lib/admin-sports-create.ts
+++ b/src/lib/admin-sports-create.ts
@@ -1046,7 +1046,7 @@ export function buildAdminSportsDerivedContent(args: {
       return null
     }
 
-    if (isGamesSection && !hasSourceIdentity && teams.some(team => !team.name)) {
+    if (isGamesSection && teams.some(team => !team.name)) {
       return null
     }
 
@@ -1119,7 +1119,7 @@ export function buildAdminSportsDerivedContent(args: {
       return null
     }
 
-    if (isGamesSection && !hasSourceIdentity && (!args.sports.sportSlug.trim() || !args.sports.leagueSlug.trim() || !eventDate || !startTimeIso)) {
+    if (isGamesSection && (!args.sports.sportSlug.trim() || !args.sports.leagueSlug.trim() || !eventDate || !startTimeIso)) {
       return null
     }
 
@@ -1200,7 +1200,6 @@ export function buildAdminSportsStepErrors(args: {
   const homeName = normalizeText(homeTeam?.name ?? '')
   const awayName = normalizeText(awayTeam?.name ?? '')
   const sourceIdentity = resolveAdminSportsSourceIdentity(args.sports)
-  const hasSourceIdentity = sourceIdentity.isComplete
 
   if (args.step === 1) {
     if (!args.sports.section) {
@@ -1211,7 +1210,7 @@ export function buildAdminSportsStepErrors(args: {
       if (sourceIdentity.hasSourceId && !sourceIdentity.provider) {
         errors.push('Select a supported sports data provider for the source event or game ID.')
       }
-      else if (!hasSourceIdentity) {
+      else {
         if (!args.sports.sportSlug.trim()) {
           errors.push('Select a sports match or enter a sport slug.')
         }

--- a/src/lib/admin-sports-create.ts
+++ b/src/lib/admin-sports-create.ts
@@ -1022,6 +1022,8 @@ export function buildAdminSportsDerivedContent(args: {
   const eventSlug = buildSportsEventSlug(args.baseSlug, effectiveEventVariant)
   const eventDate = isGamesSection ? buildEventDateFromStartTime(args.sports.startTime) : ''
   const startTimeIso = isGamesSection ? buildStartTimeIso(args.sports.startTime) : ''
+  const sportSlug = isGamesSection ? slugify(args.sports.sportSlug) : ''
+  const leagueSlug = isGamesSection ? slugify(args.sports.leagueSlug) : ''
   const options = buildSportsOptions(args.sports, eventDate)
   const variantSlug = args.sports.section && effectiveEventVariant
     ? buildSportVariantSlug(args.sports.section, effectiveEventVariant, options)
@@ -1119,7 +1121,7 @@ export function buildAdminSportsDerivedContent(args: {
       return null
     }
 
-    if (isGamesSection && (!args.sports.sportSlug.trim() || !args.sports.leagueSlug.trim() || !eventDate || !startTimeIso)) {
+    if (isGamesSection && (!sportSlug || !leagueSlug || !eventDate || !startTimeIso)) {
       return null
     }
 
@@ -1139,11 +1141,11 @@ export function buildAdminSportsDerivedContent(args: {
     }
 
     if (isGamesSection) {
-      if (args.sports.sportSlug.trim()) {
-        payloadBase.sportSlug = slugify(args.sports.sportSlug)
+      if (sportSlug) {
+        payloadBase.sportSlug = sportSlug
       }
-      if (args.sports.leagueSlug.trim()) {
-        payloadBase.leagueSlug = slugify(args.sports.leagueSlug)
+      if (leagueSlug) {
+        payloadBase.leagueSlug = leagueSlug
       }
       if (eventDate) {
         payloadBase.eventDate = eventDate
@@ -1200,6 +1202,8 @@ export function buildAdminSportsStepErrors(args: {
   const homeName = normalizeText(homeTeam?.name ?? '')
   const awayName = normalizeText(awayTeam?.name ?? '')
   const sourceIdentity = resolveAdminSportsSourceIdentity(args.sports)
+  const sportSlug = args.sports.section === 'games' ? slugify(args.sports.sportSlug) : ''
+  const leagueSlug = args.sports.section === 'games' ? slugify(args.sports.leagueSlug) : ''
 
   if (args.step === 1) {
     if (!args.sports.section) {
@@ -1211,10 +1215,10 @@ export function buildAdminSportsStepErrors(args: {
         errors.push('Select a supported sports data provider for the source event or game ID.')
       }
       else {
-        if (!args.sports.sportSlug.trim()) {
+        if (!sportSlug) {
           errors.push('Select a sports match or enter a sport slug.')
         }
-        if (!args.sports.leagueSlug.trim()) {
+        if (!leagueSlug) {
           errors.push('Select a sports match or enter a league slug.')
         }
         if (!args.sports.startTime.trim()) {
@@ -1256,14 +1260,14 @@ export function buildAdminSportsStepErrors(args: {
         (args.sports.eventVariant === 'more_markets'
           || args.sports.eventVariant === 'exact_score'
           || args.sports.eventVariant === 'halftime_result')
-        && slugify(args.sports.sportSlug) !== 'soccer'
+        && sportSlug !== 'soccer'
       ) {
         errors.push('More Markets, Exact Score, and Halftime Result currently require sport slug "soccer".')
       }
 
       if (
         args.sports.eventVariant !== 'custom'
-        && (!args.sports.sportSlug.trim() || !args.sports.leagueSlug.trim() || !eventDate || !homeName || !awayName)
+        && (!sportSlug || !leagueSlug || !eventDate || !homeName || !awayName)
       ) {
         errors.push('Generated sports templates require full game details.')
       }

--- a/tests/unit/adminSportsCreate.test.ts
+++ b/tests/unit/adminSportsCreate.test.ts
@@ -309,7 +309,7 @@ describe('admin sports create', () => {
     ])
   })
 
-  it('allows a complete source identity to replace manual game fields', () => {
+  it('requires full game details even when source identity is complete', () => {
     const sports = createInitialAdminSportsForm()
     sports.section = 'games'
     sports.eventVariant = 'standard'
@@ -321,24 +321,44 @@ describe('admin sports create', () => {
       sports,
     })
 
-    expect(derived.payload).toEqual(expect.objectContaining({
-      section: 'games',
-      eventVariant: 'standard',
-      sourceProvider: 'thesportsdb',
-      sourceEventId: 'fixture-123',
-    }))
-    expect(derived.payload?.teams).toBeUndefined()
-    expect(derived.payload?.sportSlug).toBeUndefined()
-    expect(derived.payload?.leagueSlug).toBeUndefined()
+    expect(derived.payload).toBeNull()
+    expect(buildAdminSportsStepErrors({
+      step: 1,
+      sports,
+      hasTeamLogoByHostStatus: {
+        home: false,
+        away: false,
+      },
+    })).toEqual([
+      'Select a sports match or enter a sport slug.',
+      'Select a sports match or enter a league slug.',
+      'Select a sports match or enter the game start time.',
+      'Select a sports match or enter both home and away teams.',
+      'Sports games require a logo for both home and away teams.',
+    ])
   })
 
   it('omits blank source match confidence and clamps provided values', () => {
     const sports = createInitialAdminSportsForm()
     sports.section = 'games'
     sports.eventVariant = 'standard'
+    sports.sportSlug = 'Soccer'
+    sports.leagueSlug = 'MLS'
+    sports.startTime = '2026-04-01T21:00'
     sports.sourceProvider = 'thesportsdb'
     sports.sourceEventId = 'fixture-123'
+    sports.teams[0].name = 'LA Galaxy'
+    sports.teams[1].name = 'Inter Miami'
 
+    expect(buildAdminSportsDerivedContent({
+      baseSlug: 'lakers-vs-celtics-abc',
+      sports,
+    }).payload).toEqual(expect.objectContaining({
+      sportSlug: 'soccer',
+      leagueSlug: 'mls',
+      sourceProvider: 'thesportsdb',
+      sourceEventId: 'fixture-123',
+    }))
     expect(buildAdminSportsDerivedContent({
       baseSlug: 'lakers-vs-celtics-abc',
       sports,

--- a/tests/unit/adminSportsCreate.test.ts
+++ b/tests/unit/adminSportsCreate.test.ts
@@ -207,6 +207,45 @@ describe('admin sports create', () => {
     expect(normalizeDateTimeLocalValue(derived.payload?.startTime ?? '')).toBe('2026-04-01T21:00')
   })
 
+  it('rejects game context values that normalize to empty slugs', () => {
+    const sports = createInitialAdminSportsForm()
+    sports.section = 'games'
+    sports.eventVariant = 'standard'
+    sports.sportSlug = '!!!'
+    sports.leagueSlug = '###'
+    sports.startTime = '2026-04-01T21:00'
+    sports.teams[0].name = 'LA Galaxy'
+    sports.teams[1].name = 'Inter Miami'
+
+    const derived = buildAdminSportsDerivedContent({
+      baseSlug: 'la-galaxy-vs-inter-miami-abc',
+      sports,
+    })
+
+    expect(derived.payload).toBeNull()
+    expect(buildAdminSportsStepErrors({
+      step: 1,
+      sports,
+      hasTeamLogoByHostStatus: {
+        home: true,
+        away: true,
+      },
+    })).toEqual([
+      'Select a sports match or enter a sport slug.',
+      'Select a sports match or enter a league slug.',
+    ])
+    expect(buildAdminSportsStepErrors({
+      step: 2,
+      sports,
+      hasTeamLogoByHostStatus: {
+        home: true,
+        away: true,
+      },
+    })).toEqual([
+      'Generated sports templates require full game details.',
+    ])
+  })
+
   it('keeps moneyline markets mandatory inside exact score sports packs', () => {
     const sports = createInitialAdminSportsForm()
     sports.section = 'games'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Require full game context in the admin “games” section even when a source provider/event ID is set. Tighten sports slug rules and avatar URL host validation.

- **Bug Fixes**
  - Removed `hasSourceIdentity` bypass; games now require sport, league, start time, both team names, and logos.
  - Slugify/validate sport and league slugs (reject empty after slugify). Normalize avatar URLs and require public HTTP(S) hosts; remove in-app avatar uploads.

<sup>Written for commit f68e9f096c02dbb5bbd6f2d99b4d90512e97ae58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

