### PR TITLE
fix: better ux for wallet signature rejected message

### DIFF
--- a/src/app/[locale]/(platform)/settings/_components/SettingsSdkApiKeysContent.tsx
+++ b/src/app/[locale]/(platform)/settings/_components/SettingsSdkApiKeysContent.tsx
@@ -48,7 +48,11 @@ import {
   TRADING_AUTH_PRIMARY_TYPE,
   TRADING_AUTH_TYPES,
 } from '@/lib/trading-auth/client'
-import { isUserRejectedRequestError, normalizeAddress } from '@/lib/wallet'
+import {
+  isUserRejectedRequestError,
+  isWalletRpcRequestAbortedError,
+  normalizeAddress,
+} from '@/lib/wallet'
 
 type SdkKeyOperation = 'generate' | 'revoke'
 
@@ -155,6 +159,9 @@ export default function SettingsSdkApiKeysContent() {
       if (isUserRejectedRequestError(caughtError)) {
         toast.error(t('Signature was rejected in your wallet.'))
       }
+      else if (isWalletRpcRequestAbortedError(caughtError)) {
+        toast.error(t('Unable to manage SDK key. Please try again.'))
+      }
       else {
         toast.error(caughtError instanceof Error ? caughtError.message : t('Unable to manage SDK key. Please try again.'))
       }
@@ -200,6 +207,9 @@ export default function SettingsSdkApiKeysContent() {
     catch (caughtError) {
       if (isUserRejectedRequestError(caughtError)) {
         toast.error(t('Signature was rejected in your wallet.'))
+      }
+      else if (isWalletRpcRequestAbortedError(caughtError)) {
+        toast.error(t('Unable to revoke SDK key. Please try again.'))
       }
       else {
         toast.error(caughtError instanceof Error ? caughtError.message : t('Unable to revoke SDK key. Please try again.'))

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -43,19 +43,22 @@ export function isUserRejectedRequestError(error: unknown): boolean {
     ) {
       return true
     }
-
-    if (
-      normalizedMessage?.includes('request was aborted')
-      && (
-        normalizedMessage.includes('rpc error')
-        || normalizedMessage.includes('viem@')
-      )
-    ) {
-      return true
-    }
   }
 
   return false
+}
+
+export function isWalletRpcRequestAbortedError(error: unknown): boolean {
+  const message = readWalletErrorMessage(error)
+  const normalizedMessage = message?.toLowerCase()
+
+  return Boolean(
+    normalizedMessage?.includes('request was aborted')
+    && (
+      normalizedMessage.includes('rpc error')
+      || normalizedMessage.includes('viem@')
+    ),
+  )
 }
 
 export function isRecoverableWalletConnectorError(error: unknown): boolean {

--- a/src/lib/wallet.ts
+++ b/src/lib/wallet.ts
@@ -10,6 +10,19 @@ const RECOVERABLE_WALLET_CONNECTOR_ERROR_NAMES = new Set([
   'ConnectorUnavailableReconnectingError',
 ])
 
+function readWalletErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message
+  }
+
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    const message = (error as { message?: unknown }).message
+    return typeof message === 'string' ? message : null
+  }
+
+  return null
+}
+
 export function isUserRejectedRequestError(error: unknown): boolean {
   if (error instanceof UserRejectedRequestError) {
     return true
@@ -21,8 +34,23 @@ export function isUserRejectedRequestError(error: unknown): boolean {
       return true
     }
 
-    const message = 'message' in error ? (error as { message?: string }).message : undefined
-    if (typeof message === 'string' && message.toLowerCase().includes('user rejected')) {
+    const message = readWalletErrorMessage(error)
+    const normalizedMessage = message?.toLowerCase()
+    if (
+      normalizedMessage?.includes('user rejected')
+      || normalizedMessage?.includes('user denied')
+      || normalizedMessage?.includes('rejected the request')
+    ) {
+      return true
+    }
+
+    if (
+      normalizedMessage?.includes('request was aborted')
+      && (
+        normalizedMessage.includes('rpc error')
+        || normalizedMessage.includes('viem@')
+      )
+    ) {
       return true
     }
   }

--- a/tests/unit/SettingsSdkApiKeysContent.test.tsx
+++ b/tests/unit/SettingsSdkApiKeysContent.test.tsx
@@ -1,0 +1,94 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import SettingsSdkApiKeysContent from '@/app/[locale]/(platform)/settings/_components/SettingsSdkApiKeysContent'
+
+const mocks = vi.hoisted(() => ({
+  generateSdkApiKeyAction: vi.fn(),
+  getNextSdkApiKeyNonceAction: vi.fn(),
+  openAppKit: vi.fn(),
+  revokeSdkApiKeyAction: vi.fn(),
+  signTypedDataAsync: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+  toastWarning: vi.fn(),
+  useAccount: vi.fn(),
+}))
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (value: string) => value,
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    success: mocks.toastSuccess,
+    warning: mocks.toastWarning,
+  },
+}))
+
+vi.mock('wagmi', () => ({
+  useAccount: () => mocks.useAccount(),
+  useSignTypedData: () => ({
+    signTypedDataAsync: mocks.signTypedDataAsync,
+  }),
+}))
+
+vi.mock('@/app/[locale]/(platform)/settings/_actions/sdk-api-keys', () => ({
+  generateSdkApiKeyAction: (...args: unknown[]) => mocks.generateSdkApiKeyAction(...args),
+  getNextSdkApiKeyNonceAction: (...args: unknown[]) => mocks.getNextSdkApiKeyNonceAction(...args),
+  revokeSdkApiKeyAction: (...args: unknown[]) => mocks.revokeSdkApiKeyAction(...args),
+}))
+
+vi.mock('@/hooks/useAppKit', () => ({
+  useAppKit: () => ({
+    isReady: true,
+    open: mocks.openAppKit,
+  }),
+}))
+
+vi.mock('@/hooks/useIsMobile', () => ({
+  useIsMobile: () => false,
+}))
+
+vi.mock('@/hooks/useSignaturePromptRunner', () => ({
+  useSignaturePromptRunner: () => ({
+    runWithSignaturePrompt: (callback: () => Promise<string>) => callback(),
+  }),
+}))
+
+const USER_ADDRESS = '0x0000000000000000000000000000000000000abc'
+
+describe('settingsSdkApiKeysContent', () => {
+  beforeEach(() => {
+    mocks.generateSdkApiKeyAction.mockReset()
+    mocks.getNextSdkApiKeyNonceAction.mockReset()
+    mocks.openAppKit.mockReset()
+    mocks.revokeSdkApiKeyAction.mockReset()
+    mocks.signTypedDataAsync.mockReset()
+    mocks.toastError.mockReset()
+    mocks.toastSuccess.mockReset()
+    mocks.toastWarning.mockReset()
+    mocks.useAccount.mockReset()
+
+    mocks.useAccount.mockReturnValue({ address: USER_ADDRESS })
+    mocks.getNextSdkApiKeyNonceAction.mockResolvedValue({ error: null, nonce: '0' })
+  })
+
+  it('shows a friendly SDK key error when the wallet RPC request is aborted', async () => {
+    const user = userEvent.setup()
+    mocks.signTypedDataAsync.mockRejectedValueOnce(
+      new Error('An unknown RPC error occurred. Details: Request was aborted Version: viem@2.54.3'),
+    )
+
+    render(<SettingsSdkApiKeysContent />)
+
+    await user.click(screen.getByRole('button', { name: 'Generate key' }))
+
+    await waitFor(() => {
+      expect(mocks.toastError).toHaveBeenCalledWith('Unable to manage SDK key. Please try again.')
+    })
+    expect(mocks.toastError).not.toHaveBeenCalledWith(expect.stringContaining('viem@2.54.3'))
+    expect(mocks.generateSdkApiKeyAction).not.toHaveBeenCalled()
+  })
+})

