### PR TITLE
fix: sports order panel scroll

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -21,7 +21,7 @@ import {
   FlameIcon,
 } from 'lucide-react'
 import { DynamicIcon } from 'lucide-react/dynamic'
-import { useExtracted } from 'next-intl'
+import { useExtracted, useLocale } from 'next-intl'
 import dynamic from 'next/dynamic'
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from 'react'
 import EventBookmark from '@/app/[locale]/(platform)/event/[slug]/_components/EventBookmark'
@@ -33,16 +33,22 @@ import {
   buildLinePickerOptions,
   resolveSportsGraphSelection,
 } from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils'
+import {
+  formatSportsEventLocalStartLabels,
+  formatSportsEventStartLabels,
+} from '@/app/[locale]/(platform)/sports/_components/sports-event-center-utils'
 import { buildSportsGamesCards } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 import AppLink from '@/components/AppLink'
 import EventIconImage from '@/components/EventIconImage'
 import SiteLogoIcon from '@/components/SiteLogoIcon'
 import { Button } from '@/components/ui/button'
+import { useHasHydrated } from '@/hooks/useHasHydrated'
 import { useIsMobile } from '@/hooks/useIsMobile'
 import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import { ensureReadableTextColorOnDark } from '@/lib/color-contrast'
 import { resolveEventOutcomePath, resolveEventPagePath } from '@/lib/events-routing'
 import { formatDollarValueLabel, formatVolume } from '@/lib/formatters'
+import { resolveHomeFeaturedSportsScoreLabel } from '@/lib/home-featured-sports-score'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
 import { cn } from '@/lib/utils'
 
