### PR TITLE
fix: sports game time

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
@@ -15,6 +15,7 @@ import { resolveEventOutcomePath } from '@/lib/events-routing'
 import { formatDate, formatVolume } from '@/lib/formatters'
 import { isEventResolvedLike } from '@/lib/home-events'
 import { resolveHomeSportsButtonChance, resolveResolvedHomeSportsMoneylineWinner } from '@/lib/sports-home-card'
+import { parseSportsScore } from '@/lib/sports-resolution'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
 import { cn } from '@/lib/utils'
 
@@ -253,6 +254,10 @@ export default function EventCardSportsMoneyline({
   const resolvedWinner = isResolvedEvent
     ? resolveResolvedHomeSportsMoneylineWinner(event, model)
     : null
+  const showLiveScore = !isResolvedEvent && event.sports_live === true
+  const parsedLiveScore = showLiveScore ? parseSportsScore(event.sports_score) : null
+  const team1Score = showLiveScore ? (parsedLiveScore?.team1 ?? 0) : null
+  const team2Score = showLiveScore ? (parsedLiveScore?.team2 ?? 0) : null
 
   return (
     <Card
@@ -289,6 +294,17 @@ export default function EventCardSportsMoneyline({
                     )
                   : null}
               </div>
+              {team1Score !== null && (
+                <>
+                  <span
+                    aria-label={`${model.team1.name} score ${team1Score}`}
+                    className="shrink-0 text-sm font-medium text-foreground tabular-nums"
+                  >
+                    {team1Score}
+                  </span>
+                  <span className="h-4 w-px shrink-0 bg-border" aria-hidden="true" />
+                </>
+              )}
               <p className="truncate text-sm font-medium decoration-2 group-hover/team-row-1:underline">
                 {model.team1.name}
               </p>
@@ -317,6 +333,17 @@ export default function EventCardSportsMoneyline({
                     )
                   : null}
               </div>
+              {team2Score !== null && (
+                <>
+                  <span
+                    aria-label={`${model.team2.name} score ${team2Score}`}
+                    className="shrink-0 text-sm font-medium text-foreground tabular-nums"
+                  >
+                    {team2Score}
+                  </span>
+                  <span className="h-4 w-px shrink-0 bg-border" aria-hidden="true" />
+                </>
+              )}
               <p className="truncate text-sm font-medium decoration-2 group-hover/team-row-2:underline">
                 {model.team2.name}
               </p>

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
@@ -256,8 +256,8 @@ export default function EventCardSportsMoneyline({
     : null
   const showLiveScore = !isResolvedEvent && event.sports_live === true
   const parsedLiveScore = showLiveScore ? parseSportsScore(event.sports_score) : null
-  const team1Score = showLiveScore ? (parsedLiveScore?.team1 ?? 0) : null
-  const team2Score = showLiveScore ? (parsedLiveScore?.team2 ?? 0) : null
+  const team1Score = parsedLiveScore?.team1 ?? null
+  const team2Score = parsedLiveScore?.team2 ?? null
 
   return (
     <Card

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -904,9 +904,9 @@ function SportsFeaturedLineMarketCarousel({
     <div className="grid gap-2.5">
       <div className="grid min-h-8 grid-cols-[minmax(0,1fr)_auto] items-center gap-3">
         <span className="min-w-0 truncate text-base font-semibold">{label}</span>
-        <div className="
+        <div className={cn(`
           grid grid-cols-[1.75rem_2.5rem_2.5rem_2.5rem_1.75rem] items-center gap-1 text-sm font-semibold tabular-nums
-        "
+        `)}
         >
           <LinePickerArrowButton
             direction="previous"
@@ -1308,27 +1308,27 @@ function FeaturedRightRail({
   `
   const sideCardContent = (
     <>
-      <span className="
+      <span className={cn(`
         pointer-events-none absolute bottom-0 left-[30%] h-px w-[40%] bg-linear-to-r from-transparent via-primary/60
         to-transparent
-      "
+      `)}
       />
       <DynamicIcon
         name={sideCard.icon as IconName}
         aria-hidden
-        className="
+        className={cn(`
           pointer-events-none absolute -top-6 -right-7 size-36 rotate-6 text-primary/8 transition-transform duration-300
           group-hover/side-card:scale-105
           motion-safe:animate-pulse
-        "
+        `)}
       />
 
       <div className="relative z-1 flex min-h-0 flex-1 flex-col pt-7 pb-4">
         <span
-          className="
+          className={cn(`
             mb-3 h-1 w-10 rounded-full bg-primary/70
             shadow-[0_0_18px_color-mix(in_oklab,var(--primary)_32%,transparent)]
-          "
+          `)}
         />
         <span className="line-clamp-2 max-w-[16rem] text-xl/tight font-semibold tracking-tight">
           {sideCard.title}
@@ -1343,11 +1343,11 @@ function FeaturedRightRail({
 
         {hasCta && (
           <span
-            className="
+            className={cn(`
               mt-auto ml-auto inline-flex h-9 max-w-full items-center gap-1.5 rounded-full border border-border/70
               bg-background/70 px-3 text-sm font-medium text-foreground shadow-sm shadow-black/4 transition-colors
               group-hover/side-card:border-primary/35 group-hover/side-card:text-primary
-            "
+            `)}
           >
             <span className="truncate">{sideCard.ctaLabel}</span>
             <ChevronRightIcon className="size-4 shrink-0" />
@@ -1422,12 +1422,12 @@ function FeaturedRightRailAction() {
         type="button"
         variant="outline"
         asChild
-        className="
+        className={cn(`
           h-10 w-full rounded-full bg-transparent text-muted-foreground shadow-none transition-colors
           hover:bg-secondary/80 hover:text-foreground
           dark:bg-transparent
           dark:hover:bg-secondary/80
-        "
+        `)}
       >
         <AppLink intentPrefetch href="/predictions/trending">
           Expand all

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -46,6 +46,7 @@ import {
   headerIconButtonClass,
 } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-types'
 import {
+  formatSportsEventLocalStartLabels,
   formatSportsEventStartLabels,
   normalizeLivestreamUrl,
   parseSportsScore,
@@ -84,6 +85,7 @@ import EventIconImage from '@/components/EventIconImage'
 import SiteLogoIcon from '@/components/SiteLogoIcon'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { useCurrentTimestamp } from '@/hooks/useCurrentTimestamp'
+import { useHasHydrated } from '@/hooks/useHasHydrated'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import { formatVolume } from '@/lib/formatters'
@@ -326,6 +328,7 @@ export default function SportsEventCenter({
 }: SportsEventCenterProps) {
   const verticalConfig = getSportsVerticalConfig(vertical)
   const locale = useLocale()
+  const hasHydrated = useHasHydrated()
   const site = useSiteIdentity()
   const isMobile = useIsMobile()
   const setOrderEvent = useOrder(state => state.setEvent)
@@ -699,8 +702,12 @@ export default function SportsEventCenter({
   const startLabels = startTimestamp !== null
     ? formatSportsEventStartLabels(startTimestamp, locale)
     : null
-  const timeLabel = startLabels?.timeLabel ?? 'TBD'
-  const dayLabel = startLabels?.dayLabel ?? 'Date TBD'
+  const localStartLabels = hasHydrated && startTimestamp !== null
+    ? formatSportsEventLocalStartLabels(startTimestamp, locale)
+    : null
+  const visibleStartLabels = localStartLabels ?? startLabels
+  const timeLabel = visibleStartLabels?.timeLabel ?? 'TBD'
+  const dayLabel = visibleStartLabels?.dayLabel ?? 'Date TBD'
 
   const team1 = heroCard.teams[0] ?? null
   const team2 = heroCard.teams[1] ?? null

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventRelatedGames.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventRelatedGames.tsx
@@ -3,8 +3,11 @@
 import type { SportsGamesCard } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 import type { SportsVertical } from '@/lib/sports-vertical'
 import Image from 'next/image'
-import { useMemo } from 'react'
-import { formatRelatedOddsLabel, resolveRelatedTeamOdds } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-utils'
+import {
+  formatRelatedOddsLabel,
+  formatSportsRelatedGameStartLabel,
+  resolveRelatedTeamOdds,
+} from '@/app/[locale]/(platform)/sports/_components/sports-event-center-utils'
 import AppLink from '@/components/AppLink'
 import { formatVolume } from '@/lib/formatters'
 import { getSportsVerticalConfig } from '@/lib/sports-vertical'
@@ -24,16 +27,6 @@ function SportsEventRelatedGames({
   vertical: SportsVertical
 }) {
   const verticalConfig = getSportsVerticalConfig(vertical)
-  const dateTimeFormatter = useMemo(
-    () => new Intl.DateTimeFormat(locale, {
-      month: 'short',
-      day: 'numeric',
-      hour: 'numeric',
-      minute: '2-digit',
-      timeZone: 'UTC',
-    }),
-    [locale],
-  )
 
   if (cards.length === 0) {
     return null
@@ -53,7 +46,9 @@ function SportsEventRelatedGames({
         {cards.map((relatedCard) => {
           const startTime = relatedCard.startTime ? new Date(relatedCard.startTime) : null
           const hasValidStartTime = Boolean(startTime && !Number.isNaN(startTime.getTime()))
-          const topLineDate = hasValidStartTime ? dateTimeFormatter.format(startTime as Date) : 'Date TBD'
+          const topLineDate = hasValidStartTime
+            ? formatSportsRelatedGameStartLabel(startTime as Date, locale)
+            : 'Date TBD'
           const { team1Cents, team2Cents } = resolveRelatedTeamOdds(relatedCard)
           const team1 = relatedCard.teams[0] ?? null
           const team2 = relatedCard.teams[1] ?? null

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventRelatedGames.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventRelatedGames.tsx
@@ -5,10 +5,12 @@ import type { SportsVertical } from '@/lib/sports-vertical'
 import Image from 'next/image'
 import {
   formatRelatedOddsLabel,
+  formatSportsRelatedGameLocalStartLabel,
   formatSportsRelatedGameStartLabel,
   resolveRelatedTeamOdds,
 } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-utils'
 import AppLink from '@/components/AppLink'
+import { useHasHydrated } from '@/hooks/useHasHydrated'
 import { formatVolume } from '@/lib/formatters'
 import { getSportsVerticalConfig } from '@/lib/sports-vertical'
 import { cn } from '@/lib/utils'
@@ -27,6 +29,7 @@ function SportsEventRelatedGames({
   vertical: SportsVertical
 }) {
   const verticalConfig = getSportsVerticalConfig(vertical)
+  const hasHydrated = useHasHydrated()
 
   if (cards.length === 0) {
     return null
@@ -47,7 +50,12 @@ function SportsEventRelatedGames({
           const startTime = relatedCard.startTime ? new Date(relatedCard.startTime) : null
           const hasValidStartTime = Boolean(startTime && !Number.isNaN(startTime.getTime()))
           const topLineDate = hasValidStartTime
-            ? formatSportsRelatedGameStartLabel(startTime as Date, locale)
+            ? (
+                hasHydrated
+                  ? formatSportsRelatedGameLocalStartLabel(startTime as Date, locale)
+                  ?? formatSportsRelatedGameStartLabel(startTime as Date, locale)
+                  : formatSportsRelatedGameStartLabel(startTime as Date, locale)
+              )
             : 'Date TBD'
           const { team1Cents, team2Cents } = resolveRelatedTeamOdds(relatedCard)
           const team1 = relatedCard.teams[0] ?? null

--- a/src/app/[locale]/(platform)/sports/_components/sports-event-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/sports-event-center-utils.ts
@@ -47,6 +47,45 @@ export function formatSportsEventStartLabels(timestamp: number, locale: string) 
   }
 }
 
+export function formatSportsEventLocalStartLabels(timestamp: number, locale: string, timeZone?: string) {
+  const resolvedTimeZone = timeZone ?? new Intl.DateTimeFormat().resolvedOptions().timeZone
+  if (!resolvedTimeZone) {
+    return null
+  }
+
+  const date = new Date(timestamp)
+  const timeLabel = new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: resolvedTimeZone,
+  }).format(date)
+  const dayLabel = new Intl.DateTimeFormat(locale, {
+    month: 'long',
+    day: 'numeric',
+    timeZone: resolvedTimeZone,
+  }).format(date)
+
+  return {
+    timeLabel,
+    dayLabel,
+  }
+}
+
+export function formatSportsRelatedGameStartLabel(date: Date, locale: string) {
+  const dateLabel = new Intl.DateTimeFormat(locale, {
+    month: 'short',
+    day: 'numeric',
+    timeZone: 'UTC',
+  }).format(date)
+  const timeLabel = new Intl.DateTimeFormat(locale, {
+    hour: 'numeric',
+    minute: '2-digit',
+    timeZone: 'UTC',
+  }).format(date)
+
+  return `${dateLabel}, ${timeLabel}`
+}
+
 export function subscribeToOddsFormatStorage(listener: () => void) {
   if (typeof window === 'undefined') {
     return function unsubscribeFromOddsFormatStorage() {}

--- a/src/app/[locale]/(platform)/sports/_components/sports-event-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/sports-event-center-utils.ts
@@ -71,19 +71,39 @@ export function formatSportsEventLocalStartLabels(timestamp: number, locale: str
   }
 }
 
-export function formatSportsRelatedGameStartLabel(date: Date, locale: string) {
+export function formatSportsRelatedGameStartLabel(
+  date: Date,
+  locale: string,
+  options?: { timeZone?: string, timeZoneLabel?: string | null },
+) {
+  const timeZone = options?.timeZone ?? SPORTS_EVENT_DISPLAY_TIME_ZONE
+  const timeZoneLabel = options?.timeZoneLabel === undefined
+    ? SPORTS_EVENT_DISPLAY_TIME_ZONE_LABEL
+    : options.timeZoneLabel
   const dateLabel = new Intl.DateTimeFormat(locale, {
     month: 'short',
     day: 'numeric',
-    timeZone: 'UTC',
+    timeZone,
   }).format(date)
   const timeLabel = new Intl.DateTimeFormat(locale, {
     hour: 'numeric',
     minute: '2-digit',
-    timeZone: 'UTC',
+    timeZone,
   }).format(date)
 
-  return `${dateLabel}, ${timeLabel}`
+  return `${dateLabel}, ${timeLabel}${timeZoneLabel ? ` ${timeZoneLabel}` : ''}`
+}
+
+export function formatSportsRelatedGameLocalStartLabel(date: Date, locale: string, timeZone?: string) {
+  const resolvedTimeZone = timeZone ?? new Intl.DateTimeFormat().resolvedOptions().timeZone
+  if (!resolvedTimeZone) {
+    return null
+  }
+
+  return formatSportsRelatedGameStartLabel(date, locale, {
+    timeZone: resolvedTimeZone,
+    timeZoneLabel: null,
+  })
 }
 
 export function subscribeToOddsFormatStorage(listener: () => void) {

--- a/tests/unit/EventCardSportsMoneyline.test.tsx
+++ b/tests/unit/EventCardSportsMoneyline.test.tsx
@@ -183,6 +183,65 @@ describe('eventCardSportsMoneyline', () => {
     expect(screen.queryByText('MAR')).not.toBeInTheDocument()
   })
 
+  it('shows live team scores between the logo and team name', () => {
+    const event = {
+      status: 'active',
+      volume: 2500,
+      sports_live: true,
+      sports_score: '2 - 1',
+      sports_sport_slug: 'soccer',
+      sports_start_time: '2026-03-14T23:00:00.000Z',
+      markets: [
+        {
+          condition_id: 'match-winner-condition',
+          slug: 'france-vs-morocco-match-winner',
+        },
+      ],
+    } as any
+
+    const model = {
+      team1: {
+        name: 'France',
+        abbreviation: 'FRA',
+        color: '#1d4ed8',
+        logoUrl: 'https://example.com/france.png',
+        hostStatus: 'home',
+      },
+      team2: {
+        name: 'Morocco',
+        abbreviation: 'MAR',
+        color: '#dc2626',
+        logoUrl: 'https://example.com/morocco.png',
+        hostStatus: 'away',
+      },
+      team1Button: {
+        conditionId: 'match-winner-condition',
+        outcomeIndex: 0,
+        label: 'FRA',
+        tone: 'team1',
+        color: '#1d4ed8',
+      },
+      team2Button: {
+        conditionId: 'match-winner-condition',
+        outcomeIndex: 1,
+        label: 'MAR',
+        tone: 'team2',
+        color: '#dc2626',
+      },
+    } as any
+
+    render(
+      <EventCardSportsMoneyline
+        event={event}
+        model={model}
+        getDisplayChance={() => 61}
+      />,
+    )
+
+    expect(screen.getByLabelText('France score 2')).toBeInTheDocument()
+    expect(screen.getByLabelText('Morocco score 1')).toBeInTheDocument()
+  })
+
   it('renders the resolved winner and ended footer for sports cards', () => {
     const event = {
       status: 'resolved',

--- a/tests/unit/EventCardSportsMoneyline.test.tsx
+++ b/tests/unit/EventCardSportsMoneyline.test.tsx
@@ -242,6 +242,67 @@ describe('eventCardSportsMoneyline', () => {
     expect(screen.getByLabelText('Morocco score 1')).toBeInTheDocument()
   })
 
+  it('does not show live team scores when score data is missing', () => {
+    const event = {
+      status: 'active',
+      volume: 2500,
+      sports_live: true,
+      sports_score: null,
+      sports_sport_slug: 'soccer',
+      sports_start_time: '2026-03-14T23:00:00.000Z',
+      markets: [
+        {
+          condition_id: 'match-winner-condition',
+          slug: 'france-vs-morocco-match-winner',
+        },
+      ],
+    } as any
+
+    const model = {
+      team1: {
+        name: 'France',
+        abbreviation: 'FRA',
+        color: '#1d4ed8',
+        logoUrl: 'https://example.com/france.png',
+        hostStatus: 'home',
+      },
+      team2: {
+        name: 'Morocco',
+        abbreviation: 'MAR',
+        color: '#dc2626',
+        logoUrl: 'https://example.com/morocco.png',
+        hostStatus: 'away',
+      },
+      team1Button: {
+        conditionId: 'match-winner-condition',
+        outcomeIndex: 0,
+        label: 'FRA',
+        tone: 'team1',
+        color: '#1d4ed8',
+      },
+      team2Button: {
+        conditionId: 'match-winner-condition',
+        outcomeIndex: 1,
+        label: 'MAR',
+        tone: 'team2',
+        color: '#dc2626',
+      },
+    } as any
+
+    render(
+      <EventCardSportsMoneyline
+        event={event}
+        model={model}
+        getDisplayChance={() => 61}
+      />,
+    )
+
+    expect(screen.queryByLabelText('France score 0')).not.toBeInTheDocument()
+    expect(screen.queryByLabelText('Morocco score 0')).not.toBeInTheDocument()
+    expect(screen.getAllByText('France')).toHaveLength(2)
+    expect(screen.getAllByText('Morocco')).toHaveLength(2)
+  })
+
   it('renders the resolved winner and ended footer for sports cards', () => {
     const event = {
       status: 'resolved',

--- a/tests/unit/sportsEventCenterUtils.test.ts
+++ b/tests/unit/sportsEventCenterUtils.test.ts
@@ -1,4 +1,8 @@
-import { formatSportsEventStartLabels } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-utils'
+import {
+  formatSportsEventLocalStartLabels,
+  formatSportsEventStartLabels,
+  formatSportsRelatedGameStartLabel,
+} from '@/app/[locale]/(platform)/sports/_components/sports-event-center-utils'
 
 describe('sportsEventCenterUtils', () => {
   it('formats event hero start labels in ET', () => {
@@ -6,5 +10,23 @@ describe('sportsEventCenterUtils', () => {
       timeLabel: '8:00 AM ET',
       dayLabel: 'June 9',
     })
+  })
+
+  it('formats event hero local start labels with the browser time zone', () => {
+    expect(formatSportsEventLocalStartLabels(
+      Date.parse('2026-06-09T12:00:00.000Z'),
+      'en-US',
+      'America/Sao_Paulo',
+    )).toEqual({
+      timeLabel: '9:00 AM',
+      dayLabel: 'June 9',
+    })
+  })
+
+  it('formats related game start labels without locale-specific connector text', () => {
+    expect(formatSportsRelatedGameStartLabel(
+      new Date('2026-07-10T19:00:00.000Z'),
+      'en',
+    )).toBe('Jul 10, 7:00 PM')
   })
 })

--- a/tests/unit/sportsEventCenterUtils.test.ts
+++ b/tests/unit/sportsEventCenterUtils.test.ts
@@ -1,6 +1,7 @@
 import {
   formatSportsEventLocalStartLabels,
   formatSportsEventStartLabels,
+  formatSportsRelatedGameLocalStartLabel,
   formatSportsRelatedGameStartLabel,
 } from '@/app/[locale]/(platform)/sports/_components/sports-event-center-utils'
 
@@ -23,10 +24,18 @@ describe('sportsEventCenterUtils', () => {
     })
   })
 
-  it('formats related game start labels without locale-specific connector text', () => {
+  it('formats related game start labels in ET without locale-specific connector text', () => {
     expect(formatSportsRelatedGameStartLabel(
       new Date('2026-07-10T19:00:00.000Z'),
       'en',
-    )).toBe('Jul 10, 7:00 PM')
+    )).toBe('Jul 10, 3:00 PM ET')
+  })
+
+  it('formats related game local start labels after hydration', () => {
+    expect(formatSportsRelatedGameLocalStartLabel(
+      new Date('2026-07-10T19:00:00.000Z'),
+      'en',
+      'America/Sao_Paulo',
+    )).toBe('Jul 10, 4:00 PM')
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes incorrect sports event times by hydrating to the user’s local timezone and standardizing related game time labels. Also adds live scores to active matches on moneyline cards.

- **Bug Fixes**
  - Event hero shows local start time after hydration using the browser timezone; server-side fallback remains ET.
  - Related games render in ET on the server with an "ET" suffix and no locale-specific connector text (e.g., "Jul 10, 3:00 PM ET"); after hydration, they switch to the user’s local time without a timezone suffix.

- **New Features**
  - Live team scores appear on moneyline cards during active games, with accessible labels.

<sup>Written for commit 035cc31244d68f5c1b40d20b633668567c9bb229. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

