### PR TITLE
Fix/merge all auth state

### DIFF
--- a/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
+++ b/src/app/[locale]/(platform)/profile/_components/PublicPositionsList.tsx
@@ -23,6 +23,7 @@ import {
   fetchLockedSharesByCondition,
   getDefaultSortDirection,
   getOutcomeLabel,
+  isActiveUserPositionsQueryKeyForAddress,
   matchesPositionsSearchQuery,
   sortPositions,
 } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
@@ -146,16 +147,6 @@ function useSearchChangeHandler({
   }, [resetLoadMoreState, setRetryCountState, setSearchQueryState, userAddress])
 }
 
-function useMergeButtonVisibility(userAddress: string) {
-  const [hideMergeButtonState, setHideMergeButtonState] = useState<{ key: string, value: boolean }>({
-    key: userAddress,
-    value: false,
-  })
-  const hideMergeButton = hideMergeButtonState.key === userAddress ? hideMergeButtonState.value : false
-
-  return { hideMergeButton, setHideMergeButtonState }
-}
-
 function useShareDialog() {
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false)
   const [sharePosition, setSharePosition] = useState<PublicPosition | null>(null)
@@ -199,25 +190,16 @@ function useShareCardPayload({
   }, [sharePosition, user?.image, user?.username])
 }
 