@@ -1167,6 +1173,8 @@ function SportsScoreboard({
   item: HomeFeaturedEventCard
   linkedHref: string
 }) {
+  const hasHydrated = useHasHydrated()
+  const locale = useLocale()
   const teams = card?.teams.length
     ? card.teams.map(team => ({
         name: team.name,
@@ -1176,7 +1184,20 @@ function SportsScoreboard({
         name: team.name,
         logoUrl: team.logo_url ?? item.event.sports_team_logo_urls?.[index] ?? null,
       }))
-  const score = item.event.sports_score?.trim()
+  const scoreLabel = resolveHomeFeaturedSportsScoreLabel(item.event.sports_score)
+  const parsedStartTimestamp = item.event.sports_start_time
+    ? Date.parse(item.event.sports_start_time)
+    : item.event.start_date
+      ? Date.parse(item.event.start_date)
+      : Number.NaN
+  const startTimestamp = Number.isFinite(parsedStartTimestamp) ? parsedStartTimestamp : null
+  const startLabels = startTimestamp !== null
+    ? (
+        hasHydrated
+          ? formatSportsEventLocalStartLabels(startTimestamp, locale) ?? formatSportsEventStartLabels(startTimestamp, locale)
+          : formatSportsEventStartLabels(startTimestamp, locale)
+      )
+    : null
   const liveMeta = [item.event.sports_period, item.event.sports_elapsed].filter(Boolean).join(' · ')
   if (item.kind !== 'sports' || teams.length < 2) {
     return null
@@ -1211,17 +1232,32 @@ function SportsScoreboard({
           : <p className="truncate text-sm font-medium">{homeTeam?.name}</p>}
       </div>
       <div className="text-center">
-        <p className="text-3xl font-semibold tabular-nums">{score || '0 - 0'}</p>
-        {item.temporalStatus === 'live' && (
-          <p className="mt-1 text-xs font-semibold tracking-wide text-red-500 uppercase">
-            LIVE
-          </p>
-        )}
-        {liveMeta && (
-          <p className="text-sm font-medium text-red-500">
-            {liveMeta}
-          </p>
-        )}
+        {scoreLabel
+          ? (
+              <>
+                <p className="text-3xl font-semibold tabular-nums">{scoreLabel}</p>
+                {item.temporalStatus === 'live' && (
+                  <p className="mt-1 text-xs font-semibold tracking-wide text-red-500 uppercase">
+                    LIVE
+                  </p>
+                )}
+                {liveMeta && (
+                  <p className="text-sm font-medium text-red-500">
+                    {liveMeta}
+                  </p>
+                )}
+              </>
+            )
+          : startLabels
+            ? (
+                <>
+                  <p className="text-sm font-semibold text-foreground tabular-nums">{startLabels.timeLabel}</p>
+                  <p className="mt-2 text-sm font-medium text-muted-foreground">{startLabels.dayLabel}</p>
+                </>
+              )
+            : (
+                <p className="text-sm font-semibold text-muted-foreground">{item.temporalLabel}</p>
+              )}
       </div>
       <div className="min-w-0 text-center">
         {awayLogo && (

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -48,7 +48,7 @@ import { useSiteIdentity } from '@/hooks/useSiteIdentity'
 import { ensureReadableTextColorOnDark } from '@/lib/color-contrast'
 import { resolveEventOutcomePath, resolveEventPagePath } from '@/lib/events-routing'
 import { formatDollarValueLabel, formatVolume } from '@/lib/formatters'
-import { resolveHomeFeaturedSportsScoreLabel } from '@/lib/home-featured-sports-score'
+import { resolveHomeFeaturedSportsScoreboardContent } from '@/lib/home-featured-sports-score'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
 import { cn } from '@/lib/utils'
 
@@ -1184,7 +1184,12 @@ function SportsScoreboard({
         name: team.name,
         logoUrl: team.logo_url ?? item.event.sports_team_logo_urls?.[index] ?? null,
       }))
-  const scoreLabel = resolveHomeFeaturedSportsScoreLabel(item.event.sports_score)
+  const liveMeta = [item.event.sports_period, item.event.sports_elapsed].filter(Boolean).join(' · ')
+  const scoreboardContent = resolveHomeFeaturedSportsScoreboardContent({
+    score: item.event.sports_score,
+    temporalStatus: item.temporalStatus,
+    liveMeta,
+  })
   const parsedStartTimestamp = item.event.sports_start_time
     ? Date.parse(item.event.sports_start_time)
     : item.event.start_date
@@ -1198,7 +1203,6 @@ function SportsScoreboard({
           : formatSportsEventStartLabels(startTimestamp, locale)
       )
     : null
-  const liveMeta = [item.event.sports_period, item.event.sports_elapsed].filter(Boolean).join(' · ')
   if (item.kind !== 'sports' || teams.length < 2) {
     return null
   }
@@ -1211,6 +1215,7 @@ function SportsScoreboard({
   const homeHref = card && homeButton ? resolveFeaturedSportsButtonHref(card, homeButton, linkedHref) : null
   const awayHref = card && awayButton ? resolveFeaturedSportsButtonHref(card, awayButton, linkedHref) : null
   const teamNameClassName = 'inline-block max-w-full truncate text-sm font-medium underline-offset-2 hover:underline'
+  const shouldShowScheduledStart = !scoreboardContent.scoreLabel && !scoreboardContent.showLiveStatus
 
   return (
     <div className="grid grid-cols-[minmax(0,1fr)_auto_minmax(0,1fr)] items-center gap-3 rounded-lg bg-secondary/60 p-3">
@@ -1232,32 +1237,36 @@ function SportsScoreboard({
           : <p className="truncate text-sm font-medium">{homeTeam?.name}</p>}
       </div>
       <div className="text-center">
-        {scoreLabel
+        {scoreboardContent.scoreLabel
           ? (
-              <>
-                <p className="text-3xl font-semibold tabular-nums">{scoreLabel}</p>
-                {item.temporalStatus === 'live' && (
-                  <p className="mt-1 text-xs font-semibold tracking-wide text-red-500 uppercase">
-                    LIVE
-                  </p>
-                )}
-                {liveMeta && (
-                  <p className="text-sm font-medium text-red-500">
-                    {liveMeta}
-                  </p>
-                )}
-              </>
+              <p className="text-3xl font-semibold tabular-nums">{scoreboardContent.scoreLabel}</p>
             )
-          : startLabels
+          : shouldShowScheduledStart && startLabels
             ? (
                 <>
                   <p className="text-sm font-semibold text-foreground tabular-nums">{startLabels.timeLabel}</p>
                   <p className="mt-2 text-sm font-medium text-muted-foreground">{startLabels.dayLabel}</p>
                 </>
               )
-            : (
-                <p className="text-sm font-semibold text-muted-foreground">{item.temporalLabel}</p>
-              )}
+            : shouldShowScheduledStart
+              ? (
+                  <p className="text-sm font-semibold text-muted-foreground">{item.temporalLabel}</p>
+                )
+              : null}
+        {scoreboardContent.showLiveStatus && (
+          <p className={cn(
+            'text-xs font-semibold tracking-wide text-red-500 uppercase',
+            scoreboardContent.scoreLabel ? 'mt-1' : undefined,
+          )}
+          >
+            LIVE
+          </p>
+        )}
+        {scoreboardContent.liveMeta && (
+          <p className="text-sm font-medium text-red-500">
+            {scoreboardContent.liveMeta}
+          </p>
+        )}
       </div>
       <div className="min-w-0 text-center">
         {awayLogo && (

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -1675,7 +1675,8 @@ export default function SportsEventCenter({
       </Suspense>
       <div className={cn(`
         min-[1200px]:grid min-[1200px]:h-full min-[1200px]:min-h-0 min-[1200px]:grid-cols-[minmax(0,1fr)_21.25rem]
-        min-[1200px]:[align-content:start] min-[1200px]:[align-items:start] min-[1200px]:gap-6
+        min-[1200px]:grid-rows-[minmax(0,1fr)] min-[1200px]:[align-content:start] min-[1200px]:items-stretch
+        min-[1200px]:gap-6
       `)}
       >
         <section
@@ -1976,8 +1977,8 @@ export default function SportsEventCenter({
           data-sports-scroll-pane="aside"
           className={cn(`
             hidden gap-4
-            min-[1200px]:sticky min-[1200px]:top-0 min-[1200px]:block min-[1200px]:h-fit min-[1200px]:max-h-full
-            min-[1200px]:self-start min-[1200px]:overflow-y-auto
+            min-[1200px]:sticky min-[1200px]:top-0 min-[1200px]:block min-[1200px]:h-full min-[1200px]:min-h-0
+            min-[1200px]:self-stretch min-[1200px]:overflow-y-auto min-[1200px]:overscroll-contain
           `)}
         >
           {activeTradeContext

--- a/src/lib/home-featured-sports-score.ts
+++ b/src/lib/home-featured-sports-score.ts
@@ -8,3 +8,19 @@ export function resolveHomeFeaturedSportsScoreLabel(value: string | null | undef
 
   return `${score.team1} - ${score.team2}`
 }
+
+export function resolveHomeFeaturedSportsScoreboardContent({
+  score,
+  temporalStatus,
+  liveMeta,
+}: {
+  score: string | null | undefined
+  temporalStatus: string
+  liveMeta?: string | null
+}) {
+  return {
+    scoreLabel: resolveHomeFeaturedSportsScoreLabel(score),
+    showLiveStatus: temporalStatus === 'live',
+    liveMeta: liveMeta?.trim() || null,
+  }
+}

--- a/src/lib/home-featured-sports-score.ts
+++ b/src/lib/home-featured-sports-score.ts
@@ -1,0 +1,10 @@
+import { parseSportsScore } from '@/lib/sports-resolution'
+
+export function resolveHomeFeaturedSportsScoreLabel(value: string | null | undefined) {
+  const score = parseSportsScore(value)
+  if (!score) {
+    return null
+  }
+
+  return `${score.team1} - ${score.team2}`
+}

--- a/tests/unit/homeFeaturedSportsScore.test.ts
+++ b/tests/unit/homeFeaturedSportsScore.test.ts
@@ -1,0 +1,12 @@
+import { resolveHomeFeaturedSportsScoreLabel } from '@/lib/home-featured-sports-score'
+
+describe('homeFeaturedSportsScore', () => {
+  it('formats parsed sports scores for the home carousel scoreboard', () => {
+    expect(resolveHomeFeaturedSportsScoreLabel('2 - 1')).toBe('2 - 1')
+  })
+
+  it('does not invent a score when score data is missing or invalid', () => {
+    expect(resolveHomeFeaturedSportsScoreLabel(null)).toBeNull()
+    expect(resolveHomeFeaturedSportsScoreLabel('LIVE')).toBeNull()
+  })
+})

--- a/tests/unit/homeFeaturedSportsScore.test.ts
+++ b/tests/unit/homeFeaturedSportsScore.test.ts
@@ -1,4 +1,7 @@
-import { resolveHomeFeaturedSportsScoreLabel } from '@/lib/home-featured-sports-score'
+import {
+  resolveHomeFeaturedSportsScoreboardContent,
+  resolveHomeFeaturedSportsScoreLabel,
+} from '@/lib/home-featured-sports-score'
 
 describe('homeFeaturedSportsScore', () => {
   it('formats parsed sports scores for the home carousel scoreboard', () => {
@@ -8,5 +11,17 @@ describe('homeFeaturedSportsScore', () => {
   it('does not invent a score when score data is missing or invalid', () => {
     expect(resolveHomeFeaturedSportsScoreLabel(null)).toBeNull()
     expect(resolveHomeFeaturedSportsScoreLabel('LIVE')).toBeNull()
+  })
+
+  it('keeps live status visible when score data is missing', () => {
+    expect(resolveHomeFeaturedSportsScoreboardContent({
+      score: null,
+      temporalStatus: 'live',
+      liveMeta: '1H · 21',
+    })).toEqual({
+      scoreLabel: null,
+      showLiveStatus: true,
+      liveMeta: '1H · 21',
+    })
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes the sports event sidebar/order panel scrolling on desktop and improves the home carousel scoreboard. The panel now stretches and scrolls properly; the carousel shows a real score or a clear local start time instead of a fake "0 - 0", and always shows LIVE when applicable.

- **Bug Fixes**
  - Sports Event Center: Updated grid/aside to fill its column, stretch to full height, and scroll inside it; added overscroll containment to stop page scroll jumps.
  - Home Featured Events Carousel: Parse and render real scores; when missing, show localized time/day (SSR-safe before hydration, local after). Keeps LIVE and period/elapsed visible even without a score. Removed the default "0 - 0".
  - Tests: Added unit tests for score label formatting, invalid input, and live-without-score behavior.

<sup>Written for commit 4d2fe0bc974ba6425589b76cf80e7e8b851aef66. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

