### PR TITLE
feat: testnet wallet deposit

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -19,7 +19,7 @@ allowBuilds:
   bufferutil: false
   esbuild: true
   keccak: false
-  sharp: false
+  sharp: true
   utf-8-validate: false
 
 overrides:

--- a/src/app/[locale]/(platform)/_components/WalletFlow.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletFlow.tsx
@@ -18,6 +18,7 @@ import { MAX_AMOUNT_INPUT } from '@/lib/amount-input'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
 import { COLLATERAL_TOKEN_ADDRESS } from '@/lib/contracts'
 import { formatAmountInputValue } from '@/lib/formatters'
+import { IS_TEST_MODE } from '@/lib/network'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import { signAndSubmitDepositWalletCalls } from '@/lib/wallet/client'
 import { buildSendErc20Call } from '@/lib/wallet/transactions'
@@ -280,7 +281,7 @@ export function WalletFlow({
   const {
     formattedUsdBalance: formattedConnectedWalletUsdBalance,
     isLoadingUsdBalance: isLoadingConnectedWalletUsdBalance,
-  } = useLiFiWalletUsdBalance(user?.address, { enabled: depositOpen })
+  } = useLiFiWalletUsdBalance(user?.address, { enabled: depositOpen && !IS_TEST_MODE })
   const site = useSiteIdentity()
   const connectedWalletAddress = user?.address ?? null
   const { openTradeRequirements } = useTradingOnboarding()

--- a/src/app/[locale]/(platform)/_components/WalletModal.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletModal.tsx
@@ -1,8 +1,9 @@
 'use client'
 
 import type { WalletDepositModalProps, WalletWithdrawModalProps } from '@/app/[locale]/(platform)/_components/wallet-modal/utils'
+import type { LiFiWalletTokenItem } from '@/hooks/useLiFiWalletTokens'
 import { ChevronLeftIcon } from 'lucide-react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import CountdownBadge from '@/app/[locale]/(platform)/_components/wallet-modal/CountdownBadge'
 import { getSelectedWalletTokenId } from '@/app/[locale]/(platform)/_components/wallet-modal/utils'
 import WalletAmountStep from '@/app/[locale]/(platform)/_components/wallet-modal/WalletAmountStep'
@@ -14,10 +15,15 @@ import WalletSuccessStep from '@/app/[locale]/(platform)/_components/wallet-moda
 import WalletTokenList from '@/app/[locale]/(platform)/_components/wallet-modal/WalletTokenList'
 import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Drawer, DrawerContent, DrawerDescription, DrawerHeader, DrawerTitle } from '@/components/ui/drawer'
+import { useBalance } from '@/hooks/useBalance'
 import { useLiFiQuote } from '@/hooks/useLiFiQuote'
 import { useLiFiWalletTokens } from '@/hooks/useLiFiWalletTokens'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
+import { formatDisplayAmount } from '@/lib/amount-input'
+import { COLLATERAL_TOKEN_ADDRESS } from '@/lib/contracts'
+import { DEFAULT_CHAIN_ID, IS_TEST_MODE } from '@/lib/network'
 import { cn } from '@/lib/utils'
+import { defaultViemNetwork } from '@/lib/viem-network'
 
 export type { WalletDepositModalProps, WalletWithdrawModalProps }
 
@@ -43,8 +49,47 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
   const [copied, setCopied] = useState(false)
   const site = useSiteIdentity()
   const siteLabel = siteName ?? site.name
+  const isDirectTestModeDeposit = IS_TEST_MODE
   const tokensQueryEnabled = open && (view === 'wallets' || view === 'amount' || view === 'confirm')
