### PR TITLE
fix: graph logo

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -415,13 +415,13 @@ function EventChartComponent({
     [site.logoImageUrl, site.logoSvg, site.name],
   )
   const visibleWatermark = showWatermark ? watermark : {}
-  const chartLogo = showWatermark && (watermark.iconSvg || watermark.label)
+  const chartLogo = showWatermark && (watermark.iconSvg || watermark.iconImageUrl || watermark.label)
     ? (
         <div className="flex items-center gap-1 text-xl text-muted-foreground opacity-50 select-none">
-          {watermark.iconSvg
+          {watermark.iconSvg || watermark.iconImageUrl
             ? (
                 <SiteLogoIcon
-                  logoSvg={watermark.iconSvg}
+                  logoSvg={watermark.iconSvg ?? ''}
                   logoImageUrl={watermark.iconImageUrl}
                   alt={`${watermark.label} logo`}
                   className="size-[1em] **:fill-current **:stroke-current"

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartHeader.tsx
@@ -1,8 +1,9 @@
 import type { EventSeriesEntry } from '@/types'
 import { TriangleIcon } from 'lucide-react'
 import { AnimatedCounter } from 'react-animated-counter'
+import SiteLogoIcon from '@/components/SiteLogoIcon'
 import { OUTCOME_INDEX } from '@/lib/constants'
-import { cn, sanitizeSvg } from '@/lib/utils'
+import { cn } from '@/lib/utils'
 import EventSeriesPills from './EventSeriesPills'
 import EventTweetMarketsPanel from './EventTweetMarketsPanel'
 
@@ -14,7 +15,7 @@ interface EventChartHeaderProps {
   yesChanceValue: number | null
   effectiveBaselineYesChance: number | null
   effectiveCurrentYesChance: number | null
-  watermark: { iconSvg?: string | null, label?: string | null }
+  watermark: { iconSvg?: string | null, iconImageUrl?: string | null, label?: string | null }
   currentEventSlug?: string
   seriesEvents?: EventSeriesEntry[]
   showSeriesNavigation?: boolean
@@ -163,13 +164,17 @@ export default function EventChartHeader({
           {changeIndicator}
         </div>
 
-        {(watermark.iconSvg || watermark.label) && (
+        {(watermark.iconSvg || watermark.iconImageUrl || watermark.label) && (
           <div className="mr-2 flex items-center gap-1 self-start text-xl text-muted-foreground opacity-50 select-none">
-            {watermark.iconSvg
+            {watermark.iconSvg || watermark.iconImageUrl
               ? (
-                  <div
+                  <SiteLogoIcon
+                    logoSvg={watermark.iconSvg ?? ''}
+                    logoImageUrl={watermark.iconImageUrl}
+                    alt={watermark.label ? `${watermark.label} logo` : ''}
                     className="size-[1em] **:fill-current **:stroke-current"
-                    dangerouslySetInnerHTML={{ __html: sanitizeSvg(watermark.iconSvg) }}
+                    imageClassName="size-[1em] object-contain"
+                    size={20}
                   />
                 )
               : null}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/MarketOutcomeGraph.tsx
@@ -350,9 +350,10 @@ export default function MarketOutcomeGraph({
   const watermark = useMemo(
     () => ({
       iconSvg: site.logoSvg,
+      iconImageUrl: site.logoImageUrl,
       label: site.name,
     }),
-    [site.logoSvg, site.name],
+    [site.logoImageUrl, site.logoSvg, site.name],
   )
 
   const primarySeriesColor = showBothOutcomes

--- a/src/components/PredictionChart.tsx
+++ b/src/components/PredictionChart.tsx
@@ -182,7 +182,7 @@ export default function PredictionChart({
   const rightClipId = `${clipId}-right`
   const shouldRenderLegend = showLegend && Boolean(legendContent)
   const shouldRenderWatermark = Boolean(
-    watermark && (watermark.iconSvg || watermark.label),
+    watermark && (watermark.iconSvg || watermark.iconImageUrl || watermark.label),
   )
   const resolvedLineStrokeWidth = Number.isFinite(lineStrokeWidth) && lineStrokeWidth > 0
     ? lineStrokeWidth

--- a/src/components/PredictionChartHeader.tsx
+++ b/src/components/PredictionChartHeader.tsx
@@ -1,11 +1,12 @@
 import type { ReactNode } from 'react'
-import { cn, sanitizeSvg } from '@/lib/utils'
+import SiteLogoIcon from '@/components/SiteLogoIcon'
+import { cn } from '@/lib/utils'
 
 interface PredictionChartHeaderProps {
   shouldRenderLegend: boolean
   legendContent?: ReactNode
   shouldRenderWatermark: boolean
-  watermark?: { iconSvg?: string | null, label?: string | null }
+  watermark?: { iconSvg?: string | null, iconImageUrl?: string | null, label?: string | null }
 }
 
 export default function PredictionChartHeader({
@@ -30,11 +31,15 @@ export default function PredictionChartHeader({
           lg:self-auto
         `)}
         >
-          {watermark?.iconSvg
+          {watermark?.iconSvg || watermark?.iconImageUrl
             ? (
-                <div
+                <SiteLogoIcon
+                  logoSvg={watermark.iconSvg ?? ''}
+                  logoImageUrl={watermark.iconImageUrl}
+                  alt={watermark.label ? `${watermark.label} logo` : ''}
                   className="size-[1em] **:fill-current **:stroke-current"
-                  dangerouslySetInnerHTML={{ __html: sanitizeSvg(watermark.iconSvg) }}
+                  imageClassName="size-[1em] object-contain"
+                  size={20}
                 />
               )
             : null}

--- a/src/components/SiteLogoIcon.tsx
+++ b/src/components/SiteLogoIcon.tsx
@@ -1,5 +1,5 @@
 import Image from 'next/image'
-import { cn } from '@/lib/utils'
+import { cn, sanitizeSvg } from '@/lib/utils'
 
 interface SiteLogoIconProps {
   logoSvg: string
@@ -38,7 +38,7 @@ export default function SiteLogoIcon({
   return (
     <span
       className={cn(className, svgClassName)}
-      dangerouslySetInnerHTML={{ __html: logoSvg }}
+      dangerouslySetInnerHTML={{ __html: sanitizeSvg(logoSvg) }}
     />
   )
 }

--- a/src/types/PredictionChartTypes.ts
+++ b/src/types/PredictionChartTypes.ts
@@ -91,6 +91,7 @@ export interface PredictionChartProps {
   }
   watermark?: {
     iconSvg?: string | null
+    iconImageUrl?: string | null
     label?: string | null
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes missing/blank logos in chart watermarks and headers by supporting both SVG and image logos and sanitizing SVGs via `SiteLogoIcon`. Logos now render consistently and safely across Event and Prediction charts.

- **Bug Fixes**
  - Show watermark when `iconSvg`, `iconImageUrl`, or `label` is present.
  - Replace inline SVG injection with `SiteLogoIcon`; sanitizes SVGs and adds alt text, size, and image classes.
  - Add `iconImageUrl` to `watermark` types and wire it through `MarketOutcomeGraph` and all chart components.

<sup>Written for commit bbfd93a17f8e94534cf77766ef646a9e9a9c36c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

