### PR TITLE
refactor: set deploymentId for non-vercel hosts and rely only on it

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,7 @@ const commitSha = resolveCommitSha()
 
 const config: NextConfig = {
   output: process.env.VERCEL_ENV ? undefined : 'standalone',
+  deploymentId: process.env.VERCEL_ENV ? undefined : commitSha,
   cacheComponents: true,
   typedRoutes: true,
   reactStrictMode: false,

--- a/src/components/AlertBanner.tsx
+++ b/src/components/AlertBanner.tsx
@@ -1,6 +1,5 @@
 import { AlertCircleIcon } from 'lucide-react'
 import * as React from 'react'
-
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 
 interface AlertBannerProps {

--- a/src/components/AppErrorFallback.tsx
+++ b/src/components/AppErrorFallback.tsx
@@ -3,11 +3,9 @@
 import * as Sentry from '@sentry/nextjs'
 import { RotateCcwIcon } from 'lucide-react'
 import { useEffect } from 'react'
+import AlertBanner from '@/components/AlertBanner'
 import { Button } from '@/components/ui/button'
-import {
-  isStaleNextClientAssetError,
-  requestStaleNextClientAssetReload,
-} from '@/lib/next-client-stale-assets'
+import { isNextClientStaleAssetError } from '@/lib/next-client-stale-assets'
 import { isNextNotFoundError } from '@/lib/next-http-fallback'
 import { cn } from '@/lib/utils'
 
@@ -33,7 +31,7 @@ export default function AppErrorFallback({
       return
     }
 
-    if (isStaleNextClientAssetError(error) && requestStaleNextClientAssetReload()) {
+    if (isNextClientStaleAssetError(error)) {
       return
     }
 
@@ -41,23 +39,23 @@ export default function AppErrorFallback({
   }, [error])
 
   return (
-    <div
-      role="alert"
+    <AlertBanner
+      title={title}
+      description={(
+        <>
+          {description && <p>{description}</p>}
+          <div>
+            <Button type="button" variant="outline" size="sm" onClick={reset}>
+              <RotateCcwIcon aria-hidden />
+              {retryLabel}
+            </Button>
+          </div>
+        </>
+      )}
       className={cn(
-        'grid gap-3 rounded-md border border-destructive/30 bg-destructive/5 p-4 text-left',
+        'text-left',
         variant === 'page' && 'mx-auto my-16 w-[min(100%-2rem,32rem)]',
       )}
-    >
-      <div className="grid gap-1">
-        <p className="font-semibold text-foreground">{title}</p>
-        {description && <p className="text-sm text-muted-foreground">{description}</p>}
-      </div>
-      <div>
-        <Button type="button" variant="outline" size="sm" onClick={reset}>
-          <RotateCcwIcon aria-hidden />
-          {retryLabel}
-        </Button>
-      </div>
-    </div>
+    />
   )
 }

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -1,9 +1,6 @@
 import type { PublicRuntimeConfig } from '@/lib/public-runtime-config.shared'
 import * as Sentry from '@sentry/nextjs'
-import {
-  installStaleNextClientAssetReloadHandlers,
-  isStaleNextClientAssetError,
-} from '@/lib/next-client-stale-assets'
+import { isNextClientStaleAssetError } from '@/lib/next-client-stale-assets'
 import { isNextNotFoundError } from '@/lib/next-http-fallback'
 
 declare global {
@@ -32,14 +29,12 @@ Sentry.init({
       return null
     }
 
-    if (isStaleNextClientAssetError(hint.originalException)) {
+    if (isNextClientStaleAssetError(hint.originalException)) {
       return null
     }
 
     return event
   },
 })
-
-installStaleNextClientAssetReloadHandlers()
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart

--- a/src/lib/next-client-stale-assets.ts
+++ b/src/lib/next-client-stale-assets.ts
@@ -1,5 +1,3 @@
-const STALE_NEXT_CLIENT_ASSET_RELOAD_PREFIX = 'next-stale-client-asset-reload'
-
 const staleAssetErrorPatterns = [
   /ChunkLoadError/i,
   /Loading chunk .+ failed/i,
@@ -8,101 +6,6 @@ const staleAssetErrorPatterns = [
   /module factory is not available/i,
   /was instantiated because it was required from module/i,
 ]
-
-const inMemoryReloadKeys = new Set<string>()
-
-interface ReloadOptions {
-  buildId?: string
-  location?: Pick<Location, 'pathname' | 'search'>
-  reload?: () => void
-  storage?: Pick<Storage, 'getItem' | 'setItem'>
-}
-
-function readStorage(storage: ReloadOptions['storage'], key: string) {
-  if (!storage) {
-    return inMemoryReloadKeys.has(key) ? '1' : null
-  }
-
-  try {
-    return storage.getItem(key) ?? null
-  }
-  catch {
-    return inMemoryReloadKeys.has(key) ? '1' : null
-  }
-}
-
-function writeStorage(storage: ReloadOptions['storage'], key: string) {
-  if (!storage) {
-    inMemoryReloadKeys.add(key)
-    return
-  }
-
-  try {
-    storage.setItem(key, '1')
-  }
-  catch {
-    inMemoryReloadKeys.add(key)
-  }
-}
-
-function getBuildId(buildId?: string) {
-  if (buildId && buildId.trim()) {
-    return buildId.trim()
-  }
-
-  return process.env.COMMIT_SHA || 'unknown'
-}
-
-function getCurrentLocation(location?: ReloadOptions['location']) {
-  if (location) {
-    return location
-  }
-
-  if (typeof window === 'undefined') {
-    return null
-  }
-
-  return window.location
-}
-
-function getCurrentStorage(storage?: ReloadOptions['storage']) {
-  if (storage) {
-    return storage
-  }
-
-  if (typeof window === 'undefined') {
-    return null
-  }
-
-  try {
-    return window.sessionStorage
-  }
-  catch {
-    return null
-  }
-}
-
-function getReloadKey(options: ReloadOptions) {
-  const location = getCurrentLocation(options.location)
-  if (!location) {
-    return null
-  }
-
-  const buildId = getBuildId(options.buildId)
-  return `${STALE_NEXT_CLIENT_ASSET_RELOAD_PREFIX}:${buildId}:${location.pathname}${location.search}`
-}
-
-function getReloadFn(reload?: () => void) {
-  if (reload) {
-    return reload
-  }
-
-  if (typeof window === 'undefined') {
-    return null
-  }
-
-  return () => window.location.reload()
-}
 
 function collectErrorMessages(value: unknown, seen = new Set<unknown>()): string[] {
   if (!value || seen.has(value)) {
@@ -167,7 +70,7 @@ function isNextStaticAssetEvent(event: unknown) {
   return isNextStaticAssetUrl(target?.src) || isNextStaticAssetUrl(target?.href)
 }
 
-export function isStaleNextClientAssetError(error: unknown) {
+export function isNextClientStaleAssetError(error: unknown) {
   if (isNextStaticAssetEvent(error)) {
     return true
   }
@@ -178,48 +81,4 @@ export function isStaleNextClientAssetError(error: unknown) {
   }
 
   return staleAssetErrorPatterns.some(pattern => pattern.test(message))
-}
-
-export function requestStaleNextClientAssetReload(options: ReloadOptions = {}) {
-  const reload = getReloadFn(options.reload)
-  const key = getReloadKey(options)
-  if (!reload || !key) {
-    return false
-  }
-
-  const storage = getCurrentStorage(options.storage) ?? undefined
-  if (readStorage(storage, key)) {
-    return false
-  }
-
-  writeStorage(storage, key)
-  reload()
-  return true
-}
-
-function handleWindowError(event: ErrorEvent | Event) {
-  const error = 'error' in event ? event.error : event
-  const message = 'message' in event ? event.message : undefined
-
-  if (isStaleNextClientAssetError(event) || isStaleNextClientAssetError(error) || isStaleNextClientAssetError(message)) {
-    requestStaleNextClientAssetReload()
-  }
-}
-
-function handleUnhandledRejection(event: PromiseRejectionEvent) {
-  if (isStaleNextClientAssetError(event.reason)) {
-    requestStaleNextClientAssetReload()
-  }
-}
-
-let staleNextClientAssetReloadHandlersInstalled = false
-
-export function installStaleNextClientAssetReloadHandlers() {
-  if (typeof window === 'undefined' || staleNextClientAssetReloadHandlersInstalled) {
-    return
-  }
-
-  staleNextClientAssetReloadHandlersInstalled = true
-  window.addEventListener('error', handleWindowError, true)
-  window.addEventListener('unhandledrejection', handleUnhandledRejection)
 }

--- a/tests/unit/nextClientStaleAssets.test.ts
+++ b/tests/unit/nextClientStaleAssets.test.ts
@@ -1,28 +1,10 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
+  isNextClientStaleAssetError,
   isNextStaticAssetUrl,
-  isStaleNextClientAssetError,
-  requestStaleNextClientAssetReload,
 } from '@/lib/next-client-stale-assets'
 
-function createMemoryStorage() {
-  const store = new Map<string, string>()
-
-  return {
-    getItem: (key: string) => store.get(key) ?? null,
-    setItem: (key: string, value: string) => store.set(key, value),
-  }
-}
-
 describe('next client stale assets', () => {
-  const sessionStorageDescriptor = Object.getOwnPropertyDescriptor(window, 'sessionStorage')
-
-  afterEach(() => {
-    if (sessionStorageDescriptor) {
-      Object.defineProperty(window, 'sessionStorage', sessionStorageDescriptor)
-    }
-  })
-
   it('matches Next static asset URLs', () => {
     expect(isNextStaticAssetUrl('/_next/static/chunks/app.js')).toBe(true)
     expect(isNextStaticAssetUrl('https://cdn.example/_next/static/css/app.css')).toBe(true)
@@ -30,66 +12,16 @@ describe('next client stale assets', () => {
   })
 
   it('matches Turbopack missing module errors', () => {
-    expect(isStaleNextClientAssetError(new Error(
+    expect(isNextClientStaleAssetError(new Error(
       'Module 948971 was instantiated because it was required from module 589170, but the module factory is not available.',
     ))).toBe(true)
   })
 
   it('matches chunk load errors', () => {
-    expect(isStaleNextClientAssetError(new Error('ChunkLoadError: Loading chunk 123 failed.'))).toBe(true)
+    expect(isNextClientStaleAssetError(new Error('ChunkLoadError: Loading chunk 123 failed.'))).toBe(true)
   })
 
   it('ignores ordinary app errors', () => {
-    expect(isStaleNextClientAssetError(new Error('Internal server error'))).toBe(false)
-  })
-
-  it('reloads once per build and path', () => {
-    const reload = vi.fn()
-    const storage = createMemoryStorage()
-    const location = { pathname: '/portfolio', search: '' }
-
-    expect(requestStaleNextClientAssetReload({
-      buildId: 'build-a',
-      location,
-      reload,
-      storage,
-    })).toBe(true)
-    expect(requestStaleNextClientAssetReload({
-      buildId: 'build-a',
-      location,
-      reload,
-      storage,
-    })).toBe(false)
-    expect(requestStaleNextClientAssetReload({
-      buildId: 'build-b',
-      location,
-      reload,
-      storage,
-    })).toBe(true)
-    expect(reload).toHaveBeenCalledTimes(2)
-  })
-
-  it('falls back when session storage access throws', () => {
-    const reload = vi.fn()
-    const location = { pathname: '/portfolio', search: '' }
-
-    Object.defineProperty(window, 'sessionStorage', {
-      configurable: true,
-      get() {
-        throw new DOMException('Access denied', 'SecurityError')
-      },
-    })
-
-    expect(requestStaleNextClientAssetReload({
-      buildId: 'storage-blocked',
-      location,
-      reload,
-    })).toBe(true)
-    expect(requestStaleNextClientAssetReload({
-      buildId: 'storage-blocked',
-      location,
-      reload,
-    })).toBe(false)
-    expect(reload).toHaveBeenCalledTimes(1)
+    expect(isNextClientStaleAssetError(new Error('Internal server error'))).toBe(false)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Set `deploymentId` for non-Vercel deployments (using the commit SHA) and remove custom client-asset reload logic. We now rely on `deploymentId` for cache busting and continue to ignore stale asset errors in `@sentry/nextjs`.

- **Refactors**
  - Add `deploymentId` in `next.config.ts` when `VERCEL_ENV` is unset.
  - Remove stale asset reload handlers and storage logic; keep `isNextClientStaleAssetError`.
  - Update Sentry to ignore these errors; drop handler installation.
  - Simplify `AppErrorFallback` to use `AlertBanner`; remove manual reload.
  - Trim related unit tests.

<sup>Written for commit d77b7afca77e799af84d17cd64343ec90f8e7b04. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

