### PR TITLE
fix: refine sports market buttons

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import type { CSSProperties } from 'react'
 import type { HomeSportsMoneylineButton, HomeSportsMoneylineModel } from '@/lib/sports-home-card'
 import type { Event } from '@/types'
 import { CheckIcon } from 'lucide-react'
@@ -8,7 +9,7 @@ import EventBookmark from '@/app/[locale]/(platform)/event/[slug]/_components/Ev
 import AppLink from '@/components/AppLink'
 import { Card, CardContent } from '@/components/ui/card'
 import { NewBadge } from '@/components/ui/new-badge'
-import { ensureReadableTextColorOnDark } from '@/lib/color-contrast'
+import { ensureReadableTextColorOnDark, resolveReadableTextColorOnColor } from '@/lib/color-contrast'
 import { shouldShowEventNewBadge } from '@/lib/event-new-badge'
 import { resolveEventOutcomePath } from '@/lib/events-routing'
 import { formatDate, formatVolume } from '@/lib/formatters'
@@ -25,6 +26,8 @@ export interface EventCardSportsMoneylineProps {
 }
 
 const HOME_OUTCOME_BUTTON_HEIGHT_CLASS = 'h-[40px]'
+const HOME_SPORTS_BUTTON_TEXT_VAR = '--home-sports-button-text'
+const HOME_SPORTS_BUTTON_HOVER_TEXT_VAR = '--home-sports-button-hover-text'
 const SPORTS_EVENT_TIME_ZONE = 'America/New_York'
 const SPORTS_EVENT_TIME_ZONE_LABEL = 'ET'
 const SPORTS_EVENT_TIME_FORMATTER = new Intl.DateTimeFormat('en-US', {
@@ -168,9 +171,11 @@ function getButtonToneStyles(button: HomeSportsMoneylineButton) {
 
   if (!button.color) {
     return {
-      className: cn(
-        `${HOME_OUTCOME_BUTTON_HEIGHT_CLASS} flex-1 rounded-sm px-2 text-sm font-semibold text-foreground`,
-      ),
+      className: `
+        ${HOME_OUTCOME_BUTTON_HEIGHT_CLASS}
+        flex-1 rounded-sm px-2 text-sm font-semibold text-foreground
+        hover:text-primary-foreground
+      `,
       style: undefined,
       backgroundClassName: resolveSportsTeamFallbackClassName(button.tone),
       backgroundStyle: undefined,
@@ -178,10 +183,18 @@ function getButtonToneStyles(button: HomeSportsMoneylineButton) {
   }
 
   const textColor = ensureReadableTextColorOnDark(button.color)
+  const hoverTextColor = resolveReadableTextColorOnColor(button.color)
 
   return {
-    className: `${HOME_OUTCOME_BUTTON_HEIGHT_CLASS} flex-1 rounded-sm px-2 text-sm font-semibold`,
-    style: textColor ? { color: textColor } : undefined,
+    className: `
+      ${HOME_OUTCOME_BUTTON_HEIGHT_CLASS} flex-1 rounded-sm px-2 text-sm font-semibold
+      text-[var(--home-sports-button-text)]
+      hover:text-[var(--home-sports-button-hover-text)]
+    `,
+    style: {
+      [HOME_SPORTS_BUTTON_TEXT_VAR]: textColor ?? button.color,
+      [HOME_SPORTS_BUTTON_HOVER_TEXT_VAR]: hoverTextColor,
+    } as CSSProperties,
     backgroundClassName: undefined,
     backgroundStyle: button.color ? { backgroundColor: button.color } : undefined,
   }
@@ -340,7 +353,7 @@ export default function EventCardSportsMoneyline({
                                 active:scale-[97%]
                               `,
                               button.tone === 'draw'
-                                ? 'hover:bg-secondary/80 hover:text-foreground'
+                                ? 'hover:bg-foreground/10 hover:text-foreground dark:hover:bg-background/70'
                                 : 'group/team-button hover:bg-transparent',
                               toneStyles.className,
                             )}
@@ -350,8 +363,7 @@ export default function EventCardSportsMoneyline({
                               ? <span className="relative z-1">{button.label}</span>
                               : (
                                   <span className="relative z-1 truncate">
-                                    <span className="group-hover/team-button:hidden">{button.label}</span>
-                                    <span className="hidden text-foreground group-hover/team-button:inline">{button.label}</span>
+                                    {button.label}
                                   </span>
                                 )}
                             {(toneStyles.backgroundClassName || toneStyles.backgroundStyle)
@@ -359,10 +371,8 @@ export default function EventCardSportsMoneyline({
                                   <span
                                     className={cn(
                                       `
-                                        absolute inset-0 z-0 rounded-sm opacity-20 transition-opacity
-                                        group-hover/team-button:opacity-40
-                                        dark:opacity-30
-                                        dark:group-hover/team-button:opacity-50
+                                        absolute inset-0 z-0 rounded-sm opacity-[0.15] transition-opacity
+                                        group-hover/team-button:opacity-100
                                       `,
                                       toneStyles.backgroundClassName,
                                     )}

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -1168,8 +1168,15 @@ function SportsScoreboard({
   item: HomeFeaturedEventCard
   linkedHref: string
 }) {
-  const teams = item.event.sports_teams ?? []
-  const logos = item.event.sports_team_logo_urls ?? []
+  const teams = card?.teams.length
+    ? card.teams.map(team => ({
+        name: team.name,
+        logoUrl: team.logoUrl,
+      }))
+    : (item.event.sports_teams ?? []).map((team, index) => ({
+        name: team.name,
+        logoUrl: team.logo_url ?? item.event.sports_team_logo_urls?.[index] ?? null,
+      }))
   const score = item.event.sports_score?.trim()
   const liveMeta = [item.event.sports_period, item.event.sports_elapsed].filter(Boolean).join(' · ')
   if (item.kind !== 'sports' || teams.length < 2) {
@@ -1177,7 +1184,8 @@ function SportsScoreboard({
   }
 
   const [homeTeam, awayTeam] = teams
-  const [homeLogo, awayLogo] = logos
+  const homeLogo = homeTeam?.logoUrl ?? null
+  const awayLogo = awayTeam?.logoUrl ?? null
   const homeButton = card?.buttons.find(button => button.marketType === 'moneyline' && button.tone === 'team1') ?? null
   const awayButton = card?.buttons.find(button => button.marketType === 'moneyline' && button.tone === 'team2') ?? null
   const homeHref = card && homeButton ? resolveFeaturedSportsButtonHref(card, homeButton, linkedHref) : null

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -40,7 +40,7 @@ import SiteLogoIcon from '@/components/SiteLogoIcon'
 import { Button } from '@/components/ui/button'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
-import { ensureReadableTextColorOnDark } from '@/lib/color-contrast'
+import { ensureReadableTextColorOnDark, resolveReadableTextColorOnColor } from '@/lib/color-contrast'
 import { resolveEventOutcomePath, resolveEventPagePath } from '@/lib/events-routing'
 import { formatDollarValueLabel, formatVolume } from '@/lib/formatters'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
@@ -56,6 +56,8 @@ interface HomeFeaturedEventsCarouselProps {
 const HOME_FEATURED_CHART_HEIGHT = 292
 const HOME_FEATURED_CHART_HEIGHT_OFFSET = 20
 const HOME_FEATURED_LIVE_CHART_WIDTH_OFFSET = 24
+const FEATURED_SPORTS_BUTTON_TEXT_VAR = '--featured-sports-button-text'
+const FEATURED_SPORTS_BUTTON_HOVER_TEXT_VAR = '--featured-sports-button-hover-text'
 type FeaturedSportsButtonTone = 'home' | 'away' | 'draw' | 'neutral'
 interface FeaturedSportsButtonMarket {
   key: string
@@ -180,7 +182,7 @@ function resolveSportsButtonAppearance(market: FeaturedSportsButtonMarket) {
     const normalizedLabel = normalizeText(market.label)
     if (normalizedLabel.startsWith('u ') || normalizedLabel.includes(' under')) {
       return {
-        className: 'group/team-button text-no hover:bg-transparent',
+        className: 'group/team-button text-no hover:bg-transparent hover:text-white',
         style: undefined,
         backgroundClassName: 'bg-no',
         backgroundStyle: undefined,
@@ -188,32 +190,36 @@ function resolveSportsButtonAppearance(market: FeaturedSportsButtonMarket) {
     }
     if (normalizedLabel.startsWith('o ') || normalizedLabel.includes(' over')) {
       return {
-        className: 'group/team-button text-yes hover:bg-transparent',
+        className: 'group/team-button text-yes hover:bg-transparent hover:text-white',
         style: undefined,
         backgroundClassName: 'bg-yes',
         backgroundStyle: undefined,
       }
     }
 
-    return {
-      ...resolveNeutralSportsButtonAppearance(),
-      className: 'border border-button-outline-border bg-transparent text-muted-foreground hover:bg-secondary/80 hover:text-foreground',
-    }
+    return resolveNeutralSportsButtonAppearance()
   }
 
   if (market.color) {
     const textColor = ensureReadableTextColorOnDark(market.color)
+    const hoverTextColor = resolveReadableTextColorOnColor(market.color)
 
     return {
-      className: 'group/team-button hover:bg-transparent',
-      style: textColor ? { color: textColor } : undefined,
+      className: `
+        group/team-button text-[var(--featured-sports-button-text)]
+        hover:bg-transparent hover:text-[var(--featured-sports-button-hover-text)]
+      `,
+      style: {
+        [FEATURED_SPORTS_BUTTON_TEXT_VAR]: textColor ?? market.color,
+        [FEATURED_SPORTS_BUTTON_HOVER_TEXT_VAR]: hoverTextColor,
+      } as CSSProperties,
       backgroundClassName: undefined,
       backgroundStyle: { backgroundColor: market.color },
     }
   }
 
   return {
-    className: 'group/team-button text-foreground hover:bg-transparent',
+    className: 'group/team-button text-foreground hover:bg-transparent hover:text-primary-foreground',
     style: undefined,
     backgroundClassName: resolveSportsTeamFallbackClassName(market.tone === 'home' ? 'team1' : 'team2'),
     backgroundStyle: undefined,
@@ -494,14 +500,12 @@ function SportsMarketButton({
   href,
   className,
   forceNeutral = false,
-  underlineOnHover = false,
 }: {
   groupLabel: string
   market: FeaturedSportsButtonMarket
   href: string
   className?: string
   forceNeutral?: boolean
-  underlineOnHover?: boolean
 }) {
   const appearance = forceNeutral ? resolveFilledNeutralSportsButtonAppearance() : resolveSportsButtonAppearance(market)
 
@@ -521,24 +525,14 @@ function SportsMarketButton({
       )}
       style={appearance.style}
     >
-      <span
-        className={cn(
-          'relative z-1 truncate',
-          underlineOnHover && 'decoration-2 group-hover/sports-market-button:underline',
-        )}
-      >
+      <span className={cn('relative z-1', market.tone === 'draw' ? 'whitespace-nowrap' : 'truncate')}>
         {market.label}
       </span>
       {(appearance.backgroundClassName || appearance.backgroundStyle)
         ? (
             <span
               className={cn(
-                `
-                  absolute inset-0 z-0 rounded-lg opacity-20 transition-opacity
-                  group-hover/team-button:opacity-40
-                  dark:opacity-30
-                  dark:group-hover/team-button:opacity-50
-                `,
+                'absolute inset-0 z-0 rounded-lg opacity-[0.15] transition-opacity group-hover/team-button:opacity-100',
                 appearance.backgroundClassName,
               )}
               style={appearance.backgroundStyle}
@@ -581,23 +575,28 @@ function SportsMoneylineButtons({
   }
 
   return (
-    <div
-      className="grid gap-2"
-      style={{ gridTemplateColumns: `repeat(${Math.min(moneylineButtons.length, 3)}, minmax(0, 1fr))` }}
-    >
-      {moneylineButtons.slice(0, 3).map(button => (
-        <SportsMarketButton
-          key={button.key}
-          groupLabel="Moneyline"
-          market={toFeaturedSportsButtonMarket(
-            button,
-            resolveMoneylineButtonLabel(card, button),
-          )}
-          href={resolveFeaturedSportsButtonHref(card, button, linkedHref)}
-          className="h-14 text-sm md:text-base"
-          underlineOnHover
-        />
-      ))}
+    <div className="flex items-center gap-2">
+      {moneylineButtons.slice(0, 3).map((button) => {
+        const isDraw = button.tone === 'draw'
+
+        return (
+          <SportsMarketButton
+            key={button.key}
+            groupLabel="Moneyline"
+            market={toFeaturedSportsButtonMarket(
+              button,
+              isDraw ? 'DRAW' : resolveMoneylineButtonLabel(card, button),
+            )}
+            href={resolveFeaturedSportsButtonHref(card, button, linkedHref)}
+            className={cn(
+              'h-14',
+              isDraw
+                ? 'mx-1 w-20 shrink-0 px-3 text-sm tracking-wide'
+                : 'min-w-0 flex-1 text-sm md:text-base',
+            )}
+          />
+        )
+      })}
     </div>
   )
 }
@@ -1160,7 +1159,15 @@ function ContextTicker({
   )
 }
 
-function SportsScoreboard({ item }: { item: HomeFeaturedEventCard }) {
+function SportsScoreboard({
+  card,
+  item,
+  linkedHref,
+}: {
+  card: SportsGamesCard | null
+  item: HomeFeaturedEventCard
+  linkedHref: string
+}) {
   const teams = item.event.sports_teams ?? []
   const logos = item.event.sports_team_logo_urls ?? []
   const score = item.event.sports_score?.trim()
@@ -1171,6 +1178,11 @@ function SportsScoreboard({ item }: { item: HomeFeaturedEventCard }) {
 
   const [homeTeam, awayTeam] = teams
   const [homeLogo, awayLogo] = logos
+  const homeButton = card?.buttons.find(button => button.marketType === 'moneyline' && button.tone === 'team1') ?? null
+  const awayButton = card?.buttons.find(button => button.marketType === 'moneyline' && button.tone === 'team2') ?? null
+  const homeHref = card && homeButton ? resolveFeaturedSportsButtonHref(card, homeButton, linkedHref) : null
+  const awayHref = card && awayButton ? resolveFeaturedSportsButtonHref(card, awayButton, linkedHref) : null
+  const teamNameClassName = 'inline-block max-w-full truncate text-sm font-medium underline-offset-2 hover:underline'
 
   return (
     <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 rounded-lg bg-secondary/60 p-3">
@@ -1183,7 +1195,13 @@ function SportsScoreboard({ item }: { item: HomeFeaturedEventCard }) {
             containerClassName="mx-auto mb-1 size-9 rounded-md"
           />
         )}
-        <p className="truncate text-sm font-medium">{homeTeam?.name}</p>
+        {homeHref
+          ? (
+              <AppLink intentPrefetch href={homeHref} className={teamNameClassName}>
+                {homeTeam?.name}
+              </AppLink>
+            )
+          : <p className="truncate text-sm font-medium">{homeTeam?.name}</p>}
       </div>
       <div className="text-center">
         <p className="text-3xl font-semibold tabular-nums">{score || '0 - 0'}</p>
@@ -1207,7 +1225,13 @@ function SportsScoreboard({ item }: { item: HomeFeaturedEventCard }) {
             containerClassName="mx-auto mb-1 size-9 rounded-md"
           />
         )}
-        <p className="truncate text-sm font-medium">{awayTeam?.name}</p>
+        {awayHref
+          ? (
+              <AppLink intentPrefetch href={awayHref} className={teamNameClassName}>
+                {awayTeam?.name}
+              </AppLink>
+            )
+          : <p className="truncate text-sm font-medium">{awayTeam?.name}</p>}
       </div>
     </div>
   )
@@ -1500,7 +1524,7 @@ function FeaturedSlide({
   const chartColumnNode = item.kind === 'sports'
     ? (
         <div className="grid min-h-0 content-start gap-3">
-          <SportsScoreboard item={item} />
+          <SportsScoreboard card={sportsGraphCard} item={item} linkedHref={linkedHref} />
           {chartNode}
         </div>
       )

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -415,6 +415,7 @@ function OutcomeRows({
   linkedHref: string
 }) {
   const outcomes = item.topOutcomes
+  const shouldShowOutcomeImages = item.event.show_market_icons !== false
 
   if (outcomes.length === 0) {
     return null
@@ -433,7 +434,7 @@ function OutcomeRows({
           `}
         >
           <span className="flex min-w-0 items-center gap-3">
-            {outcome.imageUrl && (
+            {shouldShowOutcomeImages && outcome.imageUrl && (
               <span className="size-9 shrink-0 overflow-hidden rounded-md bg-muted">
                 <EventIconImage
                   src={outcome.imageUrl}

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -229,8 +229,8 @@ function normalizeAuxiliaryPanelText(value: string | null | undefined) {
     ?? ''
 }
 
-function isFirstToScorePanel(entry: AuxiliaryMarketPanel) {
-  const normalizedText = normalizeAuxiliaryPanelText([
+function resolveAuxiliaryPanelSearchText(entry: AuxiliaryMarketPanel) {
+  return normalizeAuxiliaryPanelText([
     entry.title,
     ...entry.markets.flatMap(market => [
       market.sports_market_type,
@@ -239,31 +239,20 @@ function isFirstToScorePanel(entry: AuxiliaryMarketPanel) {
       market.title,
     ]),
   ].filter(Boolean).join(' '))
+}
+
+function isFirstToScorePanel(entry: AuxiliaryMarketPanel) {
+  const normalizedText = resolveAuxiliaryPanelSearchText(entry)
 
   return /\bfirst (?:team )?to score\b/.test(normalizedText)
     || /\b(?:team )?to score first\b/.test(normalizedText)
 }
 
 function isHalftimeResultPanel(entry: AuxiliaryMarketPanel) {
-  const normalizedText = normalizeAuxiliaryPanelText([
-    entry.title,
-    ...entry.markets.flatMap(market => [
-      market.sports_market_type,
-      market.sports_group_item_title,
-      market.short_title,
-      market.title,
-    ]),
-  ].filter(Boolean).join(' '))
+  const normalizedText = resolveAuxiliaryPanelSearchText(entry)
 
-  return normalizedText.includes('halftime result')
-    || normalizedText.includes('first half result')
-    || normalizedText.includes('second half result')
-    || normalizedText.includes('1st half result')
-    || normalizedText.includes('2nd half result')
-    || normalizedText.includes('first half moneyline')
-    || normalizedText.includes('second half moneyline')
-    || /\b1h moneyline\b/.test(normalizedText)
-    || /\b2h moneyline\b/.test(normalizedText)
+  return /\b(?:half\s*time|first\s+half|1st\s+half|1h|second\s+half|2nd\s+half|2h)\s+(?:result|moneyline)\b/
+    .test(normalizedText)
 }
 
 function areLineValuesEqual(left: number, right: number) {
@@ -300,18 +289,7 @@ function resolveAuxiliaryDefaultButton(buttons: SportsGamesButton[]) {
 }
 
 function resolveHalvesPanelGroup(entry: AuxiliaryMarketPanel) {
-  const marketText = entry.markets
-    .map(market => [
-      market.sports_market_type,
-      market.sports_group_item_title,
-      market.short_title,
-      market.title,
-    ].filter(Boolean).join(' '))
-    .join(' ')
-  const normalizedText = normalizeAuxiliaryPanelText([
-    entry.title,
-    marketText,
-  ].join(' '))
+  const normalizedText = resolveAuxiliaryPanelSearchText(entry)
 
   if (
     normalizedText.includes('second half')
@@ -1679,7 +1657,7 @@ export default function SportsEventCenter({
       )
     : (
         <div key={activeMarketView?.key ?? 'gameLines'} className="space-y-4">
-          {auxiliaryMarketPanels}
+          {nonSectionAuxiliaryMarketPanels}
         </div>
       )
 

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -241,6 +241,7 @@ function isFirstToScorePanel(entry: AuxiliaryMarketPanel) {
   ].filter(Boolean).join(' '))
 
   return /\bfirst (?:team )?to score\b/.test(normalizedText)
+    || /\b(?:team )?to score first\b/.test(normalizedText)
 }
 
 function areLineValuesEqual(left: number, right: number) {

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -244,6 +244,28 @@ function isFirstToScorePanel(entry: AuxiliaryMarketPanel) {
     || /\b(?:team )?to score first\b/.test(normalizedText)
 }
 
+function isHalftimeResultPanel(entry: AuxiliaryMarketPanel) {
+  const normalizedText = normalizeAuxiliaryPanelText([
+    entry.title,
+    ...entry.markets.flatMap(market => [
+      market.sports_market_type,
+      market.sports_group_item_title,
+      market.short_title,
+      market.title,
+    ]),
+  ].filter(Boolean).join(' '))
+
+  return normalizedText.includes('halftime result')
+    || normalizedText.includes('first half result')
+    || normalizedText.includes('second half result')
+    || normalizedText.includes('1st half result')
+    || normalizedText.includes('2nd half result')
+    || normalizedText.includes('first half moneyline')
+    || normalizedText.includes('second half moneyline')
+    || /\b1h moneyline\b/.test(normalizedText)
+    || /\b2h moneyline\b/.test(normalizedText)
+}
+
 function areLineValuesEqual(left: number, right: number) {
   return Math.abs(left - right) < 0.0001
 }
@@ -278,7 +300,7 @@ function resolveAuxiliaryDefaultButton(buttons: SportsGamesButton[]) {
 }
 
 function resolveHalvesPanelGroup(entry: AuxiliaryMarketPanel) {
-  const normalizedText = entry.markets
+  const marketText = entry.markets
     .map(market => [
       market.sports_market_type,
       market.sports_group_item_title,
@@ -286,12 +308,15 @@ function resolveHalvesPanelGroup(entry: AuxiliaryMarketPanel) {
       market.title,
     ].filter(Boolean).join(' '))
     .join(' ')
-    .toLowerCase()
+  const normalizedText = normalizeAuxiliaryPanelText([
+    entry.title,
+    marketText,
+  ].join(' '))
 
   if (
-    normalizedText.includes('second_half')
-    || normalizedText.includes('second half')
+    normalizedText.includes('second half')
     || normalizedText.includes('2nd half')
+    || /\b2h\b/.test(normalizedText)
   ) {
     return '2nd Half'
   }
@@ -299,9 +324,9 @@ function resolveHalvesPanelGroup(entry: AuxiliaryMarketPanel) {
   if (
     normalizedText.includes('halftime')
     || normalizedText.includes('half time')
-    || normalizedText.includes('first_half')
     || normalizedText.includes('first half')
     || normalizedText.includes('1st half')
+    || /\b1h\b/.test(normalizedText)
   ) {
     return '1st Half'
   }
@@ -804,10 +829,13 @@ export default function SportsEventCenter({
     const playerPropViewKey = resolvePlayerPropPanelViewKey(entry)
     const isPlayerPropPanel = playerPropViewKey !== null
     const isFirstToScore = isFirstToScorePanel(entry)
+    const isHalftimeResult = isHalftimeResultPanel(entry)
     const playerPropLineOptions = isPlayerPropPanel ? resolvePlayerPropLineOptions(entry) : []
-    const auxiliaryLineOptions = !isPlayerPropPanel && !isFirstToScore ? resolveAuxiliaryLineOptions(entry) : []
+    const auxiliaryLineOptions = !isPlayerPropPanel && !isFirstToScore && !isHalftimeResult
+      ? resolveAuxiliaryLineOptions(entry)
+      : []
     const linePickerOptions = isPlayerPropPanel ? playerPropLineOptions : auxiliaryLineOptions
-    const usesLinePicker = !isFirstToScore && linePickerOptions.length > 1
+    const usesLinePicker = !isFirstToScore && !isHalftimeResult && linePickerOptions.length > 1
     const selectedAuxiliaryMarket = (isPlayerPropPanel || usesLinePicker)
       ? resolvePlayerPropSelectedMarket(entry, selectedButtonKey)
       : null

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -51,7 +51,6 @@ import {
   parseSportsScore,
   resolveMoneylineButtonGridClass,
   resolveTeamShortLabel,
-  shouldUseFullScoreboardHeroLabels,
   sortSectionButtons,
 } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-utils'
 import SportsEventAboutPanel from '@/app/[locale]/(platform)/sports/_components/SportsEventAboutPanel'
@@ -218,6 +217,30 @@ function resolvePlayerPropLineOptions(entry: AuxiliaryMarketPanel) {
       })
       return options
     }, [])
+}
+
+function normalizeAuxiliaryPanelText(value: string | null | undefined) {
+  return value
+    ?.normalize('NFKD')
+    .replace(/[\u0300-\u036F]/g, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+    ?? ''
+}
+
+function isFirstToScorePanel(entry: AuxiliaryMarketPanel) {
+  const normalizedText = normalizeAuxiliaryPanelText([
+    entry.title,
+    ...entry.markets.flatMap(market => [
+      market.sports_market_type,
+      market.sports_group_item_title,
+      market.short_title,
+      market.title,
+    ]),
+  ].filter(Boolean).join(' '))
+
+  return /\bfirst (?:team )?to score\b/.test(normalizedText)
 }
 
 function areLineValuesEqual(left: number, right: number) {
@@ -677,12 +700,8 @@ export default function SportsEventCenter({
 
   const team1 = heroCard.teams[0] ?? null
   const team2 = heroCard.teams[1] ?? null
-  const useFullCompetitorHeroLabels = shouldUseFullScoreboardHeroLabels({
-    sportSlug: heroCard.event.sports_sport_slug ?? sportSlug,
-    vertical,
-  })
-  const heroTeam1Label = useFullCompetitorHeroLabels ? (team1?.name ?? '—') : (team1?.abbreviation ?? '—')
-  const heroTeam2Label = useFullCompetitorHeroLabels ? (team2?.name ?? '—') : (team2?.abbreviation ?? '—')
+  const heroTeam1Label = team1?.name ?? team1?.abbreviation ?? '—'
+  const heroTeam2Label = team2?.name ?? team2?.abbreviation ?? '—'
   const useCroppedHeroTeamLogo = shouldUseCroppedSportsTeamLogo(heroCard.event.sports_sport_slug ?? sportSlug)
   const shortTeam1Label = resolveTeamShortLabel(team1)
   const shortTeam2Label = resolveTeamShortLabel(team2)
@@ -783,10 +802,11 @@ export default function SportsEventCenter({
     const selectedButtonKey = selectedAuxiliaryButtonByConditionId[panelKey] ?? entry.buttons[0]?.key ?? null
     const playerPropViewKey = resolvePlayerPropPanelViewKey(entry)
     const isPlayerPropPanel = playerPropViewKey !== null
+    const isFirstToScore = isFirstToScorePanel(entry)
     const playerPropLineOptions = isPlayerPropPanel ? resolvePlayerPropLineOptions(entry) : []
-    const auxiliaryLineOptions = !isPlayerPropPanel ? resolveAuxiliaryLineOptions(entry) : []
+    const auxiliaryLineOptions = !isPlayerPropPanel && !isFirstToScore ? resolveAuxiliaryLineOptions(entry) : []
     const linePickerOptions = isPlayerPropPanel ? playerPropLineOptions : auxiliaryLineOptions
-    const usesLinePicker = linePickerOptions.length > 1
+    const usesLinePicker = !isFirstToScore && linePickerOptions.length > 1
     const selectedAuxiliaryMarket = (isPlayerPropPanel || usesLinePicker)
       ? resolvePlayerPropSelectedMarket(entry, selectedButtonKey)
       : null
@@ -1739,7 +1759,7 @@ export default function SportsEventCenter({
           )}
 
           <div className="mb-4 flex items-center justify-center gap-12 md:gap-14">
-            <div className={cn('flex flex-col items-center gap-2', useFullCompetitorHeroLabels ? 'w-24 sm:w-28' : 'w-20')}>
+            <div className="flex w-24 flex-col items-center gap-2 sm:w-28">
               <div
                 className={cn(
                   'pointer-events-none flex items-center justify-center select-none',
@@ -1786,12 +1806,7 @@ export default function SportsEventCenter({
                     )}
               </div>
               <span
-                className={cn(
-                  'text-center font-semibold text-foreground',
-                  useFullCompetitorHeroLabels
-                    ? 'max-w-full text-xs/tight sm:text-sm'
-                    : 'text-base uppercase',
-                )}
+                className="max-w-full text-center text-xs/tight font-semibold text-foreground sm:text-sm"
               >
                 {heroTeam1Label}
               </span>
@@ -1841,7 +1856,7 @@ export default function SportsEventCenter({
                   </div>
                 )}
 
-            <div className={cn('flex flex-col items-center gap-2', useFullCompetitorHeroLabels ? 'w-24 sm:w-28' : 'w-20')}>
+            <div className="flex w-24 flex-col items-center gap-2 sm:w-28">
               <div
                 className={cn(
                   'pointer-events-none flex items-center justify-center select-none',
@@ -1888,12 +1903,7 @@ export default function SportsEventCenter({
                     )}
               </div>
               <span
-                className={cn(
-                  'text-center font-semibold text-foreground',
-                  useFullCompetitorHeroLabels
-                    ? 'max-w-full text-xs/tight sm:text-sm'
-                    : 'text-base uppercase',
-                )}
+                className="max-w-full text-center text-xs/tight font-semibold text-foreground sm:text-sm"
               >
                 {heroTeam2Label}
               </span>

--- a/src/app/[locale]/(platform)/sports/_components/SportsGamesCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsGamesCenter.tsx
@@ -439,6 +439,7 @@ export default function SportsGamesCenter({
     const isSpreadOrTotalSelected = selectedButton?.marketType === 'spread' || selectedButton?.marketType === 'total'
     const isFinalizedCard = card.event.sports_ended === true
     const parsedFinalScore = parseSportsScore(card.event.sports_score)
+    const shouldShowLiveScore = options.topBadgeMode === 'live' && !isFinalizedCard && parsedFinalScore !== null
     const teamScores = [
       parsedFinalScore?.team1 ?? null,
       parsedFinalScore?.team2 ?? null,
@@ -718,6 +719,17 @@ export default function SportsGamesCenter({
                     key={`${card.id}-${team.abbreviation}-${team.name}`}
                     className={cn('flex items-center', vertical === 'esports' ? 'gap-2.5' : 'gap-2')}
                   >
+                    {shouldShowLiveScore && (
+                      <span
+                        className={cn(`
+                          inline-flex h-6 min-w-6 shrink-0 items-center justify-center rounded-lg bg-secondary/80 px-1.5
+                          text-sm font-bold text-foreground tabular-nums
+                        `)}
+                      >
+                        {teamScore ?? '—'}
+                      </span>
+                    )}
+
                     <div
                       className={cn(
                         useCroppedTeamLogo

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
@@ -166,7 +166,19 @@ function BttsBadge({ button }: { button: SportsGamesButton }) {
   )
 }
 
-function shouldUseTotalStyleBadge(market: Market | null | undefined) {
+function shouldUseTotalStyleBadge(
+  market: Market | null | undefined,
+  button: SportsGamesButton,
+  marketType: SportsGamesMarketType,
+) {
+  if (marketType === 'total') {
+    return true
+  }
+
+  if (button.tone !== 'over' && button.tone !== 'under') {
+    return false
+  }
+
   const normalizedText = normalizeComparableText([
     market?.sports_market_type,
     market?.sports_group_item_title,
@@ -247,10 +259,10 @@ export default function SportsOrderPanelMarketInfo({
   })
   const selectedLabelAccent = resolveSelectedLabelAccent(selectedButton)
   const isExactScoreTrade = normalizeComparableText(selectedMarket?.sports_market_type).includes('exact score')
-  const usesTotalStyleBadge = shouldUseTotalStyleBadge(selectedMarket)
+  const usesTotalStyleBadge = shouldUseTotalStyleBadge(selectedMarket, selectedButton, marketType)
   let marketIcon: React.ReactNode = null
   if (!isExactScoreTrade) {
-    if (marketType === 'total' || usesTotalStyleBadge) {
+    if (usesTotalStyleBadge) {
       marketIcon = <TotalBadge button={selectedButton} />
     }
     else if (marketType === 'btts') {

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
@@ -1,10 +1,12 @@
 'use client'
 
+import type { CSSProperties } from 'react'
 import type { SportsGamesMarketType } from './sports-games-center-types'
 import type { SportsGamesButton, SportsGamesCard } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 import type { Outcome } from '@/types'
 import { EqualIcon } from 'lucide-react'
 import Image from 'next/image'
+import { resolveSportsTeamFallbackColor } from '@/lib/sports-team-colors'
 import { shouldUseCroppedSportsTeamLogo } from '@/lib/sports-team-logo'
 import { cn } from '@/lib/utils'
 import {
@@ -164,6 +166,47 @@ function BttsBadge({ button }: { button: SportsGamesButton }) {
   )
 }
 
+function resolveSelectedLabelAccent(button: SportsGamesButton) {
+  const badgeAccent = resolveTradeHeaderBadgeAccent(button)
+
+  if ((button.tone === 'team1' || button.tone === 'team2') && badgeAccent.style?.color) {
+    return {
+      className: 'dark:mix-blend-plus-lighter',
+      style: {
+        color: badgeAccent.style.color,
+      } as CSSProperties,
+    }
+  }
+
+  if (button.tone === 'team1' || button.tone === 'team2') {
+    return {
+      className: 'dark:mix-blend-plus-lighter',
+      style: {
+        color: resolveSportsTeamFallbackColor(button.tone),
+      } as CSSProperties,
+    }
+  }
+
+  if (button.tone === 'over') {
+    return {
+      className: 'text-yes',
+      style: undefined,
+    }
+  }
+
+  if (button.tone === 'under') {
+    return {
+      className: 'text-no',
+      style: undefined,
+    }
+  }
+
+  return {
+    className: 'text-muted-foreground',
+    style: undefined,
+  }
+}
+
 export default function SportsOrderPanelMarketInfo({
   card,
   selectedButton,
@@ -183,7 +226,7 @@ export default function SportsOrderPanelMarketInfo({
     selectedMarket,
     marketType,
   })
-  const badgeAccent = resolveTradeHeaderBadgeAccent(selectedButton)
+  const selectedLabelAccent = resolveSelectedLabelAccent(selectedButton)
   const isExactScoreTrade = normalizeComparableText(selectedMarket?.sports_market_type).includes('exact score')
   let marketIcon: React.ReactNode = null
   if (!isExactScoreTrade) {
@@ -211,15 +254,15 @@ export default function SportsOrderPanelMarketInfo({
         )}
 
         <div className="min-w-0">
-          <p className="line-clamp-2 text-base/tight font-bold text-foreground">
+          <p className="line-clamp-2 text-sm/tight font-medium text-muted-foreground">
             {headerTitle}
           </p>
           <span
             className={cn(
-              'mt-1.5 inline-flex items-center rounded-sm px-2.5 py-1 text-xs font-semibold',
-              badgeAccent.className,
+              'mt-1 block text-base/tight font-semibold',
+              selectedLabelAccent.className,
             )}
-            style={badgeAccent.style}
+            style={selectedLabelAccent.style}
           >
             {badgeLabel}
           </span>

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
@@ -3,7 +3,7 @@
 import type { CSSProperties } from 'react'
 import type { SportsGamesMarketType } from './sports-games-center-types'
 import type { SportsGamesButton, SportsGamesCard } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
-import type { Outcome } from '@/types'
+import type { Market, Outcome } from '@/types'
 import { EqualIcon } from 'lucide-react'
 import Image from 'next/image'
 import { resolveSportsTeamFallbackColor } from '@/lib/sports-team-colors'
@@ -166,6 +166,18 @@ function BttsBadge({ button }: { button: SportsGamesButton }) {
   )
 }
 
+function shouldUseTotalStyleBadge(market: Market | null | undefined) {
+  const normalizedText = normalizeComparableText([
+    market?.sports_market_type,
+    market?.sports_group_item_title,
+    market?.short_title,
+    market?.title,
+  ].filter(Boolean).join(' '))
+
+  return normalizedText.includes('penalty shootout')
+    || normalizedText.includes('extra time')
+}
+
 function resolveSelectedLabelAccent(button: SportsGamesButton) {
   const badgeAccent = resolveTradeHeaderBadgeAccent(button)
 
@@ -201,6 +213,13 @@ function resolveSelectedLabelAccent(button: SportsGamesButton) {
     }
   }
 
+  if (button.tone === 'draw') {
+    return {
+      className: 'text-foreground',
+      style: undefined,
+    }
+  }
+
   return {
     className: 'text-muted-foreground',
     style: undefined,
@@ -228,9 +247,10 @@ export default function SportsOrderPanelMarketInfo({
   })
   const selectedLabelAccent = resolveSelectedLabelAccent(selectedButton)
   const isExactScoreTrade = normalizeComparableText(selectedMarket?.sports_market_type).includes('exact score')
+  const usesTotalStyleBadge = shouldUseTotalStyleBadge(selectedMarket)
   let marketIcon: React.ReactNode = null
   if (!isExactScoreTrade) {
-    if (marketType === 'total') {
+    if (marketType === 'total' || usesTotalStyleBadge) {
       marketIcon = <TotalBadge button={selectedButton} />
     }
     else if (marketType === 'btts') {

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
@@ -812,6 +812,37 @@ function resolveTotalButtonLabel(button: SportsGamesButton, selectedOutcome: Out
   return line ? `${sideLabel} ${line}` : sideLabel
 }
 
+function extractButtonLineSuffix(label: string) {
+  const normalizedLabel = label.replace(/\u2212/g, '-')
+  const signedMatch = normalizedLabel.match(/([+-])\s*(\d+(?:\.\d+)?)/)
+  if (signedMatch?.[1] && signedMatch[2]) {
+    return `${signedMatch[1]}${signedMatch[2]}`
+  }
+
+  const unsignedMatches = Array.from(normalizedLabel.matchAll(/(?:^|\s)(\d+(?:\.\d+)?)(?=\s|$)/g))
+  return unsignedMatches.at(-1)?.[1] ?? null
+}
+
+function resolveTeamButtonTradeLabel(card: SportsGamesCard, button: SportsGamesButton) {
+  if (button.tone !== 'team1' && button.tone !== 'team2') {
+    return null
+  }
+
+  const team = button.marketType === 'spread'
+    ? resolveLeadingSpreadTeam(card, button)
+    : resolveTeamByTone(card, button.tone)
+  const teamName = team?.name?.trim()
+  if (!teamName) {
+    return null
+  }
+
+  const lineSuffix = button.marketType === 'spread'
+    ? extractButtonLineSuffix(button.label)
+    : null
+
+  return lineSuffix ? `${teamName} ${lineSuffix}` : teamName
+}
+
 export function resolveSelectedTradeLabel(
   card: SportsGamesCard,
   button: SportsGamesButton | null,
@@ -829,11 +860,9 @@ export function resolveSelectedTradeLabel(
     return normalizeComparableText(button.label).includes('neither') ? 'Neither' : 'Draw'
   }
 
-  if (button.marketType === 'moneyline' && (button.tone === 'team1' || button.tone === 'team2')) {
-    const teamName = resolveTeamByTone(card, button.tone)?.name?.trim()
-    if (teamName) {
-      return teamName
-    }
+  const teamLabel = resolveTeamButtonTradeLabel(card, button)
+  if (teamLabel) {
+    return teamLabel
   }
 
   return button.label.trim().toUpperCase()
@@ -1251,12 +1280,6 @@ function shouldUseFranchiseTradeHeaderTeamLabels(sportSlugs: string[]) {
   return sportSlugs.some(slug => COMPACT_FRANCHISE_TRADE_HEADER_SPORT_SLUGS.has(slug))
 }
 
-function hasDrawMoneylineOption(card: SportsGamesCard) {
-  return card.buttons.some(button =>
-    button.marketType === 'moneyline' && button.tone === 'draw',
-  )
-}
-
 function resolveCompactTradeHeaderTitle(
   card: SportsGamesCard,
   resolveTeamLabel: (
@@ -1278,10 +1301,6 @@ function resolveCompactTradeHeaderTitle(
 
 function shouldUseCompactTradeHeaderTitle(card: SportsGamesCard, vertical: SportsVertical | null) {
   if (vertical === 'esports') {
-    return true
-  }
-
-  if (hasDrawMoneylineOption(card)) {
     return true
   }
 
@@ -1351,10 +1370,6 @@ export function resolveTradeHeaderTitle({
   const team2 = card.teams[1] ?? null
   const fullMatchupTitle = [team1?.name?.trim(), team2?.name?.trim()].filter(Boolean).join(' vs ')
     || card.title?.trim()
-
-  if (marketType === 'moneyline' && fullMatchupTitle) {
-    return fullMatchupTitle
-  }
 
   if (marketType === 'btts') {
     return 'Both Teams to Score?'

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
@@ -794,20 +794,37 @@ export function buildMoneylineGraphTargets(card: SportsGamesCard) {
   }, [])
 }
 
-function resolveTotalButtonLabel(button: SportsGamesButton, selectedOutcome: Outcome | null) {
+function formatSelectedTradeTextLabel(value: string | null | undefined, fallback = 'Yes') {
+  const trimmedValue = value?.trim().replace(/\s+/g, ' ') ?? ''
+  if (!trimmedValue) {
+    return fallback
+  }
+
+  return trimmedValue.replace(/[a-z]+/gi, word => `${word[0]?.toUpperCase() ?? ''}${word.slice(1).toLowerCase()}`)
+}
+
+function resolveTotalButtonLabel(
+  button: SportsGamesButton,
+  selectedOutcome: Outcome | null,
+  options?: { casing?: 'title' | 'upper' },
+) {
   const line = extractLineValue(button.label)
   const outcomeText = selectedOutcome?.outcome_text?.trim() ?? ''
 
-  let sideLabel: 'OVER' | 'UNDER'
+  let side: 'over' | 'under'
   if (/^under$/i.test(outcomeText) || button.tone === 'under') {
-    sideLabel = 'UNDER'
+    side = 'under'
   }
   else if (/^over$/i.test(outcomeText) || button.tone === 'over') {
-    sideLabel = 'OVER'
+    side = 'over'
   }
   else {
-    sideLabel = button.label.trim().toUpperCase().startsWith('U') ? 'UNDER' : 'OVER'
+    side = button.label.trim().toUpperCase().startsWith('U') ? 'under' : 'over'
   }
+
+  const sideLabel = side === 'under'
+    ? (options?.casing === 'title' ? 'Under' : 'UNDER')
+    : (options?.casing === 'title' ? 'Over' : 'OVER')
 
   return line ? `${sideLabel} ${line}` : sideLabel
 }
@@ -821,6 +838,11 @@ function extractButtonLineSuffix(label: string) {
 
   const unsignedMatches = Array.from(normalizedLabel.matchAll(/(?:^|\s)(\d+(?:\.\d+)?)(?=\s|$)/g))
   return unsignedMatches.at(-1)?.[1] ?? null
+}
+
+function extractButtonHalfSuffix(label: string) {
+  const match = label.match(/\b([12])H\b/i)
+  return match?.[1] ? `${match[1]}H` : null
 }
 
 function resolveTeamButtonTradeLabel(card: SportsGamesCard, button: SportsGamesButton) {
@@ -839,8 +861,13 @@ function resolveTeamButtonTradeLabel(card: SportsGamesCard, button: SportsGamesB
   const lineSuffix = button.marketType === 'spread'
     ? extractButtonLineSuffix(button.label)
     : null
+  const halfSuffix = lineSuffix ? null : extractButtonHalfSuffix(button.label)
 
-  return lineSuffix ? `${teamName} ${lineSuffix}` : teamName
+  if (lineSuffix) {
+    return `${teamName} ${lineSuffix}`
+  }
+
+  return halfSuffix ? `${teamName} ${halfSuffix}` : teamName
 }
 
 export function resolveSelectedTradeLabel(
@@ -849,11 +876,11 @@ export function resolveSelectedTradeLabel(
   selectedOutcome: Outcome | null,
 ) {
   if (!button) {
-    return selectedOutcome?.outcome_text?.trim().toUpperCase() || 'YES'
+    return formatSelectedTradeTextLabel(selectedOutcome?.outcome_text, 'Yes')
   }
 
   if (button.marketType === 'total') {
-    return resolveTotalButtonLabel(button, selectedOutcome)
+    return resolveTotalButtonLabel(button, selectedOutcome, { casing: 'title' })
   }
 
   if (button.tone === 'draw') {
@@ -865,7 +892,7 @@ export function resolveSelectedTradeLabel(
     return teamLabel
   }
 
-  return button.label.trim().toUpperCase()
+  return formatSelectedTradeTextLabel(button.label, 'Market')
 }
 
 export function resolveSelectedOrderBookTradeLabel(

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
@@ -794,13 +794,45 @@ export function buildMoneylineGraphTargets(card: SportsGamesCard) {
   }, [])
 }
 
+const SELECTED_TRADE_LABEL_ACRONYMS = new Set([
+  'BTTS',
+  'CS2',
+  'ET',
+  'EU',
+  'FIFA',
+  'LOL',
+  'MLB',
+  'NBA',
+  'NFL',
+  'NHL',
+  'OT',
+  'PK',
+  'PKS',
+  'UFC',
+  'UK',
+  'US',
+  'USA',
+  'WNBA',
+])
+
+function formatSelectedTradeWord(word: string) {
+  const upperWord = word.toLocaleUpperCase()
+  if (SELECTED_TRADE_LABEL_ACRONYMS.has(upperWord)) {
+    return upperWord
+  }
+
+  const lowerWord = word.toLocaleLowerCase()
+  const [firstLetter, ...restLetters] = Array.from(lowerWord)
+  return firstLetter ? `${firstLetter.toLocaleUpperCase()}${restLetters.join('')}` : word
+}
+
 function formatSelectedTradeTextLabel(value: string | null | undefined, fallback = 'Yes') {
   const trimmedValue = value?.trim().replace(/\s+/g, ' ') ?? ''
   if (!trimmedValue) {
     return fallback
   }
 
-  return trimmedValue.replace(/[a-z]+/gi, word => `${word[0]?.toUpperCase() ?? ''}${word.slice(1).toLowerCase()}`)
+  return trimmedValue.replace(/[\p{L}\p{N}][\p{L}\p{M}\p{N}'’]*/gu, formatSelectedTradeWord)
 }
 
 function resolveTotalButtonLabel(
@@ -991,6 +1023,24 @@ function resolveMarketTypeTitle(market: Market | null) {
   }
 
   return toMarketTitleCase(displayTokens.join(' '))
+}
+
+function resolveTeamTotalMarketHeaderTitle(market: Market | null) {
+  const normalizedType = normalizeComparableText(market?.sports_market_type)
+  if (!normalizedType.includes('team total') && !normalizedType.includes('team totals')) {
+    return null
+  }
+
+  const descriptor = resolveMarketDescriptor(market)
+  if (!descriptor) {
+    return null
+  }
+
+  return descriptor
+    .replace(/\s*:\s*(?:o\/u|over\/under|over|under)\s*\d+(?:\.\d+)?\s*$/i, '')
+    .replace(/\s+(?:o\/u|over\/under|over|under)\s*\d+(?:\.\d+)?\s*$/i, '')
+    .trim()
+    || descriptor
 }
 
 export function normalizeComparableText(value: string | null | undefined) {
@@ -1383,6 +1433,11 @@ export function resolveTradeHeaderTitle({
   }
 
   if (marketType !== 'moneyline') {
+    const teamTotalTitle = resolveTeamTotalMarketHeaderTitle(selectedMarket)
+    if (teamTotalTitle) {
+      return teamTotalTitle
+    }
+
     const marketTypeTitle = resolveMarketTypeTitle(selectedMarket)
     if (marketTypeTitle) {
       return marketTypeTitle

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
@@ -405,6 +405,13 @@ export function resolveOrderPanelOutcomeAccentOverrides(
     return {}
   }
 
+  const isMoneylineCondition = card.buttons.some(button =>
+    button.conditionId === market.condition_id && button.marketType === 'moneyline',
+  )
+  if (isMoneylineCondition) {
+    return {}
+  }
+
   const accents: Partial<Record<number, EventOrderPanelOutcomeSelectedAccent>> = {}
   card.buttons.forEach((button) => {
     if (
@@ -818,6 +825,10 @@ export function resolveSelectedTradeLabel(
     return resolveTotalButtonLabel(button, selectedOutcome)
   }
 
+  if (button.tone === 'draw') {
+    return normalizeComparableText(button.label).includes('neither') ? 'Neither' : 'Draw'
+  }
+
   if (button.marketType === 'moneyline' && (button.tone === 'team1' || button.tone === 'team2')) {
     const teamName = resolveTeamByTone(card, button.tone)?.name?.trim()
     if (teamName) {
@@ -853,6 +864,77 @@ function resolveMarketDescriptor(market: Market | null) {
     || market.title?.trim()
     || ''
   return descriptor || null
+}
+
+const SPORTS_MARKET_TYPE_PREFIXES = new Set([
+  'americanfootball',
+  'baseball',
+  'basketball',
+  'boxing',
+  'cricket',
+  'cs2',
+  'dota2',
+  'football',
+  'golf',
+  'hockey',
+  'lol',
+  'mma',
+  'nba',
+  'nfl',
+  'nhl',
+  'rugby',
+  'soccer',
+  'tennis',
+  'ufc',
+  'valorant',
+])
+
+const MARKET_TITLE_SMALL_WORDS = new Set(['a', 'an', 'and', 'by', 'for', 'in', 'of', 'on', 'or', 'the', 'to', 'vs'])
+
+function toMarketTitleCase(value: string) {
+  return value
+    .split(/\s+/)
+    .filter(Boolean)
+    .map((word, index) => {
+      const normalizedWord = word.toLowerCase()
+      if (index > 0 && MARKET_TITLE_SMALL_WORDS.has(normalizedWord)) {
+        return normalizedWord
+      }
+      if (normalizedWord === 'btts') {
+        return 'BTTS'
+      }
+
+      return `${normalizedWord[0]?.toUpperCase() ?? ''}${normalizedWord.slice(1)}`
+    })
+    .join(' ')
+}
+
+function resolveMarketTypeTitle(market: Market | null) {
+  const rawType = market?.sports_market_type?.trim().toLowerCase()
+  if (!rawType) {
+    return null
+  }
+
+  const descriptor = resolveMarketDescriptor(market)
+  const normalizedType = normalizeComparableText(rawType)
+  const normalizedDescriptor = normalizeComparableText(descriptor)
+  if (normalizedType === 'child moneyline') {
+    if (normalizedDescriptor.includes('advance') || normalizedDescriptor.includes('qualify')) {
+      return 'Team to Advance'
+    }
+
+    return descriptor || 'Map / Game Winner'
+  }
+
+  const tokens = rawType.split('_').filter(Boolean)
+  const displayTokens = SPORTS_MARKET_TYPE_PREFIXES.has(tokens[0] ?? '')
+    ? tokens.slice(1)
+    : tokens
+  if (displayTokens.length === 0) {
+    return null
+  }
+
+  return toMarketTitleCase(displayTokens.join(' '))
 }
 
 export function normalizeComparableText(value: string | null | undefined) {
@@ -1254,6 +1336,26 @@ export function resolveTradeHeaderTitle({
     return descriptor ? `Exact Score: ${descriptor}` : 'Exact Score'
   }
 
+  if (marketType !== 'moneyline') {
+    const marketTypeTitle = resolveMarketTypeTitle(selectedMarket)
+    if (marketTypeTitle) {
+      return marketTypeTitle
+    }
+    const descriptor = resolveMarketDescriptor(selectedMarket)
+    if (descriptor) {
+      return descriptor
+    }
+  }
+
+  const team1 = card.teams[0] ?? null
+  const team2 = card.teams[1] ?? null
+  const fullMatchupTitle = [team1?.name?.trim(), team2?.name?.trim()].filter(Boolean).join(' vs ')
+    || card.title?.trim()
+
+  if (marketType === 'moneyline' && fullMatchupTitle) {
+    return fullMatchupTitle
+  }
+
   if (marketType === 'btts') {
     return 'Both Teams to Score?'
   }
@@ -1262,8 +1364,6 @@ export function resolveTradeHeaderTitle({
     return 'Over vs Under'
   }
 
-  const team1 = card.teams[0] ?? null
-  const team2 = card.teams[1] ?? null
   const vertical = resolveSportsVerticalFromTags({
     tags: card.event.tags,
     mainTag: card.event.main_tag,
@@ -1282,9 +1382,6 @@ export function resolveTradeHeaderTitle({
       return compactTitle
     }
   }
-
-  const fullMatchupTitle = card.title?.trim()
-    || [team1?.name?.trim(), team2?.name?.trim()].filter(Boolean).join(' vs ')
 
   if (fullMatchupTitle) {
     return fullMatchupTitle

--- a/src/app/[locale]/(platform)/sports/_components/sports-event-center-types.ts
+++ b/src/app/[locale]/(platform)/sports/_components/sports-event-center-types.ts
@@ -63,15 +63,3 @@ export const EMPTY_QUERY_SELECTION: SportsEventQuerySelection = {
   conditionId: null,
   outcomeIndex: null,
 }
-
-export const FULL_COMPETITOR_NAME_HERO_LABEL_SPORT_SLUGS = new Set([
-  'boxing',
-  'chess',
-  'f1',
-  'golf',
-  'mma',
-  'tennis',
-  'ufc',
-  'wtt-mens-singles',
-  'zuffa',
-])

--- a/src/app/[locale]/(platform)/sports/_components/sports-event-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/sports-event-center-utils.ts
@@ -7,7 +7,6 @@ import type { OddsFormat } from '@/lib/odds-format'
 import type { SportsVertical } from '@/lib/sports-vertical'
 import type { UserPosition } from '@/types'
 import {
-  FULL_COMPETITOR_NAME_HERO_LABEL_SPORT_SLUGS,
   SPORTS_EVENT_ODDS_FORMAT_STORAGE_KEY,
 } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-types'
 import { resolveHexToRgbComponents } from '@/lib/color'
@@ -290,22 +289,6 @@ export function resolveTeamShortLabel(team: SportsGamesCard['teams'][number] | n
     .slice(0, 3)
 
   return initials || name.slice(0, 3).toUpperCase()
-}
-
-function shouldUseFullCompetitorHeroLabels(sportSlug: string | null | undefined) {
-  return FULL_COMPETITOR_NAME_HERO_LABEL_SPORT_SLUGS.has(
-    normalizeComparableToken(sportSlug),
-  )
-}
-
-export function shouldUseFullScoreboardHeroLabels({
-  sportSlug,
-  vertical,
-}: {
-  sportSlug: string | null | undefined
-  vertical: SportsVertical
-}) {
-  return vertical === 'esports' || shouldUseFullCompetitorHeroLabels(sportSlug)
 }
 
 export function parseSportsScore(value: string | null | undefined) {

--- a/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
@@ -252,6 +252,30 @@ function isHalvesMarket(market: Market) {
     || normalizedText.includes('2nd half')
 }
 
+function resolveHalvesMarketPeriodKey(market: Market) {
+  const normalizedText = resolveAuxiliaryMarketText(market)
+
+  if (
+    normalizedText.includes('second half')
+    || normalizedText.includes('2nd half')
+    || /\b2h\b/.test(normalizedText)
+  ) {
+    return '2h'
+  }
+
+  if (
+    normalizedText.includes('halftime')
+    || normalizedText.includes('half time')
+    || normalizedText.includes('first half')
+    || normalizedText.includes('1st half')
+    || /\b1h\b/.test(normalizedText)
+  ) {
+    return '1h'
+  }
+
+  return null
+}
+
 function resolvePlayerPropSourceLabel(market: Market) {
   return market.sports_group_item_title?.trim()
     || market.short_title?.trim()
@@ -359,7 +383,17 @@ function resolveAuxiliaryMarketKind(market: Market) {
     return 'goalscorers' as const
   }
 
-  if (normalizedText.includes('halftime result')) {
+  if (
+    normalizedText.includes('halftime result')
+    || normalizedText.includes('first half result')
+    || normalizedText.includes('second half result')
+    || normalizedText.includes('1st half result')
+    || normalizedText.includes('2nd half result')
+    || normalizedText.includes('first half moneyline')
+    || normalizedText.includes('second half moneyline')
+    || /\b1h moneyline\b/.test(normalizedText)
+    || /\b2h moneyline\b/.test(normalizedText)
+  ) {
     return 'halftimeResult' as const
   }
 
@@ -462,6 +496,30 @@ function marketTitleTexts(market: Market) {
   ]
     .map(value => value?.trim() ?? '')
     .filter(Boolean)
+}
+
+function extractMarketHalfLabelSuffix(market: Market | null | undefined) {
+  if (!market) {
+    return null
+  }
+
+  for (const label of marketTitleTexts(market)) {
+    const match = label.match(/\b([12])H\b/i)
+    if (match?.[1]) {
+      return `${match[1]}H`
+    }
+  }
+
+  return null
+}
+
+function appendMarketHalfLabelSuffix(label: string, market: Market | null | undefined) {
+  const suffix = extractMarketHalfLabelSuffix(market)
+  if (!suffix || new RegExp(`\\b${suffix}\\b`, 'i').test(label)) {
+    return label
+  }
+
+  return `${label} ${suffix}`
 }
 
 function isExplicitMoneylineMarket(market: Market) {
@@ -817,6 +875,11 @@ export function resolveSportsAuxiliaryMarketGroupKey(market: Market) {
   }
 
   const marketKind = resolveAuxiliaryMarketKind(market)
+  if (marketKind === 'halftimeResult') {
+    const periodKey = resolveHalvesMarketPeriodKey(market)
+    return `${market.event_id}:halftimeResult:${periodKey ?? market.condition_id}`
+  }
+
   if (marketKind === 'exactScore' || marketKind === 'goalscorers') {
     return `${market.event_id}:${market.condition_id}`
   }
@@ -1684,45 +1747,60 @@ function buildHalftimeResultButtons(
   }
 
   const { team1, team2 } = resolvePrimaryTeams(teams)
-  const drawMarket = markets.find(market => isDrawMarket(market) || hasMarketSlugSuffix(market, '-draw')) ?? null
-  let team1Market = markets.find(market => hasMarketSlugSuffix(market, '-home'))
-    ?? (team1 ? markets.find(market => doesMarketMatchTeam(market, team1, teams)) : undefined)
-  let team2Market = markets.find(market => hasMarketSlugSuffix(market, '-away'))
-    ?? (team2 ? markets.find(market => doesMarketMatchTeam(market, team2, teams)) : undefined)
-
-  const remainingNonDrawMarkets = markets.filter(market =>
-    market.condition_id !== drawMarket?.condition_id
-    && market.condition_id !== team1Market?.condition_id
-    && market.condition_id !== team2Market?.condition_id,
-  )
-
-  if (!team1Market) {
-    team1Market = remainingNonDrawMarkets.shift()
-  }
-  if (!team2Market) {
-    team2Market = remainingNonDrawMarkets.shift()
-  }
-
   const buttons: SportsGamesButton[] = []
+  const marketsByPeriod = new Map<string, Market[]>()
 
-  appendButton(buttons, usedButtonKeys, team1Market, 0, {
-    label: toTeamButtonLabel(team1, 'TEAM 1'),
-    color: team1?.color ?? null,
-    marketType: 'moneyline',
-    tone: 'team1',
+  markets.forEach((market) => {
+    const periodKey = resolveHalvesMarketPeriodKey(market) ?? 'half'
+    const currentMarkets = marketsByPeriod.get(periodKey) ?? []
+    currentMarkets.push(market)
+    marketsByPeriod.set(periodKey, currentMarkets)
   })
-  appendButton(buttons, usedButtonKeys, drawMarket ?? undefined, 0, {
-    label: 'DRAW',
-    color: null,
-    marketType: 'moneyline',
-    tone: 'draw',
-  })
-  appendButton(buttons, usedButtonKeys, team2Market, 0, {
-    label: toTeamButtonLabel(team2, 'TEAM 2'),
-    color: team2?.color ?? null,
-    marketType: 'moneyline',
-    tone: 'team2',
-  })
+
+  Array.from(marketsByPeriod.entries())
+    .sort(([leftPeriod], [rightPeriod]) => {
+      const periodOrder: Record<string, number> = { '1h': 0, '2h': 1, 'half': 2 }
+      return (periodOrder[leftPeriod] ?? 99) - (periodOrder[rightPeriod] ?? 99)
+    })
+    .forEach(([, periodMarkets]) => {
+      const drawMarket = periodMarkets.find(market => isDrawMarket(market) || hasMarketSlugSuffix(market, '-draw')) ?? null
+      let team1Market = periodMarkets.find(market => hasMarketSlugSuffix(market, '-home'))
+        ?? (team1 ? periodMarkets.find(market => doesMarketMatchTeam(market, team1, teams)) : undefined)
+      let team2Market = periodMarkets.find(market => hasMarketSlugSuffix(market, '-away'))
+        ?? (team2 ? periodMarkets.find(market => doesMarketMatchTeam(market, team2, teams)) : undefined)
+
+      const remainingNonDrawMarkets = periodMarkets.filter(market =>
+        market.condition_id !== drawMarket?.condition_id
+        && market.condition_id !== team1Market?.condition_id
+        && market.condition_id !== team2Market?.condition_id,
+      )
+
+      if (!team1Market) {
+        team1Market = remainingNonDrawMarkets.shift()
+      }
+      if (!team2Market) {
+        team2Market = remainingNonDrawMarkets.shift()
+      }
+
+      appendButton(buttons, usedButtonKeys, team1Market, 0, {
+        label: appendMarketHalfLabelSuffix(toTeamButtonLabel(team1, 'TEAM 1'), team1Market),
+        color: team1?.color ?? null,
+        marketType: 'moneyline',
+        tone: 'team1',
+      })
+      appendButton(buttons, usedButtonKeys, drawMarket ?? undefined, 0, {
+        label: appendMarketHalfLabelSuffix('DRAW', drawMarket),
+        color: null,
+        marketType: 'moneyline',
+        tone: 'draw',
+      })
+      appendButton(buttons, usedButtonKeys, team2Market, 0, {
+        label: appendMarketHalfLabelSuffix(toTeamButtonLabel(team2, 'TEAM 2'), team2Market),
+        color: team2?.color ?? null,
+        marketType: 'moneyline',
+        tone: 'team2',
+      })
+    })
 
   return buttons
 }

--- a/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
@@ -882,7 +882,7 @@ function resolveAuxiliaryMarketTone(
 ): SportsGamesButton['tone'] {
   const teams = [team1, team2].filter((team): team is SportsGamesTeam => Boolean(team))
   const normalizedLabel = normalizeText(label)
-  if (normalizedLabel.includes('draw')) {
+  if (normalizedLabel.includes('draw') || normalizedLabel.includes('neither')) {
     return 'draw'
   }
 
@@ -922,8 +922,9 @@ function resolveAuxiliaryButtonLabel(
   }
 
   if (tone === 'draw') {
+    const normalizedRawLabel = normalizeText(rawLabel)
     return {
-      label: 'DRAW',
+      label: normalizedRawLabel.includes('neither') ? 'Neither' : 'DRAW',
       color: null,
       tone,
     }

--- a/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
@@ -276,6 +276,11 @@ function resolveHalvesMarketPeriodKey(market: Market) {
   return null
 }
 
+function isHalftimeResultMarketText(value: string) {
+  return /\b(?:half\s*time|first\s+half|1st\s+half|1h|second\s+half|2nd\s+half|2h)\s+(?:result|moneyline)\b/
+    .test(value)
+}
+
 function resolvePlayerPropSourceLabel(market: Market) {
   return market.sports_group_item_title?.trim()
     || market.short_title?.trim()
@@ -383,17 +388,7 @@ function resolveAuxiliaryMarketKind(market: Market) {
     return 'goalscorers' as const
   }
 
-  if (
-    normalizedText.includes('halftime result')
-    || normalizedText.includes('first half result')
-    || normalizedText.includes('second half result')
-    || normalizedText.includes('1st half result')
-    || normalizedText.includes('2nd half result')
-    || normalizedText.includes('first half moneyline')
-    || normalizedText.includes('second half moneyline')
-    || /\b1h moneyline\b/.test(normalizedText)
-    || /\b2h moneyline\b/.test(normalizedText)
-  ) {
+  if (isHalftimeResultMarketText(normalizedText)) {
     return 'halftimeResult' as const
   }
 
@@ -503,7 +498,16 @@ function extractMarketHalfLabelSuffix(market: Market | null | undefined) {
     return null
   }
 
-  for (const label of marketTitleTexts(market)) {
+  const candidateLabels = [
+    market.sports_group_item_title,
+    market.short_title,
+    market.title,
+    market.sports_market_type,
+  ]
+    .map(value => value?.trim() ?? '')
+    .filter(Boolean)
+
+  for (const label of candidateLabels) {
     const match = label.match(/\b([12])H\b/i)
     if (match?.[1]) {
       return `${match[1]}H`

--- a/src/lib/color-contrast.ts
+++ b/src/lib/color-contrast.ts
@@ -84,3 +84,25 @@ export function ensureReadableTextColorOnDark(
 
   return color
 }
+
+export function resolveReadableTextColorOnColor(
+  color: string | null | undefined,
+  fallbackColor = '#ffffff',
+) {
+  if (!color) {
+    return fallbackColor
+  }
+
+  const backgroundLuminance = getRelativeLuminance(color)
+  const darkTextLuminance = getRelativeLuminance('#111827') ?? 0
+
+  if (backgroundLuminance == null) {
+    return fallbackColor
+  }
+
+  const whiteContrast = 1.05 / (backgroundLuminance + 0.05)
+  const darkContrast = (Math.max(backgroundLuminance, darkTextLuminance) + 0.05)
+    / (Math.min(backgroundLuminance, darkTextLuminance) + 0.05)
+
+  return darkContrast > whiteContrast ? '#111827' : '#ffffff'
+}

--- a/tests/unit/sportsGamesData.test.ts
+++ b/tests/unit/sportsGamesData.test.ts
@@ -1469,6 +1469,75 @@ describe('sportsGamesData', () => {
     expect(firstHalfPanelKeys).not.toEqual(secondHalfPanelKeys)
   })
 
+  it('classifies compact 1H and 2H result markets as halves', () => {
+    const event = buildSportsEvent({
+      id: 'france-morocco-compact-halves',
+      slug: 'france-morocco-2026-07-09-compact-halves',
+      title: 'France vs Morocco',
+      sportsTeams: [
+        { name: 'France', abbreviation: 'FRA', host_status: 'home' },
+        { name: 'Morocco', abbreviation: 'MAR', host_status: 'away' },
+      ],
+      markets: [
+        buildBinaryMarket({
+          conditionId: 'first-half-france-compact',
+          eventId: 'france-morocco-compact-halves',
+          slug: 'france-morocco-1h-home',
+          title: 'France',
+          marketType: '1H Result',
+        }),
+        buildBinaryMarket({
+          conditionId: 'first-half-draw-compact',
+          eventId: 'france-morocco-compact-halves',
+          slug: 'france-morocco-1h-draw',
+          title: 'Draw',
+          marketType: '1H Result',
+        }),
+        buildBinaryMarket({
+          conditionId: 'first-half-morocco-compact',
+          eventId: 'france-morocco-compact-halves',
+          slug: 'france-morocco-1h-away',
+          title: 'Morocco',
+          marketType: '1H Result',
+        }),
+        buildBinaryMarket({
+          conditionId: 'second-half-france-compact',
+          eventId: 'france-morocco-compact-halves',
+          slug: 'france-morocco-2h-home',
+          title: 'France',
+          marketType: '2H Result',
+        }),
+        buildBinaryMarket({
+          conditionId: 'second-half-draw-compact',
+          eventId: 'france-morocco-compact-halves',
+          slug: 'france-morocco-2h-draw',
+          title: 'Draw',
+          marketType: '2H Result',
+        }),
+        buildBinaryMarket({
+          conditionId: 'second-half-morocco-compact',
+          eventId: 'france-morocco-compact-halves',
+          slug: 'france-morocco-2h-away',
+          title: 'Morocco',
+          marketType: '2H Result',
+        }),
+      ],
+    })
+
+    const group = buildSportsGamesCardGroups([event])[0]
+    expect(group?.marketViewCards.map(view => view.key)).toEqual(['halves'])
+
+    const halvesCard = group?.marketViewCards.find(view => view.key === 'halves')?.card ?? null
+    expect(halvesCard?.buttons.map(button => `${button.conditionId}:${button.label}`)).toEqual([
+      'first-half-france-compact:FRA 1H',
+      'first-half-draw-compact:DRAW 1H',
+      'first-half-morocco-compact:MAR 1H',
+      'second-half-france-compact:FRA 2H',
+      'second-half-draw-compact:DRAW 2H',
+      'second-half-morocco-compact:MAR 2H',
+    ])
+  })
+
   it('ignores generic prediction events that fall back to /event routes', () => {
     const event = {
       id: 'generic-event',

--- a/tests/unit/sportsGamesData.test.ts
+++ b/tests/unit/sportsGamesData.test.ts
@@ -544,6 +544,73 @@ describe('sportsGamesData', () => {
     expect(binaryButtons.map(button => button.label)).toEqual(['NGA', 'DRAW', 'ZWE'])
   })
 
+  it('keeps first-to-score neither markets between both teams', () => {
+    const baseSlug = 'fifwc-fra-mar-2026-07-09'
+    const baseEventId = 'france-morocco-base-event'
+    const auxiliaryEventId = 'france-morocco-first-to-score-event'
+
+    const groupedEvents = buildSportsGamesCardGroups([
+      buildSportsEvent({
+        id: auxiliaryEventId,
+        slug: `${baseSlug}-first-to-score`,
+        title: 'France vs Morocco - First To Score',
+        sportsParentEventId: 101,
+        markets: [
+          buildBinaryMarket({
+            eventId: auxiliaryEventId,
+            conditionId: 'first-to-score-france',
+            slug: `${baseSlug}-first-to-score-france`,
+            title: 'France',
+            marketType: 'soccer_first_to_score',
+            threshold: '0',
+          }),
+          buildBinaryMarket({
+            eventId: auxiliaryEventId,
+            conditionId: 'first-to-score-neither',
+            slug: `${baseSlug}-first-to-score-neither`,
+            title: 'Neither',
+            marketType: 'soccer_first_to_score',
+            threshold: '1',
+          }),
+          buildBinaryMarket({
+            eventId: auxiliaryEventId,
+            conditionId: 'first-to-score-morocco',
+            slug: `${baseSlug}-first-to-score-morocco`,
+            title: 'Morocco',
+            marketType: 'soccer_first_to_score',
+            threshold: '2',
+          }),
+        ],
+      }),
+      buildSportsEvent({
+        id: baseEventId,
+        slug: baseSlug,
+        title: 'France vs Morocco',
+        sportsEventId: '101',
+        sportsTeams: [
+          { name: 'France', abbreviation: 'FRA', host_status: 'home' },
+          { name: 'Morocco', abbreviation: 'MAR', host_status: 'away' },
+        ],
+        markets: [
+          buildMoneylineMarket({
+            eventId: baseEventId,
+            slug: baseSlug,
+            title: 'France vs Morocco',
+            outcomes: ['France', 'Morocco'],
+          }),
+        ],
+      }),
+    ])
+
+    const card = groupedEvents[0]?.primaryCard
+    const firstToScoreButtons = card?.buttons.filter(button =>
+      button.conditionId.startsWith('first-to-score-'),
+    ) ?? []
+
+    expect(firstToScoreButtons.map(button => button.label)).toEqual(['FRA', 'Neither', 'MAR'])
+    expect(firstToScoreButtons.map(button => button.tone)).toEqual(['team1', 'draw', 'team2'])
+  })
+
   it('does not use indexed team logo fallback when unnamed teams make the logo array ambiguous', () => {
     const nigeriaLogoUrl = 'https://example.com/nigeria.png'
     const zimbabweLogoUrl = 'https://example.com/zimbabwe.png'

--- a/tests/unit/sportsGamesData.test.ts
+++ b/tests/unit/sportsGamesData.test.ts
@@ -1,6 +1,7 @@
 import {
   buildSportsGamesCardGroups,
   isSportsGamesCardResolved,
+  resolveSportsAuxiliaryMarketGroupKey,
   resolveSportsMarketLineValue,
   resolveSportsPlayerPropPlayerName,
 } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
@@ -24,6 +25,7 @@ function buildBinaryMarket(params: {
   title: string
   marketType: string
   threshold?: string
+  sportsLine?: string | null
   createdAt?: string
   volume?: number
 }) {
@@ -34,6 +36,7 @@ function buildBinaryMarket(params: {
     title,
     marketType,
     threshold = null,
+    sportsLine = null,
     createdAt = '2026-03-13T00:00:00.000Z',
     volume = 10,
   } = params
@@ -51,6 +54,7 @@ function buildBinaryMarket(params: {
     block_number: 0,
     block_timestamp: createdAt,
     sports_market_type: marketType,
+    sports_line: sportsLine,
     sports_group_item_title: title,
     sports_group_item_threshold: threshold,
     volume,
@@ -1369,6 +1373,100 @@ describe('sportsGamesData', () => {
       'goalscorer-suarez:YES',
       'goalscorer-suarez:NO',
     ])
+  })
+
+  it('keeps first and second half result markets in separate moneyline groups', () => {
+    const event = buildSportsEvent({
+      id: 'france-morocco-halves',
+      slug: 'france-morocco-2026-07-09-halves',
+      title: 'France vs Morocco',
+      sportsTeams: [
+        { name: 'France', abbreviation: 'FRA', host_status: 'home' },
+        { name: 'Morocco', abbreviation: 'MAR', host_status: 'away' },
+      ],
+      markets: [
+        buildBinaryMarket({
+          conditionId: 'first-half-france',
+          eventId: 'france-morocco-halves',
+          slug: 'france-morocco-first-half-home',
+          title: 'France',
+          marketType: 'First Half Result',
+          sportsLine: '0',
+        }),
+        buildBinaryMarket({
+          conditionId: 'first-half-draw',
+          eventId: 'france-morocco-halves',
+          slug: 'france-morocco-first-half-draw',
+          title: 'Draw',
+          marketType: 'First Half Result',
+          sportsLine: '1',
+        }),
+        buildBinaryMarket({
+          conditionId: 'first-half-morocco',
+          eventId: 'france-morocco-halves',
+          slug: 'france-morocco-first-half-away',
+          title: 'Morocco',
+          marketType: 'First Half Result',
+          sportsLine: '2',
+        }),
+        buildBinaryMarket({
+          conditionId: 'second-half-france',
+          eventId: 'france-morocco-halves',
+          slug: 'france-morocco-second-half-home',
+          title: 'France',
+          marketType: 'Second Half Result',
+          sportsLine: '0',
+        }),
+        buildBinaryMarket({
+          conditionId: 'second-half-draw',
+          eventId: 'france-morocco-halves',
+          slug: 'france-morocco-second-half-draw',
+          title: 'Draw',
+          marketType: 'Second Half Result',
+          sportsLine: '1',
+        }),
+        buildBinaryMarket({
+          conditionId: 'second-half-morocco',
+          eventId: 'france-morocco-halves',
+          slug: 'france-morocco-second-half-away',
+          title: 'Morocco',
+          marketType: 'Second Half Result',
+          sportsLine: '2',
+        }),
+      ],
+    })
+
+    const group = buildSportsGamesCardGroups([event])[0]
+    const halvesCard = group?.marketViewCards.find(view => view.key === 'halves')?.card ?? null
+    expect(halvesCard?.buttons.map(button => `${button.conditionId}:${button.label}:${button.marketType}`)).toEqual([
+      'first-half-france:FRA:moneyline',
+      'first-half-draw:DRAW:moneyline',
+      'first-half-morocco:MAR:moneyline',
+      'second-half-france:FRA:moneyline',
+      'second-half-draw:DRAW:moneyline',
+      'second-half-morocco:MAR:moneyline',
+    ])
+
+    const panelKeysByConditionId = new Map(
+      halvesCard?.detailMarkets.map(market => [
+        market.condition_id,
+        resolveSportsAuxiliaryMarketGroupKey(market),
+      ]) ?? [],
+    )
+    const firstHalfPanelKeys = new Set([
+      panelKeysByConditionId.get('first-half-france'),
+      panelKeysByConditionId.get('first-half-draw'),
+      panelKeysByConditionId.get('first-half-morocco'),
+    ])
+    const secondHalfPanelKeys = new Set([
+      panelKeysByConditionId.get('second-half-france'),
+      panelKeysByConditionId.get('second-half-draw'),
+      panelKeysByConditionId.get('second-half-morocco'),
+    ])
+
+    expect(firstHalfPanelKeys.size).toBe(1)
+    expect(secondHalfPanelKeys.size).toBe(1)
+    expect(firstHalfPanelKeys).not.toEqual(secondHalfPanelKeys)
   })
 
   it('ignores generic prediction events that fall back to /event routes', () => {

--- a/tests/unit/sportsOrderBookTradeLabel.test.ts
+++ b/tests/unit/sportsOrderBookTradeLabel.test.ts
@@ -47,6 +47,44 @@ describe('sports order-book trade label', () => {
     expect(resolveSelectedOrderBookTradeLabel(button, outcome as any)).toBe('OVER 2.5')
   })
 
+  it('uses title case total labels for order panel selections', () => {
+    const card = { teams: [] } as any
+    const button = {
+      key: 'total-over-2-5',
+      conditionId: 'total-goals',
+      outcomeIndex: 0,
+      fallbackIsNoOutcome: false,
+      label: 'O 2.5',
+      cents: 54,
+      color: null,
+      marketType: 'total',
+      tone: 'over',
+    } as const
+    const outcome = {
+      outcome_index: 0,
+      outcome_text: 'Over',
+    }
+
+    expect(resolveSelectedTradeLabel(card, button, outcome as any)).toBe('Over 2.5')
+  })
+
+  it('uses title case fallback labels for order panel selections', () => {
+    const card = { teams: [] } as any
+    const button = {
+      key: 'extra-time-yes',
+      conditionId: 'extra-time',
+      outcomeIndex: 0,
+      fallbackIsNoOutcome: false,
+      label: 'YES',
+      cents: 54,
+      color: null,
+      marketType: 'binary',
+      tone: 'over',
+    } as const
+
+    expect(resolveSelectedTradeLabel(card, button, null)).toBe('Yes')
+  })
+
   it('uses title case labels for draw-style order panel selections', () => {
     const card = { teams: [] } as any
     const drawButton = {
@@ -92,6 +130,28 @@ describe('sports order-book trade label', () => {
     } as const
 
     expect(resolveSelectedTradeLabel(card, spreadButton, null)).toBe('France -1.5')
+  })
+
+  it('preserves provided half suffixes on selected team labels', () => {
+    const card = {
+      teams: [
+        { name: 'France', abbreviation: 'FRA' },
+        { name: 'Morocco', abbreviation: 'MAR' },
+      ],
+    } as any
+    const halfButton = {
+      key: 'france-first-half',
+      conditionId: 'first-half-france',
+      outcomeIndex: 0,
+      fallbackIsNoOutcome: false,
+      label: 'FRA 1H',
+      cents: 48,
+      color: null,
+      marketType: 'moneyline',
+      tone: 'team1',
+    } as const
+
+    expect(resolveSelectedTradeLabel(card, halfButton, null)).toBe('France 1H')
   })
 
   it('keeps full moneyline headers for soccer draw markets', () => {

--- a/tests/unit/sportsOrderBookTradeLabel.test.ts
+++ b/tests/unit/sportsOrderBookTradeLabel.test.ts
@@ -1,4 +1,7 @@
-import { resolveSelectedOrderBookTradeLabel } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils'
+import {
+  resolveSelectedOrderBookTradeLabel,
+  resolveSelectedTradeLabel,
+} from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils'
 
 describe('sports order-book trade label', () => {
   it('uses the displayed moneyline button abbreviation for team outcomes', () => {
@@ -41,5 +44,30 @@ describe('sports order-book trade label', () => {
     }
 
     expect(resolveSelectedOrderBookTradeLabel(button, outcome as any)).toBe('OVER 2.5')
+  })
+
+  it('uses title case labels for draw-style order panel selections', () => {
+    const card = { teams: [] } as any
+    const drawButton = {
+      key: 'draw',
+      conditionId: 'draw',
+      outcomeIndex: 0,
+      fallbackIsNoOutcome: false,
+      label: 'DRAW',
+      cents: 32,
+      color: null,
+      marketType: 'moneyline',
+      tone: 'draw',
+    } as const
+    const neitherButton = {
+      ...drawButton,
+      key: 'neither',
+      conditionId: 'neither',
+      label: 'Neither',
+      marketType: 'binary',
+    } as const
+
+    expect(resolveSelectedTradeLabel(card, drawButton, null)).toBe('Draw')
+    expect(resolveSelectedTradeLabel(card, neitherButton, null)).toBe('Neither')
   })
 })

--- a/tests/unit/sportsOrderBookTradeLabel.test.ts
+++ b/tests/unit/sportsOrderBookTradeLabel.test.ts
@@ -1,6 +1,7 @@
 import {
   resolveSelectedOrderBookTradeLabel,
   resolveSelectedTradeLabel,
+  resolveTradeHeaderTitle,
 } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils'
 
 describe('sports order-book trade label', () => {
@@ -69,5 +70,88 @@ describe('sports order-book trade label', () => {
 
     expect(resolveSelectedTradeLabel(card, drawButton, null)).toBe('Draw')
     expect(resolveSelectedTradeLabel(card, neitherButton, null)).toBe('Neither')
+  })
+
+  it('uses full team names for selected spread labels', () => {
+    const card = {
+      teams: [
+        { name: 'France', abbreviation: 'FRA' },
+        { name: 'Morocco', abbreviation: 'MAR' },
+      ],
+    } as any
+    const spreadButton = {
+      key: 'france-spread',
+      conditionId: 'match-spread',
+      outcomeIndex: 0,
+      fallbackIsNoOutcome: false,
+      label: 'FRA -1.5',
+      cents: 48,
+      color: null,
+      marketType: 'spread',
+      tone: 'team1',
+    } as const
+
+    expect(resolveSelectedTradeLabel(card, spreadButton, null)).toBe('France -1.5')
+  })
+
+  it('keeps full moneyline headers for soccer draw markets', () => {
+    const card = {
+      title: 'France vs Morocco',
+      event: {
+        tags: [{ slug: 'sports' }],
+        main_tag: 'sports',
+        sports_sport_slug: 'soccer',
+        sports_series_slug: 'fifwc',
+      },
+      teams: [
+        { name: 'France', abbreviation: 'FRA' },
+        { name: 'Morocco', abbreviation: 'MAR' },
+      ],
+      buttons: [
+        { marketType: 'moneyline', tone: 'team1' },
+        { marketType: 'moneyline', tone: 'draw' },
+        { marketType: 'moneyline', tone: 'team2' },
+      ],
+    } as any
+    const selectedButton = {
+      label: 'FRA',
+    } as any
+
+    expect(resolveTradeHeaderTitle({
+      card,
+      selectedButton,
+      selectedMarket: null,
+      marketType: 'moneyline',
+    })).toBe('France vs Morocco')
+  })
+
+  it('keeps compact moneyline headers for esports', () => {
+    const card = {
+      title: 'Team Vitality vs 9z Team',
+      event: {
+        tags: [{ slug: 'esports' }],
+        main_tag: 'esports',
+        sports_sport_slug: 'counter-strike',
+        sports_series_slug: null,
+      },
+      teams: [
+        { name: 'Team Vitality', abbreviation: 'VIT' },
+        { name: '9z Team', abbreviation: '9Z' },
+      ],
+      buttons: [
+        { marketType: 'moneyline', tone: 'team1' },
+        { marketType: 'moneyline', tone: 'team2' },
+      ],
+    } as any
+    const selectedButton = {
+      label: 'VIT',
+    } as any
+
+    expect(resolveTradeHeaderTitle({
+      card,
+      selectedButton,
+      selectedMarket: null,
+      marketType: 'moneyline',
+    })).toBe('VIT vs 9Z')
   })
 })

--- a/tests/unit/sportsOrderBookTradeLabel.test.ts
+++ b/tests/unit/sportsOrderBookTradeLabel.test.ts
@@ -85,6 +85,23 @@ describe('sports order-book trade label', () => {
     expect(resolveSelectedTradeLabel(card, button, null)).toBe('Yes')
   })
 
+  it('formats selected labels with unicode words and acronyms intact', () => {
+    const card = { teams: [] } as any
+    const button = {
+      key: 'women-sao-no-ot',
+      conditionId: 'women-sao-no-ot',
+      outcomeIndex: 0,
+      fallbackIsNoOutcome: false,
+      label: 'WOMEN’S SÃO NO OT',
+      cents: 54,
+      color: null,
+      marketType: 'binary',
+      tone: 'neutral',
+    } as const
+
+    expect(resolveSelectedTradeLabel(card, button, null)).toBe('Women’s São No OT')
+  })
+
   it('uses title case labels for draw-style order panel selections', () => {
     const card = { teams: [] } as any
     const drawButton = {
@@ -213,5 +230,37 @@ describe('sports order-book trade label', () => {
       selectedMarket: null,
       marketType: 'moneyline',
     })).toBe('VIT vs 9Z')
+  })
+
+  it('uses team total descriptors for order panel headers', () => {
+    const card = {
+      title: 'France vs Morocco',
+      event: {
+        tags: [{ slug: 'sports' }],
+        main_tag: 'sports',
+        sports_sport_slug: 'soccer',
+        sports_series_slug: 'fifwc',
+      },
+      teams: [
+        { name: 'France', abbreviation: 'FRA' },
+        { name: 'Morocco', abbreviation: 'MAR' },
+      ],
+    } as any
+    const selectedButton = {
+      label: 'O 3.5',
+    } as any
+    const selectedMarket = {
+      sports_market_type: 'Team Total Corners',
+      sports_group_item_title: 'Morocco Corners: O/U 3.5',
+      short_title: 'Team Total Corners',
+      title: 'Team Total Corners',
+    } as any
+
+    expect(resolveTradeHeaderTitle({
+      card,
+      selectedButton,
+      selectedMarket,
+      marketType: 'total',
+    })).toBe('Morocco Corners')
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Refines sports market buttons, live score UI, and the order panel for clearer labels, readable hover text, and better titles. Fixes first‑to‑score and halves layouts, and standardizes Draw/Neither behavior across the app.

- **Bug Fixes**
  - Ensure readable hover text on colored buttons (incl. home and featured); stronger contrast and smoother overlays; refine draw hover style.
  - Standardize Draw/Neither: detect “neither” as draw, label “Neither,” keep centered (incl. first‑to‑score); disable line picker on first‑to‑score and halftime‑result panels; detect 1H/2H variants.
  - Halves markets: detect 1H/2H result/moneyline, group per half via period key, append 1H/2H to labels; keep 1st and 2nd half in separate moneyline groups.
  - Order panel: moneyline headers use full matchup for soccer draw; esports stays compact. Non‑moneyline headers humanized and prefer team‑total descriptors (e.g., Morocco Corners, Team to Advance). Selected labels title‑cased; spreads show team + line; accents use team/YES/NO colors; extra time/penalty shootout use total‑style badge; avoid overriding moneyline outcome accents.
  - Home/featured: scoreboard team names link to moneyline outcomes; hero uses full team names; optional hiding of outcome images; refine moneyline button layout (fixed draw width, “DRAW” label).
  - Live: show per‑team live score chips on game cards.
  - Add unit tests for first‑to‑score Neither ordering, Draw/Neither labels, spread/half labels, header title rules, halves grouping, and market grouping keys.

<sup>Written for commit 98792596a8ac29a1b676a52ec74767811638a311. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

