### PR TITLE
fix: merge all auth state

### DIFF
--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
@@ -23,6 +23,7 @@ import {
   fetchLockedSharesByCondition,
   getDefaultSortDirection,
   getOutcomeLabel,
+  isActiveUserPositionsQueryKeyForAddress,
   matchesPositionsSearchQuery,
   sortPositions,
 } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
@@ -146,16 +147,6 @@ function useSearchChangeHandler({
   }, [resetLoadMoreState, setRetryCountState, setSearchQueryState, userAddress])
 }
 
-function useMergeButtonVisibility(userAddress: string) {
-  const [hideMergeButtonState, setHideMergeButtonState] = useState<{ key: string, value: boolean }>({
-    key: userAddress,
-    value: false,
-  })
-  const hideMergeButton = hideMergeButtonState.key === userAddress ? hideMergeButtonState.value : false
-
-  return { hideMergeButton, setHideMergeButtonState }
-}
-
 function useShareDialog() {
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false)
   const [sharePosition, setSharePosition] = useState<PublicPosition | null>(null)
@@ -199,25 +190,16 @@ function useShareCardPayload({
   }, [sharePosition, user?.image, user?.username])
 }
 
-function useMergeDialog({
-  userAddress,
-  setHideMergeButtonState,
-}: {
-  userAddress: string
-  setHideMergeButtonState: (value: { key: string, value: boolean }) => void
-}) {
+function useMergeDialog() {
   const [isMergeDialogOpen, setIsMergeDialogOpen] = useState(false)
   const [mergeSuccess, setMergeSuccess] = useState(false)
 
   const handleMergeDialogChange = useCallback((open: boolean) => {
     setIsMergeDialogOpen(open)
     if (!open) {
-      if (mergeSuccess) {
-        setHideMergeButtonState({ key: userAddress, value: true })
-      }
       setMergeSuccess(false)
     }
-  }, [mergeSuccess, setHideMergeButtonState, userAddress])
+  }, [])
 
   return {
     isMergeDialogOpen,
@@ -811,8 +793,8 @@ function useSellPositionFlow({
 
       updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
         queryClient,
-        ['user-positions', userAddress, 'active'],
-        currentQueryKey => currentQueryKey[1] === userAddress && currentQueryKey[2] === 'active',
+        ['user-positions'],
+        currentQueryKey => isActiveUserPositionsQueryKeyForAddress(currentQueryKey, userAddress),
         current => current
           ? {
               ...current,
@@ -831,11 +813,11 @@ function useSellPositionFlow({
       )
 
       setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ['user-positions', userAddress, 'active'] })
+        void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
         void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
       }, 4_000)
       setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ['user-positions', userAddress, 'active'] })
+        void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
         void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
       }, 12_000)
 
@@ -906,8 +888,6 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
 
   const { retryCount, setRetryCountState } = useRetryCountState(userAddress)
 