-  const { items: walletTokenItems, isLoadingTokens } = useLiFiWalletTokens(walletEoaAddress, { enabled: tokensQueryEnabled })
+  const { balance: directWalletBalance, isLoadingBalance: isLoadingDirectWalletBalance } = useBalance({
+    depositWalletAddress: walletEoaAddress,
+    enabled: open && isDirectTestModeDeposit,
+  })
+  const directWalletTokenItems = useMemo<LiFiWalletTokenItem[]>(() => {
+    if (!isDirectTestModeDeposit || !walletEoaAddress || directWalletBalance.raw <= 0) {
+      return []
+    }
+
+    const formattedBalance = directWalletBalance.raw.toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 6,
+    })
+    const formattedUsdBalance = directWalletBalance.raw.toLocaleString('en-US', {
+      minimumFractionDigits: 2,
+      maximumFractionDigits: 2,
+    })
+
+    return [{
+      id: `${DEFAULT_CHAIN_ID}:${COLLATERAL_TOKEN_ADDRESS}`,
+      chainId: DEFAULT_CHAIN_ID,
+      address: COLLATERAL_TOKEN_ADDRESS,
+      decimals: 6,
+      symbol: directWalletBalance.symbol,
+      network: defaultViemNetwork.name,
+      icon: '/images/deposit/transfer/usdc_dark.png',
+      chainIcon: '/images/deposit/transfer/polygon_dark.png',
+      balance: formattedBalance,
+      balanceRaw: directWalletBalance.raw,
+      usd: formattedUsdBalance,
+      usdValue: directWalletBalance.raw,
+      disabled: false,
+    }]
+  }, [directWalletBalance.raw, directWalletBalance.symbol, isDirectTestModeDeposit, walletEoaAddress])
+  const { items: lifiWalletTokenItems, isLoadingTokens: isLoadingLiFiTokens } = useLiFiWalletTokens(walletEoaAddress, {
+    enabled: tokensQueryEnabled && !isDirectTestModeDeposit,
+  })
+  const walletTokenItems = isDirectTestModeDeposit ? directWalletTokenItems : lifiWalletTokenItems
+  const isLoadingTokens = isDirectTestModeDeposit ? isLoadingDirectWalletBalance : isLoadingLiFiTokens
   const [preferredSelectedTokenId, setPreferredSelectedTokenId] = useState('')
   const [amountValue, setAmountValue] = useState('')
   const [confirmRefreshIndex, setConfirmRefreshIndex] = useState(0)
@@ -66,13 +111,32 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
 
   const selectedTokenId = getSelectedWalletTokenId(walletTokenItems, preferredSelectedTokenId)
   const selectedToken = walletTokenItems.find(item => item.id === selectedTokenId) ?? null
