### PR TITLE
fix: sports rendering

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,7 @@ const config: NextConfig = {
   reactStrictMode: false,
   reactCompiler: true,
   staticPageGenerationTimeout: 180,
+  deploymentId: commitSha,
   experimental: {
     serverActions: {
       bodySizeLimit: '2mb',

--- a/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeContent.tsx
@@ -2,7 +2,10 @@ import type { SupportedLocale } from '@/i18n/locales'
 import type { Event, HomeFeaturedEventCard, HomeFeaturedHotTopic, HomeFeaturedSideCardSettings } from '@/types'
 import { cacheLife, cacheTag } from 'next/cache'
 import HomeClient from '@/app/[locale]/(platform)/(home)/_components/HomeClient'
-import { HOME_INITIAL_EVENTS_CACHE_LIFE } from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+import {
+  getHomeInitialCurrentTimestamp,
+  HOME_INITIAL_EVENTS_CACHE_LIFE,
+} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
 import { cacheTags } from '@/lib/cache-tags'
 import { listHomeEventsPage } from '@/lib/home-events-page'
 import { getHomeFeaturedSideCard, listHomeFeaturedEvents, listHomeFeaturedHotTopics } from '@/lib/home-featured-events'
@@ -18,7 +21,7 @@ interface HomeContentProps {
 
 export default async function HomeContent({
   locale,
-  currentTimestamp = null,
+  currentTimestamp,
   initialTag,
   initialMainTag,
 }: HomeContentProps) {
@@ -34,6 +37,7 @@ export default async function HomeContent({
   const initialMainTagSlug = initialMainTag ?? initialTagSlug
   const shouldLoadFeaturedEvents = initialTagSlug === 'trending' && initialMainTagSlug === 'trending'
   const initialSortBy = getInitialHomeEventsSortBy(initialTagSlug)
+  const resolvedCurrentTimestamp = currentTimestamp ?? getHomeInitialCurrentTimestamp()
   let initialCurrentTimestamp: number | null = null
 
   let initialEvents: Event[] = []
@@ -48,7 +52,7 @@ export default async function HomeContent({
     userId: '',
     bookmarked: false,
     locale: resolvedLocale,
-    currentTimestamp,
+    currentTimestamp: resolvedCurrentTimestamp,
     ...(initialSortBy && { sortBy: initialSortBy }),
   })
     .then(({ data: events, error, currentTimestamp: resolvedCurrentTimestamp }) => ({

--- a/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeInitialContent.tsx
@@ -1,9 +1,6 @@
 import type { SupportedLocale } from '@/i18n/locales'
 import HomeContent from '@/app/[locale]/(platform)/(home)/_components/HomeContent'
-import {
-  getCachedHomeInitialCurrentTimestamp,
-  getHomeInitialCurrentTimestamp,
-} from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
+import { getHomeInitialCurrentTimestamp } from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
 import { deferPublicShellPrerenderIfNeeded, shouldPrerenderPublicShell } from '@/lib/public-shell-rendering'
 
 interface HomeInitialContentProps {
@@ -13,32 +10,12 @@ interface HomeInitialContentProps {
   locale: SupportedLocale
 }
 
-interface HomeInitialContentBodyProps extends HomeInitialContentProps {
-  currentTimestamp?: number | null
-}
-
-async function HomeInitialContentBody({
-  currentTimestamp = null,
-  initialMainTag,
-  initialTag,
-  locale,
-}: HomeInitialContentBodyProps) {
-  return (
-    <HomeContent
-      locale={locale}
-      currentTimestamp={currentTimestamp}
-      initialTag={initialTag}
-      initialMainTag={initialMainTag}
-    />
-  )
-}
-
 async function RuntimeHomeInitialContent(props: HomeInitialContentProps) {
   await deferPublicShellPrerenderIfNeeded()
   const currentTimestamp = getHomeInitialCurrentTimestamp()
 
   return (
-    <HomeInitialContentBody
+    <HomeContent
       {...props}
       currentTimestamp={currentTimestamp}
     />
@@ -50,21 +27,14 @@ export default async function HomeInitialContent({
   ...props
 }: HomeInitialContentProps) {
   if (shouldPrerenderPublicShell()) {
-    const currentTimestamp = await getCachedHomeInitialCurrentTimestamp()
-
-    return (
-      <HomeInitialContentBody
-        {...props}
-        currentTimestamp={currentTimestamp}
-      />
-    )
+    return <HomeContent {...props} />
   }
 
   if (!deferRuntimePrerender) {
     const currentTimestamp = getHomeInitialCurrentTimestamp()
 
     return (
-      <HomeInitialContentBody
+      <HomeContent
         {...props}
         currentTimestamp={currentTimestamp}
       />

--- a/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
+++ b/src/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache.ts
@@ -1,5 +1,3 @@
-import { cacheLife } from 'next/cache'
-
 export const HOME_INITIAL_EVENTS_CACHE_LIFE = {
   stale: 900,
   revalidate: 900,
@@ -10,11 +8,4 @@ const HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS = 900_000
 
 export function getHomeInitialCurrentTimestamp() {
   return Math.floor(Date.now() / HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS) * HOME_INITIAL_EVENTS_TIMESTAMP_BUCKET_MS
-}
-
-export async function getCachedHomeInitialCurrentTimestamp() {
-  'use cache'
-  cacheLife(HOME_INITIAL_EVENTS_CACHE_LIFE)
-
-  return getHomeInitialCurrentTimestamp()
 }

--- a/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/dynamic-home-category-page.tsx
@@ -6,6 +6,7 @@ import {
   buildLocalizedPagePath,
   buildPredictionResultsOgImageUrl,
 } from '@/app/[locale]/(platform)/_lib/prediction-results-metadata'
+import { resolveCommitSha } from '@/lib/git'
 import { loadPlatformMainTags } from '@/lib/platform-main-tags'
 import {
   findDynamicHomeCategoryBySlug,
@@ -47,7 +48,7 @@ export async function buildDynamicHomeCategoryMetadata(locale: SupportedLocale, 
     locale,
     slug: category.slug,
     label: category.name,
-    version: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+    version: resolveCommitSha(),
   })
   const pageUrl = new URL(
     buildLocalizedPagePath(`/${category.slug}`, locale),
@@ -93,7 +94,7 @@ export async function buildDynamicHomeSubcategoryMetadata(
     locale,
     slug: resolvedSubcategory.subcategory.slug,
     label: resolvedSubcategory.subcategory.name,
-    version: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+    version: resolveCommitSha(),
   })
   const pageUrl = new URL(
     buildLocalizedPagePath(`/${resolvedSubcategory.category.slug}/${resolvedSubcategory.subcategory.slug}`, locale),

--- a/src/app/[locale]/(platform)/_lib/public-profile-page.tsx
+++ b/src/app/[locale]/(platform)/_lib/public-profile-page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/lib/community-profile'
 import { UserRepository } from '@/lib/db/queries/user'
 import { truncateAddress } from '@/lib/formatters'
+import { resolveCommitSha } from '@/lib/git'
 import { normalizePublicProfileSlug } from '@/lib/platform-routing'
 import { fetchPortfolioSnapshot } from '@/lib/portfolio'
 import { resolvePublicRuntimeEnv } from '@/lib/public-runtime-config.shared'
@@ -186,7 +187,7 @@ export async function buildPublicProfileMetadata({
   const imageUrl = buildPublicProfileOgImageUrl({
     locale,
     slug: canonicalSlug,
-    version: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+    version: resolveCommitSha(),
   })
   const description = `Check out this profile on ${siteName}.`
   const socialImage = {

--- a/src/app/[locale]/(platform)/esports/live/page.tsx
+++ b/src/app/[locale]/(platform)/esports/live/page.tsx
@@ -1,12 +1,8 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
-import SportsGamesCenter from '@/app/[locale]/(platform)/sports/_components/SportsGamesCenter'
-import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
-import { EventRepository } from '@/lib/db/queries/event'
-import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
+import { connection } from 'next/server'
+import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/esports/live'>): Promise<Metadata> {
@@ -27,32 +23,15 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/esports/
 export default async function EsportsLivePage({ params }: PageProps<'/[locale]/esports/live'>) {
   const { locale } = await params
   setRequestLocale(locale)
-  const [{ data: events }, { data: layoutData }] = await Promise.all([
-    EventRepository.listEvents({
-      tag: 'esports',
-      sportsVertical: 'esports',
-      search: '',
-      userId: '',
-      bookmarked: false,
-      status: 'active',
-      locale: locale as SupportedLocale,
-      sportsSection: 'games',
-      excludeSportsAuxiliary: true,
-    }),
-    SportsMenuRepository.getLayoutData('esports'),
-  ])
-  const cards = buildSportsGamesCards(events ?? [])
+  await connection()
 
   return (
-    <div key="esports-live-page" className="contents">
-      <SportsGamesCenter
-        cards={cards}
-        sportSlug="live"
-        sportTitle="Live"
-        pageMode="liveAndSoon"
-        categoryTitleBySlug={layoutData?.h1TitleBySlug ?? {}}
-        vertical="esports"
-      />
-    </div>
+    <SportsFeedPageContent
+      locale={locale as SupportedLocale}
+      sportSlug="live"
+      sportTitle="Live"
+      pageMode="liveAndSoon"
+      vertical="esports"
+    />
   )
 }

--- a/src/app/[locale]/(platform)/esports/live/page.tsx
+++ b/src/app/[locale]/(platform)/esports/live/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
-import { connection } from 'next/server'
 import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -23,7 +22,6 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/esports/
 export default async function EsportsLivePage({ params }: PageProps<'/[locale]/esports/live'>) {
   const { locale } = await params
   setRequestLocale(locale)
-  await connection()
 
   return (
     <SportsFeedPageContent

--- a/src/app/[locale]/(platform)/esports/soon/page.tsx
+++ b/src/app/[locale]/(platform)/esports/soon/page.tsx
@@ -1,12 +1,8 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
-import SportsGamesCenter from '@/app/[locale]/(platform)/sports/_components/SportsGamesCenter'
-import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
-import { EventRepository } from '@/lib/db/queries/event'
-import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
+import { connection } from 'next/server'
+import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
 
 export const metadata: Metadata = {
   title: 'Esports Upcoming',
@@ -15,32 +11,15 @@ export const metadata: Metadata = {
 export default async function EsportsSoonPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params
   setRequestLocale(locale)
-  const [{ data: events }, { data: layoutData }] = await Promise.all([
-    EventRepository.listEvents({
-      tag: 'esports',
-      sportsVertical: 'esports',
-      search: '',
-      userId: '',
-      bookmarked: false,
-      status: 'active',
-      locale: locale as SupportedLocale,
-      sportsSection: 'games',
-      excludeSportsAuxiliary: true,
-    }),
-    SportsMenuRepository.getLayoutData('esports'),
-  ])
-  const cards = buildSportsGamesCards(events ?? [])
+  await connection()
 
   return (
-    <div key="esports-soon-page" className="contents">
-      <SportsGamesCenter
-        cards={cards}
-        sportSlug="soon"
-        sportTitle="Upcoming Esports Games"
-        pageMode="soon"
-        categoryTitleBySlug={layoutData?.h1TitleBySlug ?? {}}
-        vertical="esports"
-      />
-    </div>
+    <SportsFeedPageContent
+      locale={locale as SupportedLocale}
+      sportSlug="soon"
+      sportTitle="Upcoming Esports Games"
+      pageMode="soon"
+      vertical="esports"
+    />
   )
 }

--- a/src/app/[locale]/(platform)/esports/soon/page.tsx
+++ b/src/app/[locale]/(platform)/esports/soon/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
-import { connection } from 'next/server'
 import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
 
 export const metadata: Metadata = {
@@ -11,7 +10,6 @@ export const metadata: Metadata = {
 export default async function EsportsSoonPage({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params
   setRequestLocale(locale)
-  await connection()
 
   return (
     <SportsFeedPageContent

--- a/src/app/[locale]/(platform)/leaderboard/[[...filters]]/page.tsx
+++ b/src/app/[locale]/(platform)/leaderboard/[[...filters]]/page.tsx
@@ -10,6 +10,7 @@ import {
   PERIOD_OPTIONS,
 } from '@/app/[locale]/(platform)/leaderboard/_utils/leaderboardFilters'
 import { DEFAULT_LOCALE } from '@/i18n/locales'
+import { resolveCommitSha } from '@/lib/git'
 import { deferPublicShellPrerenderIfNeeded } from '@/lib/public-shell-rendering'
 import resolveSiteUrl from '@/lib/site-url'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
@@ -72,7 +73,7 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/leaderbo
     category: parsedFilters.category,
     period: parsedFilters.period,
     order: parsedFilters.order,
-    version: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+    version: resolveCommitSha(),
   })
   const title = t('Leaderboard')
   const description = t('See top traders and biggest wins on {siteName}', { siteName })

--- a/src/app/[locale]/(platform)/predictions/[slug]/_lib/prediction-results-page.tsx
+++ b/src/app/[locale]/(platform)/predictions/[slug]/_lib/prediction-results-page.tsx
@@ -12,6 +12,7 @@ import {
 } from '@/app/[locale]/(platform)/_lib/prediction-results-metadata'
 import PredictionResultsClient from '@/app/[locale]/(platform)/predictions/[slug]/_components/PredictionResultsClient'
 import { TagRepository } from '@/lib/db/queries/tag'
+import { resolveCommitSha } from '@/lib/git'
 import { buildPlatformNavigationTags } from '@/lib/platform-navigation'
 import { listPredictionResultsPage } from '@/lib/prediction-results-events'
 import { resolvePredictionResultsRequestedApiSort } from '@/lib/prediction-results-filters'
@@ -58,7 +59,7 @@ export async function generatePredictionResultsMetadata({
     locale,
     slug,
     label: context.label,
-    version: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+    version: resolveCommitSha(),
   })
   const socialImage = {
     url: imageUrl,

--- a/src/app/[locale]/(platform)/sports/_components/SportsFeedPageContent.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsFeedPageContent.tsx
@@ -1,0 +1,75 @@
+import type { SupportedLocale } from '@/i18n/locales'
+import type { SportsVertical } from '@/lib/sports-vertical'
+import { cacheTag } from 'next/cache'
+import SportsGamesCenter from '@/app/[locale]/(platform)/sports/_components/SportsGamesCenter'
+import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
+import { cacheTags } from '@/lib/cache-tags'
+import { EventRepository } from '@/lib/db/queries/event'
+import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
+
+type SportsFeedPageMode = 'liveAndSoon' | 'soon'
+
+interface SportsFeedPageContentProps {
+  locale: SupportedLocale
+  pageMode: SportsFeedPageMode
+  sportSlug: string
+  sportTitle: string
+  vertical: SportsVertical
+}
+
+async function loadSportsFeedPageData({
+  locale,
+  vertical,
+}: {
+  locale: SupportedLocale
+  vertical: SportsVertical
+}) {
+  'use cache'
+  cacheTag(cacheTags.eventsList, cacheTags.sportsMenu)
+
+  const [{ data: events }, { data: layoutData }] = await Promise.all([
+    EventRepository.listEvents({
+      tag: vertical,
+      sportsVertical: vertical,
+      search: '',
+      userId: '',
+      bookmarked: false,
+      status: 'active',
+      locale,
+      sportsSection: 'games',
+      excludeSportsAuxiliary: true,
+    }),
+    SportsMenuRepository.getLayoutData(vertical),
+  ])
+
+  return {
+    cards: buildSportsGamesCards(events ?? []),
+    categoryTitleBySlug: layoutData?.h1TitleBySlug ?? {},
+  }
+}
+
+export default async function SportsFeedPageContent({
+  locale,
+  pageMode,
+  sportSlug,
+  sportTitle,
+  vertical,
+}: SportsFeedPageContentProps) {
+  const { cards, categoryTitleBySlug } = await loadSportsFeedPageData({
+    locale,
+    vertical,
+  })
+
+  return (
+    <div key={`${vertical}-${sportSlug}-page`} className="contents">
+      <SportsGamesCenter
+        cards={cards}
+        sportSlug={sportSlug}
+        sportTitle={sportTitle}
+        pageMode={pageMode}
+        categoryTitleBySlug={categoryTitleBySlug}
+        vertical={vertical}
+      />
+    </div>
+  )
+}

--- a/src/app/[locale]/(platform)/sports/_components/SportsFeedPageContent.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsFeedPageContent.tsx
@@ -63,6 +63,7 @@ async function loadSportsFeedPageData({
         limit: 128,
         locale,
         sportsSection: 'games',
+        excludeSportsAuxiliary: true,
       })).data
 
   return {

--- a/src/app/[locale]/(platform)/sports/_components/SportsFeedPageContent.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsFeedPageContent.tsx
@@ -4,10 +4,12 @@ import { cacheTag } from 'next/cache'
 import SportsGamesCenter from '@/app/[locale]/(platform)/sports/_components/SportsGamesCenter'
 import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 import { cacheTags } from '@/lib/cache-tags'
+import { hasDatabaseEnv } from '@/lib/db/env'
 import { EventRepository } from '@/lib/db/queries/event'
 import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
 
 type SportsFeedPageMode = 'liveAndSoon' | 'soon'
+const SPORTS_FEED_PAGE_DATA_CACHE_VERSION = 2
 
 interface SportsFeedPageContentProps {
   locale: SupportedLocale
@@ -18,29 +20,50 @@ interface SportsFeedPageContentProps {
 }
 
 async function loadSportsFeedPageData({
+  cacheVersion = SPORTS_FEED_PAGE_DATA_CACHE_VERSION,
+  databaseEnvAvailable,
   locale,
+  pageMode,
   vertical,
 }: {
+  cacheVersion?: number
+  databaseEnvAvailable: boolean
   locale: SupportedLocale
+  pageMode: SportsFeedPageMode
   vertical: SportsVertical
 }) {
   'use cache'
   cacheTag(cacheTags.eventsList, cacheTags.sportsMenu)
 
-  const [{ data: events }, { data: layoutData }] = await Promise.all([
-    EventRepository.listEvents({
-      tag: vertical,
-      sportsVertical: vertical,
-      search: '',
-      userId: '',
-      bookmarked: false,
-      status: 'active',
+  if (!databaseEnvAvailable) {
+    return {
+      cards: [],
+      categoryTitleBySlug: {},
+    }
+  }
+
+  const [{ data: feedEvents }, { data: layoutData }] = await Promise.all([
+    EventRepository.listSportsFeedEvents({
+      cacheVersion,
       locale,
-      sportsSection: 'games',
-      excludeSportsAuxiliary: true,
+      mode: pageMode,
+      sportsVertical: vertical,
     }),
     SportsMenuRepository.getLayoutData(vertical),
   ])
+  const events = feedEvents?.length
+    ? feedEvents
+    : (await EventRepository.listEvents({
+        tag: vertical,
+        sportsVertical: vertical,
+        search: '',
+        userId: '',
+        bookmarked: false,
+        status: 'active',
+        limit: 128,
+        locale,
+        sportsSection: 'games',
+      })).data
 
   return {
     cards: buildSportsGamesCards(events ?? []),
@@ -56,7 +79,10 @@ export default async function SportsFeedPageContent({
   vertical,
 }: SportsFeedPageContentProps) {
   const { cards, categoryTitleBySlug } = await loadSportsFeedPageData({
+    cacheVersion: SPORTS_FEED_PAGE_DATA_CACHE_VERSION,
+    databaseEnvAvailable: hasDatabaseEnv(),
     locale,
+    pageMode,
     vertical,
   })
 

--- a/src/app/[locale]/(platform)/sports/live/page.tsx
+++ b/src/app/[locale]/(platform)/sports/live/page.tsx
@@ -1,12 +1,8 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
-import SportsGamesCenter from '@/app/[locale]/(platform)/sports/_components/SportsGamesCenter'
-import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
-import { EventRepository } from '@/lib/db/queries/event'
-import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
+import { connection } from 'next/server'
+import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
 export async function generateMetadata({ params }: PageProps<'/[locale]/sports/live'>): Promise<Metadata> {
@@ -27,32 +23,15 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/sports/l
 export default async function SportsLivePage({ params }: PageProps<'/[locale]/sports/live'>) {
   const { locale } = await params
   setRequestLocale(locale)
-  const [{ data: events }, { data: layoutData }] = await Promise.all([
-    EventRepository.listEvents({
-      tag: 'sports',
-      sportsVertical: 'sports',
-      search: '',
-      userId: '',
-      bookmarked: false,
-      status: 'active',
-      locale: locale as SupportedLocale,
-      sportsSection: 'games',
-      excludeSportsAuxiliary: true,
-    }),
-    SportsMenuRepository.getLayoutData('sports'),
-  ])
-  const cards = buildSportsGamesCards(events ?? [])
+  await connection()
 
   return (
-    <div key="sports-live-page" className="contents">
-      <SportsGamesCenter
-        cards={cards}
-        sportSlug="live"
-        sportTitle="Live"
-        pageMode="liveAndSoon"
-        categoryTitleBySlug={layoutData?.h1TitleBySlug ?? {}}
-        vertical="sports"
-      />
-    </div>
+    <SportsFeedPageContent
+      locale={locale as SupportedLocale}
+      sportSlug="live"
+      sportTitle="Live"
+      pageMode="liveAndSoon"
+      vertical="sports"
+    />
   )
 }

--- a/src/app/[locale]/(platform)/sports/live/page.tsx
+++ b/src/app/[locale]/(platform)/sports/live/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { getExtracted, setRequestLocale } from 'next-intl/server'
-import { connection } from 'next/server'
 import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
 import { loadRuntimeThemeState } from '@/lib/theme-settings'
 
@@ -23,7 +22,6 @@ export async function generateMetadata({ params }: PageProps<'/[locale]/sports/l
 export default async function SportsLivePage({ params }: PageProps<'/[locale]/sports/live'>) {
   const { locale } = await params
   setRequestLocale(locale)
-  await connection()
 
   return (
     <SportsFeedPageContent

--- a/src/app/[locale]/(platform)/sports/soon/page.tsx
+++ b/src/app/[locale]/(platform)/sports/soon/page.tsx
@@ -1,12 +1,8 @@
-'use cache'
-
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
-import SportsGamesCenter from '@/app/[locale]/(platform)/sports/_components/SportsGamesCenter'
-import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
-import { EventRepository } from '@/lib/db/queries/event'
-import { SportsMenuRepository } from '@/lib/db/queries/sports-menu'
+import { connection } from 'next/server'
+import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
 
 export const metadata: Metadata = {
   title: 'Sports Upcoming',
@@ -15,32 +11,15 @@ export const metadata: Metadata = {
 export default async function SportsSoonPage({ params }: PageProps<'/[locale]/sports/soon'>) {
   const { locale } = await params
   setRequestLocale(locale)
-  const [{ data: events }, { data: layoutData }] = await Promise.all([
-    EventRepository.listEvents({
-      tag: 'sports',
-      sportsVertical: 'sports',
-      search: '',
-      userId: '',
-      bookmarked: false,
-      status: 'active',
-      locale: locale as SupportedLocale,
-      sportsSection: 'games',
-      excludeSportsAuxiliary: true,
-    }),
-    SportsMenuRepository.getLayoutData('sports'),
-  ])
-  const cards = buildSportsGamesCards(events ?? [])
+  await connection()
 
   return (
-    <div key="sports-soon-page" className="contents">
-      <SportsGamesCenter
-        cards={cards}
-        sportSlug="soon"
-        sportTitle="Upcoming Sports Games"
-        pageMode="soon"
-        categoryTitleBySlug={layoutData?.h1TitleBySlug ?? {}}
-        vertical="sports"
-      />
-    </div>
+    <SportsFeedPageContent
+      locale={locale as SupportedLocale}
+      sportSlug="soon"
+      sportTitle="Upcoming Sports Games"
+      pageMode="soon"
+      vertical="sports"
+    />
   )
 }

--- a/src/app/[locale]/(platform)/sports/soon/page.tsx
+++ b/src/app/[locale]/(platform)/sports/soon/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from 'next'
 import type { SupportedLocale } from '@/i18n/locales'
 import { setRequestLocale } from 'next-intl/server'
-import { connection } from 'next/server'
 import SportsFeedPageContent from '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent'
 
 export const metadata: Metadata = {
@@ -11,7 +10,6 @@ export const metadata: Metadata = {
 export default async function SportsSoonPage({ params }: PageProps<'/[locale]/sports/soon'>) {
   const { locale } = await params
   setRequestLocale(locale)
-  await connection()
 
   return (
     <SportsFeedPageContent

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -896,6 +896,41 @@ function buildSportsVerticalTagCondition(sportsVertical: SportsVertical | '' | u
     : sql`NOT ${hasEsportsTag}`
 }
 
+function buildSportsSectionCondition(sportsSection: string) {
+  const normalizedSportsSection = sportsSection.trim().toLowerCase()
+  if (normalizedSportsSection !== 'games' && normalizedSportsSection !== 'props') {
+    return null
+  }
+
+  const sectionTagSlugs = normalizedSportsSection === 'games'
+    ? ['games', 'game']
+    : ['props', 'prop']
+  const sportsTagsMatchCondition = buildSportsTagsMatchCondition(sectionTagSlugs)
+  const sportsMetadataSectionCondition = sportsTagsMatchCondition
+    ? exists(
+        db.select()
+          .from(event_sports)
+          .where(and(
+            eq(event_sports.event_id, events.id),
+            sportsTagsMatchCondition,
+          )),
+      )
+    : null
+  const genericTagSectionCondition = exists(
+    db.select()
+      .from(event_tags)
+      .innerJoin(tags, eq(event_tags.tag_id, tags.id))
+      .where(and(
+        eq(event_tags.event_id, events.id),
+        inArray(tags.slug, sectionTagSlugs),
+      )),
+  )
+
+  return sportsMetadataSectionCondition
+    ? or(sportsMetadataSectionCondition, genericTagSectionCondition)
+    : genericTagSectionCondition
+}
+
 function toOptionalIsoString(value: unknown): string | null {
   if (!value) {
     return null
@@ -1389,22 +1424,9 @@ async function buildEventListQueryContext({
     )
   }
 
-  const normalizedSportsSection = sportsSection.trim().toLowerCase()
-  if (normalizedSportsSection === 'games' || normalizedSportsSection === 'props') {
-    const sectionTagSlugs = normalizedSportsSection === 'games'
-      ? ['games', 'game']
-      : ['props', 'prop']
-    whereConditions.push(
-      exists(
-        db.select()
-          .from(event_tags)
-          .innerJoin(tags, eq(event_tags.tag_id, tags.id))
-          .where(and(
-            eq(event_tags.event_id, events.id),
-            inArray(tags.slug, sectionTagSlugs),
-          )),
-      ),
-    )
+  const sportsSectionCondition = buildSportsSectionCondition(sportsSection)
+  if (sportsSectionCondition) {
+    whereConditions.push(sportsSectionCondition)
   }
 
   const sportsVerticalCondition = buildSportsVerticalTagCondition(sportsVertical)
@@ -1637,22 +1659,9 @@ export const EventRepository = {
         )
       }
 
-      const normalizedSportsSection = sportsSection.trim().toLowerCase()
-      if (normalizedSportsSection === 'games' || normalizedSportsSection === 'props') {
-        const sectionTagSlugs = normalizedSportsSection === 'games'
-          ? ['games', 'game']
-          : ['props', 'prop']
-        whereConditions.push(
-          exists(
-            db.select()
-              .from(event_tags)
-              .innerJoin(tags, eq(event_tags.tag_id, tags.id))
-              .where(and(
-                eq(event_tags.event_id, events.id),
-                inArray(tags.slug, sectionTagSlugs),
-              )),
-          ),
-        )
+      const sportsSectionCondition = buildSportsSectionCondition(sportsSection)
+      if (sportsSectionCondition) {
+        whereConditions.push(sportsSectionCondition)
       }
 
       const sportsVerticalCondition = buildSportsVerticalTagCondition(sportsVertical)

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -51,6 +51,9 @@ type PriceApiResponse = Record<string, { BUY?: string, SELL?: string } | undefin
 interface OutcomePrices { buy?: number, sell?: number }
 const MAX_PRICE_BATCH = 500
 const DEFAULT_EVENT_LIST_LIMIT = 32
+const DEFAULT_SPORTS_FEED_EVENT_LIMIT = 128
+const MAX_SPORTS_FEED_EVENT_LIMIT = 256
+const SPORTS_FEED_EVENT_QUERY_CACHE_VERSION = 2
 
 interface LastTradePriceEntry {
   token_id: string
@@ -456,6 +459,16 @@ interface ListEventsProps {
   sportsSportSlug?: string
   sportsSection?: 'games' | 'props' | ''
   sportsVertical?: SportsVertical | ''
+}
+
+type SportsFeedMode = 'liveAndSoon' | 'soon'
+
+interface ListSportsFeedEventsProps {
+  cacheVersion?: number
+  locale?: SupportedLocale
+  limit?: number
+  mode: SportsFeedMode
+  sportsVertical: SportsVertical
 }
 
 interface RelatedEventOptions {
@@ -1181,6 +1194,11 @@ function normalizeEventListLimit(value: number | undefined) {
   return Math.min(Math.max(normalized, 1), 128)
 }
 
+function normalizeSportsFeedEventLimit(value: number | undefined) {
+  const normalized = Number.isFinite(value) ? Math.floor(value as number) : DEFAULT_SPORTS_FEED_EVENT_LIMIT
+  return Math.min(Math.max(normalized, 1), MAX_SPORTS_FEED_EVENT_LIMIT)
+}
+
 function normalizeEventListOffset(value: number | undefined) {
   return Number.isNaN(value) || (value ?? 0) < 0 ? 0 : Math.max(0, Math.floor(value ?? 0))
 }
@@ -1556,6 +1574,71 @@ async function selectOrderedEventIds({
   return rows.map(row => row.id)
 }
 
+async function selectSportsFeedEventIds({
+  baseWhere,
+  limit = DEFAULT_SPORTS_FEED_EVENT_LIMIT,
+  mode,
+  now = new Date(),
+}: {
+  baseWhere: SQL<unknown> | undefined
+  limit?: number
+  mode: SportsFeedMode
+  now?: Date
+}) {
+  if (!baseWhere) {
+    return []
+  }
+
+  const cappedLimit = normalizeSportsFeedEventLimit(limit)
+  const sportsStartTime = sql<Date | null>`COALESCE(${event_sports.sports_start_time}, ${events.start_date})`
+  const sportsReferenceEndTime = sql<Date | null>`
+    CASE
+      WHEN ${events.end_date} IS NOT NULL AND ${events.end_date} > ${sportsStartTime}
+        THEN ${events.end_date}
+      ELSE ${sportsStartTime}
+    END
+  `
+  const sportsLiveWindowCondition = sql`
+    ${event_sports.sports_live} IS TRUE
+    OR (
+      ${sportsStartTime} IS NOT NULL
+      AND ${sportsStartTime} <= ${now}
+      AND ${now} <= ${sportsReferenceEndTime} + INTERVAL '2 hours'
+    )
+  `
+  const sportsFutureCondition = sql`
+    ${sportsStartTime} IS NOT NULL
+    AND ${sportsStartTime} > ${now}
+  `
+  const sportsFeedCondition = mode === 'soon'
+    ? sportsFutureCondition
+    : or(sportsLiveWindowCondition, sportsFutureCondition)
+  const sportsLiveSortRank = sql<number>`
+    CASE
+      WHEN ${sportsLiveWindowCondition} THEN 0
+      ELSE 1
+    END
+  `
+
+  const rows = await db
+    .select({ id: events.id })
+    .from(events)
+    .innerJoin(event_sports, eq(event_sports.event_id, events.id))
+    .where(and(
+      baseWhere,
+      sql`${event_sports.sports_ended} IS NOT TRUE`,
+      sportsFeedCondition,
+    ))
+    .orderBy(
+      ...(mode === 'liveAndSoon' ? [asc(sportsLiveSortRank)] : []),
+      asc(sportsStartTime),
+      desc(events.id),
+    )
+    .limit(cappedLimit)
+
+  return rows.map(row => row.id)
+}
+
 function getEventMainTag(tags: any[] | undefined): string {
   if (!tags?.length) {
     return 'World'
@@ -1563,6 +1646,79 @@ function getEventMainTag(tags: any[] | undefined): string {
 
   const mainTag = tags.find(tag => tag.is_main_category)
   return mainTag?.name || tags[0].name
+}
+
+async function hydrateEventListResults({
+  eventsData,
+  locale,
+  skipLivePricing = false,
+  sportsSlugResolver,
+  userId = '',
+}: {
+  eventsData: DrizzleEventResult[]
+  locale: SupportedLocale
+  skipLivePricing?: boolean
+  sportsSlugResolver: SportsSlugResolver
+  userId?: string
+}) {
+  const tokensForPricing = skipLivePricing
+    ? []
+    : eventsData.flatMap(event =>
+        (event.markets ?? []).flatMap(market =>
+          (market.condition?.outcomes ?? []).map(outcome => outcome.token_id).filter(Boolean),
+        ),
+      )
+  const tagIds = Array.from(new Set(
+    eventsData.flatMap(event =>
+      (event.eventTags ?? [])
+        .map(eventTag => eventTag.tag?.id)
+        .filter((tagId): tagId is number => typeof tagId === 'number'),
+    ),
+  ))
+  const eventIds = eventsData.map(event => event.id)
+  const sportsVolumeGroupKeyByEventId = await getSportsVolumeGroupKeysByEventId(eventIds)
+  const sportsVolumeGroupKeysForAggregation = Array.from(new Set(
+    sportsVolumeGroupKeyByEventId.values(),
+  ))
+  const [priceMap, lastTradeMap, localizedTagNamesById, localizedEventTitlesById, groupedSportsVolumesByGroupKey] = await Promise.all([
+    skipLivePricing ? Promise.resolve(new Map<string, OutcomePrices>()) : fetchOutcomePrices(tokensForPricing),
+    skipLivePricing ? Promise.resolve(new Map<string, number>()) : fetchLastTradePrices(tokensForPricing),
+    getLocalizedTagNamesById(tagIds, locale),
+    getLocalizedEventTitlesById(eventIds, locale),
+    getSportsAggregatedVolumesByGroupKey(sportsVolumeGroupKeysForAggregation),
+  ])
+  const liveChartSeriesSlugs = await getEnabledLiveChartSeriesSlugs()
+
+  return eventsData
+    .filter(event => event.markets?.length > 0)
+    .map(event =>
+      eventResource(
+        event as DrizzleEventResult,
+        userId,
+        sportsSlugResolver,
+        priceMap,
+        lastTradeMap,
+        localizedTagNamesById,
+        localizedEventTitlesById,
+        liveChartSeriesSlugs,
+      ),
+    )
+    .map((event) => {
+      const groupKey = sportsVolumeGroupKeyByEventId.get(event.id)
+      if (!groupKey) {
+        return event
+      }
+
+      const groupedVolume = groupedSportsVolumesByGroupKey.get(groupKey)
+      if (groupedVolume == null) {
+        return event
+      }
+
+      return {
+        ...event,
+        volume: groupedVolume,
+      }
+    })
 }
 
 export const EventRepository = {
@@ -1979,62 +2135,90 @@ export const EventRepository = {
         })
       }
 
-      const tokensForPricing = skipLivePricing
-        ? []
-        : eventsData.flatMap(event =>
-            (event.markets ?? []).flatMap(market =>
-              (market.condition?.outcomes ?? []).map(outcome => outcome.token_id).filter(Boolean),
-            ),
-          )
-      const tagIds = Array.from(new Set(
-        eventsData.flatMap(event =>
-          (event.eventTags ?? [])
-            .map(eventTag => eventTag.tag?.id)
-            .filter((tagId): tagId is number => typeof tagId === 'number'),
+      const eventsWithMarkets = await hydrateEventListResults({
+        eventsData,
+        locale,
+        skipLivePricing,
+        sportsSlugResolver,
+        userId,
+      })
+
+      return { data: eventsWithMarkets, error: null }
+    })
+  },
+
+  async listSportsFeedEvents({
+    cacheVersion = SPORTS_FEED_EVENT_QUERY_CACHE_VERSION,
+    locale = DEFAULT_LOCALE,
+    limit = DEFAULT_SPORTS_FEED_EVENT_LIMIT,
+    mode,
+    sportsVertical,
+  }: ListSportsFeedEventsProps): Promise<QueryResult<Event[]>> {
+    'use cache'
+    cacheTag(cacheTags.events('guest'))
+    cacheTag(cacheTags.eventsList)
+    void cacheVersion
+
+    return await runQuery(async () => {
+      const { baseWhere, empty, sportsSlugResolver } = await buildEventListQueryContext({
+        tag: '',
+        sportsVertical,
+        search: '',
+        userId: '',
+        bookmarked: false,
+        status: 'active',
+        locale,
+        sportsSection: 'games',
+        excludeSportsAuxiliary: true,
+      })
+
+      if (empty) {
+        return { data: [], error: null }
+      }
+
+      const orderedIds = await selectSportsFeedEventIds({
+        baseWhere,
+        limit,
+        mode,
+      })
+
+      if (orderedIds.length === 0) {
+        return { data: [], error: null }
+      }
+
+      const orderIndex = new Map(orderedIds.map((id, index) => [id, index]))
+      const sportsFeedData = await db.query.events.findMany({
+        where: and(
+          baseWhere,
+          inArray(events.id, orderedIds),
         ),
-      ))
-      const eventIds = eventsData.map(event => event.id)
-      const sportsVolumeGroupKeyByEventId = await getSportsVolumeGroupKeysByEventId(eventIds)
-      const sportsVolumeGroupKeysForAggregation = Array.from(new Set(
-        sportsVolumeGroupKeyByEventId.values(),
-      ))
-      const [priceMap, lastTradeMap, localizedTagNamesById, localizedEventTitlesById, groupedSportsVolumesByGroupKey] = await Promise.all([
-        skipLivePricing ? Promise.resolve(new Map<string, OutcomePrices>()) : fetchOutcomePrices(tokensForPricing),
-        skipLivePricing ? Promise.resolve(new Map<string, number>()) : fetchLastTradePrices(tokensForPricing),
-        getLocalizedTagNamesById(tagIds, locale),
-        getLocalizedEventTitlesById(eventIds, locale),
-        getSportsAggregatedVolumesByGroupKey(sportsVolumeGroupKeysForAggregation),
-      ])
-      const liveChartSeriesSlugs = await getEnabledLiveChartSeriesSlugs()
+        with: {
+          markets: {
+            with: {
+              sports: true,
+              condition: {
+                with: { outcomes: true },
+              },
+            },
+          },
 
-      const eventsWithMarkets = eventsData
-        .filter(event => event.markets?.length > 0)
-        .map(event => eventResource(
-          event as DrizzleEventResult,
-          userId,
-          sportsSlugResolver,
-          priceMap,
-          lastTradeMap,
-          localizedTagNamesById,
-          localizedEventTitlesById,
-          liveChartSeriesSlugs,
-        ))
-        .map((event) => {
-          const groupKey = sportsVolumeGroupKeyByEventId.get(event.id)
-          if (!groupKey) {
-            return event
-          }
+          eventTags: {
+            with: { tag: true },
+          },
+          sports: true,
+        },
+      }) as DrizzleEventResult[]
 
-          const groupedVolume = groupedSportsVolumesByGroupKey.get(groupKey)
-          if (groupedVolume == null) {
-            return event
-          }
-
-          return {
-            ...event,
-            volume: groupedVolume,
-          }
-        })
+      const eventsData = sportsFeedData.sort((left, right) => {
+        const leftIndex = orderIndex.get(left.id) ?? Number.MAX_SAFE_INTEGER
+        const rightIndex = orderIndex.get(right.id) ?? Number.MAX_SAFE_INTEGER
+        return leftIndex - rightIndex
+      })
+      const eventsWithMarkets = await hydrateEventListResults({
+        eventsData,
+        locale,
+        sportsSlugResolver,
+      })
 
       return { data: eventsWithMarkets, error: null }
     })

--- a/src/lib/db/queries/sports-menu.ts
+++ b/src/lib/db/queries/sports-menu.ts
@@ -500,22 +500,32 @@ async function getFreshFuturesHref(vertical: SportsVertical): Promise<QueryResul
   })
 }
 
+async function withFreshSportsMenuRowsFallback<T>(
+  cachedQuery: () => Promise<QueryResult<T>>,
+  freshQuery: () => Promise<QueryResult<T>>,
+) {
+  try {
+    return await cachedQuery()
+  }
+  catch (error) {
+    if (isEmptySportsMenuRowsError(error)) {
+      return freshQuery()
+    }
+
+    throw error
+  }
+}
+
 export const SportsMenuRepository = {
   async getMenuEntries(vertical: SportsVertical = 'sports'): Promise<QueryResult<SportsMenuEntry[]>> {
     if (!hasDatabaseEnv()) {
       return buildQueryResult([])
     }
 
-    try {
-      return await getCachedMenuEntries(vertical)
-    }
-    catch (error) {
-      if (isEmptySportsMenuRowsError(error)) {
-        return getFreshMenuEntries(vertical)
-      }
-
-      throw error
-    }
+    return withFreshSportsMenuRowsFallback(
+      () => getCachedMenuEntries(vertical),
+      () => getFreshMenuEntries(vertical),
+    )
   },
 
   async getLayoutData(vertical: SportsVertical = 'sports'): Promise<QueryResult<SportsMenuLayoutData>> {
@@ -523,16 +533,10 @@ export const SportsMenuRepository = {
       return buildQueryResult(buildEmptySportsMenuLayoutData())
     }
 
-    try {
-      return await getCachedLayoutData(vertical)
-    }
-    catch (error) {
-      if (isEmptySportsMenuRowsError(error)) {
-        return getFreshLayoutData(vertical)
-      }
-
-      throw error
-    }
+    return withFreshSportsMenuRowsFallback(
+      () => getCachedLayoutData(vertical),
+      () => getFreshLayoutData(vertical),
+    )
   },
 
   async resolveCanonicalSlugByAlias(alias: string): Promise<QueryResult<string | null>> {
@@ -540,16 +544,10 @@ export const SportsMenuRepository = {
       return buildQueryResult(null)
     }
 
-    try {
-      return await getCachedCanonicalSlugByAlias(alias)
-    }
-    catch (error) {
-      if (isEmptySportsMenuRowsError(error)) {
-        return getFreshCanonicalSlugByAlias(alias)
-      }
-
-      throw error
-    }
+    return withFreshSportsMenuRowsFallback(
+      () => getCachedCanonicalSlugByAlias(alias),
+      () => getFreshCanonicalSlugByAlias(alias),
+    )
   },
 
   async getLandingHref(vertical: SportsVertical = 'sports'): Promise<QueryResult<string | null>> {
@@ -557,16 +555,10 @@ export const SportsMenuRepository = {
       return buildQueryResult(null)
     }
 
-    try {
-      return await getCachedLandingHref(vertical)
-    }
-    catch (error) {
-      if (isEmptySportsMenuRowsError(error)) {
-        return getFreshLandingHref(vertical)
-      }
-
-      throw error
-    }
+    return withFreshSportsMenuRowsFallback(
+      () => getCachedLandingHref(vertical),
+      () => getFreshLandingHref(vertical),
+    )
   },
 
   async getFuturesHref(vertical: SportsVertical = 'sports'): Promise<QueryResult<string | null>> {
@@ -574,15 +566,9 @@ export const SportsMenuRepository = {
       return buildQueryResult(null)
     }
 
-    try {
-      return await getCachedFuturesHref(vertical)
-    }
-    catch (error) {
-      if (isEmptySportsMenuRowsError(error)) {
-        return getFreshFuturesHref(vertical)
-      }
-
-      throw error
-    }
+    return withFreshSportsMenuRowsFallback(
+      () => getCachedFuturesHref(vertical),
+      () => getFreshFuturesHref(vertical),
+    )
   },
 }

--- a/src/lib/event-open-graph.ts
+++ b/src/lib/event-open-graph.ts
@@ -6,6 +6,7 @@ import { DEFAULT_LOCALE } from '@/i18n/locales'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { loadEventPageShellData } from '@/lib/event-page-data'
 import { resolveEventMarketPath, resolveEventPagePath } from '@/lib/events-routing'
+import { resolveCommitSha } from '@/lib/git'
 import resolveSiteUrl from '@/lib/site-url'
 import 'server-only'
 
@@ -140,7 +141,7 @@ export async function buildEventPageMetadata({
     eventSlug,
     locale,
     marketSlug,
-    version: process.env.VERCEL_GIT_COMMIT_SHA ?? null,
+    version: resolveCommitSha(),
   })
   const socialImage = {
     url: imageUrl,

--- a/src/lib/public-shell-env.ts
+++ b/src/lib/public-shell-env.ts
@@ -24,6 +24,10 @@ function hasBuildSiteUrlEnv(env: NodeJS.ProcessEnv) {
     || hasNonEmptyEnvValue(env.VERCEL_PROJECT_PRODUCTION_URL)
 }
 
+function isProductionBuildPhase(env: NodeJS.ProcessEnv) {
+  return env.NEXT_PHASE === 'phase-production-build'
+}
+
 export function hasPublicShellPrerenderEnv(env: NodeJS.ProcessEnv) {
   return hasBuildSiteUrlEnv(env)
     && hasNonEmptyEnvValue(env.POSTGRES_URL)
@@ -32,5 +36,9 @@ export function hasPublicShellPrerenderEnv(env: NodeJS.ProcessEnv) {
 
 export function resolvePublicShellPrerenderMode(env: NodeJS.ProcessEnv) {
   const explicitMode = parseBooleanEnv(env.BUILD_PRERENDER_PUBLIC_SHELL)
-  return explicitMode ?? hasPublicShellPrerenderEnv(env)
+  if (explicitMode !== null) {
+    return explicitMode
+  }
+
+  return isProductionBuildPhase(env) && hasPublicShellPrerenderEnv(env)
 }

--- a/tests/unit/homeContent.test.ts
+++ b/tests/unit/homeContent.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const mocks = vi.hoisted(() => ({
   listHomeEventsPage: vi.fn(),
@@ -27,7 +27,13 @@ describe('homeContent', () => {
     mocks.listHomeEventsPage.mockReset()
   })
 
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
   it('uses the route main tag when fetching initial subcategory events', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-11T12:34:56.789Z'))
     mocks.listHomeEventsPage.mockResolvedValueOnce({ data: [], error: null })
 
     const HomeContent = (await import('@/app/[locale]/(platform)/(home)/_components/HomeContent')).default
@@ -41,7 +47,7 @@ describe('homeContent', () => {
       tag: 'ai',
       mainTag: 'tech',
       locale: 'en',
-      currentTimestamp: null,
+      currentTimestamp: Date.parse('2026-05-11T12:30:00.000Z'),
     }))
   })
 

--- a/tests/unit/homeInitialEventsCache.test.ts
+++ b/tests/unit/homeInitialEventsCache.test.ts
@@ -1,14 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
-  getCachedHomeInitialCurrentTimestamp,
   getHomeInitialCurrentTimestamp,
   HOME_INITIAL_EVENTS_CACHE_LIFE,
 } from '@/app/[locale]/(platform)/(home)/_utils/homeInitialEventsCache'
-
-vi.mock('next/cache', () => ({
-  cacheLife: vi.fn(),
-}))
 
 describe('homeInitialEventsCache', () => {
   afterEach(() => {
@@ -28,12 +23,5 @@ describe('homeInitialEventsCache', () => {
     vi.setSystemTime(new Date('2026-05-11T12:34:56.789Z'))
 
     expect(getHomeInitialCurrentTimestamp()).toBe(Date.parse('2026-05-11T12:30:00.000Z'))
-  })
-
-  it('normalizes the cached prerender timestamp to the current fifteen-minute window', async () => {
-    vi.useFakeTimers()
-    vi.setSystemTime(new Date('2026-05-11T12:34:56.789Z'))
-
-    await expect(getCachedHomeInitialCurrentTimestamp()).resolves.toBe(Date.parse('2026-05-11T12:30:00.000Z'))
   })
 })

--- a/tests/unit/publicShellEnv.test.ts
+++ b/tests/unit/publicShellEnv.test.ts
@@ -8,6 +8,7 @@ describe('public shell env detection', () => {
   it('enables prerendering when build-time public shell env is complete', () => {
     const env: NodeJS.ProcessEnv = {
       NODE_ENV: 'test',
+      NEXT_PHASE: 'phase-production-build',
       POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
       REOWN_APPKIT_PROJECT_ID: 'project-id',
       SITE_URL: 'https://markets.example.com',
@@ -20,6 +21,7 @@ describe('public shell env detection', () => {
   it('accepts VERCEL_PROJECT_PRODUCTION_URL instead of SITE_URL', () => {
     const env: NodeJS.ProcessEnv = {
       NODE_ENV: 'test',
+      NEXT_PHASE: 'phase-production-build',
       POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
       REOWN_APPKIT_PROJECT_ID: 'project-id',
       VERCEL_PROJECT_PRODUCTION_URL: 'markets.example.com',
@@ -40,9 +42,23 @@ describe('public shell env detection', () => {
     expect(resolvePublicShellPrerenderMode(env)).toBe(false)
   })
 
+  it('does not infer prerendering from runtime-only env', () => {
+    const env: NodeJS.ProcessEnv = {
+      NODE_ENV: 'production',
+      NEXT_PHASE: 'phase-production-server',
+      POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
+      REOWN_APPKIT_PROJECT_ID: 'project-id',
+      SITE_URL: 'https://markets.example.com',
+    }
+
+    expect(hasPublicShellPrerenderEnv(env)).toBe(true)
+    expect(resolvePublicShellPrerenderMode(env)).toBe(false)
+  })
+
   it('lets an explicit override force the build mode', () => {
     expect(resolvePublicShellPrerenderMode({
       NODE_ENV: 'test',
+      NEXT_PHASE: 'phase-production-build',
       BUILD_PRERENDER_PUBLIC_SHELL: 'false',
       POSTGRES_URL: 'postgres://user:pass@localhost:5432/app',
       REOWN_APPKIT_PROJECT_ID: 'project-id',
@@ -51,6 +67,7 @@ describe('public shell env detection', () => {
 
     expect(resolvePublicShellPrerenderMode({
       NODE_ENV: 'test',
+      NEXT_PHASE: 'phase-production-server',
       BUILD_PRERENDER_PUBLIC_SHELL: 'true',
     })).toBe(true)
   })

--- a/tests/unit/sportsFeedPageContent.test.tsx
+++ b/tests/unit/sportsFeedPageContent.test.tsx
@@ -111,6 +111,7 @@ describe('sportsFeedPageContent', () => {
     })
 
     expect(mocks.listEvents).toHaveBeenCalledWith(expect.objectContaining({
+      excludeSportsAuxiliary: true,
       limit: 128,
       locale: 'en',
       sportsSection: 'games',

--- a/tests/unit/sportsFeedPageContent.test.tsx
+++ b/tests/unit/sportsFeedPageContent.test.tsx
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  buildSportsGamesCards: vi.fn(),
+  cacheTag: vi.fn(),
+  getLayoutData: vi.fn(),
+  hasDatabaseEnv: vi.fn(),
+  listEvents: vi.fn(),
+  listSportsFeedEvents: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+  cacheTag: (...args: any[]) => mocks.cacheTag(...args),
+}))
+
+vi.mock('@/app/[locale]/(platform)/sports/_components/SportsGamesCenter', () => ({
+  default: function SportsGamesCenter() {
+    return null
+  },
+}))
+
+vi.mock('@/app/[locale]/(platform)/sports/_utils/sports-games-data', () => ({
+  buildSportsGamesCards: (...args: any[]) => mocks.buildSportsGamesCards(...args),
+}))
+
+vi.mock('@/lib/db/env', () => ({
+  hasDatabaseEnv: () => mocks.hasDatabaseEnv(),
+}))
+
+vi.mock('@/lib/db/queries/event', () => ({
+  EventRepository: {
+    listEvents: (...args: any[]) => mocks.listEvents(...args),
+    listSportsFeedEvents: (...args: any[]) => mocks.listSportsFeedEvents(...args),
+  },
+}))
+
+vi.mock('@/lib/db/queries/sports-menu', () => ({
+  SportsMenuRepository: {
+    getLayoutData: (...args: any[]) => mocks.getLayoutData(...args),
+  },
+}))
+
+const { default: SportsFeedPageContent } = await import(
+  '@/app/[locale]/(platform)/sports/_components/SportsFeedPageContent',
+)
+
+describe('sportsFeedPageContent', () => {
+  beforeEach(() => {
+    mocks.buildSportsGamesCards.mockReset()
+    mocks.cacheTag.mockReset()
+    mocks.getLayoutData.mockReset()
+    mocks.hasDatabaseEnv.mockReset()
+    mocks.hasDatabaseEnv.mockReturnValue(true)
+    mocks.listEvents.mockReset()
+    mocks.listSportsFeedEvents.mockReset()
+  })
+
+  it('loads soon feeds from the sports metadata feed query instead of the generic event list', async () => {
+    const events = [{ id: 'event-1' }]
+    const cards = [{ id: 'card-1' }]
+    mocks.listSportsFeedEvents.mockResolvedValueOnce({ data: events, error: null })
+    mocks.getLayoutData.mockResolvedValueOnce({
+      data: { h1TitleBySlug: { soccer: 'Soccer' } },
+      error: null,
+    })
+    mocks.buildSportsGamesCards.mockReturnValueOnce(cards)
+
+    const element = await SportsFeedPageContent({
+      locale: 'en',
+      pageMode: 'soon',
+      sportSlug: 'soon',
+      sportTitle: 'Upcoming Sports Games',
+      vertical: 'sports',
+    })
+
+    expect(mocks.listSportsFeedEvents).toHaveBeenCalledWith({
+      cacheVersion: 2,
+      locale: 'en',
+      mode: 'soon',
+      sportsVertical: 'sports',
+    })
+    expect(mocks.listEvents).not.toHaveBeenCalled()
+    expect(mocks.buildSportsGamesCards).toHaveBeenCalledWith(events)
+    expect(element.props.children.props).toEqual(expect.objectContaining({
+      cards,
+      categoryTitleBySlug: { soccer: 'Soccer' },
+      pageMode: 'soon',
+      sportSlug: 'soon',
+      sportTitle: 'Upcoming Sports Games',
+      vertical: 'sports',
+    }))
+  })
+
+  it('falls back to the generic sports list when the feed query returns no events', async () => {
+    const fallbackEvents = [{ id: 'event-2' }]
+    const cards = [{ id: 'card-2' }]
+    mocks.listSportsFeedEvents.mockResolvedValueOnce({ data: [], error: null })
+    mocks.listEvents.mockResolvedValueOnce({ data: fallbackEvents, error: null })
+    mocks.getLayoutData.mockResolvedValueOnce({
+      data: { h1TitleBySlug: {} },
+      error: null,
+    })
+    mocks.buildSportsGamesCards.mockReturnValueOnce(cards)
+
+    await SportsFeedPageContent({
+      locale: 'en',
+      pageMode: 'liveAndSoon',
+      sportSlug: 'live',
+      sportTitle: 'Live',
+      vertical: 'sports',
+    })
+
+    expect(mocks.listEvents).toHaveBeenCalledWith(expect.objectContaining({
+      limit: 128,
+      locale: 'en',
+      sportsSection: 'games',
+      sportsVertical: 'sports',
+      status: 'active',
+      tag: 'sports',
+    }))
+    expect(mocks.buildSportsGamesCards).toHaveBeenCalledWith(fallbackEvents)
+  })
+
+  it('keeps no-database build results out of the runtime feed cache key', async () => {
+    mocks.hasDatabaseEnv.mockReturnValueOnce(false)
+
+    const element = await SportsFeedPageContent({
+      locale: 'en',
+      pageMode: 'soon',
+      sportSlug: 'soon',
+      sportTitle: 'Upcoming Sports Games',
+      vertical: 'sports',
+    })
+
+    expect(mocks.listSportsFeedEvents).not.toHaveBeenCalled()
+    expect(mocks.listEvents).not.toHaveBeenCalled()
+    expect(mocks.getLayoutData).not.toHaveBeenCalled()
+    expect(element.props.children.props).toEqual(expect.objectContaining({
+      cards: [],
+      categoryTitleBySlug: {},
+    }))
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes sports/esports Live and Soon pages by centralizing feed loading and correcting “Games”/“Props” filtering. Stabilizes the home feed timestamp, uses the commit SHA for deployment/OG caching, and only infers prerendering during production builds.

- **Bug Fixes**
  - Sports/esports Live/Soon pages render reliably; “Games”/“Props” lists populate correctly and exclude auxiliary markets.
  - Home feed uses the current 15‑minute bucket; timestamp resolved in `HomeContent`.
  - Sports feed caching skips no‑env builds; prerendering inferred only in production build phase.

- **Refactors**
  - Added `SportsFeedPageContent` to centralize feed fetching/UI with tagged caching for events and menu.
  - Introduced `EventRepository.listSportsFeedEvents` (cache v2, limit, fallback to generic list) and `withFreshSportsMenuRowsFallback`; set Next.js `deploymentId` and OG metadata version via `resolveCommitSha()`.

<sup>Written for commit c17c3e5830eda3d47e70b88a05b8f63916a2fce9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

