### PR TITLE
fix: handle string timestamps in creator source refresh

### DIFF
--- a/src/lib/allowed-market-creators-server.ts
+++ b/src/lib/allowed-market-creators-server.ts
@@ -39,12 +39,25 @@ export function normalizeAllowedMarketCreatorWallets(wallets: Iterable<string>) 
   return [...deduped].sort()
 }
 
-function shouldRefreshSiteSource(refreshedAt: Date | null, now: Date) {
+function timestampFromRefreshedAt(refreshedAt: Date | string | number | null) {
   if (!refreshedAt) {
+    return null
+  }
+
+  const timestamp = refreshedAt instanceof Date
+    ? refreshedAt.getTime()
+    : new Date(refreshedAt).getTime()
+
+  return Number.isNaN(timestamp) ? null : timestamp
+}
+
+function shouldRefreshSiteSource(refreshedAt: Date | string | number | null, now: Date) {
+  const refreshedAtTimestamp = timestampFromRefreshedAt(refreshedAt)
+  if (!refreshedAtTimestamp) {
     return true
   }
 
-  return now.getTime() - refreshedAt.getTime() >= SITE_SOURCE_REFRESH_INTERVAL_MS
+  return now.getTime() - refreshedAtTimestamp >= SITE_SOURCE_REFRESH_INTERVAL_MS
 }
 
 function errorMessageFromUnknown(error: unknown) {

--- a/src/lib/db/queries/allowed-market-creators.ts
+++ b/src/lib/db/queries/allowed-market-creators.ts
@@ -16,7 +16,7 @@ interface UpsertAllowedMarketCreatorInput {
 export interface AllowedMarketCreatorSiteSourceRecord {
   sourceUrl: string
   displayName: string
-  refreshedAt: Date | null
+  refreshedAt: Date | string | number | null
 }
 
 function normalizeWalletAddress(walletAddress: string) {
@@ -70,7 +70,7 @@ export const AllowedMarketCreatorRepository = {
         .select({
           sourceUrl: allowed_market_creators.source_url,
           displayName: sql<string>`MIN(${allowed_market_creators.display_name})`,
-          refreshedAt: sql<Date | null>`MAX(${allowed_market_creators.updated_at})`,
+          refreshedAt: sql<Date | string | number | null>`MAX(${allowed_market_creators.updated_at})`,
         })
         .from(allowed_market_creators)
         .where(and(

--- a/tests/unit/allowedMarketCreatorsServer.test.ts
+++ b/tests/unit/allowedMarketCreatorsServer.test.ts
@@ -81,6 +81,31 @@ describe('allowed market creators server helpers', () => {
     expect(mocks.replaceSiteSource).not.toHaveBeenCalled()
   })
 
+  it('skips recently refreshed site sources with string timestamps', async () => {
+    const now = new Date('2026-06-18T12:00:00.000Z')
+    mocks.listSiteSources.mockResolvedValueOnce({
+      data: [{
+        sourceUrl: 'https://site2.com',
+        displayName: 'site2.com',
+        refreshedAt: '2026-06-18T11:00:00.000Z',
+      }],
+      error: null,
+    })
+
+    const { refreshAllowedMarketCreatorSiteSources } = await import('@/lib/allowed-market-creators-server')
+
+    await expect(refreshAllowedMarketCreatorSiteSources({ now })).resolves.toEqual({
+      scanned: 1,
+      checked: 0,
+      refreshed: 0,
+      skippedFresh: 1,
+      wallets: 0,
+      errors: [],
+    })
+    expect(mocks.fetch).not.toHaveBeenCalled()
+    expect(mocks.replaceSiteSource).not.toHaveBeenCalled()
+  })
+
   it('refreshes stale site sources and persists normalized wallets', async () => {
     const now = new Date('2026-06-18T12:00:00.000Z')
     mocks.listSiteSources.mockResolvedValueOnce({


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes site source refresh logic to accept string and numeric timestamps from the DB, preventing runtime errors and unnecessary refreshes. Recent sources are now correctly skipped based on the refresh interval.

- **Bug Fixes**
  - Parse refreshedAt from Date | string | number | null and compare using timestamps.
  - Update repository and record types to allow non-Date values.
  - Add unit test verifying string timestamps skip fresh sources without fetch or write.

<sup>Written for commit c4edbcfebed557dc27fd57e7efc815649bb2ca22. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

