### PR TITLE
feat: add limit to merge batch

### DIFF
--- a/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
+++ b/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
@@ -15,9 +15,20 @@ import { toMicro } from '@/lib/formatters'
 import { applyConditionReductionsToPublicPositions, applyShareDeltas, updateQueryDataWhere } from '@/lib/optimistic-trading'
 import { isTradingAuthRequiredError } from '@/lib/trading-auth/errors'
 import { normalizeAddress } from '@/lib/wallet'
-import { signAndSubmitDepositWalletCalls } from '@/lib/wallet/client'
+import {
+  DepositWalletCallItemsSplitFallbackError,
+  signAndSubmitDepositWalletCallItemsWithSplitFallback,
+} from '@/lib/wallet/client'
 import { buildMergePositionCall } from '@/lib/wallet/transactions'
 import { useNotifications } from '@/stores/useNotifications'
+
+const MAX_MERGE_POSITION_CALLS_PER_BATCH = 25
+
+interface PreparedMerge {
+  conditionId: string
+  mergeAmount: number
+  isNegRisk: boolean
+}
 
 interface UseMergePositionsActionOptions {
   mergeableMarkets: MergeableMarket[]
@@ -45,6 +56,65 @@ export function useMergePositionsAction({
   const addLocalOrderFillNotification = useNotifications(state => state.addLocalOrderFillNotification)
   const { runWithSignaturePrompt } = useSignaturePromptRunner()
   const { signTypedDataAsync } = useSignTypedData()
+
+  const applySuccessfulMerges = useCallback((successfulMerges: PreparedMerge[]) => {
+    if (successfulMerges.length === 0) {
+      return
+    }
+
+    const normalizedDepositWallet = normalizeAddress(user?.deposit_wallet_address)
+    const publicPositionReductions = successfulMerges.map(entry => ({
+      conditionId: entry.conditionId,
+      sharesDelta: -entry.mergeAmount,
+    }))
+    const shareDeltas = successfulMerges.flatMap(entry => ([
+      {
+        conditionId: entry.conditionId,
+        outcomeIndex: 0 as const,
+        sharesDelta: -entry.mergeAmount,
+      },
+      {
+        conditionId: entry.conditionId,
+        outcomeIndex: 1 as const,
+        sharesDelta: -entry.mergeAmount,
+      },
+    ]))
+
+    updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
+      queryClient,
+      ['user-positions'],
+      (currentQueryKey) => {
+        if (currentQueryKey[2] !== 'active') {
+          return false
+        }
+
+        return !normalizedDepositWallet || !currentQueryKey[1]
+          ? false
+          : String(currentQueryKey[1]).toLowerCase() === normalizedDepositWallet.toLowerCase()
+      },
+      current => current
+        ? {
+            ...current,
+            pages: current.pages.map(page =>
+              applyConditionReductionsToPublicPositions(page, publicPositionReductions) ?? page,
+            ),
+          }
+        : current,
+    )
+
+    updateQueryDataWhere<SharesByCondition>(
+      queryClient,
+      ['user-conditional-shares'],
+      () => true,
+      current => applyShareDeltas(current, shareDeltas),
+    )
+  }, [queryClient, user?.deposit_wallet_address])
+
+  const invalidateMergeQueries = useCallback(() => {
+    void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
+    void queryClient.invalidateQueries({ queryKey: [DEPOSIT_WALLET_BALANCE_QUERY_KEY] })
+    void queryClient.invalidateQueries({ queryKey: ['user-conditional-shares'] })
+  }, [queryClient])
 
   const handleMergeAll = useCallback(async () => {
     if (!hasMergeableMarkets) {
@@ -109,7 +179,7 @@ export function useMergePositionsAction({
             isNegRisk: market.isNegRisk,
           }
         })
-        .filter((entry): entry is { conditionId: string, mergeAmount: number, isNegRisk: boolean } => Boolean(entry))
+        .filter((entry): entry is PreparedMerge => Boolean(entry))
 
       if (preparedMerges.length === 0) {
         toast.info('No eligible pairs to merge.')
@@ -117,23 +187,23 @@ export function useMergePositionsAction({
         return
       }
 
-      const calls = preparedMerges.map(entry =>
-        buildMergePositionCall({
-          conditionId: entry.conditionId as `0x${string}`,
-          partition: [...DEFAULT_CONDITION_PARTITION],
-          amount: toMicro(entry.mergeAmount),
-          parentCollectionId: ZERO_BYTES32,
-          contract: entry.isNegRisk ? UMA_NEG_RISK_ADAPTER_ADDRESS : undefined,
-        }),
-      )
+      setMergeBatchCount(0)
 
-      setMergeBatchCount(preparedMerges.length)
-
-      const response = await runWithSignaturePrompt(() => signAndSubmitDepositWalletCalls({
+      const response = await runWithSignaturePrompt(() => signAndSubmitDepositWalletCallItemsWithSplitFallback({
         user,
-        calls,
+        items: preparedMerges,
+        getCall: entry =>
+          buildMergePositionCall({
+            conditionId: entry.conditionId as `0x${string}`,
+            partition: [...DEFAULT_CONDITION_PARTITION],
+            amount: toMicro(entry.mergeAmount),
+            parentCollectionId: ZERO_BYTES32,
+            contract: entry.isNegRisk ? UMA_NEG_RISK_ADAPTER_ADDRESS : undefined,
+          }),
         metadata: 'merge_position',
         signTypedDataAsync,
+        maxChunkSize: MAX_MERGE_POSITION_CALLS_PER_BATCH,
+        onProgress: progress => setMergeBatchCount(progress.successfulItems.length + progress.failedItems.length),
       }))
 
       if (response?.error) {
@@ -151,74 +221,34 @@ export function useMergePositionsAction({
           action: 'merge',
           txHash: response.txHash,
           title: 'Merge shares',
-          description: preparedMerges.length > 1
+          description: response.successfulItems.length > 1
             ? 'Request submitted for multiple markets.'
             : 'Request submitted.',
         })
       }
 
-      onSuccess?.()
+      applySuccessfulMerges(response.successfulItems)
 
-      const normalizedDepositWallet = normalizeAddress(user.deposit_wallet_address)
-      const publicPositionReductions = preparedMerges.map(entry => ({
-        conditionId: entry.conditionId,
-        sharesDelta: -entry.mergeAmount,
-      }))
-      const shareDeltas = preparedMerges.flatMap(entry => ([
-        {
-          conditionId: entry.conditionId,
-          outcomeIndex: 0 as const,
-          sharesDelta: -entry.mergeAmount,
-        },
-        {
-          conditionId: entry.conditionId,
-          outcomeIndex: 1 as const,
-          sharesDelta: -entry.mergeAmount,
-        },
-      ]))
-
-      updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
-        queryClient,
-        ['user-positions'],
-        (currentQueryKey) => {
-          if (currentQueryKey[2] !== 'active') {
-            return false
-          }
-
-          return !normalizedDepositWallet || !currentQueryKey[1]
-            ? false
-            : String(currentQueryKey[1]).toLowerCase() === normalizedDepositWallet.toLowerCase()
-        },
-        current => current
-          ? {
-              ...current,
-              pages: current.pages.map(page =>
-                applyConditionReductionsToPublicPositions(page, publicPositionReductions) ?? page,
-              ),
-            }
-          : current,
-      )
-
-      updateQueryDataWhere<SharesByCondition>(
-        queryClient,
-        ['user-conditional-shares'],
-        () => true,
-        current => applyShareDeltas(current, shareDeltas),
-      )
+      if (response.partialFailure) {
+        toast.error('Some positions could not be merged. Please try again.')
+      }
+      else {
+        onSuccess?.()
+      }
 
       setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
-        void queryClient.invalidateQueries({ queryKey: [DEPOSIT_WALLET_BALANCE_QUERY_KEY] })
-        void queryClient.invalidateQueries({ queryKey: ['user-conditional-shares'] })
+        invalidateMergeQueries()
       }, 4_000)
 
       setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
-        void queryClient.invalidateQueries({ queryKey: [DEPOSIT_WALLET_BALANCE_QUERY_KEY] })
-        void queryClient.invalidateQueries({ queryKey: ['user-conditional-shares'] })
+        invalidateMergeQueries()
       }, 12_000)
     }
     catch (error) {
+      if (error instanceof DepositWalletCallItemsSplitFallbackError) {
+        applySuccessfulMerges(error.successfulItems as PreparedMerge[])
+        invalidateMergeQueries()
+      }
       console.error('Failed to submit merge operation.', error)
       toast.error('We could not submit your merge request. Please try again.')
     }
@@ -236,6 +266,8 @@ export function useMergePositionsAction({
     runWithSignaturePrompt,
     signTypedDataAsync,
     addLocalOrderFillNotification,
+    applySuccessfulMerges,
+    invalidateMergeQueries,
     user,
     viemRpcUrl,
   ])

--- a/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
+++ b/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
@@ -231,6 +231,10 @@ export function useMergePositionsAction({
 
       if (response.partialFailure) {
         toast.error('Some positions could not be merged. Please try again.')
+        const failureError = response.failure?.error
+        if (failureError && isTradingAuthRequiredError(failureError)) {
+          openTradeRequirements({ forceTradingAuth: true })
+        }
       }
       else {
         onSuccess?.()

--- a/src/lib/wallet/client.ts
+++ b/src/lib/wallet/client.ts
@@ -161,6 +161,8 @@ function shouldSplitDepositWalletCallFailure(result: SignAndSubmitDepositWalletC
   const normalized = result.error.toLowerCase()
   return normalized.includes('revert')
     || normalized.includes('transaction failed')
+    || (normalized.includes('estimated gas') && normalized.includes('tx_gas_limit'))
+    || (normalized.includes('gas') && normalized.includes('exceeds') && normalized.includes('cap'))
 }
 
 function getPreferredFailure(
@@ -184,17 +186,28 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
   getCall,
   metadata,
   signTypedDataAsync,
+  maxChunkSize,
+  onProgress,
 }: {
   user: Pick<User, 'address' | 'deposit_wallet_address'>
   items: T[]
   getCall: (item: T) => WalletCall
   metadata?: string
   signTypedDataAsync: SignTypedDataFn
+  maxChunkSize?: number
+  onProgress?: (progress: { successfulItems: T[], failedItems: T[] }) => void
 }): Promise<SignAndSubmitDepositWalletCallItemsResult<T>> {
   const successfulItems: T[] = []
   const failedItems: T[] = []
   let lastSuccess: SignAndSubmitDepositWalletCallsResult | null = null
   let firstFailure: SignAndSubmitDepositWalletCallsResult | null = null
+
+  function notifyProgress() {
+    onProgress?.({
+      successfulItems: [...successfulItems],
+      failedItems: [...failedItems],
+    })
+  }
 
   async function submitChunk(chunk: T[]): Promise<void> {
     let result: SignAndSubmitDepositWalletCallsResult
@@ -219,12 +232,14 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
     if (!result.error) {
       successfulItems.push(...chunk)
       lastSuccess = result
+      notifyProgress()
       return
     }
 
     firstFailure = getPreferredFailure(firstFailure, result)
     if (chunk.length <= 1 || !shouldSplitDepositWalletCallFailure(result)) {
       failedItems.push(...chunk)
+      notifyProgress()
       return
     }
 
@@ -233,7 +248,17 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
     await submitChunk(chunk.slice(midpoint))
   }
 
-  await submitChunk(items)
+  const initialChunkSize = Math.max(
+    1,
+    Math.min(
+      items.length || 1,
+      Number.isFinite(maxChunkSize) ? Math.floor(maxChunkSize as number) : items.length || 1,
+    ),
+  )
+
+  for (let index = 0; index < items.length; index += initialChunkSize) {
+    await submitChunk(items.slice(index, index + initialChunkSize))
+  }
 
   if (successfulItems.length === 0) {
     return {

--- a/src/lib/wallet/client.ts
+++ b/src/lib/wallet/client.ts
@@ -209,7 +209,7 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
     })
   }
 
-  async function submitChunk(chunk: T[]): Promise<void> {
+  async function submitChunk(chunk: T[], unprocessedAfterChunk: T[]): Promise<void> {
     let result: SignAndSubmitDepositWalletCallsResult
     try {
       result = await signAndSubmitDepositWalletCalls({
@@ -224,6 +224,7 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
         throw new DepositWalletCallItemsSplitFallbackError(error, successfulItems, [
           ...failedItems,
           ...chunk,
+          ...unprocessedAfterChunk,
         ])
       }
       throw error
@@ -244,8 +245,10 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
     }
 
     const midpoint = Math.ceil(chunk.length / 2)
-    await submitChunk(chunk.slice(0, midpoint))
-    await submitChunk(chunk.slice(midpoint))
+    const left = chunk.slice(0, midpoint)
+    const right = chunk.slice(midpoint)
+    await submitChunk(left, [...right, ...unprocessedAfterChunk])
+    await submitChunk(right, unprocessedAfterChunk)
   }
 
   const initialChunkSize = Math.max(
@@ -257,7 +260,10 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
   )
 
   for (let index = 0; index < items.length; index += initialChunkSize) {
-    await submitChunk(items.slice(index, index + initialChunkSize))
+    await submitChunk(
+      items.slice(index, index + initialChunkSize),
+      items.slice(index + initialChunkSize),
+    )
   }
 
   if (successfulItems.length === 0) {

--- a/tests/unit/walletClient.test.ts
+++ b/tests/unit/walletClient.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { WALLET_CONNECTOR_NOT_CONNECTED_MESSAGE } from '@/lib/wallet'
 
 const mocks = vi.hoisted(() => ({
@@ -11,9 +11,17 @@ vi.mock('@/app/[locale]/(platform)/_actions/approve-tokens', () => ({
   submitDepositWalletTransactionAction: mocks.submitDepositWalletTransactionAction,
 }))
 
-const { signAndSubmitDepositWalletCalls } = await import('@/lib/wallet/client')
+const {
+  DepositWalletCallItemsSplitFallbackError,
+  signAndSubmitDepositWalletCallItemsWithSplitFallback,
+  signAndSubmitDepositWalletCalls,
+} = await import('@/lib/wallet/client')
 
 describe('wallet client', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
   it('maps stale wagmi connector signature failures to a reconnect result', async () => {
     mocks.getDepositWalletNonceAction.mockResolvedValue({
       error: null,
@@ -43,5 +51,36 @@ describe('wallet client', () => {
       code: 'wallet_connector_not_connected',
     })
     expect(mocks.submitDepositWalletTransactionAction).not.toHaveBeenCalled()
+  })
+
+  it('includes unprocessed items when a later limited chunk throws after a partial submit', async () => {
+    mocks.getDepositWalletNonceAction.mockResolvedValue({
+      error: null,
+      nonce: '1',
+    })
+    mocks.submitDepositWalletTransactionAction
+      .mockResolvedValueOnce({ error: null, txHash: '0x1' })
+      .mockRejectedValueOnce(new Error('submit unavailable'))
+
+    const request = signAndSubmitDepositWalletCallItemsWithSplitFallback({
+      user: {
+        address: '0x0000000000000000000000000000000000000001',
+        deposit_wallet_address: '0x0000000000000000000000000000000000000002',
+      },
+      items: [1, 2, 3, 4, 5],
+      getCall: () => ({
+        target: '0x0000000000000000000000000000000000000003',
+        value: '0',
+        data: '0x',
+      }),
+      maxChunkSize: 2,
+      signTypedDataAsync: vi.fn().mockResolvedValue('0xsignature'),
+    })
+
+    await expect(request).rejects.toMatchObject({
+      successfulItems: [1, 2],
+      failedItems: [3, 4, 5],
+    })
+    await expect(request).rejects.toBeInstanceOf(DepositWalletCallItemsSplitFallbackError)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit merge batches to 25 and submit in chunks with split fallback to prevent gas limit failures. Improves reliability and partial failure handling, with progress that counts processed items and optimistic updates for completed merges.

- **New Features**
  - Cap merge calls per batch at 25 via `maxChunkSize`; use `onProgress` so `mergeBatchCount` reflects successful + failed items.
  - Switch to `signAndSubmitDepositWalletCallItemsWithSplitFallback` and auto-split on common “estimated gas/tx_gas_limit” and “gas exceeds cap” errors.

- **Bug Fixes**
  - Apply optimistic updates only for successful merges; on partial failure, show a toast and prompt trading auth when needed, then revalidate queries.
  - Ensure split-fallback errors include unprocessed items so the UI can reflect remaining work.

<sup>Written for commit b4387be619dbe763b5e172d45d40f87062ba5c88. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