-  const { quote } = useLiFiQuote({
+  const { quote: lifiQuote } = useLiFiQuote({
     fromToken: selectedToken,
     amountValue,
     fromAddress: walletEoaAddress,
     toAddress: walletAddress,
     refreshIndex: confirmRefreshIndex,
+    enabled: !isDirectTestModeDeposit,
   })
+  const directQuote = useMemo(() => {
+    if (!isDirectTestModeDeposit || !amountValue.trim()) {
+      return null
+    }
+
+    const amountNumber = Number.parseFloat(amountValue)
+    if (!Number.isFinite(amountNumber) || amountNumber <= 0) {
+      return null
+    }
+
+    return {
+      toAmountDisplay: formatDisplayAmount(amountValue),
+      gasUsdDisplay: null,
+    }
+  }, [amountValue, isDirectTestModeDeposit])
+  const quote = isDirectTestModeDeposit ? directQuote : lifiQuote
+  const effectiveWalletBalance = isDirectTestModeDeposit ? directWalletBalance.text : walletBalance
+  const isEffectiveWalletBalanceLoading = isDirectTestModeDeposit ? isLoadingDirectWalletBalance : isBalanceLoading
 
   const content = view === 'fund'
     ? (
@@ -86,8 +150,8 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
           disabledReceive={!hasDeployedDepositWallet}
           meldUrl={meldUrl}
           walletEoaAddress={walletEoaAddress}
-          walletBalance={walletBalance}
-          isBalanceLoading={isBalanceLoading}
+          walletBalance={effectiveWalletBalance}
+          isBalanceLoading={isEffectiveWalletBalanceLoading}
         />
       )
     : view === 'receive'
@@ -106,6 +170,7 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
               isLoadingTokens={isLoadingTokens}
               selectedId={selectedTokenId}
               onSelect={setPreferredSelectedTokenId}
+              emptyMessage={isDirectTestModeDeposit ? 'No Amoy USDC balance found.' : undefined}
             />
           )
         : view === 'amount'
@@ -129,6 +194,7 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
                   selectedToken={selectedToken}
                   quote={quote}
                   refreshIndex={confirmRefreshIndex}
+                  executionMode={isDirectTestModeDeposit ? 'direct-usdc' : 'lifi'}
                 />
               )
             : (

--- a/src/app/[locale]/(platform)/_components/WalletModal.tsx
+++ b/src/app/[locale]/(platform)/_components/WalletModal.tsx
@@ -120,12 +120,16 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
     enabled: !isDirectTestModeDeposit,
   })
   const directQuote = useMemo(() => {
-    if (!isDirectTestModeDeposit || !amountValue.trim()) {
+    if (!isDirectTestModeDeposit || !selectedToken || !amountValue.trim()) {
       return null
     }
 
     const amountNumber = Number.parseFloat(amountValue)
-    if (!Number.isFinite(amountNumber) || amountNumber <= 0) {
+    if (
+      !Number.isFinite(amountNumber)
+      || amountNumber <= 0
+      || amountNumber > selectedToken.balanceRaw
+    ) {
       return null
     }
 
@@ -133,7 +137,7 @@ export function WalletDepositModal(props: WalletDepositModalProps) {
       toAmountDisplay: formatDisplayAmount(amountValue),
       gasUsdDisplay: null,
     }
-  }, [amountValue, isDirectTestModeDeposit])
+  }, [amountValue, isDirectTestModeDeposit, selectedToken])
   const quote = isDirectTestModeDeposit ? directQuote : lifiQuote
   const effectiveWalletBalance = isDirectTestModeDeposit ? directWalletBalance.text : walletBalance
   const isEffectiveWalletBalanceLoading = isDirectTestModeDeposit ? isLoadingDirectWalletBalance : isBalanceLoading

--- a/src/app/[locale]/(platform)/_components/wallet-modal/WalletConfirmStep.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/WalletConfirmStep.tsx
@@ -10,11 +10,13 @@ import {
 } from 'lucide-react'
 import Image from 'next/image'
 import { useState } from 'react'
+import { formatWalletModalAddress } from '@/app/[locale]/(platform)/_components/wallet-modal/utils'
 import SiteLogoIcon from '@/components/SiteLogoIcon'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Skeleton } from '@/components/ui/skeleton'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { useDirectUsdcDepositExecution } from '@/hooks/useDirectUsdcDepositExecution'
 import { useLiFiExecution } from '@/hooks/useLiFiExecution'
 import { useLiFiQuote } from '@/hooks/useLiFiQuote'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
