### PR TITLE
fix: refine sports order and featured footer

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
@@ -173,7 +173,7 @@ function getButtonToneStyles(button: HomeSportsMoneylineButton) {
     return {
       className: `
         ${HOME_OUTCOME_BUTTON_HEIGHT_CLASS}
-        flex-1 rounded-sm px-2 text-sm font-semibold text-foreground
+        flex-1 rounded-sm px-2 text-xs/snug font-semibold text-foreground
         hover:text-primary-foreground
       `,
       style: undefined,
@@ -187,9 +187,9 @@ function getButtonToneStyles(button: HomeSportsMoneylineButton) {
 
   return {
     className: `
-      ${HOME_OUTCOME_BUTTON_HEIGHT_CLASS} flex-1 rounded-sm px-2 text-sm font-semibold
-      text-[var(--home-sports-button-text)]
+      ${HOME_OUTCOME_BUTTON_HEIGHT_CLASS} flex-1 rounded-sm px-2 text-xs/snug font-semibold text-foreground
       hover:text-[var(--home-sports-button-hover-text)]
+      dark:text-[var(--home-sports-button-text)]
     `,
     style: {
       [HOME_SPORTS_BUTTON_TEXT_VAR]: textColor ?? button.color,
@@ -198,6 +198,18 @@ function getButtonToneStyles(button: HomeSportsMoneylineButton) {
     backgroundClassName: undefined,
     backgroundStyle: button.color ? { backgroundColor: button.color } : undefined,
   }
+}
+
+function resolveButtonDisplayLabel(model: HomeSportsMoneylineModel, button: HomeSportsMoneylineButton) {
+  if (button.tone === 'team1') {
+    return model.team1.name
+  }
+
+  if (button.tone === 'team2') {
+    return model.team2.name
+  }
+
+  return button.label
 }
 
 export default function EventCardSportsMoneyline({
@@ -341,6 +353,7 @@ export default function EventCardSportsMoneyline({
                       .filter((button): button is HomeSportsMoneylineButton => Boolean(button))
                       .map((button) => {
                         const toneStyles = getButtonToneStyles(button)
+                        const displayLabel = resolveButtonDisplayLabel(model, button)
 
                         return (
                           <AppLink
@@ -360,10 +373,10 @@ export default function EventCardSportsMoneyline({
                             style={toneStyles.style}
                           >
                             {button.tone === 'draw'
-                              ? <span className="relative z-1">{button.label}</span>
+                              ? <span className="relative z-1">{displayLabel}</span>
                               : (
-                                  <span className="relative z-1 truncate">
-                                    {button.label}
+                                  <span className="relative z-1 line-clamp-2 max-w-full text-center">
+                                    {displayLabel}
                                   </span>
                                 )}
                             {(toneStyles.backgroundClassName || toneStyles.backgroundStyle)

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -1252,38 +1252,38 @@ function FeaturedFooter({ item }: { item: HomeFeaturedEventCard }) {
   return (
     <div
       className={`
-        absolute inset-x-4 bottom-3 z-20 flex h-10 shrink-0 items-center justify-between gap-3 bg-card text-xs
-        leading-none font-normal text-muted-foreground
-        md:inset-x-5 md:bottom-4 md:text-sm
+        absolute inset-x-4 bottom-2 z-20 flex h-8 shrink-0 items-center justify-between gap-3 bg-card/95 text-[13px]
+        leading-none font-normal text-muted-foreground/60
+        md:inset-x-5 md:text-sm
       `}
     >
       <span className="shrink-0">{formatVolumeLabel(item.event.volume)}</span>
       <span className="flex min-w-0 items-center justify-end gap-2">
         <span className={cn(
           'inline-flex items-center gap-1.5 whitespace-nowrap',
-          item.temporalStatus === 'live' && 'text-red-500',
+          item.temporalStatus === 'live' && 'text-red-500/70',
         )}
         >
           {item.temporalStatus === 'live' && (
             <span className="relative flex size-2">
-              <span className="absolute inline-flex size-2 animate-ping rounded-full bg-red-500 opacity-75" />
-              <span className="relative inline-flex size-2 rounded-full bg-red-500" />
+              <span className="absolute inline-flex size-2 animate-ping rounded-full bg-red-500 opacity-50" />
+              <span className="relative inline-flex size-2 rounded-full bg-red-500/70" />
             </span>
           )}
           {item.temporalLabel}
         </span>
-        <span className="text-muted-foreground">·</span>
-        <span className="flex min-w-0 items-center gap-1.5 leading-none">
+        <span className="text-muted-foreground/35">·</span>
+        <span className="flex min-w-0 items-center gap-1 leading-none">
           <SiteLogoIcon
             logoSvg={site.logoSvg}
             logoImageUrl={site.logoImageUrl}
             alt={`${site.name} logo`}
             className={cn(`
-              pointer-events-none size-4 shrink-0 text-current select-none
+              pointer-events-none size-4 shrink-0 text-current opacity-65 select-none
               [&_svg]:size-4
               [&_svg_*]:fill-current [&_svg_*]:stroke-current
             `)}
-            imageClassName="pointer-events-none size-4 object-contain select-none"
+            imageClassName="pointer-events-none size-4 object-contain opacity-65 select-none"
             size={16}
           />
           <span className="truncate select-none">{site.name}</span>
@@ -1484,7 +1484,7 @@ function FeaturedSlide({
         item.kind === 'sports'
           ? 'relative min-h-[190px] min-w-0 overflow-hidden md:min-h-[210px] lg:min-h-[230px]'
           : 'relative min-h-60 min-w-0 overflow-hidden md:min-h-[260px] lg:min-h-[280px]',
-        shouldRenderLiveSeriesChart && 'lg:-mt-1',
+        shouldRenderLiveSeriesChart && 'mt-4 md:mt-5 lg:mt-6',
       )}
     >
       {shouldRenderChart && (
@@ -1542,8 +1542,8 @@ function FeaturedSlide({
   if (item.kind === 'sports') {
     return (
       <article className="
-        relative flex h-full min-w-full flex-col gap-4 overflow-hidden p-4 pb-[64px]
-        md:p-5 md:pb-[68px]
+        relative flex h-full min-w-full flex-col gap-4 overflow-hidden p-4 pb-[52px]
+        md:p-5 md:pb-[56px]
       "
       >
         <div className="
@@ -1568,8 +1568,8 @@ function FeaturedSlide({
   if (shouldRenderLiveSeriesChart) {
     return (
       <article className="
-        relative flex h-full min-w-full flex-col gap-4 overflow-hidden p-4 pb-[64px]
-        md:p-5 md:pb-[68px]
+        relative flex h-full min-w-full flex-col gap-4 overflow-hidden p-4 pb-[52px]
+        md:p-5 md:pb-[56px]
       "
       >
         <div className="
@@ -1597,8 +1597,8 @@ function FeaturedSlide({
 
   return (
     <article className="
-      relative flex h-full min-w-full flex-col gap-4 overflow-hidden p-4 pb-[64px]
-      md:p-5 md:pb-[68px]
+      relative flex h-full min-w-full flex-col gap-4 overflow-hidden p-4 pb-[52px]
+      md:p-5 md:pb-[56px]
     "
     >
       <FeaturedHeader item={item} />

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
@@ -154,7 +154,7 @@ export default function EventHeader({ event }: EventHeaderProps) {
       <div className="relative z-10 flex flex-1 items-center gap-2 lg:gap-4">
         <div
           className={cn(
-            'shrink-0 rounded-sm transition-all ease-in-out dark:bg-foreground',
+            'shrink-0 rounded-sm transition-all ease-in-out',
             scrolled ? 'size-10' : 'size-10 lg:size-16',
           )}
         >

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
@@ -1043,6 +1043,25 @@ function resolveTeamTotalMarketHeaderTitle(market: Market | null) {
     || descriptor
 }
 
+function resolveHalftimeResultHeaderTitle(market: Market | null) {
+  const normalizedText = normalizeComparableText([
+    market?.sports_market_type,
+    market?.sports_group_item_title,
+    market?.short_title,
+    market?.title,
+  ].filter(Boolean).join(' '))
+
+  const isHalftimeResult = /\b(?:half\s*time|first half|1st half|1h|second half|2nd half|2h)\s+(?:result|moneyline)\b/
+    .test(normalizedText)
+  if (!isHalftimeResult) {
+    return null
+  }
+
+  return /\b(?:second half|2nd half|2h)\b/.test(normalizedText)
+    ? 'Second Half Result'
+    : 'Halftime Result'
+}
+
 export function normalizeComparableText(value: string | null | undefined) {
   return value
     ?.normalize('NFKD')
@@ -1430,6 +1449,11 @@ export function resolveTradeHeaderTitle({
   if (normalizedMarketType.includes('exact score')) {
     const descriptor = resolveMarketDescriptor(selectedMarket)
     return descriptor ? `Exact Score: ${descriptor}` : 'Exact Score'
+  }
+
+  const halftimeResultTitle = resolveHalftimeResultHeaderTitle(selectedMarket)
+  if (halftimeResultTitle) {
+    return halftimeResultTitle
   }
 
   if (marketType !== 'moneyline') {

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
@@ -1051,15 +1051,19 @@ function resolveHalftimeResultHeaderTitle(market: Market | null) {
     market?.title,
   ].filter(Boolean).join(' '))
 
-  const isHalftimeResult = /\b(?:half\s*time|first half|1st half|1h|second half|2nd half|2h)\s+(?:result|moneyline)\b/
-    .test(normalizedText)
-  if (!isHalftimeResult) {
-    return null
+  if (/\b(?:second half|2nd half|2h)\s+(?:result|moneyline)\b/.test(normalizedText)) {
+    return 'Second Half Result'
   }
 
-  return /\b(?:second half|2nd half|2h)\b/.test(normalizedText)
-    ? 'Second Half Result'
-    : 'Halftime Result'
+  if (/\b(?:first half|1st half|1h)\s+(?:result|moneyline)\b/.test(normalizedText)) {
+    return 'First Half Result'
+  }
+
+  if (/\bhalf\s*time\s+(?:result|moneyline)\b/.test(normalizedText)) {
+    return 'Halftime Result'
+  }
+
+  return null
 }
 
 export function normalizeComparableText(value: string | null | undefined) {

--- a/tests/unit/EventCardSportsMoneyline.test.tsx
+++ b/tests/unit/EventCardSportsMoneyline.test.tsx
@@ -111,6 +111,72 @@ describe('eventCardSportsMoneyline', () => {
     }))
   })
 
+  it('renders full team names in active moneyline buttons', () => {
+    const event = {
+      status: 'active',
+      volume: 2500,
+      sports_sport_slug: 'soccer',
+      sports_start_time: '2026-03-14T23:00:00.000Z',
+      markets: [
+        {
+          condition_id: 'match-winner-condition',
+          slug: 'france-vs-morocco-match-winner',
+        },
+      ],
+    } as any
+
+    const model = {
+      team1: {
+        name: 'France',
+        abbreviation: 'FRA',
+        color: '#1d4ed8',
+        logoUrl: null,
+        hostStatus: 'home',
+      },
+      team2: {
+        name: 'Morocco',
+        abbreviation: 'MAR',
+        color: '#dc2626',
+        logoUrl: null,
+        hostStatus: 'away',
+      },
+      team1Button: {
+        conditionId: 'match-winner-condition',
+        outcomeIndex: 0,
+        label: 'FRA',
+        tone: 'team1',
+        color: '#1d4ed8',
+      },
+      team2Button: {
+        conditionId: 'match-winner-condition',
+        outcomeIndex: 1,
+        label: 'MAR',
+        tone: 'team2',
+        color: '#dc2626',
+      },
+    } as any
+
+    render(
+      <EventCardSportsMoneyline
+        event={event}
+        model={model}
+        getDisplayChance={() => 61}
+      />,
+    )
+
+    const franceButtonLabel = screen.getAllByText('France')
+      .find(element => element.tagName.toLowerCase() === 'span')
+    const moroccoButtonLabel = screen.getAllByText('Morocco')
+      .find(element => element.tagName.toLowerCase() === 'span')
+
+    expect(franceButtonLabel).toBeInTheDocument()
+    expect(moroccoButtonLabel).toBeInTheDocument()
+    expect(franceButtonLabel?.closest('a')).toHaveClass('text-foreground')
+    expect(moroccoButtonLabel?.closest('a')).toHaveClass('text-foreground')
+    expect(screen.queryByText('FRA')).not.toBeInTheDocument()
+    expect(screen.queryByText('MAR')).not.toBeInTheDocument()
+  })
+
   it('renders the resolved winner and ended footer for sports cards', () => {
     const event = {
       status: 'resolved',

--- a/tests/unit/sportsOrderBookTradeLabel.test.ts
+++ b/tests/unit/sportsOrderBookTradeLabel.test.ts
@@ -202,6 +202,49 @@ describe('sports order-book trade label', () => {
     })).toBe('France vs Morocco')
   })
 
+  it('uses halftime market names for moneyline order panel headers', () => {
+    const card = {
+      title: 'France vs Morocco',
+      event: {
+        tags: [{ slug: 'sports' }],
+        main_tag: 'sports',
+        sports_sport_slug: 'soccer',
+        sports_series_slug: 'fifwc',
+      },
+      teams: [
+        { name: 'France', abbreviation: 'FRA' },
+        { name: 'Morocco', abbreviation: 'MAR' },
+      ],
+    } as any
+    const selectedButton = {
+      label: 'FRA',
+    } as any
+
+    expect(resolveTradeHeaderTitle({
+      card,
+      selectedButton,
+      selectedMarket: {
+        sports_market_type: 'Halftime Result',
+        sports_group_item_title: 'France',
+        short_title: 'France',
+        title: 'France',
+      } as any,
+      marketType: 'moneyline',
+    })).toBe('Halftime Result')
+
+    expect(resolveTradeHeaderTitle({
+      card,
+      selectedButton,
+      selectedMarket: {
+        sports_market_type: 'Second Half Result',
+        sports_group_item_title: 'Morocco',
+        short_title: 'Morocco',
+        title: 'Morocco',
+      } as any,
+      marketType: 'moneyline',
+    })).toBe('Second Half Result')
+  })
+
   it('keeps compact moneyline headers for esports', () => {
     const card = {
       title: 'Team Vitality vs 9z Team',

--- a/tests/unit/sportsOrderBookTradeLabel.test.ts
+++ b/tests/unit/sportsOrderBookTradeLabel.test.ts
@@ -236,6 +236,30 @@ describe('sports order-book trade label', () => {
       card,
       selectedButton,
       selectedMarket: {
+        sports_market_type: 'First Half Result',
+        sports_group_item_title: 'France',
+        short_title: 'France',
+        title: 'France',
+      } as any,
+      marketType: 'moneyline',
+    })).toBe('First Half Result')
+
+    expect(resolveTradeHeaderTitle({
+      card,
+      selectedButton,
+      selectedMarket: {
+        sports_market_type: '1H Result',
+        sports_group_item_title: 'France',
+        short_title: 'France',
+        title: 'France',
+      } as any,
+      marketType: 'moneyline',
+    })).toBe('First Half Result')
+
+    expect(resolveTradeHeaderTitle({
+      card,
+      selectedButton,
+      selectedMarket: {
         sports_market_type: 'Second Half Result',
         sports_group_item_title: 'Morocco',
         short_title: 'Morocco',


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes moneyline headers to correctly show First Half, Halftime, and Second Half results. Polishes the Featured footer and home sports moneyline buttons for better readability, and removes an unintended dark background in the event header.

- **Bug Fixes**
  - Moneyline order panel now shows "First Half Result", "Halftime Result", or "Second Half Result" when the selected market is a half-time market (tests added).
  - Removed dark-mode background from the event header logo container.

- **UI Improvements**
  - Featured footer: shorter height, tighter padding, softer colors, and subtler live pulse and site logo.
  - Home card moneyline buttons now use full team names with better wrapping and smaller text; adjusted slide padding and chart spacing across breakpoints.

<sup>Written for commit 73ebb53e3e01ee82f81acc9d75e03517ed2881b4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