-  const { hideMergeButton, setHideMergeButtonState } = useMergeButtonVisibility(userAddress)
-
   const {
     isShareDialogOpen,
     sharePosition,
@@ -921,7 +901,7 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
     mergeSuccess,
     setMergeSuccess,
     handleMergeDialogChange,
-  } = useMergeDialog({ userAddress, setHideMergeButtonState })
+  } = useMergeDialog()
 
   const {
     status,
@@ -1047,7 +1027,7 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
         sortBy={sortBy}
         onSearchChange={handleSearchChange}
         onSortChange={handleSortChange}
-        showMergeButton={hasMergeableMarkets && marketStatusFilter === 'active' && !hideMergeButton}
+        showMergeButton={hasMergeableMarkets && marketStatusFilter === 'active'}
         onMergeClick={() => {
           setMergeSuccess(false)
           setIsMergeDialogOpen(true)

--- a/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
+++ b/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
@@ -6,7 +6,7 @@ import type { User } from '@/types'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 import { useSignTypedData } from 'wagmi'
-import { fetchLockedSharesByCondition, fetchOnchainSharesByCondition } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
+import { fetchLockedSharesByCondition, fetchOnchainSharesByCondition, isActiveUserPositionsQueryKeyForAddress } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
 import { DEPOSIT_WALLET_BALANCE_QUERY_KEY } from '@/hooks/useBalance'
 import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
 import { DEFAULT_CONDITION_PARTITION } from '@/lib/constants'
@@ -83,15 +83,7 @@ export function useMergePositionsAction({
     updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
       queryClient,
       ['user-positions'],
-      (currentQueryKey) => {
-        if (currentQueryKey[2] !== 'active') {
-          return false
-        }
-
-        return !normalizedDepositWallet || !currentQueryKey[1]
-          ? false
-          : String(currentQueryKey[1]).toLowerCase() === normalizedDepositWallet.toLowerCase()
-      },
+      currentQueryKey => isActiveUserPositionsQueryKeyForAddress(currentQueryKey, normalizedDepositWallet),
       current => current
         ? {
             ...current,
@@ -230,10 +222,13 @@ export function useMergePositionsAction({
       applySuccessfulMerges(response.successfulItems)
 
       if (response.partialFailure) {
-        toast.error('Some positions could not be merged. Please try again.')
         const failureError = response.failure?.error
         if (failureError && isTradingAuthRequiredError(failureError)) {
+          toast.info('Enable trading to continue merging the remaining positions.')
           openTradeRequirements({ forceTradingAuth: true })
+        }
+        else {
+          toast.error('Some positions could not be merged. Please try again.')
         }
       }
       else {

--- a/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
+++ b/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
@@ -310,6 +310,28 @@ function normalizeAsset(value?: string | null) {
   return trimmed.length > 0 ? trimmed : null
 }
 
+function normalizeQueryKeyAddress(value: unknown) {
+  const trimmed = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function isActiveUserPositionsQueryKeyForAddress(queryKey: readonly unknown[], userAddress?: string | null) {
+  const normalizedAddress = normalizeQueryKeyAddress(userAddress)
+  if (!normalizedAddress) {
+    return false
+  }
+
+  if (queryKey[3] === 'active') {
+    return normalizeQueryKeyAddress(queryKey[2]) === normalizedAddress
+  }
+
+  if (queryKey[2] === 'active') {
+    return normalizeQueryKeyAddress(queryKey[1]) === normalizedAddress
+  }
+
+  return false
+}
+
 export function buildMergeableMarkets(positions: PublicPosition[]): MergeableMarket[] {
   const activePositions = positions.filter(
     position =>

--- a/tests/unit/PublicPositionsUtils.test.ts
+++ b/tests/unit/PublicPositionsUtils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { isActiveUserPositionsQueryKeyForAddress } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
+
+describe('publicPositionsUtils', () => {
+  it('matches the current public positions query key shape', () => {
+    expect(isActiveUserPositionsQueryKeyForAddress(
+      ['user-positions', 'https://data-api.kuest.com', '0xAbC', 'active', 'All', '', 'currentValue', 'desc'],
+      '0xabc',
+    )).toBe(true)
+  })
+
+  it('keeps compatibility with the legacy public positions query key shape', () => {
+    expect(isActiveUserPositionsQueryKeyForAddress(
+      ['user-positions', '0xAbC', 'active'],
+      '0xabc',
+    )).toBe(true)
+  })
+
+  it('does not match closed positions or another address', () => {
+    expect(isActiveUserPositionsQueryKeyForAddress(
+      ['user-positions', 'https://data-api.kuest.com', '0xAbC', 'closed'],
+      '0xabc',
+    )).toBe(false)
+    expect(isActiveUserPositionsQueryKeyForAddress(
+      ['user-positions', 'https://data-api.kuest.com', '0xDef', 'active'],
+      '0xabc',
+    )).toBe(false)
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes stale caches after merges and sells by updating all active `user-positions` queries for the address across auth states and key shapes. Keeps the Merge button visible and improves messaging when trading authorization is needed.

- **Bug Fixes**
  - Added `isActiveUserPositionsQueryKeyForAddress` to match both current and legacy `user-positions` keys; used for optimistic updates and invalidations in merge and sell flows.
  - Merge button no longer hides after a merge; it stays visible when markets are mergeable and the filter is active.
  - On partial merge failures requiring trading auth, show an info toast and open trading requirements; otherwise show a generic error.
  - Added unit tests for the new query key matcher.

<sup>Written for commit 0b46e560894944b3aea764654444f236c6df4a27. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

