### PR TITLE
fix: avoid sharp runtime crash in og routes

### DIFF
--- a/src/lib/og-image-security.ts
+++ b/src/lib/og-image-security.ts
@@ -5,7 +5,6 @@ import { lookup } from 'node:dns/promises'
 import * as http from 'node:http'
 import * as https from 'node:https'
 import { isIP } from 'node:net'
-import sharp from 'sharp'
 import 'server-only'
 
 const DEFAULT_MAX_IMAGE_BYTES = 2 * 1024 * 1024
@@ -50,6 +49,13 @@ interface RenderableImagePayload {
 }
 
 type WebpRenderableContentType = 'image/jpeg' | 'image/png'
+
+let sharpModulePromise: Promise<typeof import('sharp')> | null = null
+
+async function loadSharp() {
+  sharpModulePromise ??= import('sharp')
+  return (await sharpModulePromise).default
+}
 
 function normalizeHostname(hostname: string) {
   return hostname.trim().toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '')
@@ -516,13 +522,14 @@ async function normalizeRenderableImagePayload(
 
   try {
     const sourceBuffer = Buffer.from(body)
+    const sharp = await loadSharp()
     const metadata = await sharp(sourceBuffer).metadata()
     const preferredContentTypes: WebpRenderableContentType[] = metadata.hasAlpha
       ? ['image/png', 'image/jpeg']
       : ['image/jpeg', 'image/png']
 
     for (const preferredContentType of preferredContentTypes) {
-      const converted = await convertWebpToRenderableImage(sourceBuffer, preferredContentType)
+      const converted = await convertWebpToRenderableImage(sourceBuffer, preferredContentType, sharp)
       if (!isRenderableConvertedImage(converted, maxBytes)) {
         continue
       }
@@ -543,6 +550,7 @@ async function normalizeRenderableImagePayload(
 async function convertWebpToRenderableImage(
   sourceBuffer: Buffer,
   contentType: WebpRenderableContentType,
+  sharp: Awaited<ReturnType<typeof loadSharp>>,
 ) {
   const image = sharp(sourceBuffer)
   return contentType === 'image/png'


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Lazily load `sharp` in OG image routes to prevent runtime crashes and reduce cold-start overhead. The module is loaded only when needed and reused across calls.

- **Bug Fixes**
  - Replaced top-level `sharp` import with a memoized dynamic import (`loadSharp`) to avoid initialization errors.
  - Passed the `sharp` instance into WebP conversion helpers to prevent repeated loads and ensure stable processing.

<sup>Written for commit 753628712744f7f68bf590fc4bc2b19d5530c877. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