--- a/tests/unit/wallet.test.ts
+++ b/tests/unit/wallet.test.ts
@@ -29,6 +29,9 @@ describe('wallet', () => {
     it('detects errors by message substring', () => {
       expect(isUserRejectedRequestError({ message: 'User rejected the request' })).toBe(true)
       expect(isUserRejectedRequestError({ message: 'USER REJECTED' })).toBe(true)
+      expect(isUserRejectedRequestError({
+        message: 'An unknown RPC error occurred. Details: Request was aborted Version: viem@2.54.3',
+      })).toBe(true)
     })
 
     it('returns false for unrelated values', () => {
@@ -36,6 +39,7 @@ describe('wallet', () => {
       expect(isUserRejectedRequestError(undefined)).toBe(false)
       expect(isUserRejectedRequestError({ name: 'OtherError' })).toBe(false)
       expect(isUserRejectedRequestError({ message: 'something else' })).toBe(false)
+      expect(isUserRejectedRequestError({ message: 'Request was aborted' })).toBe(false)
     })
   })
 

--- a/tests/unit/wallet.test.ts
+++ b/tests/unit/wallet.test.ts
@@ -11,6 +11,7 @@ vi.mock('viem', () => ({
 const {
   isRecoverableWalletConnectorError,
   isUserRejectedRequestError,
+  isWalletRpcRequestAbortedError,
   isWalletConnectorNotConnectedError,
   normalizeAddress,
   WALLET_CONNECTOR_NOT_CONNECTED_MESSAGE,
@@ -29,9 +30,6 @@ describe('wallet', () => {
     it('detects errors by message substring', () => {
       expect(isUserRejectedRequestError({ message: 'User rejected the request' })).toBe(true)
       expect(isUserRejectedRequestError({ message: 'USER REJECTED' })).toBe(true)
-      expect(isUserRejectedRequestError({
-        message: 'An unknown RPC error occurred. Details: Request was aborted Version: viem@2.54.3',
-      })).toBe(true)
     })
 
     it('returns false for unrelated values', () => {
@@ -40,6 +38,20 @@ describe('wallet', () => {
       expect(isUserRejectedRequestError({ name: 'OtherError' })).toBe(false)
       expect(isUserRejectedRequestError({ message: 'something else' })).toBe(false)
       expect(isUserRejectedRequestError({ message: 'Request was aborted' })).toBe(false)
+      expect(isUserRejectedRequestError({
+        message: 'An unknown RPC error occurred. Details: Request was aborted Version: viem@2.54.3',
+      })).toBe(false)
+    })
+  })
+
+  describe('isWalletRpcRequestAbortedError', () => {
+    it('detects viem RPC aborts without treating every abort as wallet-specific', () => {
+      expect(isWalletRpcRequestAbortedError({
+        message: 'An unknown RPC error occurred. Details: Request was aborted Version: viem@2.54.3',
+      })).toBe(true)
+      expect(isWalletRpcRequestAbortedError(new Error('RPC error: Request was aborted'))).toBe(true)
+      expect(isWalletRpcRequestAbortedError(new Error('Request was aborted'))).toBe(false)
+      expect(isWalletRpcRequestAbortedError({ message: 'User rejected the request' })).toBe(false)
     })
   })
 


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Improves wallet UX by correctly handling signature rejection and RPC aborts in SDK API key flows. Shows a clear rejection message or a friendly retry message, depending on the error.

- **Bug Fixes**
  - Added a helper to safely read error messages from `Error` or plain objects.
  - Expanded user-rejection detection to include “user denied” and “rejected the request”.
  - Added `isWalletRpcRequestAbortedError` to detect “request was aborted” when paired with “rpc error” or `viem@`, and use it in generate/revoke flows to show a generic retry message; added unit tests for these cases.

<sup>Written for commit 1d74a56328bf84a4562ea5e792f0e16cab644bf6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

