### PR TITLE
fix: snake livechart behavior

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -215,6 +215,7 @@ function EventLiveSeriesChartContent({
   const { data, status } = useLiveSeriesWebSocket({
     topic: config.topic,
     eventType: config.event_type,
+    eventEndTimestamp: explicitEndTimestamp,
     subscriptionSymbol,
     isLiveView: isLiveView && !isEventClosed,
     setBaselinePrice,
@@ -348,13 +349,27 @@ function EventLiveSeriesChartContent({
       return data
     }
 
-    const hasPreCloseData = data.some((point) => {
+    const preCloseData = data.filter((point) => {
       const timestamp = point.date.getTime()
       return Number.isFinite(timestamp) && timestamp <= endTimestamp
     })
 
-    return hasPreCloseData ? data : closedFallbackData
-  }, [closedFallbackData, data, endTimestamp, isEventClosed])
+    if (!preCloseData.length) {
+      return closedFallbackData
+    }
+
+    if (!isFinitePositivePrice(finalPrice)) {
+      return preCloseData
+    }
+
+    return [
+      ...preCloseData.filter(point => point.date.getTime() < endTimestamp),
+      {
+        date: new Date(endTimestamp),
+        [SERIES_KEY]: finalPrice,
+      },
+    ].slice(-MAX_POINTS)
+  }, [closedFallbackData, data, endTimestamp, finalPrice, isEventClosed])
 
   const renderData = useMemo(() => {
     if (!dataSource.length) {
@@ -422,9 +437,7 @@ function EventLiveSeriesChartContent({
     renderedPrice,
     fallbackCurrentPrice,
   })
-  const axisSourceData = isEventClosed
-    ? renderData
-    : data.length > 0 ? data : renderData
+  const axisSourceData = renderData
   const resolvedBaselinePrice = isEventClosed
     ? referenceOpeningPrice
     : baselinePrice ?? referenceOpeningPrice
@@ -637,6 +650,7 @@ function EventLiveSeriesChartContent({
                 <PredictionChart
                   data={renderData}
                   series={series}
+                  dataSyncMode="replace"
                   width={chartWidth}
                   height={chartHeight}
                   margin={{

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
@@ -107,6 +107,7 @@ export function useLiveSeriesWebSocket({
           }
         })
         .filter((update): update is { price: number, timestamp: number, symbol: string | null } => update !== null)
+        .filter(update => eventEndTimestamp == null || update.timestamp <= eventEndTimestamp)
 
       const messageIsSnapshot = isSnapshotMessage(payload)
       const wsUpdatesForRender = messageIsSnapshot
@@ -117,19 +118,18 @@ export function useLiveSeriesWebSocket({
         return
       }
 
-      if (eventEndTimestamp != null && arrivalTimestamp > eventEndTimestamp) {
-        return
-      }
-
       const cadenceTransitionDurationMs = resolveLivePriceTransitionDuration(
         previousPriceMessageTimestamp,
         arrivalTimestamp,
       )
+      const transitionStartTimestamp = eventEndTimestamp == null
+        ? arrivalTimestamp
+        : Math.min(arrivalTimestamp, eventEndTimestamp)
       const transitionDurationMs = eventEndTimestamp == null
         ? cadenceTransitionDurationMs
         : Math.min(
             cadenceTransitionDurationMs,
-            Math.max(0, eventEndTimestamp - arrivalTimestamp),
+            Math.max(0, eventEndTimestamp - transitionStartTimestamp),
           )
       previousPriceMessageTimestamp = arrivalTimestamp
 
@@ -181,7 +181,7 @@ export function useLiveSeriesWebSocket({
         return appendLivePriceTransition(
           retainedPoints,
           latestUpdate.price,
-          arrivalTimestamp,
+          transitionStartTimestamp,
           transitionDurationMs,
         )
       })

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
@@ -3,13 +3,14 @@ import { useEffect, useState } from 'react'
 import { usePublicRuntimeConfig } from '@/hooks/usePublicRuntimeConfig'
 import { closeWebSocketWhenReady, createWebSocketReconnectController } from '@/lib/websocket-reconnect'
 import {
+  appendLivePriceTransition,
   extractLivePriceUpdates,
   isSnapshotMessage,
   keepWithinLiveWindow,
   LIVE_DATA_RETENTION_MS,
-  LIVE_WS_USE_ONLY_LAST_UPDATE_PER_MESSAGE,
   MAX_POINTS,
   normalizeLiveChartPrice,
+  resolveLivePriceTransitionDuration,
   SERIES_KEY,
   writePersistedLivePrice,
 } from '../_utils/eventLiveSeriesChartUtils'
@@ -17,6 +18,7 @@ import {
 interface UseLiveSeriesWebSocketOptions {
   topic: string
   eventType: string
+  eventEndTimestamp: number | null
   subscriptionSymbol: string
   isLiveView: boolean
   setBaselinePrice: React.Dispatch<React.SetStateAction<number | null>>
@@ -25,6 +27,7 @@ interface UseLiveSeriesWebSocketOptions {
 export function useLiveSeriesWebSocket({
   topic,
   eventType,
+  eventEndTimestamp,
   subscriptionSymbol,
   isLiveView,
   setBaselinePrice,
@@ -49,6 +52,7 @@ export function useLiveSeriesWebSocket({
 
     let isActive = true
     let ws: WebSocket | null = null
+    let previousPriceMessageTimestamp: number | null = null
 
     function buildSubscriptionPayload(action: 'subscribe' | 'unsubscribe') {
       const filters = JSON.stringify({
@@ -88,7 +92,8 @@ export function useLiveSeriesWebSocket({
         return
       }
 
-      const updates = extractLivePriceUpdates(payload, topic, subscriptionSymbol, Date.now())
+      const arrivalTimestamp = Date.now()
+      const updates = extractLivePriceUpdates(payload, topic, subscriptionSymbol, arrivalTimestamp)
       const normalizedUpdates = updates
         .map((update) => {
           const normalizedPrice = normalizeLiveChartPrice(update.price, topic)
@@ -104,14 +109,29 @@ export function useLiveSeriesWebSocket({
         .filter((update): update is { price: number, timestamp: number, symbol: string | null } => update !== null)
 
       const messageIsSnapshot = isSnapshotMessage(payload)
-      const messageHasBatchUpdates = normalizedUpdates.length > 1
-      const wsUpdatesForRender = LIVE_WS_USE_ONLY_LAST_UPDATE_PER_MESSAGE
-        ? (messageIsSnapshot || messageHasBatchUpdates ? normalizedUpdates : normalizedUpdates.slice(-1))
-        : normalizedUpdates
+      const wsUpdatesForRender = messageIsSnapshot
+        ? normalizedUpdates
+        : normalizedUpdates.slice(-1)
 
       if (!wsUpdatesForRender.length) {
         return
       }
+
+      if (eventEndTimestamp != null && arrivalTimestamp > eventEndTimestamp) {
+        return
+      }
+
+      const cadenceTransitionDurationMs = resolveLivePriceTransitionDuration(
+        previousPriceMessageTimestamp,
+        arrivalTimestamp,
+      )
+      const transitionDurationMs = eventEndTimestamp == null
+        ? cadenceTransitionDurationMs
+        : Math.min(
+            cadenceTransitionDurationMs,
+            Math.max(0, eventEndTimestamp - arrivalTimestamp),
+          )
+      previousPriceMessageTimestamp = arrivalTimestamp
 
       setStatus('live')
       const latest = wsUpdatesForRender.at(-1)
@@ -120,10 +140,9 @@ export function useLiveSeriesWebSocket({
       }
 
       setData((prev) => {
-        const arrivalTimestamp = Date.now()
         const cutoff = arrivalTimestamp - LIVE_DATA_RETENTION_MS
 
-        if (messageIsSnapshot && wsUpdatesForRender.length > 1) {
+        if (messageIsSnapshot) {
           let lastSnapshotTimestamp: number | null = null
           const snapshotPoints: DataPoint[] = []
 
@@ -145,33 +164,26 @@ export function useLiveSeriesWebSocket({
             lastSnapshotTimestamp = pointTimestamp
           }
 
-          if (snapshotPoints.length > 0) {
+          if (snapshotPoints.length > 1 || (snapshotPoints.length === 1 && prev.length === 0)) {
             return snapshotPoints.slice(-MAX_POINTS)
           }
         }
 
-        let next = keepWithinLiveWindow(prev, cutoff)
-        const lastPoint = next.length ? next.at(-1) : null
-        let lastTimestamp = lastPoint ? lastPoint.date.getTime() : null
-
-        for (const update of wsUpdatesForRender) {
-          // Anchor incoming points to arrival time to avoid delayed-source timestamp jumps.
-          let pointTimestamp = Math.max(update.timestamp, arrivalTimestamp)
-
-          if (lastTimestamp !== null && pointTimestamp <= lastTimestamp) {
-            pointTimestamp = lastTimestamp + 1
-          }
-
-          const nextPoint: DataPoint = {
-            date: new Date(pointTimestamp),
-            [SERIES_KEY]: update.price,
-          }
-
-          next = [...next, nextPoint].slice(-MAX_POINTS)
-          lastTimestamp = pointTimestamp
+        const latestUpdate = wsUpdatesForRender.at(-1)
+        if (!latestUpdate) {
+          return prev
         }
 
-        return next
+        const retainedPoints = keepWithinLiveWindow(prev, cutoff)
+
+        // Treat live values as targets. Future samples are revealed by the existing
+        // 30 FPS chart clock, and a new target retakes the current visual price.
+        return appendLivePriceTransition(
+          retainedPoints,
+          latestUpdate.price,
+          arrivalTimestamp,
+          transitionDurationMs,
+        )
       })
 
       setBaselinePrice(current => current ?? wsUpdatesForRender[0]?.price ?? null)
@@ -246,7 +258,7 @@ export function useLiveSeriesWebSocket({
         })
       }
     }
-  }, [eventType, topic, isLiveView, wsUrl, subscriptionSymbol, setBaselinePrice])
+  }, [eventEndTimestamp, eventType, topic, isLiveView, wsUrl, subscriptionSymbol, setBaselinePrice])
 
   return { data, status }
 }

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
@@ -14,7 +14,9 @@ export const LIVE_X_AXIS_STEP_MS = 10 * 1000
 export const LIVE_X_AXIS_LEFT_LABEL_GUARD_MS = 3600
 const LIVE_MAX_Y_AXIS_TICKS = 6
 export const MAX_POINTS = 4000
-export const LIVE_WS_USE_ONLY_LAST_UPDATE_PER_MESSAGE = true
+export const LIVE_PRICE_TRANSITION_MS = 650
+const LIVE_PRICE_TRANSITION_MIN_MS = 120
+const LIVE_PRICE_TRANSITION_CADENCE_RATIO = 0.8
 export const LIVE_CHART_HEIGHT = 332
 export const LIVE_CHART_MARGIN_TOP = 22
 export const LIVE_CHART_MARGIN_BOTTOM = 52
@@ -379,6 +381,164 @@ export function keepWithinLiveWindow(points: DataPoint[], cutoffMs: number) {
     date: new Date(cutoffMs + 1),
     [SERIES_KEY]: lastPrice,
   }]
+}
+
+function readLiveSeriesPoint(point: DataPoint) {
+  const timestamp = point.date.getTime()
+  const price = point[SERIES_KEY]
+
+  if (
+    !Number.isFinite(timestamp)
+    || typeof price !== 'number'
+    || !Number.isFinite(price)
+  ) {
+    return null
+  }
+
+  return { timestamp, price }
+}
+
+function resolveLiveSeriesPriceAt(points: DataPoint[], timestamp: number) {
+  let previousPoint: { timestamp: number, price: number } | null = null
+
+  for (const point of points) {
+    const currentPoint = readLiveSeriesPoint(point)
+    if (!currentPoint) {
+      continue
+    }
+
+    if (currentPoint.timestamp === timestamp) {
+      return currentPoint.price
+    }
+
+    if (currentPoint.timestamp > timestamp) {
+      if (!previousPoint) {
+        return null
+      }
+
+      const span = currentPoint.timestamp - previousPoint.timestamp
+      if (span <= 0) {
+        return previousPoint.price
+      }
+
+      const progress = (timestamp - previousPoint.timestamp) / span
+      return previousPoint.price + (currentPoint.price - previousPoint.price) * progress
+    }
+
+    previousPoint = currentPoint
+  }
+
+  return previousPoint?.price ?? null
+}
+
+function smoothStep(progress: number) {
+  const clamped = Math.max(0, Math.min(1, progress))
+  return clamped * clamped * (3 - 2 * clamped)
+}
+
+export function resolveLivePriceTransitionDuration(
+  previousMessageTimestamp: number | null,
+  currentMessageTimestamp: number,
+) {
+  if (
+    previousMessageTimestamp == null
+    || !Number.isFinite(previousMessageTimestamp)
+    || !Number.isFinite(currentMessageTimestamp)
+  ) {
+    return LIVE_PRICE_TRANSITION_MS
+  }
+
+  const messageIntervalMs = Math.max(0, currentMessageTimestamp - previousMessageTimestamp)
+  return Math.min(
+    LIVE_PRICE_TRANSITION_MS,
+    Math.max(
+      LIVE_PRICE_TRANSITION_MIN_MS,
+      Math.round(messageIntervalMs * LIVE_PRICE_TRANSITION_CADENCE_RATIO),
+    ),
+  )
+}
+
+export function appendLivePriceTransition(
+  points: DataPoint[],
+  targetPrice: number,
+  transitionStartMs: number,
+  transitionDurationMs = LIVE_PRICE_TRANSITION_MS,
+) {
+  if (
+    !Number.isFinite(targetPrice)
+    || targetPrice <= 0
+    || !Number.isFinite(transitionStartMs)
+  ) {
+    return points
+  }
+
+  const startTimestamp = Math.round(transitionStartMs)
+  const latestScheduledPoint = [...points]
+    .reverse()
+    .map(readLiveSeriesPoint)
+    .find(point => point !== null)
+
+  // Repeated WS values should keep an in-flight trajectory instead of restarting it.
+  if (latestScheduledPoint?.price === targetPrice) {
+    return points.slice(-MAX_POINTS)
+  }
+
+  const startPrice = resolveLiveSeriesPriceAt(points, startTimestamp)
+  const retainedPoints = points.filter((point) => {
+    const timestamp = point.date.getTime()
+    return Number.isFinite(timestamp) && timestamp < startTimestamp
+  })
+
+  if (startPrice == null || startPrice === targetPrice) {
+    return [
+      ...retainedPoints,
+      {
+        date: new Date(startTimestamp),
+        [SERIES_KEY]: targetPrice,
+      },
+    ].slice(-MAX_POINTS)
+  }
+
+  const durationMs = Number.isFinite(transitionDurationMs)
+    ? Math.max(0, Math.round(transitionDurationMs))
+    : LIVE_PRICE_TRANSITION_MS
+  if (durationMs === 0) {
+    return [
+      ...retainedPoints,
+      {
+        date: new Date(startTimestamp),
+        [SERIES_KEY]: targetPrice,
+      },
+    ].slice(-MAX_POINTS)
+  }
+
+  const frameCount = Math.max(1, Math.ceil(durationMs / LIVE_CLOCK_FRAME_MS))
+  const transitionPoints: DataPoint[] = [{
+    date: new Date(startTimestamp),
+    [SERIES_KEY]: startPrice,
+  }]
+  let lastTimestamp = startTimestamp
+
+  for (let frame = 1; frame <= frameCount; frame += 1) {
+    const progress = frame / frameCount
+    const pointTimestamp = frame === frameCount
+      ? startTimestamp + durationMs
+      : Math.round(startTimestamp + durationMs * progress)
+
+    if (pointTimestamp <= lastTimestamp) {
+      continue
+    }
+
+    transitionPoints.push({
+      date: new Date(pointTimestamp),
+      [SERIES_KEY]: frame === frameCount
+        ? targetPrice
+        : startPrice + (targetPrice - startPrice) * smoothStep(progress),
+    })
+    lastTimestamp = pointTimestamp
+  }
+
+  return [...retainedPoints, ...transitionPoints].slice(-MAX_POINTS)
 }
 
 export function resolveLiveSeriesDisplayPrice({

--- a/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
+++ b/src/app/[locale]/(platform)/profile/_hooks/useMergePositionsAction.ts
@@ -244,9 +244,6 @@ export function useMergePositionsAction({
         else {
           toast.error('Some positions could not be merged. Please try again.')
         }
-        else {
-          toast.error('Some positions could not be merged. Please try again.')
-        }
       }
       else {
         onSuccess?.()

--- a/src/components/PredictionChart.tsx
+++ b/src/components/PredictionChart.tsx
@@ -65,6 +65,7 @@ export default function PredictionChart({
   height = 400,
   margin = defaultMargin,
   dataSignature,
+  dataSyncMode = 'append',
   onCursorDataChange,
   cursorStepMs,
   xAxisTickCount = DEFAULT_X_AXIS_TICKS,
@@ -114,6 +115,7 @@ export default function PredictionChart({
   const { data, isClient, lastDataUpdateTypeRef, previousDataRef } = usePredictionChartData(
     providedData,
     normalizedSignature,
+    dataSyncMode,
   )
   const isDarkMode = useDarkMode()
   const annotationHoverScopeKey = `${normalizedSignature}:${showAnnotations ? '1' : '0'}`

--- a/src/hooks/usePredictionChartData.ts
+++ b/src/hooks/usePredictionChartData.ts
@@ -2,6 +2,14 @@ import type { DataPoint } from '@/types/PredictionChartTypes'
 import { useCallback, useLayoutEffect, useRef, useState } from 'react'
 import { arePointsEqual } from '@/lib/prediction-chart'
 
+function haveSameSeriesKeys(a: DataPoint, b: DataPoint) {
+  const aKeys = Object.keys(a).filter(key => key !== 'date')
+  const bKeys = Object.keys(b).filter(key => key !== 'date')
+
+  return aKeys.length === bKeys.length
+    && aKeys.every(key => Object.hasOwn(b, key))
+}
+
 function usePredictionChartData(
   providedData: DataPoint[] | undefined,
   normalizedSignature: string | number,
@@ -78,6 +86,7 @@ function usePredictionChartData(
             return Boolean(
               incomingPoint
               && point.date.getTime() === incomingPoint.date.getTime()
+              && haveSameSeriesKeys(point, incomingPoint)
               && arePointsEqual(point, incomingPoint),
             )
           })

--- a/src/hooks/usePredictionChartData.ts
+++ b/src/hooks/usePredictionChartData.ts
@@ -5,6 +5,7 @@ import { arePointsEqual } from '@/lib/prediction-chart'
 function usePredictionChartData(
   providedData: DataPoint[] | undefined,
   normalizedSignature: string | number,
+  dataSyncMode: 'append' | 'replace' = 'append',
 ) {
   const [data, setData] = useState<DataPoint[]>([])
   const [isClient, setIsClient] = useState(false)
@@ -67,6 +68,26 @@ function usePredictionChartData(
 
       if (previousData.length === 0) {
         lastDataUpdateTypeRef.current = 'reset'
+        return providedData
+      }
+
+      if (dataSyncMode === 'replace') {
+        const dataMatchesExactly = previousData.length === providedData.length
+          && previousData.every((point, index) => {
+            const incomingPoint = providedData[index]
+            return Boolean(
+              incomingPoint
+              && point.date.getTime() === incomingPoint.date.getTime()
+              && arePointsEqual(point, incomingPoint),
+            )
+          })
+
+        if (dataMatchesExactly) {
+          lastDataUpdateTypeRef.current = 'none'
+          return previousData
+        }
+
+        lastDataUpdateTypeRef.current = 'append'
         return providedData
       }
 
@@ -167,7 +188,7 @@ function usePredictionChartData(
       lastDataUpdateTypeRef.current = 'none'
       return previousData
     })
-  }, [providedData, normalizedSignature, isClient, scheduleStateUpdate])
+  }, [providedData, normalizedSignature, dataSyncMode, isClient, scheduleStateUpdate])
 
   return {
     data,

--- a/src/lib/prediction-chart.ts
+++ b/src/lib/prediction-chart.ts
@@ -49,11 +49,9 @@ export function arePointsEqual(a: DataPoint, b: DataPoint) {
     const bValue = b[key]
 
     if (typeof aValue === 'number' || typeof bValue === 'number') {
-      if (
-        typeof aValue !== 'number'
-        || typeof bValue !== 'number'
-        || Math.abs(aValue - bValue) > DATA_POINT_EPSILON
-      ) {
+      const numericA = typeof aValue === 'number' ? aValue : 0
+      const numericB = typeof bValue === 'number' ? bValue : 0
+      if (Math.abs(numericA - numericB) > DATA_POINT_EPSILON) {
         return false
       }
       continue

--- a/src/lib/prediction-chart.ts
+++ b/src/lib/prediction-chart.ts
@@ -49,9 +49,11 @@ export function arePointsEqual(a: DataPoint, b: DataPoint) {
     const bValue = b[key]
 
     if (typeof aValue === 'number' || typeof bValue === 'number') {
-      const numericA = typeof aValue === 'number' ? aValue : 0
-      const numericB = typeof bValue === 'number' ? bValue : 0
-      if (Math.abs(numericA - numericB) > DATA_POINT_EPSILON) {
+      if (
+        typeof aValue !== 'number'
+        || typeof bValue !== 'number'
+        || Math.abs(aValue - bValue) > DATA_POINT_EPSILON
+      ) {
         return false
       }
       continue

--- a/src/types/PredictionChartTypes.ts
+++ b/src/types/PredictionChartTypes.ts
@@ -34,6 +34,7 @@ export interface PredictionChartProps {
   height?: number
   margin?: { top: number, right: number, bottom: number, left: number }
   dataSignature?: string | number
+  dataSyncMode?: 'append' | 'replace'
   onCursorDataChange?: (snapshot: PredictionChartCursorSnapshot | null) => void
   cursorStepMs?: number
   xAxisTickCount?: number

--- a/tests/unit/eventLiveSeriesChartUtils.test.ts
+++ b/tests/unit/eventLiveSeriesChartUtils.test.ts
@@ -1,9 +1,26 @@
 import type { Event } from '@/types'
+import type { DataPoint } from '@/types/PredictionChartTypes'
 import { describe, expect, it } from 'vitest'
 import {
+  appendLivePriceTransition,
+  LIVE_PRICE_TRANSITION_MS,
+  MAX_POINTS,
   resolveEventEndTimestamp,
+  resolveLivePriceTransitionDuration,
   resolveLiveSeriesDisplayPrice,
+  SERIES_KEY,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils'
+
+function createLivePoint(timestamp: number, price: number): DataPoint {
+  return {
+    date: new Date(timestamp),
+    [SERIES_KEY]: price,
+  }
+}
+
+function readLivePrice(point: DataPoint) {
+  return point[SERIES_KEY] as number
+}
 
 function createEvent(overrides: Partial<Event> = {}): Event {
   return {
@@ -65,6 +82,138 @@ function createEvent(overrides: Partial<Event> = {}): Event {
 }
 
 describe('event live series chart utils', () => {
+  it.each([
+    { startPrice: 100, targetPrice: 110 },
+    { startPrice: 110, targetPrice: 100 },
+  ])('builds a monotonic live transition from $startPrice to $targetPrice', ({ startPrice, targetPrice }) => {
+    const transitionStart = 10_000
+    const result = appendLivePriceTransition(
+      [createLivePoint(1_000, startPrice)],
+      targetPrice,
+      transitionStart,
+    )
+    const transition = result.filter(point => point.date.getTime() >= transitionStart)
+    const prices = transition.map(readLivePrice)
+
+    expect(transition.length).toBeGreaterThan(10)
+    expect(transition[0]?.date.getTime()).toBe(transitionStart)
+    expect(prices[0]).toBe(startPrice)
+    expect(transition.at(-1)?.date.getTime()).toBe(transitionStart + LIVE_PRICE_TRANSITION_MS)
+    expect(prices.at(-1)).toBe(targetPrice)
+
+    for (let index = 1; index < transition.length; index += 1) {
+      expect(transition[index]!.date.getTime()).toBeGreaterThan(transition[index - 1]!.date.getTime())
+      if (targetPrice > startPrice) {
+        expect(prices[index]).toBeGreaterThan(prices[index - 1]!)
+      }
+      else {
+        expect(prices[index]).toBeLessThan(prices[index - 1]!)
+      }
+    }
+  })
+
+  it('retargets an in-flight transition from the currently displayed price', () => {
+    const firstTransitionStart = 10_000
+    const retargetTimestamp = firstTransitionStart + 173
+    const firstTransition = appendLivePriceTransition(
+      [createLivePoint(1_000, 100)],
+      110,
+      firstTransitionStart,
+    )
+    const pointBeforeRetarget = firstTransition
+      .filter(point => point.date.getTime() < retargetTimestamp)
+      .at(-1)!
+    const pointAfterRetarget = firstTransition
+      .find(point => point.date.getTime() > retargetTimestamp)!
+    const interpolationProgress = (
+      retargetTimestamp - pointBeforeRetarget.date.getTime()
+    ) / (
+      pointAfterRetarget.date.getTime() - pointBeforeRetarget.date.getTime()
+    )
+    const expectedRetargetPrice = readLivePrice(pointBeforeRetarget) + (
+      readLivePrice(pointAfterRetarget) - readLivePrice(pointBeforeRetarget)
+    ) * interpolationProgress
+    const result = appendLivePriceTransition(
+      firstTransition,
+      90,
+      retargetTimestamp,
+    )
+    const retargetedTransition = result.filter(point => point.date.getTime() >= retargetTimestamp)
+    const retargetedPrices = retargetedTransition.map(readLivePrice)
+
+    expect(retargetedTransition[0]?.date.getTime()).toBe(retargetTimestamp)
+    expect(retargetedPrices[0]).toBeCloseTo(expectedRetargetPrice, 8)
+    expect(retargetedPrices.at(-1)).toBe(90)
+    expect(result.some(point => (
+      point.date.getTime() > retargetTimestamp
+      && readLivePrice(point) > (retargetedPrices[0] ?? Number.POSITIVE_INFINITY)
+    ))).toBe(false)
+  })
+
+  it('does not restart a transition when the WS repeats the same target', () => {
+    const transitionStart = 10_000
+    const firstTransition = appendLivePriceTransition(
+      [createLivePoint(1_000, 100)],
+      110,
+      transitionStart,
+    )
+    const repeatedTarget = appendLivePriceTransition(
+      firstTransition,
+      110,
+      transitionStart + 200,
+    )
+
+    expect(repeatedTarget).toEqual(firstTransition)
+    expect(repeatedTarget.at(-1)?.date.getTime()).toBe(transitionStart + LIVE_PRICE_TRANSITION_MS)
+  })
+
+  it('keeps the smoothed live history within the chart point limit', () => {
+    const points = Array.from({ length: MAX_POINTS }, (_value, index) => (
+      createLivePoint(index * 10, 100)
+    ))
+    const result = appendLivePriceTransition(points, 110, MAX_POINTS * 10)
+
+    expect(result).toHaveLength(MAX_POINTS)
+    expect(result.at(-1)?.[SERIES_KEY]).toBe(110)
+  })
+
+  it('adapts the transition duration to the incoming message cadence', () => {
+    expect(resolveLivePriceTransitionDuration(null, 10_000)).toBe(LIVE_PRICE_TRANSITION_MS)
+    expect(resolveLivePriceTransitionDuration(9_900, 10_000)).toBe(120)
+    expect(resolveLivePriceTransitionDuration(9_500, 10_000)).toBe(400)
+    expect(resolveLivePriceTransitionDuration(8_000, 10_000)).toBe(LIVE_PRICE_TRANSITION_MS)
+  })
+
+  it('keeps up with a rapid sequence of distinct price targets', () => {
+    let points = [createLivePoint(0, 100)]
+    let previousTimestamp: number | null = null
+
+    for (let update = 1; update <= 20; update += 1) {
+      const timestamp = update * 100
+      const duration = resolveLivePriceTransitionDuration(previousTimestamp, timestamp)
+      points = appendLivePriceTransition(points, 100 + update, timestamp, duration)
+      previousTimestamp = timestamp
+    }
+
+    const finalTransitionStart = points.find(point => point.date.getTime() === 2_000)
+    expect(finalTransitionStart?.[SERIES_KEY]).toBeGreaterThan(118)
+    expect(points.at(-1)?.[SERIES_KEY]).toBe(120)
+    expect(points.at(-1)?.date.getTime()).toBe(2_120)
+  })
+
+  it('falls back to the default transition duration for a non-finite duration', () => {
+    const transitionStart = 10_000
+    const result = appendLivePriceTransition(
+      [createLivePoint(1_000, 100)],
+      110,
+      transitionStart,
+      Number.POSITIVE_INFINITY,
+    )
+
+    expect(result.at(-1)?.date.getTime()).toBe(transitionStart + LIVE_PRICE_TRANSITION_MS)
+    expect(result.at(-1)?.[SERIES_KEY]).toBe(110)
+  })
+
   it('uses event resolved_at as the live chart end timestamp', () => {
     const resolvedAt = '2026-06-22T23:59:12.000Z'
     const event = createEvent({

--- a/tests/unit/useLiveSeriesWebSocket.test.tsx
+++ b/tests/unit/useLiveSeriesWebSocket.test.tsx
@@ -1,0 +1,184 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { useState } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLiveSeriesWebSocket } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket'
+import {
+  resolveLivePriceTransitionDuration,
+  SERIES_KEY,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils'
+
+class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+  static instances: MockWebSocket[] = []
+
+  readyState = MockWebSocket.CONNECTING
+  onopen: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent<string>) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  sentMessages: string[] = []
+
+  constructor(readonly url: string | URL) {
+    MockWebSocket.instances.push(this)
+  }
+
+  send(payload: string) {
+    this.sentMessages.push(payload)
+  }
+
+  close() {
+    this.readyState = MockWebSocket.CLOSED
+  }
+
+  emitOpen() {
+    this.readyState = MockWebSocket.OPEN
+    this.onopen?.(new Event('open'))
+  }
+
+  emitMessage(payload: unknown) {
+    this.onmessage?.({ data: JSON.stringify(payload) } as MessageEvent<string>)
+  }
+}
+
+describe('useLiveSeriesWebSocket', () => {
+  let now = 1_800_000_000_000
+  let dateNowSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    now = 1_800_000_000_000
+    MockWebSocket.instances = []
+    window.localStorage.clear()
+    vi.stubGlobal('WebSocket', MockWebSocket as unknown as typeof WebSocket)
+    dateNowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  function mountHook(eventEndTimestamp: number | null = null) {
+    const view = renderHook(() => {
+      const [baseline, setBaseline] = useState<number | null>(null)
+      const live = useLiveSeriesWebSocket({
+        topic: 'crypto_prices',
+        eventType: 'price',
+        eventEndTimestamp,
+        subscriptionSymbol: 'BTC',
+        isLiveView: true,
+        setBaselinePrice: setBaseline,
+      })
+
+      return { ...live, baseline }
+    })
+
+    const socket = MockWebSocket.instances[0]!
+    act(() => socket.emitOpen())
+    return { ...view, socket }
+  }
+
+  it.each([
+    { prices: [100] },
+    { prices: [100, 101] },
+  ])('loads a $prices.length-point subscribe payload as the initial snapshot', ({ prices }) => {
+    const { result, socket } = mountHook()
+    const snapshot = prices.map((price, index) => ({
+      symbol: 'BTC',
+      value: price,
+      timestamp: now - (prices.length - index) * 1_000,
+    }))
+
+    act(() => socket.emitMessage({
+      type: 'subscribe',
+      payload: { data: snapshot },
+    }))
+
+    expect(result.current.data.map(point => [point.date.getTime(), point[SERIES_KEY]])).toEqual(
+      snapshot.map(point => [point.timestamp, point.value]),
+    )
+    expect(result.current.baseline).toBe(100)
+    expect(result.current.status).toBe('live')
+  })
+
+  it('uses the latest batch value and retargets from the in-flight visual price', () => {
+    const { result, socket } = mountHook()
+    const initialNow = now
+
+    act(() => socket.emitMessage({
+      type: 'subscribe',
+      data: [{ symbol: 'BTC', value: 100, timestamp: initialNow - 500 }],
+    }))
+
+    const callsBeforeUpdates = dateNowSpy.mock.calls.length
+    act(() => {
+      now = initialNow + 100
+      socket.emitMessage({
+        type: 'update',
+        topic: 'crypto_prices',
+        symbol: 'BTC',
+        value: 110,
+        timestamp: now,
+      })
+
+      now = initialNow + 200
+      socket.emitMessage({
+        type: 'update',
+        data: [
+          { symbol: 'BTC', value: 90, timestamp: initialNow + 195 },
+          { symbol: 'BTC', value: 92, timestamp: initialNow + 190 },
+        ],
+      })
+    })
+
+    expect(dateNowSpy.mock.calls.length - callsBeforeUpdates).toBe(2)
+
+    const retargetStart = initialNow + 200
+    const transition = result.current.data.filter(point => point.date.getTime() >= retargetStart)
+    const firstPrice = transition[0]?.[SERIES_KEY] as number
+    const duration = resolveLivePriceTransitionDuration(initialNow + 100, retargetStart)
+
+    expect(transition[0]?.date.getTime()).toBe(retargetStart)
+    expect(firstPrice).toBeGreaterThan(100)
+    expect(firstPrice).toBeLessThan(110)
+    expect(transition.at(-1)?.date.getTime()).toBe(retargetStart + duration)
+    expect(transition.at(-1)?.[SERIES_KEY]).toBe(90)
+    expect(result.current.baseline).toBe(100)
+  })
+
+  it('finishes the last transition at the event cutoff and ignores later updates', () => {
+    const initialNow = now
+    const eventEndTimestamp = initialNow + 150
+    const { result, socket } = mountHook(eventEndTimestamp)
+
+    act(() => socket.emitMessage({
+      type: 'subscribe',
+      data: [{ symbol: 'BTC', value: 100, timestamp: initialNow - 500 }],
+    }))
+
+    now = initialNow + 100
+    act(() => socket.emitMessage({
+      type: 'update',
+      symbol: 'BTC',
+      value: 110,
+      timestamp: now,
+    }))
+
+    expect(result.current.data.at(-1)?.date.getTime()).toBe(eventEndTimestamp)
+    expect(result.current.data.at(-1)?.[SERIES_KEY]).toBe(110)
+
+    const dataAtCutoff = result.current.data
+    now = eventEndTimestamp + 1
+    act(() => socket.emitMessage({
+      type: 'update',
+      symbol: 'BTC',
+      value: 120,
+      timestamp: now,
+    }))
+
+    expect(result.current.data).toBe(dataAtCutoff)
+  })
+})

--- a/tests/unit/useLiveSeriesWebSocket.test.tsx
+++ b/tests/unit/useLiveSeriesWebSocket.test.tsx
@@ -181,4 +181,32 @@ describe('useLiveSeriesWebSocket', () => {
 
     expect(result.current.data).toBe(dataAtCutoff)
   })
+
+  it('accepts a pre-close update delivered after the event cutoff', () => {
+    const initialNow = now
+    const eventEndTimestamp = initialNow + 150
+    const { result, socket } = mountHook(eventEndTimestamp)
+
+    act(() => socket.emitMessage({
+      type: 'subscribe',
+      data: [{ symbol: 'BTC', value: 100, timestamp: initialNow - 500 }],
+    }))
+
+    now = eventEndTimestamp + 1_000
+    act(() => socket.emitMessage({
+      type: 'update',
+      symbol: 'BTC',
+      value: 110,
+      timestamp: eventEndTimestamp - 1,
+    }))
+
+    expect(result.current.data.at(-1)).toEqual({
+      date: new Date(eventEndTimestamp),
+      [SERIES_KEY]: 110,
+    })
+    expect(JSON.parse(window.localStorage.getItem('kuest-live-last-price:crypto_prices:BTC')!)).toEqual({
+      price: 110,
+      timestamp: eventEndTimestamp - 1,
+    })
+  })
 })

--- a/tests/unit/usePredictionChartData.test.tsx
+++ b/tests/unit/usePredictionChartData.test.tsx
@@ -22,18 +22,45 @@ describe('usePredictionChartData', () => {
     )
 
     await waitFor(() => {
-      expect(result.current.data.map(point => point.date.getTime())).toEqual([1_000, 1_100])
+      expect(result.current.data).toEqual(firstData)
     })
 
+    const replacementData = [
+      createPoint(1_000, 100),
+      createPoint(1_200, 101),
+    ]
     rerender({
-      data: [
-        createPoint(1_000, 100),
-        createPoint(1_200, 101),
-      ],
+      data: replacementData,
     })
 
     await waitFor(() => {
-      expect(result.current.data.map(point => point.date.getTime())).toEqual([1_000, 1_200])
+      expect(result.current.data).toEqual(replacementData)
+    })
+  })
+
+  it('replaces a point when the incoming data adds a zero-valued series', async () => {
+    const initialPoint: DataPoint = {
+      date: new Date(1_000),
+      yes: 50,
+    }
+    const replacementPoint: DataPoint = {
+      date: new Date(1_000),
+      yes: 50,
+      no: 0,
+    }
+    const { result, rerender } = renderHook(
+      ({ data }) => usePredictionChartData(data, 'market', 'replace'),
+      { initialProps: { data: [initialPoint] } },
+    )
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([initialPoint])
+    })
+
+    rerender({ data: [replacementPoint] })
+
+    await waitFor(() => {
+      expect(result.current.data).toEqual([replacementPoint])
     })
   })
 })

--- a/tests/unit/usePredictionChartData.test.tsx
+++ b/tests/unit/usePredictionChartData.test.tsx
@@ -1,0 +1,39 @@
+import type { DataPoint } from '@/types/PredictionChartTypes'
+import { renderHook, waitFor } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import usePredictionChartData from '@/hooks/usePredictionChartData'
+
+function createPoint(timestamp: number, price: number): DataPoint {
+  return {
+    date: new Date(timestamp),
+    price,
+  }
+}
+
+describe('usePredictionChartData', () => {
+  it('drops an obsolete moving endpoint in replace sync mode', async () => {
+    const firstData = [
+      createPoint(1_000, 100),
+      createPoint(1_100, 100),
+    ]
+    const { result, rerender } = renderHook(
+      ({ data }) => usePredictionChartData(data, 'live-series', 'replace'),
+      { initialProps: { data: firstData } },
+    )
+
+    await waitFor(() => {
+      expect(result.current.data.map(point => point.date.getTime())).toEqual([1_000, 1_100])
+    })
+
+    rerender({
+      data: [
+        createPoint(1_000, 100),
+        createPoint(1_200, 101),
+      ],
+    })
+
+    await waitFor(() => {
+      expect(result.current.data.map(point => point.date.getTime())).toEqual([1_000, 1_200])
+    })
+  })
+})

--- a/tests/unit/usePredictionChartData.test.tsx
+++ b/tests/unit/usePredictionChartData.test.tsx
@@ -63,4 +63,26 @@ describe('usePredictionChartData', () => {
       expect(result.current.data).toEqual([replacementPoint])
     })
   })
+
+  it('does not append when a sparse series is equivalent to zero', async () => {
+    const initialData: DataPoint[] = [{
+      date: new Date(1_000),
+      yes: 0,
+    }]
+    const { result, rerender } = renderHook(
+      ({ data }) => usePredictionChartData(data, 'market'),
+      { initialProps: { data: initialData } },
+    )
+
+    await waitFor(() => {
+      expect(result.current.data).toBe(initialData)
+    })
+
+    rerender({ data: [{ date: new Date(1_000) }] })
+
+    await waitFor(() => {
+      expect(result.current.lastDataUpdateTypeRef.current).toBe('none')
+      expect(result.current.data).toBe(initialData)
+    })
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Smooths the live event chart to eliminate the “snake” effect and anchors the series at the event cutoff for a stable timeline. Preserves the last transition and final price at cutoff, accepts late pre‑close updates, and reduces flicker with adaptive animation and clean `replace` data sync.

- **Bug Fixes**
  - Smooth live updates with eased transitions; repeated targets no longer restart animations.
  - Stop rendering past the event end; cap the last transition at the cutoff; accept delayed pre‑close updates and persist the final tick.
  - Use closed fallback data when there’s no pre‑close data; stabilize axes by sourcing ticks from rendered data only.
  - Preserve equality for sparse series (missing zero‑valued keys don’t trigger appends).
  - Remove duplicate else branch in merge positions action.

- **New Features**
  - Adaptive transition duration based on WebSocket cadence, capped by the event cutoff.
  - `PredictionChart` supports `dataSyncMode="replace"` to swap datasets cleanly.
  - New utils for live smoothing and timing; unit tests for utils, WebSocket hook, and chart data sync.

<sup>Written for commit 95a05d2aabaa5a8ab56baee2fa973b41c2d09631. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

