### PR TITLE
fix: 2fa schema

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -5,6 +5,7 @@ const config: KnipConfig = {
     'docs.config.ts',
     'public/**/*',
     'scripts/**',
+    'src/lib/db/schema/**',
     'src/components/ui/**',
   ],
   treatConfigHintsAsErrors: false,

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -260,6 +260,8 @@ export const auth = betterAuth({
             secret: 'secret',
             backupCodes: 'backup_codes',
             userId: 'user_id',
+            failedVerificationCount: 'failed_verification_count',
+            lockedUntil: 'locked_until',
           },
         },
       },

--- a/src/lib/db/migrations/2026_07_10_001_two_factor_lockout.sql
+++ b/src/lib/db/migrations/2026_07_10_001_two_factor_lockout.sql
@@ -1,0 +1,3 @@
+ALTER TABLE two_factors
+  ADD COLUMN IF NOT EXISTS failed_verification_count INTEGER NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS locked_until TIMESTAMPTZ;

--- a/src/lib/db/schema/auth/tables.ts
+++ b/src/lib/db/schema/auth/tables.ts
@@ -111,6 +111,8 @@ export const two_factors = pgTable('two_factors', {
   secret: text().notNull(),
   backup_codes: text().notNull(),
   verified: boolean().default(true).notNull(),
+  failed_verification_count: integer().default(0).notNull(),
+  locked_until: timestamp({ withTimezone: true }),
   user_id: text('user_id')
     .notNull()
     .references(() => users.id, { onDelete: 'cascade' }),

--- a/tests/unit/authSchemaRelations.test.ts
+++ b/tests/unit/authSchemaRelations.test.ts
@@ -1,3 +1,4 @@
+import { getTableColumns } from 'drizzle-orm'
 import { createTableRelationsHelpers, extractTablesRelationalConfig } from 'drizzle-orm/relations'
 import { describe, expect, it } from 'vitest'
 import * as schema from '@/lib/db/schema'
@@ -10,5 +11,15 @@ describe('auth schema relations', () => {
     expect(tables.accounts.relations.users?.referencedTableName).toBe('users')
     expect(tables.wallets.relations.users?.referencedTableName).toBe('users')
     expect(tables.two_factors.relations.users?.referencedTableName).toBe('users')
+  })
+
+  it('exposes Better Auth two-factor lockout fields', () => {
+    const columns = getTableColumns(schema.two_factors)
+
+    expect(columns.failed_verification_count.name).toBe('failed_verification_count')
+    expect(columns.failed_verification_count.default).toBe(0)
+    expect(columns.failed_verification_count.notNull).toBe(true)
+    expect(columns.locked_until.name).toBe('locked_until')
+    expect(columns.locked_until.notNull).toBe(false)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add missing two-factor lockout fields to align our DB and Better Auth config, enabling 2FA lockout and preventing runtime errors when lockout is used.

- **Bug Fixes**
  - Added migration to `two_factors`: `failed_verification_count` (default 0, not null) and `locked_until` (timestamptz).
  - Mapped new fields in Better Auth config and updated Drizzle schema.
  - Added unit test to assert column presence/defaults; ignored `src/lib/db/schema/**` in `knip.config.ts`.

<sup>Written for commit b2d16acfdf2385e1d1449456e63f48e357606178. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

