### PR TITLE
fix: reply mention target and add new sports tabs

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
@@ -31,12 +31,27 @@ interface CommentItemProps {
   onRepliesLoaded: (commentId: string) => void
   onDeleteReply: (commentId: string, replyId: string) => void
   onUpdateReply: (commentId: string, replyId: string) => void
-  createReply: (parentCommentId: string, content: string) => Promise<Comment>
+  createReply: (parentCommentId: string, content: string, replyToCommentId?: string) => Promise<Comment>
   isCreatingComment: boolean
   isTogglingLikeForComment: (commentId: string) => boolean
   isLoadingRepliesForComment: (commentId: string) => boolean
   loadRepliesError: Error | null
   retryLoadReplies: (commentId: string) => void
+}
+
+function resolveReplyParentCommentId(reply: Comment) {
+  return reply.parent_comment_id ?? reply.parentCommentID ?? null
+}
+
+function resolveReplyTargetIdentity(comment: Comment, reply: Comment, replies: Comment[]) {
+  const rootIdentity = resolveCommentUserIdentity(comment)
+  const parentCommentId = resolveReplyParentCommentId(reply)
+  if (!parentCommentId || parentCommentId === comment.id) {
+    return rootIdentity
+  }
+
+  const parentReply = replies.find(candidate => candidate.id === parentCommentId)
+  return parentReply ? resolveCommentUserIdentity(parentReply) : rootIdentity
 }
 
 function useCommentItemHandlers({
@@ -222,28 +237,32 @@ export default function EventCommentItem({
 
       {comment.recent_replies && comment.recent_replies.length > 0 && (
         <div className="ml-13">
-          {comment.recent_replies.map(reply => (
-            <EventCommentReplyItem
-              key={reply.id}
-              reply={reply}
-              parentDisplayName={displayName}
-              parentProfileSlug={profileSlug}
-              commentId={comment.id}
-              user={user}
-              usePrimaryPositionTone={usePrimaryPositionTone}
-              isSingleMarket={isSingleMarket}
-              marketsByConditionId={marketsByConditionId}
-              onLikeToggle={onUpdateReply}
-              onDelete={onDeleteReply}
-              replyingTo={replyingTo}
-              onSetReplyingTo={onSetReplyingTo}
-              replyText={replyText}
-              onSetReplyText={onSetReplyText}
-              createReply={createReply}
-              isCreatingComment={isCreatingComment}
-              isTogglingLikeForComment={isTogglingLikeForComment}
-            />
-          ))}
+          {comment.recent_replies.map((reply) => {
+            const replyTargetIdentity = resolveReplyTargetIdentity(comment, reply, comment.recent_replies ?? [])
+
+            return (
+              <EventCommentReplyItem
+                key={reply.id}
+                reply={reply}
+                parentDisplayName={replyTargetIdentity.displayName}
+                parentProfileSlug={replyTargetIdentity.profileSlug}
+                commentId={comment.id}
+                user={user}
+                usePrimaryPositionTone={usePrimaryPositionTone}
+                isSingleMarket={isSingleMarket}
+                marketsByConditionId={marketsByConditionId}
+                onLikeToggle={onUpdateReply}
+                onDelete={onDeleteReply}
+                replyingTo={replyingTo}
+                onSetReplyingTo={onSetReplyingTo}
+                replyText={replyText}
+                onSetReplyText={onSetReplyText}
+                createReply={createReply}
+                isCreatingComment={isCreatingComment}
+                isTogglingLikeForComment={isTogglingLikeForComment}
+              />
+            )
+          })}
 
           {comment.replies_count > 3 && !expandedComments.has(comment.id) && (
             <EventCommentsLoadMoreReplies

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyForm.tsx
@@ -12,11 +12,12 @@ import { cn } from '@/lib/utils'
 interface EventCommentReplyFormProps {
   user: User | null
   parentCommentId: string
+  replyToCommentId?: string
   placeholder: string
   initialValue?: string
   onCancel: () => void
   onReplyAddedAction?: () => void
-  createReply: (parentCommentId: string, content: string) => Promise<Comment>
+  createReply: (parentCommentId: string, content: string, replyToCommentId?: string) => Promise<Comment>
   isCreatingComment: boolean
 }
 
@@ -29,6 +30,7 @@ function useReplyFormState(initialValue?: string) {
 export default function EventCommentReplyForm({
   user,
   parentCommentId,
+  replyToCommentId,
   placeholder,
   initialValue,
   onReplyAddedAction,
@@ -47,7 +49,7 @@ export default function EventCommentReplyForm({
     }
 
     try {
-      await createReply(parentCommentId, content.trim())
+      await createReply(parentCommentId, content.trim(), replyToCommentId)
       setContent('')
       onReplyAddedAction?.()
     }

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
@@ -30,7 +30,7 @@ interface ReplyItemProps {
   onSetReplyingTo: (id: string | null) => void
   replyText: string
   onSetReplyText: (text: string) => void
-  createReply: (parentCommentId: string, content: string) => Promise<Comment>
+  createReply: (parentCommentId: string, content: string, replyToCommentId?: string) => Promise<Comment>
   isCreatingComment: boolean
   isTogglingLikeForComment: (commentId: string) => boolean
 }
@@ -216,6 +216,7 @@ export default function EventCommentReplyItem({
           <EventCommentReplyForm
             user={user}
             parentCommentId={commentId}
+            replyToCommentId={reply.id}
             placeholder={`Reply to ${displayName}`}
             initialValue={replyText}
             onCancel={handleReplyCancel}

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useInfiniteComments.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useInfiniteComments.ts
@@ -16,6 +16,12 @@ const COMMENTS_PAGE_SIZE = 20
 
 type CommentSort = 'newest' | 'most_liked'
 
+interface CreateCommentVariables {
+  content: string
+  parentCommentId?: string
+  replyToCommentId?: string
+}
+
 function resolveSort(sortBy: CommentSort) {
   return sortBy === 'most_liked' ? 'top' : 'recent'
 }
@@ -149,10 +155,7 @@ export function useInfiniteComments(
   const hasInfiniteScrollError = infiniteScrollError !== null && data?.pages && data.pages.length > 0
 
   const createCommentMutation = useMutation({
-    mutationFn: async ({ content, parentCommentId }: {
-      content: string
-      parentCommentId?: string
-    }) => {
+    mutationFn: async ({ content, parentCommentId, replyToCommentId }: CreateCommentVariables) => {
       const trimmedContent = content.trim()
       if (!trimmedContent) {
         throw new Error('Comment content is required')
@@ -172,7 +175,7 @@ export function useInfiniteComments(
         body: JSON.stringify({
           event_slug: eventSlug,
           content: trimmedContent,
-          parent_comment_id: parentCommentId ?? null,
+          parent_comment_id: replyToCommentId ?? parentCommentId ?? null,
         }),
       })
 
@@ -186,7 +189,7 @@ export function useInfiniteComments(
 
       return await response.json() as Comment
     },
-    onMutate: async ({ content, parentCommentId }) => {
+    onMutate: async ({ content, parentCommentId, replyToCommentId }) => {
       if (!user) {
         throw new Error('User is required to post a comment')
       }
@@ -208,6 +211,8 @@ export function useInfiniteComments(
         created_at: new Date().toISOString(),
         is_owner: true,
         user_has_liked: false,
+        parent_comment_id: replyToCommentId ?? parentCommentId ?? null,
+        parentCommentID: replyToCommentId ?? parentCommentId ?? null,
         recent_replies: [],
       }
 
@@ -255,6 +260,15 @@ export function useInfiniteComments(
     },
     onSuccess: (newComment, variables, context) => {
       queryClient.invalidateQueries({ queryKey: commentMetricsQueryKey(eventSlug) })
+      const submittedParentCommentId = variables.replyToCommentId ?? variables.parentCommentId ?? null
+      const normalizedNewComment = submittedParentCommentId
+        ? {
+            ...newComment,
+            parent_comment_id: newComment.parent_comment_id ?? submittedParentCommentId,
+            parentCommentID: newComment.parentCommentID ?? submittedParentCommentId,
+          }
+        : newComment
+
       queryClient.setQueryData(commentsQueryKey, (oldData: any) => {
         if (!oldData) {
           return oldData
@@ -265,7 +279,7 @@ export function useInfiniteComments(
             return page.map((comment: Comment) => {
               if (comment.id === variables.parentCommentId && comment.recent_replies) {
                 const updatedReplies = comment.recent_replies.map(reply =>
-                  reply.id === context?.optimisticComment.id ? newComment : reply,
+                  reply.id === context?.optimisticComment.id ? normalizedNewComment : reply,
                 )
                 return {
                   ...comment,
@@ -277,7 +291,7 @@ export function useInfiniteComments(
           }
           else {
             return page.map((comment: Comment) =>
-              comment.id === context?.optimisticComment.id ? newComment : comment,
+              comment.id === context?.optimisticComment.id ? normalizedNewComment : comment,
             )
           }
         })
@@ -408,8 +422,8 @@ export function useInfiniteComments(
     deleteCommentMutation.mutate({ commentId })
   }, [deleteCommentMutation])
 
-  const createReply = useCallback(async (parentCommentId: string, content: string) => {
-    return await createCommentMutation.mutateAsync({ content, parentCommentId })
+  const createReply = useCallback(async (parentCommentId: string, content: string, replyToCommentId?: string) => {
+    return await createCommentMutation.mutateAsync({ content, parentCommentId, replyToCommentId })
   }, [createCommentMutation])
 
   const toggleReplyLike = useCallback((replyId: string) => {

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveCommentsChannel.ts
@@ -63,8 +63,27 @@ function buildLiveComment(payload: LiveCommentPayload, user: User | null): Comme
     created_at: createdAt,
     is_owner: normalizeAddress(user?.address) === normalizeAddress(userAddress),
     user_has_liked: false,
+    parent_comment_id: payload.parentCommentID ? String(payload.parentCommentID) : null,
+    parentCommentID: payload.parentCommentID ? String(payload.parentCommentID) : null,
     positions,
     recent_replies: [],
+  }
+}
+
+function appendLiveReplyToComment(comment: Comment, parentId: string, newComment: Comment) {
+  if (comment.id !== parentId && !comment.recent_replies?.some(reply => reply.id === parentId)) {
+    return null
+  }
+
+  const replies = comment.recent_replies ? [...comment.recent_replies] : []
+  if (replies.some(reply => reply.id === newComment.id)) {
+    return comment
+  }
+
+  return {
+    ...comment,
+    recent_replies: [newComment, ...replies],
+    replies_count: comment.replies_count + 1,
   }
 }
 
@@ -188,20 +207,17 @@ export function useLiveCommentsChannel({ eventSlug, user, enabled }: LiveComment
           let didChange = false
           const newPages = pages.map(page =>
             page.map((comment) => {
-              if (comment.id !== parentId) {
+              const updatedComment = appendLiveReplyToComment(comment, parentId, newComment)
+              if (!updatedComment) {
                 return comment
               }
-              const replies = comment.recent_replies ? [...comment.recent_replies] : []
-              if (replies.some(reply => reply.id === newComment.id)) {
-                return comment
+
+              if (updatedComment !== comment) {
+                didChange = true
+                didInsert = true
               }
-              didChange = true
-              didInsert = true
-              return {
-                ...comment,
-                recent_replies: [newComment, ...replies],
-                replies_count: comment.replies_count + 1,
-              }
+
+              return updatedComment
             }),
           )
 

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import type {
+  AuxiliaryMarketPanel,
   EventSectionKey,
   SportsEventCenterProps,
 } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-types'
 import type {
   SportsGamesButton,
 } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
-import { ChevronLeftIcon } from 'lucide-react'
+import { ChevronLeftIcon, InfoIcon } from 'lucide-react'
 import { useLocale } from 'next-intl'
 import Image from 'next/image'
 import { Suspense, useMemo } from 'react'
@@ -73,8 +74,16 @@ import SportsLivestreamFloatingPlayer
   from '@/app/[locale]/(platform)/sports/_components/SportsLivestreamFloatingPlayer'
 import SportsRedeemModal from '@/app/[locale]/(platform)/sports/_components/SportsRedeemModal'
 import SportsSegmentNumberPicker from '@/app/[locale]/(platform)/sports/_components/SportsSegmentNumberPicker'
+import {
+  resolveSportsMarketLineLabel,
+  resolveSportsMarketLineValue,
+  resolveSportsPlayerPropMarketViewKey,
+  resolveSportsPlayerPropPlayerName,
+} from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 import AppLink from '@/components/AppLink'
+import EventIconImage from '@/components/EventIconImage'
 import SiteLogoIcon from '@/components/SiteLogoIcon'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useCurrentTimestamp } from '@/hooks/useCurrentTimestamp'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
@@ -85,6 +94,196 @@ import { cn } from '@/lib/utils'
 import { useOrder } from '@/stores/useOrder'
 import { useSportsLivestream } from '@/stores/useSportsLivestream'
 import { useUser } from '@/stores/useUser'
+
+const PLAYER_PROP_TOOLTIP_BY_VIEW_KEY = {
+  goals:
+    'Player to record X or more goals. If the player is listed as inactive or otherwise does not play, the market will resolve "No". This market refers only to the outcome within the first 90 minutes of regular play plus stoppage time.',
+  assists:
+    'Player to record X or more assists. If the player is listed as inactive or otherwise does not play, the market will resolve "No". This market refers only to the outcome within the first 90 minutes of regular play plus stoppage time.',
+  shots:
+    'Player to record X or more shots. If the player is listed as inactive or otherwise does not play, the market will resolve "No". This market refers only to the outcome within the first 90 minutes of regular play plus stoppage time.',
+} as const
+
+const HALVES_REG_TIME_TOOLTIP
+  = 'This market refers only to the outcome within the first 45 minutes of regular play plus stoppage time.'
+const EXACT_SCORE_REG_TIME_TOOLTIP
+  = 'This market refers only to the outcome within the first 90 minutes of regular play plus stoppage time.'
+
+function resolvePlayerPropPanelViewKey(entry: AuxiliaryMarketPanel) {
+  for (const market of entry.markets) {
+    const viewKey = resolveSportsPlayerPropMarketViewKey(market)
+    if (viewKey) {
+      return viewKey
+    }
+  }
+
+  return null
+}
+
+function toSortableCreatedAt(value: unknown) {
+  if (value instanceof Date) {
+    return value.getTime()
+  }
+
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : Number.POSITIVE_INFINITY
+  }
+
+  if (typeof value === 'string') {
+    const timestamp = Date.parse(value)
+    return Number.isFinite(timestamp) ? timestamp : Number.POSITIVE_INFINITY
+  }
+
+  return Number.POSITIVE_INFINITY
+}
+
+function compareMarketCreatedAt(
+  left: { condition_id?: string | null, created_at?: unknown },
+  right: { condition_id?: string | null, created_at?: unknown },
+) {
+  const timestampComparison = toSortableCreatedAt(left.created_at) - toSortableCreatedAt(right.created_at)
+  if (timestampComparison !== 0) {
+    return timestampComparison
+  }
+
+  return (left.condition_id ?? '').localeCompare(right.condition_id ?? '')
+}
+
+function resolveAuxiliaryLineOptions(entry: AuxiliaryMarketPanel) {
+  const seenLineValues = new Set<number>()
+
+  return [...entry.markets]
+    .filter(market => Number.isFinite(Number(market.sports_line)))
+    .sort((left, right) => {
+      const leftLineValue = resolveSportsMarketLineValue(left)
+      const rightLineValue = resolveSportsMarketLineValue(right)
+      if (leftLineValue !== rightLineValue) {
+        if (!Number.isFinite(leftLineValue)) {
+          return 1
+        }
+        if (!Number.isFinite(rightLineValue)) {
+          return -1
+        }
+        return leftLineValue - rightLineValue
+      }
+
+      return compareMarketCreatedAt(left, right)
+    })
+    .reduce<Array<{ key: string, label: string, number: number }>>((options, market) => {
+      const lineValue = resolveSportsMarketLineValue(market)
+      if (!Number.isFinite(lineValue) || seenLineValues.has(lineValue)) {
+        return options
+      }
+
+      seenLineValues.add(lineValue)
+      options.push({
+        key: `${market.condition_id}:${lineValue}`,
+        label: resolveSportsMarketLineLabel(market),
+        number: lineValue,
+      })
+      return options
+    }, [])
+}
+
+function resolvePlayerPropLineOptions(entry: AuxiliaryMarketPanel) {
+  const seenLineValues = new Set<number>()
+
+  return [...entry.markets]
+    .sort((left, right) => {
+      const leftLineValue = resolveSportsMarketLineValue(left)
+      const rightLineValue = resolveSportsMarketLineValue(right)
+      if (leftLineValue !== rightLineValue) {
+        if (!Number.isFinite(leftLineValue)) {
+          return 1
+        }
+        if (!Number.isFinite(rightLineValue)) {
+          return -1
+        }
+        return leftLineValue - rightLineValue
+      }
+
+      return compareMarketCreatedAt(left, right)
+    })
+    .reduce<Array<{ key: string, label: string, number: number }>>((options, market) => {
+      const lineValue = resolveSportsMarketLineValue(market)
+      if (!Number.isFinite(lineValue) || seenLineValues.has(lineValue)) {
+        return options
+      }
+
+      seenLineValues.add(lineValue)
+      options.push({
+        key: `${market.condition_id}:${lineValue}`,
+        label: resolveSportsMarketLineLabel(market),
+        number: lineValue,
+      })
+      return options
+    }, [])
+}
+
+function areLineValuesEqual(left: number, right: number) {
+  return Math.abs(left - right) < 0.0001
+}
+
+function resolveAuxiliaryMarketByLineValue(entry: AuxiliaryMarketPanel, lineValue: number) {
+  return entry.markets.find(market =>
+    areLineValuesEqual(resolveSportsMarketLineValue(market), lineValue),
+  ) ?? null
+}
+
+function resolvePlayerPropSelectedMarket(entry: AuxiliaryMarketPanel, selectedButtonKey: string | null) {
+  const selectedButton = selectedButtonKey
+    ? entry.buttons.find(button => button.key === selectedButtonKey) ?? null
+    : null
+  const selectedMarket = selectedButton
+    ? entry.markets.find(market => market.condition_id === selectedButton.conditionId) ?? null
+    : null
+
+  return selectedMarket ?? entry.markets[0] ?? null
+}
+
+function resolveAuxiliaryLineButtons(entry: AuxiliaryMarketPanel, conditionId: string | null) {
+  return conditionId
+    ? entry.buttons.filter(button => button.conditionId === conditionId)
+    : []
+}
+
+function resolveAuxiliaryDefaultButton(buttons: SportsGamesButton[]) {
+  return buttons.find(button => button.tone === 'over')
+    ?? buttons[0]
+    ?? null
+}
+
+function resolveHalvesPanelGroup(entry: AuxiliaryMarketPanel) {
+  const normalizedText = entry.markets
+    .map(market => [
+      market.sports_market_type,
+      market.sports_group_item_title,
+      market.short_title,
+      market.title,
+    ].filter(Boolean).join(' '))
+    .join(' ')
+    .toLowerCase()
+
+  if (
+    normalizedText.includes('second_half')
+    || normalizedText.includes('second half')
+    || normalizedText.includes('2nd half')
+  ) {
+    return '2nd Half'
+  }
+
+  if (
+    normalizedText.includes('halftime')
+    || normalizedText.includes('half time')
+    || normalizedText.includes('first_half')
+    || normalizedText.includes('first half')
+    || normalizedText.includes('1st half')
+  ) {
+    return '1st Half'
+  }
+
+  return null
+}
 
 export default function SportsEventCenter({
   card,
@@ -131,7 +330,7 @@ export default function SportsEventCenter({
     heroGroupedButtons,
     segmentLabel,
     segmentPluralLabel,
-    isHalftimeResultView,
+    isHalvesView,
     baseUsesSectionLayout,
     hasEsportsSegmentedLayout,
   } = useDerivedActiveCard({ card, activeMarketView, vertical })
@@ -578,9 +777,29 @@ export default function SportsEventCenter({
         </div>
       )
     : null
-  const auxiliaryMarketPanels = renderedAuxiliaryMarketCards.map((entry) => {
+  const auxiliaryMarketPanelEntries = renderedAuxiliaryMarketCards.map((entry) => {
     const panelKey = entry.key
+    const halvesGroup = resolveHalvesPanelGroup(entry)
     const selectedButtonKey = selectedAuxiliaryButtonByConditionId[panelKey] ?? entry.buttons[0]?.key ?? null
+    const playerPropViewKey = resolvePlayerPropPanelViewKey(entry)
+    const isPlayerPropPanel = playerPropViewKey !== null
+    const playerPropLineOptions = isPlayerPropPanel ? resolvePlayerPropLineOptions(entry) : []
+    const auxiliaryLineOptions = !isPlayerPropPanel ? resolveAuxiliaryLineOptions(entry) : []
+    const linePickerOptions = isPlayerPropPanel ? playerPropLineOptions : auxiliaryLineOptions
+    const usesLinePicker = linePickerOptions.length > 1
+    const selectedAuxiliaryMarket = (isPlayerPropPanel || usesLinePicker)
+      ? resolvePlayerPropSelectedMarket(entry, selectedButtonKey)
+      : null
+    const linePickerSelectedMarket = usesLinePicker ? selectedAuxiliaryMarket : null
+    const linePickerActiveLineValue = linePickerSelectedMarket
+      ? resolveSportsMarketLineValue(linePickerSelectedMarket)
+      : null
+    const visibleButtons = usesLinePicker
+      ? resolveAuxiliaryLineButtons(entry, linePickerSelectedMarket?.condition_id ?? null)
+      : entry.buttons
+    const visibleSelectedButtonKey = visibleButtons.some(button => button.key === selectedButtonKey)
+      ? selectedButtonKey
+      : (resolveAuxiliaryDefaultButton(visibleButtons)?.key ?? selectedButtonKey)
     const isOpen = openAuxiliaryConditionId === panelKey
     const activeTab = tabByAuxiliaryConditionId[panelKey] ?? 'orderBook'
     const isResolved = auxiliaryResolvedByConditionId.get(panelKey) === true
@@ -591,10 +810,22 @@ export default function SportsEventCenter({
     const shouldShowRedeemButton = Boolean(singleConditionId && isResolved && claimGroup)
     const marketTitle = entry.title
     const panelVolume = Number(entry.volume)
-    const firstButtonKey = entry.buttons[0]?.key ?? null
-    const isMoneylinePanel = entry.buttons.every(button => button.marketType === 'moneyline')
+    const firstButtonKey = visibleButtons[0]?.key ?? entry.buttons[0]?.key ?? null
+    const isMoneylinePanel = visibleButtons.every(button => button.marketType === 'moneyline')
     const shouldShowResolvedSegmentedButtons = hasEsportsSegmentedLayout && entry.mapNumber != null
-    const shouldRenderButtons = (!isResolved || shouldShowResolvedSegmentedButtons) && entry.buttons.length > 0
+    const shouldRenderButtons = (!isResolved || shouldShowResolvedSegmentedButtons) && visibleButtons.length > 0
+    const playerPropTooltip = playerPropViewKey ? PLAYER_PROP_TOOLTIP_BY_VIEW_KEY[playerPropViewKey] : null
+    const regTimeTooltip = playerPropTooltip
+      ?? (activeMarketView?.key === 'halves'
+        ? HALVES_REG_TIME_TOOLTIP
+        : activeMarketView?.key === 'exactScore'
+          ? EXACT_SCORE_REG_TIME_TOOLTIP
+          : null)
+    const detailsAllowedConditionIds = new Set(
+      usesLinePicker && linePickerSelectedMarket
+        ? [linePickerSelectedMarket.condition_id]
+        : entry.markets.map(market => market.condition_id),
+    )
 
     function toggleCondition() {
       setOpenAuxiliaryConditionId(current => current === panelKey ? null : panelKey)
@@ -626,7 +857,17 @@ export default function SportsEventCenter({
       toggleCondition()
     }
 
-    return (
+    function handlePickAuxiliaryLine(lineValue: number) {
+      const pickedMarket = resolveAuxiliaryMarketByLineValue(entry, lineValue)
+      const pickedButtons = resolveAuxiliaryLineButtons(entry, pickedMarket?.condition_id ?? null)
+      const pickedButton = resolveAuxiliaryDefaultButton(pickedButtons)
+
+      if (pickedButton) {
+        updateAuxiliarySelection(panelKey, pickedButton.key, { panelMode: 'preserve' })
+      }
+    }
+
+    const node = (
       <article
         key={`${activeCard.id}-${panelKey}`}
         className="overflow-hidden rounded-xl border bg-card"
@@ -644,13 +885,53 @@ export default function SportsEventCenter({
           onClick={handleCardClick}
           onKeyDown={handleCardKeyDown}
         >
-          <div className="min-w-0 text-left transition-colors hover:text-foreground/90">
-            <h3 className="text-sm font-semibold text-foreground">{marketTitle}</h3>
-            <p className="mt-0.5 text-xs font-semibold text-muted-foreground">
-              {formatVolume(panelVolume)}
-              {' '}
-              Vol.
-            </p>
+          <div className="flex min-w-0 items-center gap-3 text-left transition-colors hover:text-foreground/90">
+            {isPlayerPropPanel && selectedAuxiliaryMarket?.icon_url && (
+              <EventIconImage
+                src={selectedAuxiliaryMarket.icon_url}
+                alt={resolveSportsPlayerPropPlayerName(selectedAuxiliaryMarket)}
+                containerClassName="size-11 shrink-0"
+                imageClassName="object-contain"
+                sizes="44px"
+              />
+            )}
+
+            <div className="min-w-0">
+              <div className="flex min-w-0 flex-wrap items-center gap-x-2 gap-y-1">
+                <h3 className="min-w-0 text-sm font-semibold text-foreground">{marketTitle}</h3>
+                {regTimeTooltip && (
+                  <span className="inline-flex shrink-0 items-center gap-1.5">
+                    <span className="text-2xs font-semibold tracking-normal text-muted-foreground">REG. TIME</span>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <button
+                          type="button"
+                          data-sports-card-control="true"
+                          onClick={event => event.stopPropagation()}
+                          className={cn(`
+                            inline-flex size-4 items-center justify-center rounded-full text-muted-foreground
+                            transition-colors
+                            hover:text-foreground
+                            focus-visible:ring-1 focus-visible:ring-ring focus-visible:outline-none
+                          `)}
+                          aria-label="Regular time rules"
+                        >
+                          <InfoIcon className="size-3.5" />
+                        </button>
+                      </TooltipTrigger>
+                      <TooltipContent side="top" className="max-w-80 text-left leading-relaxed">
+                        {regTimeTooltip}
+                      </TooltipContent>
+                    </Tooltip>
+                  </span>
+                )}
+              </div>
+              <p className="mt-0.5 text-xs font-semibold text-muted-foreground">
+                {formatVolume(panelVolume)}
+                {' '}
+                Vol.
+              </p>
+            </div>
           </div>
 
           {shouldRenderButtons && (
@@ -663,16 +944,18 @@ export default function SportsEventCenter({
                   `
                   : 'grid min-w-0 flex-1 items-stretch gap-2',
                 !isMoneylinePanel && (
-                  entry.buttons.length >= 3
-                    ? 'min-[1200px]:ml-auto min-[1200px]:w-[380px] min-[1200px]:flex-none'
-                    : 'min-[1200px]:ml-auto min-[1200px]:w-[248px] min-[1200px]:flex-none'
+                  usesLinePicker
+                    ? 'sm:ml-auto sm:w-[248px] sm:flex-none'
+                    : visibleButtons.length >= 3
+                      ? 'min-[1200px]:ml-auto min-[1200px]:w-[380px] min-[1200px]:flex-none'
+                      : 'min-[1200px]:ml-auto min-[1200px]:w-[248px] min-[1200px]:flex-none'
                 ),
                 isMoneylinePanel
-                  ? resolveMoneylineButtonGridClass(entry.buttons.length)
-                  : (entry.buttons.length >= 3 ? 'grid-cols-3' : 'grid-cols-2'),
+                  ? resolveMoneylineButtonGridClass(visibleButtons.length)
+                  : (visibleButtons.length >= 3 ? 'grid-cols-3' : 'grid-cols-2'),
               )}
             >
-              {entry.buttons.map((button) => {
+              {visibleButtons.map((button) => {
                 const isActive = activeTradeButtonKey === button.key
                 const hasTeamColor = (button.tone === 'team1' || button.tone === 'team2')
                   && (button.marketType === 'moneyline' || isActive)
@@ -787,14 +1070,23 @@ export default function SportsEventCenter({
           )}
         </div>
 
+        {usesLinePicker && linePickerOptions.length > 1 && (
+          <SportsSegmentNumberPicker
+            options={linePickerOptions}
+            activeNumber={linePickerActiveLineValue}
+            segmentLabel="Line"
+            onPick={handlePickAuxiliaryLine}
+          />
+        )}
+
         <div className={cn('bg-card px-2.5', isOpen ? 'border-t pt-3' : 'pt-0')}>
           <SportsGameDetailsPanel
             card={activeCard}
             activeDetailsTab={activeTab}
-            selectedButtonKey={selectedButtonKey}
+            selectedButtonKey={visibleSelectedButtonKey}
             showBottomContent={isOpen}
             defaultGraphTimeRange="ALL"
-            allowedConditionIds={new Set(entry.markets.map(market => market.condition_id))}
+            allowedConditionIds={detailsAllowedConditionIds}
             showAboutTab
             aboutEvent={activeCard.event}
             rulesEvent={heroCard.event}
@@ -809,8 +1101,51 @@ export default function SportsEventCenter({
         </div>
       </article>
     )
+
+    return {
+      key: panelKey,
+      halvesGroup,
+      node,
+    }
   })
-  const nonSectionAuxiliaryMarketPanels = auxiliaryMarketPanels
+  const auxiliaryMarketPanels = auxiliaryMarketPanelEntries.map(entry => entry.node)
+  const nonSectionAuxiliaryMarketPanels = activeMarketView?.key === 'halves'
+    ? ([
+        ...auxiliaryMarketPanelEntries
+          .filter(entry => entry.halvesGroup === '1st Half')
+          .flatMap((entry, index) => [
+            index === 0
+              ? (
+                  <h2
+                    key="halves-1st-half-heading"
+                    className="px-1 pt-1 text-sm font-semibold text-muted-foreground"
+                  >
+                    1st Half
+                  </h2>
+                )
+              : null,
+            entry.node,
+          ]),
+        ...auxiliaryMarketPanelEntries
+          .filter(entry => entry.halvesGroup === '2nd Half')
+          .flatMap((entry, index) => [
+            index === 0
+              ? (
+                  <h2
+                    key="halves-2nd-half-heading"
+                    className="px-1 pt-3 text-sm font-semibold text-muted-foreground"
+                  >
+                    2nd Half
+                  </h2>
+                )
+              : null,
+            entry.node,
+          ]),
+        ...auxiliaryMarketPanelEntries
+          .filter(entry => entry.halvesGroup == null)
+          .map(entry => entry.node),
+      ])
+    : auxiliaryMarketPanels
   const seriesPreviewSegmentWinnerCard = activeSeriesPreviewSegmentWinnerPanel
     && hasEsportsSegmentedLayout
     && activeEsportsSegmentTabKey === 'series'
@@ -970,8 +1305,8 @@ export default function SportsEventCenter({
               const isSectionResolved = sectionResolvedByKey[section.key]
               const sectionClaimGroups = claimGroupsBySection[section.key]
               const shouldShowRedeemButton = isSectionResolved && sectionClaimGroups.length > 0
-              const sectionTitle = isHalftimeResultView && section.key === 'moneyline'
-                ? 'Halftime Result'
+              const sectionTitle = isHalvesView && section.key === 'moneyline'
+                ? 'Halves'
                 : hasEsportsSegmentedLayout && activeEsportsSegmentTabKey === 'series' && section.key === 'spread'
                   ? `${segmentLabel} Handicap`
                   : hasEsportsSegmentedLayout && activeEsportsSegmentTabKey === 'series' && section.key === 'total'

--- a/src/app/[locale]/(platform)/sports/_components/sports-event-center-hooks.ts
+++ b/src/app/[locale]/(platform)/sports/_components/sports-event-center-hooks.ts
@@ -1404,8 +1404,8 @@ export function useDerivedActiveCard({
     [activeCard],
   )
   const isGameLinesView = (activeMarketView?.key ?? 'gameLines') === 'gameLines'
-  const isHalftimeResultView = activeMarketView?.key === 'halftimeResult'
-  const baseUsesSectionLayout = isGameLinesView || isHalftimeResultView
+  const isHalvesView = activeMarketView?.key === 'halves'
+  const baseUsesSectionLayout = isGameLinesView
   const hasEsportsSegmentedLayout = useMemo(
     () => baseUsesSectionLayout
       && isSegmentedEsportsEventCard(activeCard, vertical)
@@ -1418,7 +1418,7 @@ export function useDerivedActiveCard({
     heroGroupedButtons,
     segmentLabel,
     segmentPluralLabel,
-    isHalftimeResultView,
+    isHalvesView,
     baseUsesSectionLayout,
     hasEsportsSegmentedLayout,
   }

--- a/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
@@ -261,11 +261,12 @@ function resolvePlayerPropSourceLabel(market: Market) {
 
 export function resolveSportsPlayerPropPlayerName(market: Market) {
   const sourceLabel = resolvePlayerPropSourceLabel(market)
-  const [nameFromPrefix] = sourceLabel.split(':')
-  const trimmedName = nameFromPrefix?.trim()
-
-  if (trimmedName) {
-    return trimmedName
+  const colonIndex = sourceLabel.indexOf(':')
+  if (colonIndex >= 0) {
+    const nameFromPrefix = sourceLabel.slice(0, colonIndex).trim()
+    if (nameFromPrefix) {
+      return nameFromPrefix
+    }
   }
 
   return sourceLabel
@@ -276,6 +277,10 @@ export function resolveSportsPlayerPropPlayerName(market: Market) {
 }
 
 function toFiniteNumber(value: string | number | null | undefined) {
+  if (value == null) {
+    return null
+  }
+
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : null
   }

--- a/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
@@ -126,6 +126,8 @@ export interface SportsGamesCardMarketView {
   card: SportsGamesCard
 }
 
+export type SportsPlayerPropMarketViewKey = Extract<SportsEventMarketViewKey, 'goals' | 'assists' | 'shots'>
+
 export interface SportsGamesCardGroup {
   key: string
   primaryCard: SportsGamesCard
@@ -209,6 +211,130 @@ function resolveAuxiliaryMarketText(market: Market) {
     .join(' '))
 }
 
+export function resolveSportsPlayerPropMarketViewKey(market: Market): SportsPlayerPropMarketViewKey | null {
+  const normalizedType = normalizeText(market.sports_market_type)
+
+  if (normalizedType === 'soccer player goals') {
+    return 'goals'
+  }
+
+  if (normalizedType === 'soccer player assists') {
+    return 'assists'
+  }
+
+  if (normalizedType === 'soccer player shots') {
+    return 'shots'
+  }
+
+  return null
+}
+
+function isSportsPlayerMarketType(market: Market) {
+  return normalizeText(market.sports_market_type).startsWith('soccer player ')
+}
+
+function isSportsPlayerPropMarket(market: Market) {
+  return resolveSportsPlayerPropMarketViewKey(market) !== null
+}
+
+function isCornersMarket(market: Market) {
+  return resolveAuxiliaryMarketText(market).includes('corner')
+}
+
+function isHalvesMarket(market: Market) {
+  const normalizedText = resolveAuxiliaryMarketText(market)
+
+  return normalizedText.includes('halftime')
+    || normalizedText.includes('half time')
+    || normalizedText.includes('first half')
+    || normalizedText.includes('second half')
+    || normalizedText.includes('1st half')
+    || normalizedText.includes('2nd half')
+}
+
+function resolvePlayerPropSourceLabel(market: Market) {
+  return market.sports_group_item_title?.trim()
+    || market.short_title?.trim()
+    || market.title?.trim()
+    || ''
+}
+
+export function resolveSportsPlayerPropPlayerName(market: Market) {
+  const sourceLabel = resolvePlayerPropSourceLabel(market)
+  const [nameFromPrefix] = sourceLabel.split(':')
+  const trimmedName = nameFromPrefix?.trim()
+
+  if (trimmedName) {
+    return trimmedName
+  }
+
+  return sourceLabel
+    .replace(/\b\d+(?:\.\d+)?\s*\+\s*(?:goals?|assists?|shots?)\b/gi, '')
+    .replace(/\s+/g, ' ')
+    .trim()
+    || 'Player'
+}
+
+function toFiniteNumber(value: string | number | null | undefined) {
+  if (typeof value === 'number') {
+    return Number.isFinite(value) ? value : null
+  }
+
+  const parsed = Number(value)
+  return Number.isFinite(parsed) ? parsed : null
+}
+
+function formatLineLabel(value: number) {
+  const rounded = Math.round(value * 1000) / 1000
+  return `${rounded}`
+}
+
+export function resolveSportsMarketLineValue(market: Market) {
+  const sportsLineValue = toFiniteNumber(market.sports_line)
+  if (sportsLineValue !== null) {
+    return sportsLineValue
+  }
+
+  const sourceLabel = resolvePlayerPropSourceLabel(market)
+  const plusMatch = sourceLabel.match(/\b(\d+(?:\.\d+)?)\s*\+/)
+  const plusValue = toFiniteNumber(plusMatch?.[1])
+  if (plusValue !== null) {
+    return Math.max(0, plusValue - 0.5)
+  }
+
+  return toFiniteNumber(market.sports_group_item_threshold) ?? Number.POSITIVE_INFINITY
+}
+
+export function resolveSportsMarketLineLabel(market: Market) {
+  const lineValue = resolveSportsMarketLineValue(market)
+  return Number.isFinite(lineValue) ? formatLineLabel(lineValue) : 'Line'
+}
+
+function resolveSportsLineMarketGroupTitle(market: Market) {
+  const rawLabel = market.sports_group_item_title?.trim()
+    || market.short_title?.trim()
+    || market.title?.trim()
+    || 'Market'
+
+  const withoutColonLine = rawLabel.replace(
+    /\s*:\s*(?:o\/u|over\/under|over|under)\s*\d+(?:\.\d+)?\s*$/i,
+    '',
+  )
+  const withoutTrailingLine = withoutColonLine.replace(
+    /\s+(?:o\/u|over\/under|over|under)\s*\d+(?:\.\d+)?\s*$/i,
+    '',
+  )
+
+  return withoutTrailingLine.trim() || rawLabel
+}
+
+function shouldGroupLineMarketBySubject(market: Market) {
+  const normalizedType = normalizeText(market.sports_market_type)
+
+  return normalizedType.includes('team total')
+    || normalizedType.includes('team totals')
+}
+
 function isGoalscorerAuxiliaryMarketText(value: string) {
   return value.includes('goalscorer')
     || value.includes('goal scorer')
@@ -235,8 +361,30 @@ function resolveAuxiliaryMarketKind(market: Market) {
   return null
 }
 
-function resolveMarketViewKeyForMarket(market: Market): SportsEventMarketViewKey {
-  return resolveAuxiliaryMarketKind(market) ?? 'gameLines'
+function resolveMarketViewKeyForMarket(market: Market): SportsEventMarketViewKey | null {
+  const playerPropViewKey = resolveSportsPlayerPropMarketViewKey(market)
+  if (playerPropViewKey) {
+    return playerPropViewKey
+  }
+
+  if (isSportsPlayerMarketType(market)) {
+    return null
+  }
+
+  if (isCornersMarket(market)) {
+    return 'corners'
+  }
+
+  if (isHalvesMarket(market)) {
+    return 'halves'
+  }
+
+  const auxiliaryMarketKind = resolveAuxiliaryMarketKind(market)
+  if (auxiliaryMarketKind === 'halftimeResult') {
+    return 'halves'
+  }
+
+  return auxiliaryMarketKind ?? 'gameLines'
 }
 
 function resolveSportsMarketTypeLabel(value: string | null | undefined) {
@@ -651,6 +799,18 @@ function sortAuxiliaryButtons(buttons: SportsGamesButton[]) {
 }
 
 export function resolveSportsAuxiliaryMarketGroupKey(market: Market) {
+  const playerPropViewKey = resolveSportsPlayerPropMarketViewKey(market)
+  if (playerPropViewKey) {
+    const playerKey = normalizeText(resolveSportsPlayerPropPlayerName(market))
+    return `${market.event_id}:${playerPropViewKey}:${playerKey || market.condition_id}`
+  }
+
+  if (shouldGroupLineMarketBySubject(market)) {
+    const subjectKey = normalizeText(resolveSportsLineMarketGroupTitle(market))
+    const normalizedType = normalizeText(market.sports_market_type)
+    return `${market.event_id}:${normalizedType}:${subjectKey || market.condition_id}`
+  }
+
   const marketKind = resolveAuxiliaryMarketKind(market)
   if (marketKind === 'exactScore' || marketKind === 'goalscorers') {
     return `${market.event_id}:${market.condition_id}`
@@ -675,6 +835,14 @@ export function resolveSportsAuxiliaryMarketTitle(markets: Market[]) {
   }
 
   const marketKind = resolveAuxiliaryMarketKind(primaryMarket)
+  if (isSportsPlayerPropMarket(primaryMarket)) {
+    return resolveSportsPlayerPropPlayerName(primaryMarket)
+  }
+
+  if (shouldGroupLineMarketBySubject(primaryMarket)) {
+    return resolveSportsLineMarketGroupTitle(primaryMarket)
+  }
+
   if (marketKind === 'exactScore' || marketKind === 'goalscorers') {
     return primaryMarket.sports_group_item_title?.trim()
       ?? primaryMarket.short_title?.trim()
@@ -786,7 +954,7 @@ function buildCompositeAuxiliaryButtons(
   const buttons: SportsGamesButton[] = []
 
   Array.from(groupedMarkets.values())
-    .filter(group => group.length > 1)
+    .filter(group => group.length > 1 && !isSportsPlayerPropMarket(group[0]!))
     .sort((left, right) => {
       const leftTimestamp = toSortableTimestamp(left[0]?.created_at ?? null)
       const rightTimestamp = toSortableTimestamp(right[0]?.created_at ?? null)
@@ -1035,6 +1203,11 @@ function toNumericLine(value: string | null) {
 }
 
 function resolveTotalLine(market: Market) {
+  const sportsLineValue = toFiniteNumber(market.sports_line)
+  if (sportsLineValue !== null) {
+    return formatLineLabel(sportsLineValue)
+  }
+
   const marketText = [market.short_title, market.title]
     .filter((value): value is string => Boolean(value?.trim()))
     .join(' ')

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -1037,6 +1037,7 @@ function eventResource(
       sports_market_type: market.sports?.sports_market_type ?? null,
       sports_game_start_time: market.sports?.sports_game_start_time?.toISOString?.() ?? null,
       sports_start_time: market.sports?.sports_start_time?.toISOString?.() ?? null,
+      sports_line: market.sports?.sports_line ?? null,
       sports_group_item_title: market.sports?.sports_group_item_title ?? null,
       sports_group_item_threshold: market.sports?.sports_group_item_threshold ?? null,
       end_time: market.end_time?.toISOString?.() ?? null,

--- a/src/lib/sports-event-slugs.ts
+++ b/src/lib/sports-event-slugs.ts
@@ -1,17 +1,33 @@
-export type SportsEventMarketViewKey = 'gameLines' | 'exactScore' | 'goalscorers' | 'halftimeResult'
+export type SportsEventMarketViewKey
+  = | 'gameLines'
+    | 'exactScore'
+    | 'goalscorers'
+    | 'halves'
+    | 'corners'
+    | 'goals'
+    | 'assists'
+    | 'shots'
 
 export const SPORTS_EVENT_MARKET_VIEW_LABELS: Record<SportsEventMarketViewKey, string> = {
   gameLines: 'Game Lines',
   exactScore: 'Exact Score',
   goalscorers: 'Goalscorers',
-  halftimeResult: 'Halftime Result',
+  halves: 'Halves',
+  corners: 'Corners',
+  goals: 'Goals',
+  assists: 'Assists',
+  shots: 'Shots',
 }
 
 export const SPORTS_EVENT_MARKET_VIEW_ORDER: SportsEventMarketViewKey[] = [
   'gameLines',
   'exactScore',
   'goalscorers',
-  'halftimeResult',
+  'halves',
+  'corners',
+  'goals',
+  'assists',
+  'shots',
 ]
 
 const MORE_MARKETS_SUFFIX_REGEX = /-more-markets(?:-\d+)?$/i
@@ -21,9 +37,10 @@ const GOALSCORERS_SUFFIX_REGEX = /-goalscorers?$/i
 const HALFTIME_RESULT_SUFFIX_REGEX = /-halftime-result$/i
 const SECOND_HALF_RESULT_SUFFIX_REGEX = /-second-half-result$/i
 const TOTAL_CORNERS_SUFFIX_REGEX = /-total-corners$/i
-const SPORTS_AUXILIARY_SUFFIX_REGEX = /(?:-more-markets(?:-\d+)?|-exact-score|-first-to-score|-goalscorers?|-halftime-result|-second-half-result|-total-corners)$/i
+const PLAYER_PROPS_SUFFIX_REGEX = /-player-props$/i
+const SPORTS_AUXILIARY_SUFFIX_REGEX = /(?:-more-markets(?:-\d+)?|-exact-score|-first-to-score|-goalscorers?|-halftime-result|-second-half-result|-total-corners|-player-props)$/i
 
-export const SPORTS_AUXILIARY_SLUG_SQL_REGEX = '(-more-markets(?:-[0-9]+)?|-exact-score|-first-to-score|-goalscorers?|-halftime-result|-second-half-result|-total-corners)$'
+export const SPORTS_AUXILIARY_SLUG_SQL_REGEX = '(-more-markets(?:-[0-9]+)?|-exact-score|-first-to-score|-goalscorers?|-halftime-result|-second-half-result|-total-corners|-player-props)$'
 
 export function isSportsMoreMarketsSlug(slug: string | null | undefined) {
   return MORE_MARKETS_SUFFIX_REGEX.test(slug?.trim() ?? '')
@@ -49,13 +66,23 @@ export function resolveSportsEventMarketViewKey(slug: string | null | undefined)
   }
 
   if (HALFTIME_RESULT_SUFFIX_REGEX.test(normalizedSlug)) {
-    return 'halftimeResult'
+    return 'halves'
+  }
+
+  if (SECOND_HALF_RESULT_SUFFIX_REGEX.test(normalizedSlug)) {
+    return 'halves'
+  }
+
+  if (TOTAL_CORNERS_SUFFIX_REGEX.test(normalizedSlug)) {
+    return 'corners'
+  }
+
+  if (PLAYER_PROPS_SUFFIX_REGEX.test(normalizedSlug)) {
+    return 'goals'
   }
 
   if (
     FIRST_TO_SCORE_SUFFIX_REGEX.test(normalizedSlug)
-    || SECOND_HALF_RESULT_SUFFIX_REGEX.test(normalizedSlug)
-    || TOTAL_CORNERS_SUFFIX_REGEX.test(normalizedSlug)
   ) {
     return 'gameLines'
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -283,6 +283,7 @@ export interface Market {
   sports_market_type?: string | null
   sports_game_start_time?: string | null
   sports_start_time?: string | null
+  sports_line?: string | null
   sports_group_item_title?: string | null
   sports_group_item_threshold?: string | null
   volume_24h: number
@@ -435,6 +436,8 @@ export interface Comment {
   created_at: string
   is_owner: boolean
   user_has_liked: boolean
+  parent_comment_id?: string | null
+  parentCommentID?: string | null
   positions?: CommentPosition[]
   recent_replies?: Comment[]
 }

--- a/tests/unit/sportsGamesData.test.ts
+++ b/tests/unit/sportsGamesData.test.ts
@@ -1,4 +1,9 @@
-import { buildSportsGamesCardGroups, isSportsGamesCardResolved } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
+import {
+  buildSportsGamesCardGroups,
+  isSportsGamesCardResolved,
+  resolveSportsMarketLineValue,
+  resolveSportsPlayerPropPlayerName,
+} from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 
 function buildOutcome(conditionId: string, outcomeIndex: number, outcomeText: string) {
   return {
@@ -216,6 +221,43 @@ function buildResolvedBinaryMarket(params?: {
 }
 
 describe('sportsGamesData', () => {
+  it('removes player prop line text from plain player labels without a colon', () => {
+    const plainLabelMarket = buildBinaryMarket({
+      conditionId: 'messi-goals-0pt5',
+      slug: 'messi-goals-0pt5',
+      title: 'Lionel Messi 0.5+ Goals',
+      marketType: 'soccer_player_goals',
+    })
+    const colonLabelMarket = {
+      ...plainLabelMarket,
+      sports_group_item_title: 'Lionel Messi: 0.5+ Goals',
+      short_title: 'Lionel Messi: 0.5+ Goals',
+      title: 'Lionel Messi: 0.5+ Goals',
+    }
+
+    expect(resolveSportsPlayerPropPlayerName(plainLabelMarket as any)).toBe('Lionel Messi')
+    expect(resolveSportsPlayerPropPlayerName(colonLabelMarket as any)).toBe('Lionel Messi')
+  })
+
+  it('falls back to market text and threshold lines when sports_line is missing', () => {
+    const playerPropMarket = buildBinaryMarket({
+      conditionId: 'messi-goals-2plus',
+      slug: 'messi-goals-2plus',
+      title: 'Lionel Messi 2+ Goals',
+      marketType: 'soccer_player_goals',
+    })
+    const thresholdMarket = buildBinaryMarket({
+      conditionId: 'total-corners-7pt5',
+      slug: 'total-corners-7pt5',
+      title: 'Total Corners',
+      marketType: 'total_corners',
+      threshold: '7.5',
+    })
+
+    expect(resolveSportsMarketLineValue(playerPropMarket as any)).toBe(1.5)
+    expect(resolveSportsMarketLineValue(thresholdMarket as any)).toBe(7.5)
+  })
+
   it('treats cards as resolved when the event is resolved', () => {
     const resolvedMarket = buildResolvedBinaryMarket()
     const resolvedEvent = {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes reply mention targeting in event comments and expands the Sports Event Center with new Halves, Corners, and Player Props tabs, including line pickers, player icons, and “REG. TIME” rules. Normalizes line values (from `sports_line`, titles, or thresholds) for accurate labels, sorting, and button defaults.

- **Bug Fixes**
  - Reply mentions now point to the correct user (root or parent reply) in threads.
  - Reply creation accepts an optional reply target and sets the correct `parent_comment_id` for API, optimistic updates, and live events; live replies append under the right parent.
  - Line value fallbacks: when `sports_line` is missing, extract from market text or threshold so labels, sorting, and defaults stay correct.

- **New Features**
  - Added sports views: Halves, Corners, Goals, Assists, Shots (with updated slug routing and labels).
  - Halves grouped into “1st Half” and “2nd Half”; “REG. TIME” tooltip on Halves and Exact Score; player props include “REG. TIME” and inactivity rules.
  - Player props panels show player icons, group by player, and include a line number picker; default buttons adapt to the chosen line; details panel scopes to the selected line.
  - Consistent line parsing and labels using `sports_line` with fallbacks and sorting by line/time; data model: `sports_line` added to market query and `Market` type.

<sup>Written for commit ef4e22c47ed4a88222d762f3ed3544e0fc044fc7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

