### PR TITLE
fix: improve comment actions and stale asset recovery

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -99,7 +99,3 @@ globalThis.addEventListener('notificationclick', (event) => {
     }
   })())
 })
-
-// Keep a fetch handler so Chrome treats the app as installable.
-globalThis.addEventListener('fetch', () => {
-})

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -41,7 +41,7 @@ import { Button } from '@/components/ui/button'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import { ensureReadableTextColorOnDark } from '@/lib/color-contrast'
-import { resolveEventPagePath } from '@/lib/events-routing'
+import { resolveEventOutcomePath, resolveEventPagePath } from '@/lib/events-routing'
 import { formatDollarValueLabel, formatVolume } from '@/lib/formatters'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
 import { cn } from '@/lib/utils'
@@ -398,7 +398,27 @@ function FeaturedHeader({
   )
 }
 
-function OutcomeRows({ outcomes, linkedHref }: { outcomes: HomeFeaturedOutcomeSummary[], linkedHref: string }) {
+function resolveFeaturedOutcomeHref(
+  event: HomeFeaturedEventCard['event'],
+  outcome: HomeFeaturedOutcomeSummary,
+  fallbackHref: string,
+) {
+  return resolveEventOutcomePath(event, {
+    marketSlug: outcome.marketSlug,
+    conditionId: outcome.conditionId,
+    outcomeIndex: outcome.outcomeIndex,
+  }) || fallbackHref
+}
+
+function OutcomeRows({
+  item,
+  linkedHref,
+}: {
+  item: HomeFeaturedEventCard
+  linkedHref: string
+}) {
+  const outcomes = item.topOutcomes
+
   if (outcomes.length === 0) {
     return null
   }
@@ -409,7 +429,7 @@ function OutcomeRows({ outcomes, linkedHref }: { outcomes: HomeFeaturedOutcomeSu
         <AppLink
           key={outcome.key}
           intentPrefetch
-          href={linkedHref}
+          href={resolveFeaturedOutcomeHref(item.event, outcome, linkedHref)}
           className={`
             group/outcome grid min-h-14 grid-cols-[minmax(0,1fr)_auto] items-center gap-3 border-b border-border/50 py-2
             last:border-b-0
@@ -467,7 +487,7 @@ function StandardActions({ item, linkedHref }: { item: HomeFeaturedEventCard, li
               `,
             )}
           >
-            <AppLink intentPrefetch href={linkedHref}>
+            <AppLink intentPrefetch href={resolveFeaturedOutcomeHref(item.event, outcome, linkedHref)}>
               <span className="truncate">{outcome.label}</span>
             </AppLink>
           </Button>
@@ -480,15 +500,17 @@ function StandardActions({ item, linkedHref }: { item: HomeFeaturedEventCard, li
 function SportsMarketButton({
   groupLabel,
   market,
-  linkedHref,
+  href,
   className,
   forceNeutral = false,
+  underlineOnHover = false,
 }: {
   groupLabel: string
   market: FeaturedSportsButtonMarket
-  linkedHref: string
+  href: string
   className?: string
   forceNeutral?: boolean
+  underlineOnHover?: boolean
 }) {
   const appearance = forceNeutral ? resolveFilledNeutralSportsButtonAppearance() : resolveSportsButtonAppearance(market)
 
@@ -496,11 +518,11 @@ function SportsMarketButton({
     <AppLink
       key={`${groupLabel}:${market.key}`}
       intentPrefetch
-      href={linkedHref}
+      href={href}
       className={cn(
         `
-          relative inline-flex min-w-0 items-center justify-center overflow-hidden rounded-lg px-3 text-center
-          font-semibold transition duration-150
+          group/sports-market-button relative inline-flex min-w-0 items-center justify-center overflow-hidden rounded-lg
+          px-3 text-center font-semibold transition duration-150
           active:scale-[98%]
         `,
         appearance.className,
@@ -508,7 +530,14 @@ function SportsMarketButton({
       )}
       style={appearance.style}
     >
-      <span className="relative z-1 truncate">{market.label}</span>
+      <span
+        className={cn(
+          'relative z-1 truncate',
+          underlineOnHover && 'decoration-2 group-hover/sports-market-button:underline',
+        )}
+      >
+        {market.label}
+      </span>
       {(appearance.backgroundClassName || appearance.backgroundStyle)
         ? (
             <span
@@ -527,6 +556,22 @@ function SportsMarketButton({
         : null}
     </AppLink>
   )
+}
+
+function resolveFeaturedSportsButtonHref(
+  card: SportsGamesCard,
+  button: SportsGamesButton,
+  fallbackHref: string,
+) {
+  const market = card.detailMarkets.find(market => market.condition_id === button.conditionId)
+    ?? card.event.markets.find(market => market.condition_id === button.conditionId)
+  const href = resolveEventOutcomePath(card.event, {
+    marketSlug: market?.slug,
+    conditionId: button.conditionId,
+    outcomeIndex: button.outcomeIndex,
+  })
+
+  return href || fallbackHref
 }
 
 function SportsMoneylineButtons({
@@ -557,8 +602,9 @@ function SportsMoneylineButtons({
             button,
             resolveMoneylineButtonLabel(card, button),
           )}
-          linkedHref={linkedHref}
+          href={resolveFeaturedSportsButtonHref(card, button, linkedHref)}
           className="h-14 text-sm md:text-base"
+          underlineOnHover
         />
       ))}
     </div>
@@ -907,7 +953,7 @@ function SportsFeaturedLineMarketCarousel({
               button,
               resolveLineButtonLabel(card, activeOption, button, activeMarket, marketType),
             )}
-            linkedHref={linkedHref}
+            href={resolveFeaturedSportsButtonHref(card, button, linkedHref)}
             className="h-10 text-sm"
             forceNeutral
           />
@@ -1513,7 +1559,7 @@ function FeaturedSlide({
 
             {item.kind === 'standard'
               ? <StandardActions item={item} linkedHref={linkedHref} />
-              : <OutcomeRows outcomes={item.topOutcomes} linkedHref={linkedHref} />}
+              : <OutcomeRows item={item} linkedHref={linkedHref} />}
 
             <ContextTicker item={item} currentTimestamp={currentTimestamp} linkedHref={linkedHref} />
           </div>
@@ -1541,7 +1587,7 @@ function FeaturedSlide({
         <div className={featuredDetailsClassName}>
           {item.kind === 'standard'
             ? <StandardActions item={item} linkedHref={linkedHref} />
-            : <OutcomeRows outcomes={item.topOutcomes} linkedHref={linkedHref} />}
+            : <OutcomeRows item={item} linkedHref={linkedHref} />}
 
           <ContextTicker item={item} currentTimestamp={currentTimestamp} linkedHref={linkedHref} />
         </div>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
@@ -2,7 +2,10 @@ import type { Comment, Market } from '@/types'
 import { MoreHorizontalIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useCallback } from 'react'
-import { resolveCommentUserIdentity } from '@/app/[locale]/(platform)/event/[slug]/_components/comment-user'
+import {
+  isCommentOwnedByUser,
+  resolveCommentUserIdentity,
+} from '@/app/[locale]/(platform)/event/[slug]/_components/comment-user'
 import EventCommentContent from '@/app/[locale]/(platform)/event/[slug]/_components/EventCommentContent'
 import { CommentPositionsIndicator } from '@/app/[locale]/(platform)/event/[slug]/_components/EventCommentPositionsIndicator'
 import ProfileLink from '@/components/ProfileLink'
@@ -33,6 +36,7 @@ interface CommentItemProps {
   onUpdateReply: (commentId: string, replyId: string) => void
   createReply: (parentCommentId: string, content: string, replyToCommentId?: string) => Promise<Comment>
   isCreatingComment: boolean
+  isDeletingComment?: boolean
   isTogglingLikeForComment: (commentId: string) => boolean
   isLoadingRepliesForComment: (commentId: string) => boolean
   loadRepliesError: Error | null
@@ -130,12 +134,14 @@ export default function EventCommentItem({
   onUpdateReply,
   createReply,
   isCreatingComment,
+  isDeletingComment,
   isTogglingLikeForComment,
   isLoadingRepliesForComment,
   loadRepliesError,
   retryLoadReplies,
 }: CommentItemProps) {
   const { displayName, profileSlug } = resolveCommentUserIdentity(comment)
+  const canManageComment = isCommentOwnedByUser(comment, user)
   const t = useExtracted()
   const {
     handleReplyClick,
@@ -198,7 +204,7 @@ export default function EventCommentItem({
               </button>
             </div>
           </div>
-          {comment.is_owner && (
+          {canManageComment && (
             <div className="relative">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -211,8 +217,8 @@ export default function EventCommentItem({
                   </button>
                 </DropdownMenuTrigger>
                 <EventCommentMenu
-                  comment={comment}
                   onDelete={handleDelete}
+                  isDeleting={isDeletingComment}
                 />
               </DropdownMenu>
             </div>
@@ -259,6 +265,7 @@ export default function EventCommentItem({
                 onSetReplyText={onSetReplyText}
                 createReply={createReply}
                 isCreatingComment={isCreatingComment}
+                isDeletingComment={isDeletingComment}
                 isTogglingLikeForComment={isTogglingLikeForComment}
               />
             )

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentItem.tsx
@@ -36,7 +36,7 @@ interface CommentItemProps {
   onUpdateReply: (commentId: string, replyId: string) => void
   createReply: (parentCommentId: string, content: string, replyToCommentId?: string) => Promise<Comment>
   isCreatingComment: boolean
-  isDeletingComment?: boolean
+  isDeletingCommentForComment: (commentId: string) => boolean
   isTogglingLikeForComment: (commentId: string) => boolean
   isLoadingRepliesForComment: (commentId: string) => boolean
   loadRepliesError: Error | null
@@ -134,7 +134,7 @@ export default function EventCommentItem({
   onUpdateReply,
   createReply,
   isCreatingComment,
-  isDeletingComment,
+  isDeletingCommentForComment,
   isTogglingLikeForComment,
   isLoadingRepliesForComment,
   loadRepliesError,
@@ -142,6 +142,7 @@ export default function EventCommentItem({
 }: CommentItemProps) {
   const { displayName, profileSlug } = resolveCommentUserIdentity(comment)
   const canManageComment = isCommentOwnedByUser(comment, user)
+  const isDeletingComment = isDeletingCommentForComment(comment.id)
   const t = useExtracted()
   const {
     handleReplyClick,
@@ -265,7 +266,7 @@ export default function EventCommentItem({
                 onSetReplyText={onSetReplyText}
                 createReply={createReply}
                 isCreatingComment={isCreatingComment}
-                isDeletingComment={isDeletingComment}
+                isDeletingCommentForComment={isDeletingCommentForComment}
                 isTogglingLikeForComment={isTogglingLikeForComment}
               />
             )

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentMenu.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentMenu.tsx
@@ -1,4 +1,3 @@
-import type { Comment } from '@/types'
 import { Trash2Icon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useState } from 'react'
@@ -6,7 +5,6 @@ import { DropdownMenuContent, DropdownMenuItem } from '@/components/ui/dropdown-
 import EventCommentDeleteForm from './EventCommentDeleteForm'
 
 interface CommentMenuProps {
-  comment: Comment
   onDelete: () => void
   isDeleting?: boolean
 }
@@ -16,24 +14,22 @@ function useDeleteDialog() {
   return { isDeleteOpen, setIsDeleteOpen }
 }
 
-export default function EventCommentMenu({ comment, onDelete, isDeleting }: CommentMenuProps) {
+export default function EventCommentMenu({ onDelete, isDeleting }: CommentMenuProps) {
   const { isDeleteOpen, setIsDeleteOpen } = useDeleteDialog()
   const t = useExtracted()
 
   return (
     <>
       <DropdownMenuContent className="w-32" align="end">
-        {comment.is_owner && (
-          <DropdownMenuItem
-            className="text-destructive"
-            onSelect={() => {
-              setTimeout(setIsDeleteOpen, 0, true)
-            }}
-          >
-            <Trash2Icon />
-            {t('Delete')}
-          </DropdownMenuItem>
-        )}
+        <DropdownMenuItem
+          className="text-destructive"
+          onSelect={() => {
+            setTimeout(setIsDeleteOpen, 0, true)
+          }}
+        >
+          <Trash2Icon />
+          {t('Delete')}
+        </DropdownMenuItem>
       </DropdownMenuContent>
       <EventCommentDeleteForm
         open={isDeleteOpen}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
@@ -2,7 +2,10 @@ import type { Comment, Market } from '@/types'
 import { MoreHorizontalIcon } from 'lucide-react'
 import { useExtracted } from 'next-intl'
 import { useCallback } from 'react'
-import { resolveCommentUserIdentity } from '@/app/[locale]/(platform)/event/[slug]/_components/comment-user'
+import {
+  isCommentOwnedByUser,
+  resolveCommentUserIdentity,
+} from '@/app/[locale]/(platform)/event/[slug]/_components/comment-user'
 import EventCommentContent from '@/app/[locale]/(platform)/event/[slug]/_components/EventCommentContent'
 import { CommentPositionsIndicator } from '@/app/[locale]/(platform)/event/[slug]/_components/EventCommentPositionsIndicator'
 import AppLink from '@/components/AppLink'
@@ -32,6 +35,7 @@ interface ReplyItemProps {
   onSetReplyText: (text: string) => void
   createReply: (parentCommentId: string, content: string, replyToCommentId?: string) => Promise<Comment>
   isCreatingComment: boolean
+  isDeletingComment?: boolean
   isTogglingLikeForComment: (commentId: string) => boolean
 }
 
@@ -112,10 +116,12 @@ export default function EventCommentReplyItem({
   onSetReplyText,
   createReply,
   isCreatingComment,
+  isDeletingComment,
   isTogglingLikeForComment,
 }: ReplyItemProps) {
   const { displayName, profileSlug } = resolveCommentUserIdentity(reply)
   const parentHref = parentProfileSlug ? ((buildPublicProfilePath(parentProfileSlug) ?? '#') as any) : ('#' as any)
+  const canManageReply = isCommentOwnedByUser(reply, user)
   const t = useExtracted()
   const {
     handleReplyClick,
@@ -189,7 +195,7 @@ export default function EventCommentReplyItem({
               </button>
             </div>
           </div>
-          {reply.is_owner && (
+          {canManageReply && (
             <div className="relative">
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
@@ -202,8 +208,8 @@ export default function EventCommentReplyItem({
                   </button>
                 </DropdownMenuTrigger>
                 <EventCommentMenu
-                  comment={reply}
                   onDelete={handleDelete}
+                  isDeleting={isDeletingComment}
                 />
               </DropdownMenu>
             </div>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventCommentReplyItem.tsx
@@ -35,7 +35,7 @@ interface ReplyItemProps {
   onSetReplyText: (text: string) => void
   createReply: (parentCommentId: string, content: string, replyToCommentId?: string) => Promise<Comment>
   isCreatingComment: boolean
-  isDeletingComment?: boolean
+  isDeletingCommentForComment: (commentId: string) => boolean
   isTogglingLikeForComment: (commentId: string) => boolean
 }
 
@@ -116,12 +116,13 @@ export default function EventCommentReplyItem({
   onSetReplyText,
   createReply,
   isCreatingComment,
-  isDeletingComment,
+  isDeletingCommentForComment,
   isTogglingLikeForComment,
 }: ReplyItemProps) {
   const { displayName, profileSlug } = resolveCommentUserIdentity(reply)
   const parentHref = parentProfileSlug ? ((buildPublicProfilePath(parentProfileSlug) ?? '#') as any) : ('#' as any)
   const canManageReply = isCommentOwnedByUser(reply, user)
+  const isDeletingReply = isDeletingCommentForComment(reply.id)
   const t = useExtracted()
   const {
     handleReplyClick,
@@ -209,7 +210,7 @@ export default function EventCommentReplyItem({
                 </DropdownMenuTrigger>
                 <EventCommentMenu
                   onDelete={handleDelete}
-                  isDeleting={isDeletingComment}
+                  isDeleting={isDeletingReply}
                 />
               </DropdownMenu>
             </div>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
@@ -213,6 +213,7 @@ export default function EventComments({ event, user }: EventCommentsProps) {
     loadMoreReplies,
     createReply,
     isCreatingComment,
+    isDeletingComment,
     isTogglingLikeForComment,
     status,
     isLoadingRepliesForComment,
@@ -359,6 +360,7 @@ export default function EventComments({ event, user }: EventCommentsProps) {
                   onUpdateReply={handleUpdateReply}
                   createReply={createReply}
                   isCreatingComment={isCreatingComment}
+                  isDeletingComment={isDeletingComment}
                   isLoadingRepliesForComment={isLoadingRepliesForComment}
                   loadRepliesError={loadRepliesError}
                   retryLoadReplies={retryLoadReplies}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventComments.tsx
@@ -213,7 +213,7 @@ export default function EventComments({ event, user }: EventCommentsProps) {
     loadMoreReplies,
     createReply,
     isCreatingComment,
-    isDeletingComment,
+    isDeletingCommentForComment,
     isTogglingLikeForComment,
     status,
     isLoadingRepliesForComment,
@@ -360,7 +360,7 @@ export default function EventComments({ event, user }: EventCommentsProps) {
                   onUpdateReply={handleUpdateReply}
                   createReply={createReply}
                   isCreatingComment={isCreatingComment}
-                  isDeletingComment={isDeletingComment}
+                  isDeletingCommentForComment={isDeletingCommentForComment}
                   isLoadingRepliesForComment={isLoadingRepliesForComment}
                   loadRepliesError={loadRepliesError}
                   retryLoadReplies={retryLoadReplies}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/comment-user.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/comment-user.ts
@@ -28,12 +28,12 @@ export function resolveCommentUserIdentity(comment: CommentUser) {
 }
 
 export function isCommentOwnedByUser(comment: CommentOwnership, user: CommentOwnershipUser) {
-  if (comment.is_owner) {
-    return true
-  }
-
   if (!user) {
     return false
+  }
+
+  if (comment.is_owner) {
+    return true
   }
 
   const userAddresses = new Set(

--- a/src/app/[locale]/(platform)/event/[slug]/_components/comment-user.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/comment-user.ts
@@ -1,10 +1,21 @@
-import type { Comment } from '@/types'
+import type { Comment, User } from '@/types'
 import { truncateAddress } from '@/lib/formatters'
 
 type CommentUser = Pick<Comment, 'username' | 'user_proxy_wallet_address' | 'user_address'>
+type CommentOwnership = Pick<Comment, 'is_owner' | 'user_proxy_wallet_address' | 'user_address'>
+type CommentOwnershipUser = Pick<User, 'address' | 'deposit_wallet_address'> | null | undefined
 
 function normalizeUsername(value?: string | null) {
   return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeCommentAddress(value?: string | null) {
+  if (typeof value !== 'string') {
+    return null
+  }
+
+  const trimmed = value.trim()
+  return /^0x[0-9a-fA-F]{40}$/.test(trimmed) ? trimmed.toLowerCase() : null
 }
 
 export function resolveCommentUserIdentity(comment: CommentUser) {
@@ -14,4 +25,28 @@ export function resolveCommentUserIdentity(comment: CommentUser) {
   const profileSlug = username || address
 
   return { displayName, profileSlug }
+}
+
+export function isCommentOwnedByUser(comment: CommentOwnership, user: CommentOwnershipUser) {
+  if (comment.is_owner) {
+    return true
+  }
+
+  if (!user) {
+    return false
+  }
+
+  const userAddresses = new Set(
+    [user.address, user.deposit_wallet_address]
+      .map(normalizeCommentAddress)
+      .filter((address): address is string => Boolean(address)),
+  )
+
+  if (userAddresses.size === 0) {
+    return false
+  }
+
+  return [comment.user_address, comment.user_proxy_wallet_address]
+    .map(normalizeCommentAddress)
+    .some(address => Boolean(address && userAddresses.has(address)))
 }

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useInfiniteComments.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useInfiniteComments.ts
@@ -53,6 +53,7 @@ export function useInfiniteComments(
   const [infiniteScrollError, setInfiniteScrollError] = useState<Error | null>(null)
   const [loadingRepliesForComment, setLoadingRepliesForComment] = useState<string | null>(null)
   const [pendingLikeIds, setPendingLikeIds] = useState<Set<string>>(() => new Set())
+  const [pendingDeleteIds, setPendingDeleteIds] = useState<Set<string>>(() => new Set())
   const userAddress = user?.address ?? null
   const userDepositWalletAddress = user?.deposit_wallet_address ?? null
   const commentsQueryKey = ['event-comments', communityUrl, eventSlug, sortBy, holdersOnly, userAddress]
@@ -367,6 +368,11 @@ export function useInfiniteComments(
       return commentId
     },
     onMutate: async ({ commentId }) => {
+      setPendingDeleteIds((prev) => {
+        const next = new Set(prev)
+        next.add(commentId)
+        return next
+      })
       await queryClient.cancelQueries({ queryKey: commentsQueryKey })
 
       const previousComments = queryClient.getQueryData(commentsQueryKey)
@@ -407,6 +413,17 @@ export function useInfiniteComments(
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: commentMetricsQueryKey(eventSlug) })
+    },
+    onSettled: (_data, _error, variables) => {
+      if (!variables?.commentId) {
+        return
+      }
+
+      setPendingDeleteIds((prev) => {
+        const next = new Set(prev)
+        next.delete(variables.commentId)
+        return next
+      })
     },
   })
 
@@ -495,6 +512,10 @@ export function useInfiniteComments(
     return pendingLikeIds.has(commentId)
   }, [pendingLikeIds])
 
+  const isDeletingCommentForComment = useCallback((commentId: string) => {
+    return pendingDeleteIds.has(commentId)
+  }, [pendingDeleteIds])
+
   const retryLoadReplies = useCallback((commentId: string) => {
     loadMoreRepliesMutation.reset()
     loadMoreRepliesMutation.mutate({ commentId })
@@ -525,6 +546,7 @@ export function useInfiniteComments(
     isTogglingLike: likeCommentMutation.isPending,
     isTogglingLikeForComment,
     isDeletingComment: deleteCommentMutation.isPending,
+    isDeletingCommentForComment,
     isLoadingReplies: loadMoreRepliesMutation.isPending,
     isLoadingRepliesForComment,
 

--- a/src/app/[locale]/admin/(general)/_components/HomeFeaturedMarketsSection.tsx
+++ b/src/app/[locale]/admin/(general)/_components/HomeFeaturedMarketsSection.tsx
@@ -501,7 +501,7 @@ function HomeFeaturedSettingsDialog({
               id="home-featured-comment-blacklist"
               value={commentBlacklist}
               onChange={event => onCommentBlacklistChange(event.target.value)}
-              placeholder="www&#10;.com&#10;spam"
+              placeholder="www&#10;.com&#10;scam&#10;damn"
               disabled={disabled}
               className="min-h-28"
             />

--- a/src/components/AppErrorFallback.tsx
+++ b/src/components/AppErrorFallback.tsx
@@ -4,6 +4,10 @@ import * as Sentry from '@sentry/nextjs'
 import { RotateCcwIcon } from 'lucide-react'
 import { useEffect } from 'react'
 import { Button } from '@/components/ui/button'
+import {
+  isStaleNextClientAssetError,
+  requestStaleNextClientAssetReload,
+} from '@/lib/next-client-stale-assets'
 import { isNextNotFoundError } from '@/lib/next-http-fallback'
 import { cn } from '@/lib/utils'
 
@@ -26,6 +30,10 @@ export default function AppErrorFallback({
 }: AppErrorFallbackProps) {
   useEffect(function captureExceptionEffect() {
     if (isNextNotFoundError(error)) {
+      return
+    }
+
+    if (isStaleNextClientAssetError(error) && requestStaleNextClientAssetReload()) {
       return
     }
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,5 +1,9 @@
 import type { PublicRuntimeConfig } from '@/lib/public-runtime-config.shared'
 import * as Sentry from '@sentry/nextjs'
+import {
+  installStaleNextClientAssetReloadHandlers,
+  isStaleNextClientAssetError,
+} from '@/lib/next-client-stale-assets'
 import { isNextNotFoundError } from '@/lib/next-http-fallback'
 
 declare global {
@@ -28,8 +32,14 @@ Sentry.init({
       return null
     }
 
+    if (isStaleNextClientAssetError(hint.originalException)) {
+      return null
+    }
+
     return event
   },
 })
+
+installStaleNextClientAssetReloadHandlers()
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/src/lib/home-featured-events.ts
+++ b/src/lib/home-featured-events.ts
@@ -101,6 +101,12 @@ function resolveOutcomeImageUrl(market: Market) {
   return metadataImage || market.icon_url || null
 }
 
+function resolveFeaturedMarketOutcomeIndex(market: Market) {
+  return market.outcomes.find(outcome => outcome.outcome_index === OUTCOME_INDEX.YES)?.outcome_index
+    ?? market.outcomes[0]?.outcome_index
+    ?? OUTCOME_INDEX.YES
+}
+
 function buildTopOutcomes(event: Event, kind: HomeFeaturedCardKind): HomeFeaturedOutcomeSummary[] {
   const activeMarkets = getActiveMarkets(event)
 
@@ -117,6 +123,9 @@ function buildTopOutcomes(event: Event, kind: HomeFeaturedCardKind): HomeFeature
 
       return {
         key: `${primaryMarket.condition_id}:${outcome.outcome_index}`,
+        conditionId: primaryMarket.condition_id,
+        marketSlug: primaryMarket.slug,
+        outcomeIndex: outcome.outcome_index,
         label: outcome.outcome_text,
         chance,
         imageUrl: null,
@@ -128,6 +137,9 @@ function buildTopOutcomes(event: Event, kind: HomeFeaturedCardKind): HomeFeature
   return activeMarkets
     .map((market, index) => ({
       key: market.condition_id,
+      conditionId: market.condition_id,
+      marketSlug: market.slug,
+      outcomeIndex: resolveFeaturedMarketOutcomeIndex(market),
       label: market.short_title || market.title,
       chance: resolveMarketChance(market),
       imageUrl: resolveOutcomeImageUrl(market),

--- a/src/lib/next-client-stale-assets.ts
+++ b/src/lib/next-client-stale-assets.ts
@@ -19,8 +19,12 @@ interface ReloadOptions {
 }
 
 function readStorage(storage: ReloadOptions['storage'], key: string) {
+  if (!storage) {
+    return inMemoryReloadKeys.has(key) ? '1' : null
+  }
+
   try {
-    return storage?.getItem(key) ?? null
+    return storage.getItem(key) ?? null
   }
   catch {
     return inMemoryReloadKeys.has(key) ? '1' : null
@@ -28,8 +32,13 @@ function readStorage(storage: ReloadOptions['storage'], key: string) {
 }
 
 function writeStorage(storage: ReloadOptions['storage'], key: string) {
+  if (!storage) {
+    inMemoryReloadKeys.add(key)
+    return
+  }
+
   try {
-    storage?.setItem(key, '1')
+    storage.setItem(key, '1')
   }
   catch {
     inMemoryReloadKeys.add(key)
@@ -65,7 +74,12 @@ function getCurrentStorage(storage?: ReloadOptions['storage']) {
     return null
   }
 
-  return window.sessionStorage
+  try {
+    return window.sessionStorage
+  }
+  catch {
+    return null
+  }
 }
 
 function getReloadKey(options: ReloadOptions) {

--- a/src/lib/next-client-stale-assets.ts
+++ b/src/lib/next-client-stale-assets.ts
@@ -1,0 +1,211 @@
+const STALE_NEXT_CLIENT_ASSET_RELOAD_PREFIX = 'next-stale-client-asset-reload'
+
+const staleAssetErrorPatterns = [
+  /ChunkLoadError/i,
+  /Loading chunk .+ failed/i,
+  /Failed to fetch dynamically imported module/i,
+  /Importing a module script failed/i,
+  /module factory is not available/i,
+  /was instantiated because it was required from module/i,
+]
+
+const inMemoryReloadKeys = new Set<string>()
+
+interface ReloadOptions {
+  buildId?: string
+  location?: Pick<Location, 'pathname' | 'search'>
+  reload?: () => void
+  storage?: Pick<Storage, 'getItem' | 'setItem'>
+}
+
+function readStorage(storage: ReloadOptions['storage'], key: string) {
+  try {
+    return storage?.getItem(key) ?? null
+  }
+  catch {
+    return inMemoryReloadKeys.has(key) ? '1' : null
+  }
+}
+
+function writeStorage(storage: ReloadOptions['storage'], key: string) {
+  try {
+    storage?.setItem(key, '1')
+  }
+  catch {
+    inMemoryReloadKeys.add(key)
+  }
+}
+
+function getBuildId(buildId?: string) {
+  if (buildId && buildId.trim()) {
+    return buildId.trim()
+  }
+
+  return process.env.COMMIT_SHA || 'unknown'
+}
+
+function getCurrentLocation(location?: ReloadOptions['location']) {
+  if (location) {
+    return location
+  }
+
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return window.location
+}
+
+function getCurrentStorage(storage?: ReloadOptions['storage']) {
+  if (storage) {
+    return storage
+  }
+
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return window.sessionStorage
+}
+
+function getReloadKey(options: ReloadOptions) {
+  const location = getCurrentLocation(options.location)
+  if (!location) {
+    return null
+  }
+
+  const buildId = getBuildId(options.buildId)
+  return `${STALE_NEXT_CLIENT_ASSET_RELOAD_PREFIX}:${buildId}:${location.pathname}${location.search}`
+}
+
+function getReloadFn(reload?: () => void) {
+  if (reload) {
+    return reload
+  }
+
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  return () => window.location.reload()
+}
+
+function collectErrorMessages(value: unknown, seen = new Set<unknown>()): string[] {
+  if (!value || seen.has(value)) {
+    return []
+  }
+
+  if (typeof value === 'string') {
+    return [value]
+  }
+
+  if (typeof value !== 'object') {
+    return []
+  }
+
+  seen.add(value)
+
+  const messages: string[] = []
+  const errorLike = value as {
+    cause?: unknown
+    digest?: unknown
+    error?: unknown
+    message?: unknown
+    name?: unknown
+    reason?: unknown
+    stack?: unknown
+  }
+
+  for (const field of [errorLike.name, errorLike.message, errorLike.stack, errorLike.digest]) {
+    if (typeof field === 'string' && field.trim()) {
+      messages.push(field)
+    }
+  }
+
+  messages.push(...collectErrorMessages(errorLike.error, seen))
+  messages.push(...collectErrorMessages(errorLike.reason, seen))
+  messages.push(...collectErrorMessages(errorLike.cause, seen))
+
+  return messages
+}
+
+export function isNextStaticAssetUrl(value: unknown) {
+  if (typeof value !== 'string' || !value.trim()) {
+    return false
+  }
+
+  try {
+    return new URL(value, typeof window === 'undefined' ? 'https://example.com' : window.location.origin)
+      .pathname
+      .startsWith('/_next/static/')
+  }
+  catch {
+    return value.includes('/_next/static/')
+  }
+}
+
+function isNextStaticAssetEvent(event: unknown) {
+  if (typeof event !== 'object' || event === null || !('target' in event)) {
+    return false
+  }
+
+  const target = (event as { target?: { href?: unknown, src?: unknown } | null }).target
+  return isNextStaticAssetUrl(target?.src) || isNextStaticAssetUrl(target?.href)
+}
+
+export function isStaleNextClientAssetError(error: unknown) {
+  if (isNextStaticAssetEvent(error)) {
+    return true
+  }
+
+  const message = collectErrorMessages(error).join('\n')
+  if (!message) {
+    return false
+  }
+
+  return staleAssetErrorPatterns.some(pattern => pattern.test(message))
+}
+
+export function requestStaleNextClientAssetReload(options: ReloadOptions = {}) {
+  const reload = getReloadFn(options.reload)
+  const key = getReloadKey(options)
+  if (!reload || !key) {
+    return false
+  }
+
+  const storage = getCurrentStorage(options.storage) ?? undefined
+  if (readStorage(storage, key)) {
+    return false
+  }
+
+  writeStorage(storage, key)
+  reload()
+  return true
+}
+
+function handleWindowError(event: ErrorEvent | Event) {
+  const error = 'error' in event ? event.error : event
+  const message = 'message' in event ? event.message : undefined
+
+  if (isStaleNextClientAssetError(event) || isStaleNextClientAssetError(error) || isStaleNextClientAssetError(message)) {
+    requestStaleNextClientAssetReload()
+  }
+}
+
+function handleUnhandledRejection(event: PromiseRejectionEvent) {
+  if (isStaleNextClientAssetError(event.reason)) {
+    requestStaleNextClientAssetReload()
+  }
+}
+
+let staleNextClientAssetReloadHandlersInstalled = false
+
+export function installStaleNextClientAssetReloadHandlers() {
+  if (typeof window === 'undefined' || staleNextClientAssetReloadHandlersInstalled) {
+    return
+  }
+
+  staleNextClientAssetReloadHandlersInstalled = true
+  window.addEventListener('error', handleWindowError, true)
+  window.addEventListener('unhandledrejection', handleUnhandledRejection)
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -166,6 +166,9 @@ export interface HomeFeaturedContextItem {
 
 export interface HomeFeaturedOutcomeSummary {
   key: string
+  conditionId: string
+  marketSlug: string | null
+  outcomeIndex: number
   label: string
   chance: number
   imageUrl: string | null

--- a/tests/unit/commentUser.test.ts
+++ b/tests/unit/commentUser.test.ts
@@ -25,8 +25,12 @@ function comment(overrides: Partial<Comment>): Comment {
 }
 
 describe('comment user helpers', () => {
-  it('trusts the API owner flag when present', () => {
-    expect(isCommentOwnedByUser(comment({ is_owner: true }), null)).toBe(true)
+  it('does not trust the API owner flag without a current user', () => {
+    expect(isCommentOwnedByUser(comment({ is_owner: true }), null)).toBe(false)
+  })
+
+  it('trusts the API owner flag when a current user is present', () => {
+    expect(isCommentOwnedByUser(comment({ is_owner: true }), user)).toBe(true)
   })
 
   it('detects ownership from the connected base wallet address', () => {

--- a/tests/unit/commentUser.test.ts
+++ b/tests/unit/commentUser.test.ts
@@ -1,0 +1,47 @@
+import type { Comment, User } from '@/types'
+import { describe, expect, it } from 'vitest'
+import { isCommentOwnedByUser } from '@/app/[locale]/(platform)/event/[slug]/_components/comment-user'
+
+const user = {
+  address: '0x1111111111111111111111111111111111111111',
+  deposit_wallet_address: '0x2222222222222222222222222222222222222222',
+} as User
+
+function comment(overrides: Partial<Comment>): Comment {
+  return {
+    id: 'comment-1',
+    content: 'hello',
+    user_id: 'user-1',
+    username: 'user',
+    user_avatar: '',
+    user_address: '0x3333333333333333333333333333333333333333',
+    likes_count: 0,
+    replies_count: 0,
+    created_at: '2026-01-01T00:00:00.000Z',
+    is_owner: false,
+    user_has_liked: false,
+    ...overrides,
+  }
+}
+
+describe('comment user helpers', () => {
+  it('trusts the API owner flag when present', () => {
+    expect(isCommentOwnedByUser(comment({ is_owner: true }), null)).toBe(true)
+  })
+
+  it('detects ownership from the connected base wallet address', () => {
+    expect(isCommentOwnedByUser(comment({
+      user_address: '0x1111111111111111111111111111111111111111',
+    }), user)).toBe(true)
+  })
+
+  it('detects ownership from the connected deposit wallet address', () => {
+    expect(isCommentOwnedByUser(comment({
+      user_proxy_wallet_address: '0x2222222222222222222222222222222222222222',
+    }), user)).toBe(true)
+  })
+
+  it('does not match a different connected user', () => {
+    expect(isCommentOwnedByUser(comment({}), user)).toBe(false)
+  })
+})

--- a/tests/unit/nextClientStaleAssets.test.ts
+++ b/tests/unit/nextClientStaleAssets.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  isNextStaticAssetUrl,
+  isStaleNextClientAssetError,
+  requestStaleNextClientAssetReload,
+} from '@/lib/next-client-stale-assets'
+
+function createMemoryStorage() {
+  const store = new Map<string, string>()
+
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => store.set(key, value),
+  }
+}
+
+describe('next client stale assets', () => {
+  it('matches Next static asset URLs', () => {
+    expect(isNextStaticAssetUrl('/_next/static/chunks/app.js')).toBe(true)
+    expect(isNextStaticAssetUrl('https://cdn.example/_next/static/css/app.css')).toBe(true)
+    expect(isNextStaticAssetUrl('/images/logo.png')).toBe(false)
+  })
+
+  it('matches Turbopack missing module errors', () => {
+    expect(isStaleNextClientAssetError(new Error(
+      'Module 948971 was instantiated because it was required from module 589170, but the module factory is not available.',
+    ))).toBe(true)
+  })
+
+  it('matches chunk load errors', () => {
+    expect(isStaleNextClientAssetError(new Error('ChunkLoadError: Loading chunk 123 failed.'))).toBe(true)
+  })
+
+  it('ignores ordinary app errors', () => {
+    expect(isStaleNextClientAssetError(new Error('Internal server error'))).toBe(false)
+  })
+
+  it('reloads once per build and path', () => {
+    const reload = vi.fn()
+    const storage = createMemoryStorage()
+    const location = { pathname: '/portfolio', search: '' }
+
+    expect(requestStaleNextClientAssetReload({
+      buildId: 'build-a',
+      location,
+      reload,
+      storage,
+    })).toBe(true)
+    expect(requestStaleNextClientAssetReload({
+      buildId: 'build-a',
+      location,
+      reload,
+      storage,
+    })).toBe(false)
+    expect(requestStaleNextClientAssetReload({
+      buildId: 'build-b',
+      location,
+      reload,
+      storage,
+    })).toBe(true)
+    expect(reload).toHaveBeenCalledTimes(2)
+  })
+})

--- a/tests/unit/nextClientStaleAssets.test.ts
+++ b/tests/unit/nextClientStaleAssets.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   isNextStaticAssetUrl,
   isStaleNextClientAssetError,
@@ -15,6 +15,14 @@ function createMemoryStorage() {
 }
 
 describe('next client stale assets', () => {
+  const sessionStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'sessionStorage')
+
+  afterEach(() => {
+    if (sessionStorageDescriptor) {
+      Object.defineProperty(window, 'sessionStorage', sessionStorageDescriptor)
+    }
+  })
+
   it('matches Next static asset URLs', () => {
     expect(isNextStaticAssetUrl('/_next/static/chunks/app.js')).toBe(true)
     expect(isNextStaticAssetUrl('https://cdn.example/_next/static/css/app.css')).toBe(true)
@@ -59,5 +67,29 @@ describe('next client stale assets', () => {
       storage,
     })).toBe(true)
     expect(reload).toHaveBeenCalledTimes(2)
+  })
+
+  it('falls back when session storage access throws', () => {
+    const reload = vi.fn()
+    const location = { pathname: '/portfolio', search: '' }
+
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      get() {
+        throw new DOMException('Access denied', 'SecurityError')
+      },
+    })
+
+    expect(requestStaleNextClientAssetReload({
+      buildId: 'storage-blocked',
+      location,
+      reload,
+    })).toBe(true)
+    expect(requestStaleNextClientAssetReload({
+      buildId: 'storage-blocked',
+      location,
+      reload,
+    })).toBe(false)
+    expect(reload).toHaveBeenCalledTimes(1)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Shows comment delete actions only to the actual owner (connected base or deposit wallet), adds automatic reloads for stale Next.js client assets to avoid blank screens, and fixes featured market selections to deep‑link to the correct outcome pages.

- **Bug Fixes**
  - Comment actions: use `isCommentOwnedByUser` to detect ownership via base or deposit wallet; render the menu only for owners; track per‑comment deleting state for comments and replies.
  - Featured selections linking: use `resolveEventOutcomePath` with `conditionId`/`marketSlug`/`outcomeIndex` so featured rows and sports buttons open the selected outcome, not just the event page.
  - Stale asset recovery: detect chunk load/Turbopack missing module/static asset errors and auto‑reload once per build+path; install global handlers; ignore these in `@sentry/nextjs`; trigger reload from the error fallback.
  - Tests: add unit tests for ownership checks and reload behavior.

<sup>Written for commit 183e482d2eab5f6080ee61f8865952a8ad33ebe0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