@@ -30,6 +32,7 @@ function WalletConfirmStep({
   selectedToken,
   quote,
   refreshIndex,
+  executionMode = 'lifi',
 }: {
   walletEoaAddress?: string | null
   walletAddress?: string | null
@@ -39,9 +42,10 @@ function WalletConfirmStep({
   selectedToken?: LiFiWalletTokenItem | null
   quote?: { toAmountDisplay: string | null, gasUsdDisplay: string | null } | null
   refreshIndex: number
+  executionMode?: 'lifi' | 'direct-usdc'
 }) {
   const [isSubmitting, setIsSubmitting] = useState(false)
-  const eoaSuffix = walletEoaAddress?.slice(-4)
+  const walletEoaLabel = formatWalletModalAddress(walletEoaAddress)
   const [isBreakdownOpen, setIsBreakdownOpen] = useState(false)
   const site = useSiteIdentity()
   const formattedAmount = formatDisplayAmount(amountValue)
@@ -52,20 +56,31 @@ function WalletConfirmStep({
     fromAddress: walletEoaAddress,
     toAddress: walletAddress,
     refreshIndex,
+    enabled: executionMode === 'lifi',
   })
-  const effectiveQuote = quote ?? fetchedQuote
+  const effectiveQuote = quote ?? (executionMode === 'lifi' ? fetchedQuote : null)
   const hasAmount = amountValue.trim() !== ''
   const isQuoteLoading = isLoadingQuote && hasAmount
   const status: 'quote' | 'gas' | 'ready' = effectiveQuote ? 'ready' : (isLoadingQuote ? 'gas' : 'quote')
   const {
-    execute,
-    isExecuting,
+    execute: executeLiFi,
+    isExecuting: isExecutingLiFi,
   } = useLiFiExecution({
     fromToken: selectedToken,
     amountValue,
     fromAddress: walletEoaAddress,
     toAddress: walletAddress,
   })
+  const {
+    execute: executeDirectUsdcDeposit,
+    isExecuting: isExecutingDirectUsdcDeposit,
+  } = useDirectUsdcDepositExecution({
+    amountValue,
+    fromAddress: walletEoaAddress,
+    toAddress: walletAddress,
+  })
+  const execute = executionMode === 'direct-usdc' ? executeDirectUsdcDeposit : executeLiFi
+  const isExecuting = executionMode === 'direct-usdc' ? isExecutingDirectUsdcDeposit : isExecutingLiFi
   const isCtaDisabled = isExecuting || isSubmitting || !effectiveQuote || isLoadingQuote
   const sendSymbol = selectedToken?.symbol ?? 'Token'
   const sendIcon = selectedToken?.icon ?? '/images/deposit/transfer/polygon_dark.png'
@@ -89,7 +104,7 @@ function WalletConfirmStep({
               <span className="flex items-center gap-2 font-semibold text-foreground">
                 <WalletIcon className="size-4" />
                 Wallet
-                {eoaSuffix ? ` (...${eoaSuffix})` : ''}
+                {walletEoaLabel ? ` (${walletEoaLabel})` : ''}
               </span>
             </div>
           </div>

--- a/src/app/[locale]/(platform)/_components/wallet-modal/WalletFundMenu.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/WalletFundMenu.tsx
@@ -4,14 +4,17 @@ import {
   CircleDollarSignIcon,
   CreditCardIcon,
   ExternalLinkIcon,
-  InfoIcon,
   WalletIcon,
 } from 'lucide-react'
 import { useTheme } from 'next-themes'
 import Image from 'next/image'
-import { MELD_PAYMENT_METHODS, TEST_MODE_DISCORD_URL, TRANSFER_PAYMENT_METHODS } from '@/app/[locale]/(platform)/_components/wallet-modal/utils'
+import {
+  formatWalletModalAddress,
+  MELD_PAYMENT_METHODS,
+  TEST_MODE_DISCORD_URL,
+  TRANSFER_PAYMENT_METHODS,
+} from '@/app/[locale]/(platform)/_components/wallet-modal/utils'
 import { Skeleton } from '@/components/ui/skeleton'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import { IS_TEST_MODE } from '@/lib/network'
 import { cn } from '@/lib/utils'
 
@@ -41,7 +44,7 @@ function WalletFundMenu({
   const logoVariant = isDark ? 'dark' : 'light'
   const paymentLogos = MELD_PAYMENT_METHODS.map(method => `/images/deposit/meld/${method}_${logoVariant}.png`)
   const transferLogos = TRANSFER_PAYMENT_METHODS.map(method => `/images/deposit/transfer/${method}_${logoVariant}.png`)
-  const walletSuffix = walletEoaAddress?.slice(-4) ?? '----'
+  const walletLabel = formatWalletModalAddress(walletEoaAddress) ?? '----'
   const formattedWalletBalance = walletBalance && walletBalance !== '' ? walletBalance : '0.00'
 
   return (
@@ -96,15 +99,9 @@ function WalletFundMenu({
         className={cn(`
           group flex w-full items-center justify-between gap-4 rounded-lg border border-border px-4 py-2 text-left
           transition
-          ${IS_TEST_MODE ? 'cursor-not-allowed opacity-50' : 'hover:bg-muted/50'}
+          hover:bg-muted/50
         `)}
-        onClick={() => {
-          if (IS_TEST_MODE) {
-            return
-          }
-          onWallet()
-        }}
-        aria-disabled={IS_TEST_MODE}
+        onClick={onWallet}
       >
         <div className="flex items-center gap-3">
           <div className="flex size-12 items-center justify-center text-foreground">
@@ -112,26 +109,9 @@ function WalletFundMenu({
           </div>
           <div className="space-y-1">
             <p className="text-sm font-semibold text-foreground">
-              Wallet (...
-              {walletSuffix}
+              Wallet (
+              {walletLabel}
               )
-              {IS_TEST_MODE && (
-                <TooltipProvider>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className={cn(`
-                        ml-2 inline-flex size-4 items-center justify-center rounded-full text-muted-foreground
-                      `)}
-                      >
-                        <InfoIcon className="size-3" />
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      Wallet deposits are not available in test mode.
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              )}
             </p>
             <div className="flex items-center gap-2 text-xs text-muted-foreground">
               {isBalanceLoading

--- a/src/app/[locale]/(platform)/_components/wallet-modal/WalletSuccessStep.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/WalletSuccessStep.tsx
@@ -8,6 +8,7 @@ import {
   WalletIcon,
 } from 'lucide-react'
 import Image from 'next/image'
+import { formatWalletModalAddress } from '@/app/[locale]/(platform)/_components/wallet-modal/utils'
 import SiteLogoIcon from '@/components/SiteLogoIcon'
 import { Button } from '@/components/ui/button'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
@@ -33,8 +34,8 @@ function WalletSuccessStep({
   onClose: () => void
   onNewDeposit: () => void
 }) {
-  const eoaSuffix = walletEoaAddress?.slice(-4)
-  const safeSuffix = walletAddress?.slice(-4)
+  const walletEoaLabel = formatWalletModalAddress(walletEoaAddress)
+  const walletLabel = formatWalletModalAddress(walletAddress)
   const site = useSiteIdentity()
   const supportUrl = site.supportUrl
   const supportIsEmail = supportUrl?.startsWith('mailto:') ?? false
@@ -84,7 +85,7 @@ function WalletSuccessStep({
               <span className="flex items-center gap-2 font-semibold text-foreground">
                 <WalletIcon className="size-4" />
                 Wallet
-                {eoaSuffix ? ` (...${eoaSuffix})` : ''}
+                {walletEoaLabel ? ` (${walletEoaLabel})` : ''}
                 {walletEoaAddress && (
                   <a
                     href={`${POLYGON_SCAN_BASE}/address/${walletEoaAddress}`}
@@ -115,7 +116,7 @@ function WalletSuccessStep({
                 {siteLabel}
                 {' '}
                 Wallet
-                {safeSuffix ? ` (...${safeSuffix})` : ''}
+                {walletLabel ? ` (${walletLabel})` : ''}
                 {walletAddress && (
                   <a
                     href={`${POLYGON_SCAN_BASE}/address/${walletAddress}`}

--- a/src/app/[locale]/(platform)/_components/wallet-modal/WalletTokenList.tsx
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/WalletTokenList.tsx
@@ -12,6 +12,7 @@ function WalletTokenList({
   isLoadingTokens,
   selectedId,
   onSelect,
+  emptyMessage = 'No LI.FI-supported tokens with balance found.',
 }: {
   onContinue: () => void
   items: Array<{
@@ -27,6 +28,7 @@ function WalletTokenList({
   isLoadingTokens: boolean
   selectedId: string
   onSelect: (id: string) => void
+  emptyMessage?: string
 }) {
   const showEmptyState = !isLoadingTokens && items.length === 0
   const selectedItem = items.find(item => item.id === selectedId)
@@ -63,7 +65,7 @@ function WalletTokenList({
           )}
           {showEmptyState && (
             <div className="rounded-lg border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
-              No LI.FI-supported tokens with balance found.
+              {emptyMessage}
             </div>
           )}
           {items.map((item) => {

--- a/src/app/[locale]/(platform)/_components/wallet-modal/utils.ts
+++ b/src/app/[locale]/(platform)/_components/wallet-modal/utils.ts
@@ -18,6 +18,19 @@ export const TRANSFER_PAYMENT_METHODS = [
 ] as const
 export const TEST_MODE_DISCORD_URL = 'https://discord.gg/kuest'
 
+export function formatWalletModalAddress(address: string | null | undefined) {
+  const normalized = address?.trim()
+  if (!normalized) {
+    return null
+  }
+
+  if (normalized.length <= 12) {
+    return normalized
+  }
+
+  return `${normalized.slice(0, 7)}...${normalized.slice(-5)}`
+}
+
 export const WITHDRAW_TOKEN_OPTIONS = [
   { value: 'USDC', label: 'USDC', icon: '/images/withdraw/token/usdc.svg', enabled: true },
   { value: 'ARB', label: 'ARB', icon: '/images/withdraw/token/arb.svg', enabled: false },

--- a/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
+++ b/src/app/[locale]/admin/(general)/_actions/update-general-settings.ts
@@ -4,7 +4,6 @@ import type { SupportedLocale } from '@/i18n/locales'
 import { Buffer } from 'node:buffer'
 import { getLocale } from 'next-intl/server'
 import { revalidatePath } from 'next/cache'
-import sharp from 'sharp'
 import { DEFAULT_LOCALE, SUPPORTED_LOCALES } from '@/i18n/locales'
 import { cacheTags } from '@/lib/cache-tags'
 import { DEFAULT_ERROR_MESSAGE } from '@/lib/constants'
@@ -55,6 +54,17 @@ function buildTermsOfServicePdfPath() {
   return `legal/terms-of-service-${Date.now()}-${random}.pdf`
 }
 
+async function loadSharp() {
+  try {
+    const sharpModule = await import('sharp')
+    return { sharp: sharpModule.default, error: null }
+  }
+  catch (error) {
+    console.error('Failed to load sharp for admin image processing', error)
+    return { sharp: null, error: 'Image processing is temporarily unavailable. Please try again later.' }
+  }
+}
+
 async function processThemeLogoFile(file: File) {
   if (!ACCEPTED_LOGO_TYPES.includes(file.type)) {
     return { mode: null, path: null, svg: null, error: 'Logo must be PNG, JPG, WebP, or SVG.' }
@@ -67,6 +77,11 @@ async function processThemeLogoFile(file: File) {
   if (file.type === 'image/svg+xml') {
     const svg = await file.text()
     return { mode: 'svg' as const, path: null, svg, error: null }
+  }
+
+  const { sharp, error: sharpError } = await loadSharp()
+  if (!sharp) {
+    return { mode: null, path: null, svg: null, error: sharpError ?? DEFAULT_ERROR_MESSAGE }
   }
 
   const buffer = Buffer.from(await file.arrayBuffer())
@@ -96,6 +111,11 @@ async function processPwaIconFile(file: File, size: number, label: string) {
 
   if (file.size > MAX_PWA_ICON_FILE_SIZE) {
     return { path: null as string | null, error: `${label} must be 2MB or smaller.` }
+  }
+
+  const { sharp, error: sharpError } = await loadSharp()
+  if (!sharp) {
+    return { path: null as string | null, error: sharpError ?? DEFAULT_ERROR_MESSAGE }
   }
 
   const buffer = Buffer.from(await file.arrayBuffer())

--- a/src/hooks/useDirectUsdcDepositExecution.ts
+++ b/src/hooks/useDirectUsdcDepositExecution.ts
@@ -1,0 +1,75 @@
+import { useMutation } from '@tanstack/react-query'
+import { encodeFunctionData, erc20Abi, parseUnits } from 'viem'
+import { usePublicClient, useWalletClient } from 'wagmi'
+import { COLLATERAL_TOKEN_ADDRESS } from '@/lib/contracts'
+import { sanitizeLiFiAmount } from '@/lib/lifi-amount'
+import { DEFAULT_CHAIN_ID } from '@/lib/network'
+import { defaultViemNetwork } from '@/lib/viem-network'
+
+interface UseDirectUsdcDepositExecutionParams {
+  amountValue: string
+  fromAddress?: string | null
+  toAddress?: string | null
+}
+
+export function useDirectUsdcDepositExecution({
+  amountValue,
+  fromAddress,
+  toAddress,
+}: UseDirectUsdcDepositExecutionParams) {
+  const { data: walletClient } = useWalletClient()
+  const publicClient = usePublicClient({ chainId: DEFAULT_CHAIN_ID })
+
+  const mutation = useMutation({
+    mutationFn: async () => {
+      if (!walletClient) {
+        throw new Error('Wallet not connected.')
+      }
+      if (!publicClient) {
+        throw new Error('Public client not available.')
+      }
+      if (!fromAddress || !toAddress) {
+        throw new Error('Missing wallet addresses.')
+      }
+
+      const sanitizedAmount = sanitizeLiFiAmount(amountValue, 6)
+      let amount: bigint
+      try {
+        amount = parseUnits(sanitizedAmount, 6)
+      }
+      catch {
+        throw new Error('Enter a valid amount.')
+      }
+      if (amount <= 0n) {
+        throw new Error('Enter a valid amount.')
+      }
+
+      if (walletClient.chain?.id && walletClient.chain.id !== DEFAULT_CHAIN_ID) {
+        throw new Error(`Switch wallet to ${defaultViemNetwork.name} before depositing.`)
+      }
+
+      const hash = await walletClient.sendTransaction({
+        account: fromAddress as `0x${string}`,
+        chain: defaultViemNetwork,
+        to: COLLATERAL_TOKEN_ADDRESS,
+        data: encodeFunctionData({
+          abi: erc20Abi,
+          functionName: 'transfer',
+          args: [toAddress as `0x${string}`, amount],
+        }),
+        value: 0n,
+      })
+
+      await publicClient.waitForTransactionReceipt({ hash })
+
+      return hash
+    },
+  })
+
+  return {
+    execute: mutation.mutateAsync,
+    isExecuting: mutation.isPending,
+    executionError: mutation.error,
+    executionHash: mutation.data,
+  }
+}

--- a/src/hooks/useDirectUsdcDepositExecution.ts
+++ b/src/hooks/useDirectUsdcDepositExecution.ts
@@ -60,7 +60,10 @@ export function useDirectUsdcDepositExecution({
         value: 0n,
       })
 
-      await publicClient.waitForTransactionReceipt({ hash })
+      const receipt = await publicClient.waitForTransactionReceipt({ hash })
+      if (receipt.status !== 'success') {
+        throw new Error('USDC transfer reverted.')
+      }
 
       return hash
     },

--- a/src/hooks/useLiFiQuote.ts
+++ b/src/hooks/useLiFiQuote.ts
@@ -11,6 +11,7 @@ interface UseLiFiQuoteParams {
   fromAddress?: string | null
   toAddress?: string | null
   refreshIndex?: number
+  enabled?: boolean
 }
 
 export function useLiFiQuote({
@@ -19,6 +20,7 @@ export function useLiFiQuote({
   fromAddress,
   toAddress,
   refreshIndex = 0,
+  enabled = true,
 }: UseLiFiQuoteParams) {
   const tokenDecimals = fromToken?.decimals ?? 18
   const sanitizedAmount = sanitizeLiFiAmount(amountValue, tokenDecimals)
@@ -34,7 +36,7 @@ export function useLiFiQuote({
       return false
     }
   })()
-  const canQuote = hasAddresses && hasValidAmount
+  const canQuote = enabled && hasAddresses && hasValidAmount
 
   const query = useQuery({
     queryKey: [LIFI_QUOTE_QUERY_KEY, fromToken?.id, amountValue, fromAddress, toAddress, refreshIndex],

--- a/tests/unit/updateGeneralSettingsAction.test.ts
+++ b/tests/unit/updateGeneralSettingsAction.test.ts
@@ -43,6 +43,7 @@ vi.mock('@/lib/storage', () => ({
 describe('updateGeneralSettingsAction', () => {
   beforeEach(() => {
     vi.resetModules()
+    vi.doUnmock('sharp')
     vi.stubGlobal('fetch', mocks.fetch)
     mocks.revalidatePath.mockReset()
     mocks.getCurrentUser.mockReset()
@@ -187,6 +188,58 @@ describe('updateGeneralSettingsAction', () => {
     expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]/admin/market-context', 'page')
     expect(mocks.revalidatePath).toHaveBeenCalledWith('/[locale]/tos', 'page')
     expect(mocks.revalidatePath).not.toHaveBeenCalledWith('/[locale]', 'layout')
+  })
+
+  it('saves SVG settings without loading sharp', async () => {
+    mocks.getCurrentUser.mockResolvedValueOnce({ id: 'admin-1', is_admin: true })
+    mocks.updateSettings.mockResolvedValueOnce({ data: [], error: null })
+    vi.doMock('sharp', () => {
+      throw new Error('sharp should not load for SVG-only settings saves')
+    })
+
+    try {
+      const { updateGeneralSettingsAction } = await import('@/app/[locale]/admin/(general)/_actions/update-general-settings')
+      const formData = new FormData()
+      formData.set('site_name', 'Kuest')
+      formData.set('site_description', 'Prediction market')
+      formData.set('logo_mode', 'svg')
+      formData.set('logo_svg', '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"/></svg>')
+      formData.set('logo_image_path', '')
+
+      const result = await updateGeneralSettingsAction({ error: null }, formData)
+      expect(result).toEqual({ error: null })
+      expect(mocks.updateSettings).toHaveBeenCalledTimes(1)
+    }
+    finally {
+      vi.doUnmock('sharp')
+    }
+  })
+
+  it('returns a form error when raster logo processing is unavailable', async () => {
+    mocks.getCurrentUser.mockResolvedValueOnce({ id: 'admin-1', is_admin: true })
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    vi.doMock('sharp', () => {
+      throw new Error('sharp missing')
+    })
+
+    try {
+      const { updateGeneralSettingsAction } = await import('@/app/[locale]/admin/(general)/_actions/update-general-settings')
+      const formData = new FormData()
+      formData.set('site_name', 'Kuest')
+      formData.set('site_description', 'Prediction market')
+      formData.set('logo_mode', 'image')
+      formData.set('logo_svg', '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><circle cx="5" cy="5" r="4"/></svg>')
+      formData.set('logo_image_path', '')
+      formData.set('logo_image', new File(['png'], 'logo.png', { type: 'image/png' }))
+
+      const result = await updateGeneralSettingsAction({ error: null }, formData)
+      expect(result).toEqual({ error: 'Image processing is temporarily unavailable. Please try again later.' })
+      expect(mocks.updateSettings).not.toHaveBeenCalled()
+    }
+    finally {
+      consoleErrorSpy.mockRestore()
+      vi.doUnmock('sharp')
+    }
   })
 
   it('keeps featured markets saves successful when post-save revalidation fails', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Enable testnet wallet deposits by bypassing LI.FI and sending USDC directly from the user’s wallet to the deposit address, with validation for amount, balance, and network. Also lazy-load `sharp` only for image uploads and surface a clear error when image processing isn’t available.

- **New Features**
  - Added `useDirectUsdcDepositExecution` to transfer USDC directly on testnet, with preflight checks (valid amount, sufficient balance, correct chain).
  - Wallet modal auto-switches to direct mode in test mode: disables LI.FI token/quote/balance calls, uses on-chain USDC via `useBalance`, and shows a simple in-app quote.
  - Improved UI: always enable Wallet funding in test mode, clearer address labels via `formatWalletModalAddress`, and customizable empty token list message.
  - `useLiFiQuote` now supports an `enabled` flag to avoid unnecessary requests.

- **Dependencies**
  - Enabled `sharp` builds in `pnpm-workspace.yaml`.
  - Admin settings: dynamically import `sharp` only for raster images and return a friendly error if unavailable; added unit tests for SVG-only saves and sharp-missing scenarios.

<sup>Written for commit cffc99ae587a683ab1ece0d21eca5f3b06f2388f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

