### PR TITLE
fix: highlight synced sports trophy

### DIFF
--- a/src/app/[locale]/admin/events/_components/columns.tsx
+++ b/src/app/[locale]/admin/events/_components/columns.tsx
@@ -12,6 +12,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { formatCompactCurrency, formatDate } from '@/lib/formatters'
 import { isSportsAuxiliaryEventSlug } from '@/lib/sports-event-slugs'
 import { cn } from '@/lib/utils'
+import { shouldHighlightSportsFinalAction } from './sports-final-action-state'
 
 interface EventColumnOptions {
   onToggleHidden: (event: AdminEventRow, nextValue: boolean) => void
@@ -230,6 +231,7 @@ export function useAdminEventsColumns({
         const hiddenUpdatePending = isUpdatingHidden(event.id)
         const nextHiddenState = !event.is_hidden
         const shouldHideSportsAdminControls = isSportsAuxiliaryEventSlug(event.slug)
+        const shouldHighlightSportsFinal = shouldHighlightSportsFinalAction(event)
 
         return (
           <div className="flex w-full items-center justify-end gap-1">
@@ -240,7 +242,7 @@ export function useAdminEventsColumns({
                     type="button"
                     variant="ghost"
                     size="icon"
-                    className={`size-8 ${event.sports_ended
+                    className={`size-8 ${shouldHighlightSportsFinal
                       ? 'text-primary hover:text-primary'
                       : 'text-muted-foreground'}`}
                     onClick={() => onOpenSportsFinalModal(event)}

--- a/src/app/[locale]/admin/events/_components/sports-final-action-state.ts
+++ b/src/app/[locale]/admin/events/_components/sports-final-action-state.ts
@@ -1,0 +1,18 @@
+import type { AdminEventRow } from '@/app/[locale]/admin/events/_hooks/useAdminEvents'
+import { normalizeSingleSportsSourceProvider } from '@/lib/sports-source/providers'
+
+export function shouldHighlightSportsFinalAction(event: Pick<
+  AdminEventRow,
+  'sports_ended' | 'sports_source_event_id' | 'sports_source_game_id' | 'sports_source_provider'
+>) {
+  if (event.sports_ended) {
+    return true
+  }
+
+  const provider = normalizeSingleSportsSourceProvider(event.sports_source_provider)
+  if (!provider) {
+    return false
+  }
+
+  return Boolean(event.sports_source_event_id?.trim() || event.sports_source_game_id?.trim())
+}

--- a/tests/unit/adminEventsSportsFinalActionState.test.ts
+++ b/tests/unit/adminEventsSportsFinalActionState.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { shouldHighlightSportsFinalAction } from '@/app/[locale]/admin/events/_components/sports-final-action-state'
+
+function makeEvent(overrides: Partial<Parameters<typeof shouldHighlightSportsFinalAction>[0]> = {}) {
+  return {
+    sports_ended: false,
+    sports_source_event_id: null,
+    sports_source_game_id: null,
+    sports_source_provider: null,
+    ...overrides,
+  }
+}
+
+describe('shouldHighlightSportsFinalAction', () => {
+  it('keeps the trophy highlighted when the sport final state is set manually', () => {
+    expect(shouldHighlightSportsFinalAction(makeEvent({
+      sports_ended: true,
+    }))).toBe(true)
+  })
+
+  it('highlights the trophy when TheSportsDB source details are filled', () => {
+    expect(shouldHighlightSportsFinalAction(makeEvent({
+      sports_source_event_id: '12345',
+      sports_source_provider: 'thesportsdb',
+    }))).toBe(true)
+  })
+
+  it('highlights the trophy when PandaScore source details are filled', () => {
+    expect(shouldHighlightSportsFinalAction(makeEvent({
+      sports_source_game_id: 'match-123',
+      sports_source_provider: 'pandascore',
+    }))).toBe(true)
+  })
+
+  it('does not highlight the trophy for recognized providers without event details', () => {
+    expect(shouldHighlightSportsFinalAction(makeEvent({
+      sports_source_provider: 'thesportsdb',
+    }))).toBe(false)
+  })
+
+  it('does not highlight the trophy for unsupported providers', () => {
+    expect(shouldHighlightSportsFinalAction(makeEvent({
+      sports_source_event_id: '12345',
+      sports_source_provider: 'legacy-provider',
+    }))).toBe(false)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the sports final trophy icon in Admin Events so it correctly stays highlighted when an event is final or synced to a supported provider with IDs. Improves clarity for admins managing sports results.

- **Bug Fixes**
  - Centralized logic in `shouldHighlightSportsFinalAction` and applied it in the events table.
  - Trophy highlights when `sports_ended` is true or when linked to `thesportsdb` (event ID) or `pandascore` (game ID); not highlighted for recognized providers without IDs or unsupported providers.
  - Added unit tests covering manual final, provider syncs, missing IDs, and unsupported providers.

<sup>Written for commit 5cce1c204255c28b520dc267e1ee540c9a620743. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

