### PR TITLE
chore: disable sentry siwe verify message

### DIFF
--- a/src/components/AppErrorFallback.tsx
+++ b/src/components/AppErrorFallback.tsx
@@ -7,6 +7,7 @@ import AlertBanner from '@/components/AlertBanner'
 import { Button } from '@/components/ui/button'
 import { isNextClientStaleAssetError } from '@/lib/next-client-stale-assets'
 import { isNextNotFoundError } from '@/lib/next-http-fallback'
+import { isSiweVerificationError } from '@/lib/siwe-errors'
 import { cn } from '@/lib/utils'
 
 interface AppErrorFallbackProps {
@@ -32,6 +33,10 @@ export default function AppErrorFallback({
     }
 
     if (isNextClientStaleAssetError(error)) {
+      return
+    }
+
+    if (isSiweVerificationError(error)) {
       return
     }
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -2,6 +2,7 @@ import type { PublicRuntimeConfig } from '@/lib/public-runtime-config.shared'
 import * as Sentry from '@sentry/nextjs'
 import { isNextClientStaleAssetError } from '@/lib/next-client-stale-assets'
 import { isNextNotFoundError } from '@/lib/next-http-fallback'
+import { isSiweVerificationError } from '@/lib/siwe-errors'
 
 declare global {
   interface Window {
@@ -30,6 +31,10 @@ Sentry.init({
     }
 
     if (isNextClientStaleAssetError(hint.originalException)) {
+      return null
+    }
+
+    if (isSiweVerificationError(event.message)) {
       return null
     }
 

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -34,7 +34,7 @@ Sentry.init({
       return null
     }
 
-    if (isSiweVerificationError(event.message)) {
+    if (isSiweVerificationError(hint.originalException)) {
       return null
     }
 

--- a/src/lib/siwe-errors.ts
+++ b/src/lib/siwe-errors.ts
@@ -1,0 +1,14 @@
+const SIWE_VERIFICATION_ERROR_MESSAGE = 'Failed to verify message'
+
+export function isSiweVerificationError(error: unknown) {
+  if (typeof error === 'string') {
+    return error === SIWE_VERIFICATION_ERROR_MESSAGE
+  }
+
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+
+  const message = (error as { message?: unknown }).message
+  return message === SIWE_VERIFICATION_ERROR_MESSAGE
+}

--- a/tests/unit/instrumentationClient.test.ts
+++ b/tests/unit/instrumentationClient.test.ts
@@ -1,0 +1,34 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  captureRouterTransitionStart: vi.fn(),
+  init: vi.fn(),
+}))
+
+vi.mock('@sentry/nextjs', () => mocks)
+
+describe('client instrumentation', () => {
+  let options: any
+
+  beforeAll(async () => {
+    await import('@/instrumentation-client')
+    options = mocks.init.mock.calls[0]?.[0]
+  })
+
+  it('drops Reown SIWE verification errors', () => {
+    const error = new Error('Failed to verify message')
+
+    expect(options.beforeSend({ message: error.message }, {})).toBeNull()
+  })
+
+  it('keeps unrelated errors', () => {
+    const error = new Error('Failed to verify transaction')
+    const event = {
+      exception: {
+        values: [{ value: error.message }],
+      },
+    }
+
+    expect(options.beforeSend(event, { originalException: error })).toBe(event)
+  })
+})

--- a/tests/unit/instrumentationClient.test.ts
+++ b/tests/unit/instrumentationClient.test.ts
@@ -18,7 +18,7 @@ describe('client instrumentation', () => {
   it('drops Reown SIWE verification errors', () => {
     const error = new Error('Failed to verify message')
 
-    expect(options.beforeSend({ message: error.message }, {})).toBeNull()
+    expect(options.beforeSend({}, { originalException: error })).toBeNull()
   })
 
   it('keeps unrelated errors', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop sending SIWE “Failed to verify message” errors to Sentry to reduce noise. Added `isSiweVerificationError` and used it in `instrumentation-client` and `AppErrorFallback` to drop these events, with unit tests validating the filter.

<sup>Written for commit 5ac005324912db546bbd27a59625c45dd95cf593. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

