### PR TITLE
fix: load sharp only for image uploads

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ allowBuilds:
   bufferutil: false
   esbuild: true
   keccak: false
-  sharp: false
+  sharp: true
   utf-8-validate: false
 
 overrides:

--- a/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
+++ b/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
@@ -4,7 +4,6 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { Buffer } from 'node:buffer'
 import { getLocale } from 'next-intl/server'
 import { revalidatePath } from 'next/cache'
-import sharp from 'sharp'
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/i18n/locales'
 import { cacheTags } from '@/lib/cache-tags'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
@@ -55,6 +54,17 @@ function buildTermsOfServicePdfPath() {
   return `legal/terms-of-service-${Date.now()}-${random}.pdf`
 }
 
+async function loadSharp() {
+  try {
+    const sharpModule = await import('sharp')
+    return { sharp: sharpModule.default, error: null }
+  }
+  catch (error) {
+    console.error('Failed to load sharp for admin image processing', error)
+    return { sharp: null, error: 'Image processing is temporarily unavailable. Please try again later.' }
+  }
+}
+
 async function processThemeLogoFile(file: File) {
   if (!ACCEPTED_LOGO_TYPES.includes(file.type)) {
     return { mode: null, path: null, svg: null, error: 'Logo must be PNG, JPG, WebP, or SVG.' }
@@ -67,6 +77,11 @@ async function processThemeLogoFile(file: File) {
   if (file.type === 'image/svg+xml') {
     const svg = await file.text()
     return { mode: 'svg' as const, path: null, svg, error: null }
+  }
+
+  const { sharp, error: sharpError } = await loadSharp()
+  if (!sharp) {
+    return { mode: null, path: null, svg: null, error: sharpError ?? DEFAULT_ERROR_MESSAGE }
   }
 
   const buffer = Buffer.from(await file.arrayBuffer())
@@ -96,6 +111,11 @@ async function processPwaIconFile(file: File, size: number, label: string) {
 
   if (file.size > MAX_PWA_ICON_FILE_SIZE) {
     return { path: null as string | null, error: `${label} must be 2MB or smaller.` }
+  }
+
+  const { sharp, error: sharpError } = await loadSharp()
+  if (!sharp) {
+    return { path: null as string | null, error: sharpError ?? DEFAULT_ERROR_MESSAGE }
   }
 
   const buffer = Buffer.from(await file.arrayBuffer())

--- a/tests/unit/updateGeneralSettingsAction.test.ts
+++ b/tests/unit/updateGeneralSettingsAction.test.ts
@@ -43,6 +43,7 @@ vi.mock('@/lib/storage', () => ({
 describe('updateGeneralSettingsAction', () => {
   beforeEach(() => {
     vi.resetModules()
+    vi.doUnmock('sharp')
     vi.stubGlobal('fetch', mocks.fetch)
     mocks.revalidatePath.mockReset()
     mocks.getCurrentUser.mockReset()
@@ -187,6 +188,58 @@ describe('updateGeneralSettingsAction', () => {
     expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]/admin/market-context', 'page')
     expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]/tos', 'page')
     expect(mocks.revalidatePath).not.toHaveBeenCalledWith('/[locale]', 'layout')
+  })
+
+  it('saves SVG settings without loading sharp', async () => {
+    mocks.getCurrentUser.mockResolvedValueOnce({ id: 'admin-1', is_admin: true })
+    mocks.updateSettings.mockResolvedValueOnce({ data: [], error: null })
+    vi.doMock('sharp', () => {
+      throw new Error('sharp should not load for SVG-only settings saves')
+    })
+
+    try {
+      const { updateGeneralSettingsAction } = await import('@/app/[locale]/admin/(general)/_actions/update-general-settings')
+      const formData = new FormData()
+      formData.set('site_name', 'Kuest')
+      formData.set('site_description', 'Prediction market')
+      formData.set('logo_mode', 'svg')
+      formData.set('logo_svg', '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"/></svg>')
+      formData.set('logo_image_path', '')
+
+      const result = await updateGeneralSettingsAction({ error: null }, formData)
+      expect(result).toEqual({ error: null })
+      expect(mocks.updateSettings).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      vi.doUnmock('sharp')
+    }
+  })
+
+  it('returns a form error when raster logo processing is unavailable', async () => {
+    mocks.getCurrentUser.mockResolvedValueOnce({ id: 'admin-1', is_admin: true })
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.doMock('sharp', () => {
+      throw new Error('sharp missing')
+    })
+
+    try {
+      const { updateGeneralSettingsAction } = await import('@/app/[locale]/admin/(general)/_actions/update-general-settings')
+      const formData = new FormData()
+      formData.set('site_name', 'Kuest')
+      formData.set('site_description', 'Prediction market')
+      formData.set('logo_mode', 'image')
+      formData.set('logo_svg', '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"/></svg>')
+      formData.set('logo_image_path', '')
+      formData.set('logo_image', new File(['png'], 'logo.png', { type: 'image/png' }))
+
+      const result = await updateGeneralSettingsAction({ error: null }, formData)
+      expect(result).toEqual({ error: 'Image processing is temporarily unavailable. Please try again later.' })
+      expect(mocks.updateSettings).not.toHaveBeenCalled()
+    }
+    finally {
+      consoleErrorSpy.mockRestore()
+      vi.doUnmock('sharp')
+    }
   })
 
   it('keeps featured markets saves successful when post-save revalidation fails', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lazily load `sharp` only when processing raster image uploads in Admin General Settings. This prevents crashes on SVG-only saves and shows a clear error if image processing is unavailable.

- **Bug Fixes**
  - Dynamically import `sharp` only for PNG/JPG/WebP logo and PWA icon processing; skip for SVG.
  - Show a user-friendly error when `sharp` fails to load; do not persist changes; log the error.
  - Added unit tests to verify no `sharp` load for SVG-only saves and the error path for raster uploads.

- **Dependencies**
  - Set `sharp: true` under `allowBuilds` in `pnpm-workspace.yaml`.

<sup>Written for commit ce533e4a0fb2e0ad6c8972f0be4b6e054507a2d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

