### PR TITLE
fix: catch all not found

### DIFF
--- a/src/app/[locale]/(platform)/[slug]/[subcategory]/[...slugParts]/page.tsx
+++ b/src/app/[locale]/(platform)/[slug]/[subcategory]/[...slugParts]/page.tsx
@@ -1,0 +1,5 @@
+import { notFound } from 'next/navigation'
+
+export default function UnknownPlatformNestedPage() {
+  notFound()
+}


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add a catch-all page for nested platform routes that calls `notFound()` from `next/navigation`, so unknown URLs under [locale]/(platform)/[slug]/[subcategory]/* return a 404 instead of rendering.

<sup>Written for commit 43b4273d3b5a86712f7fc5daf004958847800b33. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

