### PR TITLE
fix: include sharp runtime packages

### DIFF
--- a/infra/docker/Dockerfile
+++ b/infra/docker/Dockerfile
@@ -22,7 +22,10 @@ RUN pnpm install --frozen-lockfile
 COPY . .
 RUN pnpm build
 RUN mkdir -p /tmp/runtime-node_modules \
-  && cp -aL node_modules/postgres /tmp/runtime-node_modules/postgres
+  && for package in postgres sharp detect-libc semver; do \
+    cp -aL "node_modules/${package}" "/tmp/runtime-node_modules/${package}"; \
+  done \
+  && cp -aL node_modules/@img /tmp/runtime-node_modules/@img
 
 FROM node:24-bookworm-slim AS runner
 WORKDIR /app
@@ -48,7 +51,7 @@ RUN corepack enable \
 COPY --from=build --chown=nextjs:nodejs /app/public ./public
 COPY --from=build --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=build --chown=nextjs:nodejs /app/.next/static ./.next/static
-COPY --from=build --chown=nextjs:nodejs /tmp/runtime-node_modules/postgres ./node_modules/postgres
+COPY --from=build --chown=nextjs:nodejs /tmp/runtime-node_modules/. ./node_modules/
 COPY --from=build --chown=nextjs:nodejs /app/package.json ./package.json
 COPY --from=build --chown=nextjs:nodejs /app/scripts ./scripts
 COPY --from=build --chown=nextjs:nodejs /app/src/lib/site-url.ts ./src/lib/site-url.ts


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Bundle Sharp and its runtime packages in the Docker image to prevent missing-module/libvips errors during OG WebP image generation.

- **Bug Fixes**
  - Copy `sharp`, `@img/*`, `detect-libc`, `semver`, and `postgres` into `/tmp/runtime-node_modules` during build.
  - Copy the entire cached directory into `node_modules/` in the runner image instead of only `postgres`.

<sup>Written for commit 9be563f63faba20d5293c8edfaacfd6398220d14. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

