### PR TITLE
fix: remove merge conflict duplicate else

### DIFF
--- a/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
+++ b/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
@@ -244,9 +244,6 @@ export function useMergePositionsAction({
         else {
           toast.error('Some positions could not be merged. Please try again.')
         }
-        else {
-          toast.error('Some positions could not be merged. Please try again.')
-        }
       }
       else {
         onSuccess?.()


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removed a leftover merge-conflict else branch in `useMergePositionsAction`. Restores valid control flow and avoids duplicate error toasts.

<sup>Written for commit b568f585ceb7a9c79e28e82138f2b12a45e41bfe. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