-function useMergeDialog({
-  userAddress,
-  setHideMergeButtonState,
-}: {
-  userAddress: string
-  setHideMergeButtonState: (value: { key: string, value: boolean }) => void
-}) {
+function useMergeDialog() {
   const [isMergeDialogOpen, setIsMergeDialogOpen] = useState(false)
   const [mergeSuccess, setMergeSuccess] = useState(false)
 
   const handleMergeDialogChange = useCallback((open: boolean) => {
     setIsMergeDialogOpen(open)
     if (!open) {
-      if (mergeSuccess) {
-        setHideMergeButtonState({ key: userAddress, value: true })
-      }
       setMergeSuccess(false)
     }
-  }, [mergeSuccess, setHideMergeButtonState, userAddress])
+  }, [])
 
   return {
     isMergeDialogOpen,
@@ -811,8 +793,8 @@ function useSellPositionFlow({
 
       updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
         queryClient,
-        ['user-positions', userAddress, 'active'],
-        currentQueryKey => currentQueryKey[1] === userAddress && currentQueryKey[2] === 'active',
+        ['user-positions'],
+        currentQueryKey => isActiveUserPositionsQueryKeyForAddress(currentQueryKey, userAddress),
         current => current
           ? {
               ...current,
@@ -831,11 +813,11 @@ function useSellPositionFlow({
       )
 
       setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ['user-positions', userAddress, 'active'] })
+        void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
         void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
       }, 4_000)
       setTimeout(() => {
-        void queryClient.invalidateQueries({ queryKey: ['user-positions', userAddress, 'active'] })
+        void queryClient.invalidateQueries({ queryKey: ['user-positions'] })
         void queryClient.invalidateQueries({ queryKey: ['portfolio-value'] })
       }, 12_000)
 
@@ -906,8 +888,6 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
 
   const { retryCount, setRetryCountState } = useRetryCountState(userAddress)
 
-  const { hideMergeButton, setHideMergeButtonState } = useMergeButtonVisibility(userAddress)
-
   const {
     isShareDialogOpen,
     sharePosition,
@@ -921,7 +901,7 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
     mergeSuccess,
     setMergeSuccess,
     handleMergeDialogChange,
-  } = useMergeDialog({ userAddress, setHideMergeButtonState })
+  } = useMergeDialog()
 
   const {
     status,
@@ -1047,7 +1027,7 @@ export default function PublicPositionsList({ userAddress }: PublicPositionsList
         sortBy={sortBy}
         onSearchChange={handleSearchChange}
         onSortChange={handleSortChange}
-        showMergeButton={hasMergeableMarkets && marketStatusFilter === 'active' && !hideMergeButton}
+        showMergeButton={hasMergeableMarkets && marketStatusFilter === 'active'}
         onMergeClick={() => {
           setMergeSuccess(false)
           setIsMergeDialogOpen(true)

--- a/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
+++ b/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
@@ -6,7 +6,7 @@ import type { User } from '@/types'
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
 import { useSignTypedData } from 'wagmi'
-import { fetchLockedSharesByCondition, fetchOnchainSharesByCondition } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
+import { fetchLockedSharesByCondition, fetchOnchainSharesByCondition, isActiveUserPositionsQueryKeyForAddress } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
 import { DEPOSIT_WALLET_BALANCE_QUERY_KEY } from '@/hooks/useBalance'
 import { useSignaturePromptRunner } from '@/hooks/useSignaturePromptRunner'
 import { DEFAULT_CONDITION_PARTITION } from '@/lib/constants'
@@ -83,15 +83,7 @@ export function useMergePositionsAction({
     updateQueryDataWhere<InfiniteData<PublicPosition[]>>(
       queryClient,
       ['user-positions'],
-      (currentQueryKey) => {
-        if (currentQueryKey[2] !== 'active') {
-          return false
-        }
-
-        return !normalizedDepositWallet || !currentQueryKey[1]
-          ? false
-          : String(currentQueryKey[1]).toLowerCase() === normalizedDepositWallet.toLowerCase()
-      },
+      currentQueryKey => isActiveUserPositionsQueryKeyForAddress(currentQueryKey, normalizedDepositWallet),
       current => current
         ? {
             ...current,
@@ -230,10 +222,13 @@ export function useMergePositionsAction({
       applySuccessfulMerges(response.successfulItems)
 
       if (response.partialFailure) {
-        toast.error('Some positions could not be merged. Please try again.')
         const failureError = response.failure?.error
         if (failureError && isTradingAuthRequiredError(failureError)) {
+          toast.info('Enable trading to continue merging the remaining positions.')
           openTradeRequirements({ forceTradingAuth: true })
+        }
+        else {
+          toast.error('Some positions could not be merged. Please try again.')
         }
       }
       else {

--- a/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
+++ b/src/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils.ts
@@ -310,6 +310,28 @@ function normalizeAsset(value?: string | null) {
   return trimmed.length > 0 ? trimmed : null
 }
 
+function normalizeQueryKeyAddress(value: unknown) {
+  const trimmed = typeof value === 'string' ? value.trim().toLowerCase() : ''
+  return trimmed.length > 0 ? trimmed : null
+}
+
+export function isActiveUserPositionsQueryKeyForAddress(queryKey: readonly unknown[], userAddress?: string | null) {
+  const normalizedAddress = normalizeQueryKeyAddress(userAddress)
+  if (!normalizedAddress) {
+    return false
+  }
+
+  if (queryKey[3] === 'active') {
+    return normalizeQueryKeyAddress(queryKey[2]) === normalizedAddress
+  }
+
+  if (queryKey[2] === 'active') {
+    return normalizeQueryKeyAddress(queryKey[1]) === normalizedAddress
+  }
+
+  return false
+}
+
 export function buildMergeableMarkets(positions: PublicPosition[]): MergeableMarket[] {
   const activePositions = positions.filter(
     position =>

--- a/src/lib/wallet/client.ts
+++ b/src/lib/wallet/client.ts
@@ -209,7 +209,7 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
     })
   }
 
-  async function submitChunk(chunk: T[], unprocessedAfterChunk: T[]): Promise<void> {
+  async function submitChunk(chunk: T[], unprocessedAfterChunk: T[]): Promise<boolean> {
     let result: SignAndSubmitDepositWalletCallsResult
     try {
       result = await signAndSubmitDepositWalletCalls({
@@ -234,21 +234,31 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
       successfulItems.push(...chunk)
       lastSuccess = result
       notifyProgress()
-      return
+      return true
     }
 
     firstFailure = getPreferredFailure(firstFailure, result)
+    if (isTradingAuthRequiredError(result.error)) {
+      failedItems.push(...chunk, ...unprocessedAfterChunk)
+      notifyProgress()
+      return false
+    }
+
     if (chunk.length <= 1 || !shouldSplitDepositWalletCallFailure(result)) {
       failedItems.push(...chunk)
       notifyProgress()
-      return
+      return true
     }
 
     const midpoint = Math.ceil(chunk.length / 2)
     const left = chunk.slice(0, midpoint)
     const right = chunk.slice(midpoint)
-    await submitChunk(left, [...right, ...unprocessedAfterChunk])
-    await submitChunk(right, unprocessedAfterChunk)
+    const shouldContinueAfterLeft = await submitChunk(left, [...right, ...unprocessedAfterChunk])
+    if (!shouldContinueAfterLeft) {
+      return false
+    }
+
+    return await submitChunk(right, unprocessedAfterChunk)
   }
 
   const initialChunkSize = Math.max(
@@ -260,10 +270,13 @@ export async function signAndSubmitDepositWalletCallItemsWithSplitFallback<T>({
   )
 
   for (let index = 0; index < items.length; index += initialChunkSize) {
-    await submitChunk(
+    const shouldContinue = await submitChunk(
       items.slice(index, index + initialChunkSize),
       items.slice(index + initialChunkSize),
     )
+    if (!shouldContinue) {
+      break
+    }
   }
 
   if (successfulItems.length === 0) {

--- a/tests/unit/PublicPositionsUtils.test.ts
+++ b/tests/unit/PublicPositionsUtils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { isActiveUserPositionsQueryKeyForAddress } from '@/app/[locale]/(platform)/profile/_utils/PublicPositionsUtils'
+
+describe('publicPositionsUtils', () => {
+  it('matches the current public positions query key shape', () => {
+    expect(isActiveUserPositionsQueryKeyForAddress(
+      ['user-positions', 'https://data-api.kuest.com', '0xAbC', 'active', 'All', '', 'currentValue', 'desc'],
+      '0xabc',
+    )).toBe(true)
+  })
+
+  it('keeps compatibility with the legacy public positions query key shape', () => {
+    expect(isActiveUserPositionsQueryKeyForAddress(
+      ['user-positions', '0xAbC', 'active'],
+      '0xabc',
+    )).toBe(true)
+  })
+
+  it('does not match closed positions or another address', () => {
+    expect(isActiveUserPositionsQueryKeyForAddress(
+      ['user-positions', 'https://data-api.kuest.com', '0xAbC', 'closed'],
+      '0xabc',
+    )).toBe(false)
+    expect(isActiveUserPositionsQueryKeyForAddress(
+      ['user-positions', 'https://data-api.kuest.com', '0xDef', 'active'],
+      '0xabc',
+    )).toBe(false)
+  })
+})

--- a/tests/unit/walletClient.test.ts
+++ b/tests/unit/walletClient.test.ts
@@ -83,4 +83,45 @@ describe('wallet client', () => {
     })
     await expect(request).rejects.toBeInstanceOf(DepositWalletCallItemsSplitFallbackError)
   })
+
+  it('stops submitting remaining chunks when trading auth is required', async () => {
+    mocks.getDepositWalletNonceAction.mockResolvedValue({
+      error: null,
+      nonce: '1',
+    })
+    mocks.submitDepositWalletTransactionAction.mockResolvedValueOnce({
+      error: 'Enable trading to continue.',
+    })
+    const signTypedDataAsync = vi.fn().mockResolvedValue('0xsignature')
+    const onProgress = vi.fn()
+
+    const result = await signAndSubmitDepositWalletCallItemsWithSplitFallback({
+      user: {
+        address: '0x0000000000000000000000000000000000000001',
+        deposit_wallet_address: '0x0000000000000000000000000000000000000002',
+      },
+      items: [1, 2, 3, 4, 5],
+      getCall: () => ({
+        target: '0x0000000000000000000000000000000000000003',
+        value: '0',
+        data: '0x',
+      }),
+      maxChunkSize: 2,
+      signTypedDataAsync,
+      onProgress,
+    })
+
+    expect(result).toMatchObject({
+      error: 'Enable trading to continue.',
+      successfulItems: [],
+      failedItems: [1, 2, 3, 4, 5],
+      partialFailure: false,
+    })
+    expect(signTypedDataAsync).toHaveBeenCalledTimes(1)
+    expect(mocks.submitDepositWalletTransactionAction).toHaveBeenCalledTimes(1)
+    expect(onProgress).toHaveBeenLastCalledWith({
+      successfulItems: [],
+      failedItems: [1, 2, 3, 4, 5],
+    })
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the merge flow to respect trading authorization and makes user positions cache updates reliable across both legacy and new query keys. Also simplifies the Merge button logic.

- **Bug Fixes**
  - Stop the merge batch when trading auth is required; mark remaining items as failed and prompt to enable trading.
  - Added `isActiveUserPositionsQueryKeyForAddress` and used it in cache updates/invalidations to match both query key shapes; switched invalidations to `['user-positions']`.
  - Removed the state that hid the Merge button after a successful merge.

<sup>Written for commit 0409869e5e189ac356b5cc56198dfd45febfd39d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

