### PR TITLE
feat: enhance image handling with sharp integration

### DIFF
--- a/src/lib/og-image-security.ts
+++ b/src/lib/og-image-security.ts
@@ -13,6 +13,8 @@ const DEFAULT_TIMEOUT_MS = 1200
 const DEFAULT_MAX_REDIRECTS = 3
 const MAX_URL_LENGTH = 2048
 const MAX_TRUSTED_DATA_URI_LENGTH = DEFAULT_MAX_IMAGE_BYTES * 2
+const WEBP_RENDERABLE_MAX_BYTE_MULTIPLIER = 4
+const WEBP_JPEG_QUALITY = 90
 
 const IMAGE_DATA_URI_CONTENT_TYPES = new Set([
   'image/gif',
@@ -46,6 +48,8 @@ interface RenderableImagePayload {
   body: Uint8Array
   contentType: string
 }
+
+type WebpRenderableContentType = 'image/jpeg' | 'image/png'
 
 function normalizeHostname(hostname: string) {
   return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '')
@@ -511,19 +515,44 @@ async function normalizeRenderableImagePayload(
   }
 
   try {
-    const converted = await sharp(Buffer.from(body)).png().toBuffer()
-    if (converted.byteLength === 0 || converted.byteLength > maxBytes) {
-      return null
+    const sourceBuffer = Buffer.from(body)
+    const metadata = await sharp(sourceBuffer).metadata()
+    const preferredContentTypes: WebpRenderableContentType[] = metadata.hasAlpha
+      ? ['image/png', 'image/jpeg']
+      : ['image/jpeg', 'image/png']
+
+    for (const preferredContentType of preferredContentTypes) {
+      const converted = await convertWebpToRenderableImage(sourceBuffer, preferredContentType)
+      if (!isRenderableConvertedImage(converted, maxBytes)) {
+        continue
+      }
+
+      return {
+        body: converted,
+        contentType: preferredContentType,
+      }
     }
 
-    return {
-      body: converted,
-      contentType: 'image/png',
-    }
+    return null
   }
   catch {
     return null
   }
+}
+
+async function convertWebpToRenderableImage(
+  sourceBuffer: Buffer,
+  contentType: WebpRenderableContentType,
+) {
+  const image = sharp(sourceBuffer)
+  return contentType === 'image/png'
+    ? image.png().toBuffer()
+    : image.jpeg({ quality: WEBP_JPEG_QUALITY }).toBuffer()
+}
+
+function isRenderableConvertedImage(body: Uint8Array, maxBytes: number) {
+  const maxRenderableBytes = maxBytes * WEBP_RENDERABLE_MAX_BYTE_MULTIPLIER
+  return body.byteLength > 0 && body.byteLength <= maxRenderableBytes
 }
 
 export async function fetchSafeOgImageDataUrl(rawUrl: string | null | undefined, options: SafeImageOptions = {}) {

--- a/src/lib/og-image-security.ts
+++ b/src/lib/og-image-security.ts
@@ -5,6 +5,7 @@ import { lookup } from 'node:dns/promises'
 import * as http from 'node:http'
 import * as https from 'node:https'
 import { isIP } from 'node:net'
+import sharp from 'sharp'
 import 'server-only'
 
 const DEFAULT_MAX_IMAGE_BYTES = 2 * 1024 * 1024
@@ -39,6 +40,11 @@ interface ImageResponsePayload {
   contentType: string
   location: string
   statusCode: number
+}
+
+interface RenderableImagePayload {
+  body: Uint8Array
+  contentType: string
 }
 
 function normalizeHostname(hostname: string) {
@@ -483,7 +489,41 @@ async function fetchValidatedImageDataUrl(url: URL, options: Required<Omit<SafeI
     return ''
   }
 
-  return `data:${response.contentType};base64,${Buffer.from(response.body).toString('base64')}`
+  const renderablePayload = await normalizeRenderableImagePayload(
+    response.body,
+    response.contentType,
+    options.maxBytes,
+  )
+  if (!renderablePayload) {
+    return ''
+  }
+
+  return `data:${renderablePayload.contentType};base64,${Buffer.from(renderablePayload.body).toString('base64')}`
+}
+
+async function normalizeRenderableImagePayload(
+  body: Uint8Array,
+  contentType: string,
+  maxBytes: number,
+): Promise<RenderableImagePayload | null> {
+  if (contentType !== 'image/webp') {
+    return { body, contentType }
+  }
+
+  try {
+    const converted = await sharp(Buffer.from(body)).png().toBuffer()
+    if (converted.byteLength === 0 || converted.byteLength > maxBytes) {
+      return null
+    }
+
+    return {
+      body: converted,
+      contentType: 'image/png',
+    }
+  }
+  catch {
+    return null
+  }
 }
 
 export async function fetchSafeOgImageDataUrl(rawUrl: string | null | undefined, options: SafeImageOptions = {}) {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Converts `image/webp` OG images to JPEG or PNG with `sharp` (prefers PNG if alpha). Enforces safe size limits (allows up to 4× for conversions) and returns a data URL with the right content type to prevent oversized or empty images.

<sup>Written for commit 986f10c6a632ea0847410461ecb4c02e2e98e1b9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

