### PR TITLE
fix: show primary sports cards on home

### DIFF
--- a/src/lib/home-events.ts
+++ b/src/lib/home-events.ts
@@ -28,8 +28,11 @@ interface HomeVisibleEventCandidate {
   slug: string
   status: 'draft' | 'active' | 'resolved' | 'archived'
   series_slug?: string | null
+  sports_event_id?: string | null
   sports_event_slug?: string | null
   sports_parent_event_id?: number | string | null
+  sports_series_slug?: string | null
+  sports_sport_slug?: string | null
   end_date?: string | null
   created_at: string
   updated_at: string
@@ -56,6 +59,21 @@ function isSportsAuxiliaryHomeEvent(event: HomeVisibleEventCandidate) {
   return hasSportsParentEventId(event.sports_parent_event_id)
     || isSportsAuxiliaryEventSlug(event.slug)
     || isSportsAuxiliaryEventSlug(event.sports_event_slug)
+}
+
+function hasTrimmedValue(value: string | null | undefined) {
+  return Boolean(value?.trim())
+}
+
+function isSportsPrimaryHomeEvent(event: HomeVisibleEventCandidate) {
+  if (isSportsAuxiliaryHomeEvent(event)) {
+    return false
+  }
+
+  return hasTrimmedValue(event.sports_event_id)
+    || hasTrimmedValue(event.sports_event_slug)
+    || hasTrimmedValue(event.sports_series_slug)
+    || hasTrimmedValue(event.sports_sport_slug)
 }
 
 function toTimestamp(value: string | null | undefined) {
@@ -225,6 +243,10 @@ export function filterHomeEvents<T extends HomeVisibleEventCandidate>(
   const newestBySeriesSlug = new Map<string, T>()
 
   for (const event of activeSeriesCandidates) {
+    if (isSportsPrimaryHomeEvent(event)) {
+      continue
+    }
+
     const seriesSlug = normalizeSeriesSlug(event.series_slug)
     if (!seriesSlug) {
       continue
@@ -251,6 +273,10 @@ export function filterHomeEvents<T extends HomeVisibleEventCandidate>(
 
     const seriesSlug = normalizeSeriesSlug(event.series_slug)
     if (!seriesSlug) {
+      return true
+    }
+
+    if (isSportsPrimaryHomeEvent(event)) {
       return true
     }
 

--- a/tests/unit/homeEvents.test.ts
+++ b/tests/unit/homeEvents.test.ts
@@ -126,11 +126,12 @@ describe('home-events', () => {
     )).toEqual([soonerActiveEvent, resolvedEvent])
   })
 
-  it('filters sports child market rows before choosing the newest series entry', () => {
+  it('keeps sports primary events from the same series while filtering child market rows', () => {
     const moneylineEvent = {
       id: 'moneyline-event',
       slug: 'fifwc-bra-nor-2026-07-05',
       sports_event_slug: 'fifwc-bra-nor-2026-07-05',
+      sports_sport_slug: 'soccer',
       sports_parent_event_id: null,
       series_slug: 'soccer-fifwc',
       status: 'active' as const,
@@ -139,10 +140,24 @@ describe('home-events', () => {
       updated_at: '2026-07-05T10:53:16.000Z',
       markets: [{ is_resolved: false }],
     }
+    const nextMoneylineEvent = {
+      id: 'next-moneyline-event',
+      slug: 'fifwc-esp-bel-2026-07-10',
+      sports_event_slug: 'fifwc-esp-bel-2026-07-10',
+      sports_sport_slug: 'soccer',
+      sports_parent_event_id: null,
+      series_slug: 'soccer-fifwc',
+      status: 'active' as const,
+      end_date: '2026-07-10T20:00:00.000Z',
+      created_at: '2026-07-06T10:53:16.000Z',
+      updated_at: '2026-07-06T10:53:16.000Z',
+      markets: [{ is_resolved: false }],
+    }
     const firstToScoreEvent = {
       id: 'first-to-score-event',
       slug: 'fifwc-bra-nor-2026-07-05-first-to-score',
       sports_event_slug: 'fifwc-bra-nor-2026-07-05-first-to-score',
+      sports_sport_slug: 'soccer',
       sports_parent_event_id: 654615,
       series_slug: 'soccer-fifwc',
       status: 'active' as const,
@@ -155,6 +170,7 @@ describe('home-events', () => {
       id: 'total-corners-event',
       slug: 'fifwc-bra-nor-2026-07-05-total-corners',
       sports_event_slug: 'fifwc-bra-nor-2026-07-05-total-corners',
+      sports_sport_slug: 'soccer',
       sports_parent_event_id: null,
       series_slug: 'soccer-fifwc',
       status: 'active' as const,
@@ -167,6 +183,7 @@ describe('home-events', () => {
       id: 'zero-parent-event',
       slug: 'nba-bos-nyk-2026-07-05',
       sports_event_slug: 'nba-bos-nyk-2026-07-05',
+      sports_sport_slug: 'basketball',
       sports_parent_event_id: 0,
       series_slug: 'basketball-nba',
       status: 'active' as const,
@@ -177,12 +194,12 @@ describe('home-events', () => {
     }
 
     expect(filterHomeEvents(
-      [firstToScoreEvent, totalCornersEvent, zeroParentEvent, moneylineEvent],
+      [firstToScoreEvent, totalCornersEvent, zeroParentEvent, moneylineEvent, nextMoneylineEvent],
       {
         currentTimestamp: Date.parse('2026-07-05T14:00:00.000Z'),
         status: 'active',
       },
-    )).toEqual([zeroParentEvent, moneylineEvent])
+    )).toEqual([zeroParentEvent, moneylineEvent, nextMoneylineEvent])
   })
 
   it('prefers the current active series event over an overdue unresolved entry', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Ensure primary sports cards always appear on the home page. They no longer get hidden by series grouping that filters out child markets.

- **Bug Fixes**
  - Identify primary sports events (via `sports_event_id`, `sports_event_slug`, `sports_series_slug`, or `sports_sport_slug`) and include them unless marked auxiliary.
  - Skip collapsing primary events into the per-series "newest" selection; always keep them in the results.
  - Expanded unit tests to verify multiple primary events in the same series are shown.

<sup>Written for commit a3d5b536fa12bd5ac83b012d096bef9536266076. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

