### PR TITLE
fix: animate order prices and resolve sports market details

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton.tsx
@@ -1,7 +1,8 @@
 import type { CSSProperties } from 'react'
 import type { OddsFormat } from '@/lib/odds-format'
+import { AnimatedCounter } from 'react-animated-counter'
 import { Button } from '@/components/ui/button'
-import { formatCentsLabel } from '@/lib/formatters'
+import { formatCentsLabel, toCents } from '@/lib/formatters'
 import { formatOddsFromPrice } from '@/lib/odds-format'
 import { cn } from '@/lib/utils'
 
@@ -21,6 +22,51 @@ interface EventOrderPanelOutcomeButtonProps {
   styleVariant?: 'default' | 'sports3d'
   selectedAccent?: EventOrderPanelOutcomeSelectedAccent | null
   onSelect: () => void
+}
+
+function resolveAnimatedCentsValue(price: number | null) {
+  if (price === null || !Number.isFinite(price)) {
+    return null
+  }
+
+  return price <= 1 ? toCents(price) : Number(price.toFixed(1))
+}
+
+function OutcomePrice({ price, priceLabel, oddsFormat }: {
+  price: number | null
+  priceLabel: string
+  oddsFormat: OddsFormat
+}) {
+  const centsValue = oddsFormat === 'price' ? resolveAnimatedCentsValue(price) : null
+  if (centsValue === null) {
+    return priceLabel
+  }
+
+  return (
+    <span className="inline-flex items-baseline">
+      <AnimatedCounter
+        value={centsValue}
+        color="currentColor"
+        fontSize="16px"
+        includeCommas={false}
+        includeDecimals={!Number.isInteger(centsValue)}
+        decimalPrecision={1}
+        incrementColor="currentColor"
+        decrementColor="currentColor"
+        digitStyles={{
+          fontWeight: 700,
+          lineHeight: '1',
+        }}
+        containerStyles={{
+          display: 'inline-flex',
+          alignItems: 'baseline',
+          flexDirection: 'row-reverse',
+          lineHeight: '1',
+        }}
+      />
+      <span>¢</span>
+    </span>
+  )
 }
 
 export default function EventOrderPanelOutcomeButton({
@@ -86,7 +132,7 @@ export default function EventOrderPanelOutcomeButton({
             {label}
           </span>
           <span className="relative z-10 shrink-0 text-base font-bold">
-            {priceLabel}
+            <OutcomePrice price={price} priceLabel={priceLabel} oddsFormat={oddsFormat} />
           </span>
         </button>
       </div>
@@ -110,7 +156,7 @@ export default function EventOrderPanelOutcomeButton({
         {label}
       </span>
       <span className="shrink-0 text-base font-bold">
-        {priceLabel}
+        <OutcomePrice price={price} priceLabel={priceLabel} oddsFormat={oddsFormat} />
       </span>
     </Button>
   )

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo.tsx
@@ -6,6 +6,8 @@ import type { SportsGamesButton, SportsGamesCard } from '@/app/[locale]/(platfor
 import type { Market, Outcome } from '@/types'
 import { EqualIcon } from 'lucide-react'
 import Image from 'next/image'
+import { isStandaloneSportsAuxiliaryMarket } from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
+import EventIconImage from '@/components/EventIconImage'
 import { resolveSportsTeamFallbackColor } from '@/lib/sports-team-colors'
 import { shouldUseCroppedSportsTeamLogo } from '@/lib/sports-team-logo'
 import { cn } from '@/lib/utils'
@@ -258,10 +260,21 @@ export default function SportsOrderPanelMarketInfo({
     marketType,
   })
   const selectedLabelAccent = resolveSelectedLabelAccent(selectedButton)
+  const usesEventIcon = Boolean(selectedMarket && isStandaloneSportsAuxiliaryMarket(selectedMarket))
   const isExactScoreTrade = normalizeComparableText(selectedMarket?.sports_market_type).includes('exact score')
   const usesTotalStyleBadge = shouldUseTotalStyleBadge(selectedMarket, selectedButton, marketType)
   let marketIcon: React.ReactNode = null
-  if (!isExactScoreTrade) {
+  if (usesEventIcon) {
+    marketIcon = (
+      <EventIconImage
+        src={card.event.icon_url}
+        alt={card.event.title}
+        sizes="44px"
+        containerClassName="size-11 shrink-0 rounded-lg"
+      />
+    )
+  }
+  else if (!isExactScoreTrade) {
     if (usesTotalStyleBadge) {
       marketIcon = <TotalBadge button={selectedButton} />
     }

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/sports-games-center-utils.ts
@@ -12,6 +12,10 @@ import type { SportsGamesButton, SportsGamesCard } from '@/app/[locale]/(platfor
 import type { OddsFormat } from '@/lib/odds-format'
 import type { SportsVertical } from '@/lib/sports-vertical'
 import type { Market, Outcome, UserPosition } from '@/types'
+import {
+  isStandaloneSportsAuxiliaryMarket,
+  resolveSportsAuxiliaryMarketTitle,
+} from '@/app/[locale]/(platform)/sports/_utils/sports-games-data'
 import { resolveHexToRgbComponents } from '@/lib/color'
 import { MICRO_UNIT, OUTCOME_INDEX } from '@/lib/constants'
 import {
@@ -1449,6 +1453,10 @@ export function resolveTradeHeaderTitle({
   selectedMarket: Market | null
   marketType: SportsGamesMarketType
 }) {
+  if (selectedMarket && isStandaloneSportsAuxiliaryMarket(selectedMarket)) {
+    return resolveSportsAuxiliaryMarketTitle([selectedMarket])
+  }
+
   const normalizedMarketType = normalizeComparableText(selectedMarket?.sports_market_type)
   if (normalizedMarketType.includes('exact score')) {
     const descriptor = resolveMarketDescriptor(selectedMarket)

--- a/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
+++ b/src/app/[locale]/(platform)/sports/_utils/sports-games-data.ts
@@ -573,7 +573,7 @@ function isBinaryYesNoMarket(market: Market) {
   return outcomeTexts.every(isYesNoOutcomeText)
 }
 
-function shouldUseStandaloneAuxiliaryMarketGrouping(market: Market) {
+export function isStandaloneSportsAuxiliaryMarket(market: Market) {
   if (!isBinaryYesNoMarket(market)) {
     return false
   }
@@ -888,7 +888,7 @@ export function resolveSportsAuxiliaryMarketGroupKey(market: Market) {
     return `${market.event_id}:${market.condition_id}`
   }
 
-  if (shouldUseStandaloneAuxiliaryMarketGrouping(market)) {
+  if (isStandaloneSportsAuxiliaryMarket(market)) {
     return `${market.event_id}:${market.condition_id}`
   }
 
@@ -922,7 +922,7 @@ export function resolveSportsAuxiliaryMarketTitle(markets: Market[]) {
       ?? 'Market'
   }
 
-  if (markets.length === 1 && shouldUseStandaloneAuxiliaryMarketGrouping(primaryMarket)) {
+  if (markets.length === 1 && isStandaloneSportsAuxiliaryMarket(primaryMarket)) {
     return primaryMarket.sports_group_item_title?.trim()
       ?? primaryMarket.short_title?.trim()
       ?? primaryMarket.title

--- a/tests/unit/EventOrderPanelOutcomeButton.test.tsx
+++ b/tests/unit/EventOrderPanelOutcomeButton.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen } from '@testing-library/react'
+import EventOrderPanelOutcomeButton from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton'
+
+vi.mock('react-animated-counter', () => ({
+  AnimatedCounter: ({ value }: { value: number }) => (
+    <span data-testid="animated-counter">{value}</span>
+  ),
+}))
+
+describe('eventOrderPanelOutcomeButton', () => {
+  it('animates cent values when the order-side price changes', () => {
+    const { rerender } = render(
+      <EventOrderPanelOutcomeButton
+        variant="yes"
+        price={0.43}
+        label="Yes"
+        isSelected
+        onSelect={() => {}}
+      />,
+    )
+
+    expect(screen.getByTestId('animated-counter')).toHaveTextContent('43')
+    expect(screen.getByText('¢')).toBeInTheDocument()
+
+    rerender(
+      <EventOrderPanelOutcomeButton
+        variant="yes"
+        price={0.275}
+        label="Yes"
+        isSelected
+        onSelect={() => {}}
+      />,
+    )
+
+    expect(screen.getByTestId('animated-counter')).toHaveTextContent('27.5')
+  })
+
+  it('keeps non-price odds formats as plain labels', () => {
+    render(
+      <EventOrderPanelOutcomeButton
+        variant="yes"
+        price={0.5}
+        label="Yes"
+        isSelected
+        oddsFormat="american"
+        onSelect={() => {}}
+      />,
+    )
+
+    expect(screen.queryByTestId('animated-counter')).not.toBeInTheDocument()
+    expect(screen.getByText('+100')).toBeInTheDocument()
+  })
+})

--- a/tests/unit/SportsOrderPanelMarketInfo.test.tsx
+++ b/tests/unit/SportsOrderPanelMarketInfo.test.tsx
@@ -1,0 +1,67 @@
+import { render, screen } from '@testing-library/react'
+import SportsOrderPanelMarketInfo
+  from '@/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsOrderPanelMarketInfo'
+
+vi.mock('@/components/EventIconImage', () => ({
+  default: ({ src, alt }: { src: string, alt: string }) => (
+    <span role="img" aria-label={alt} data-src={src} />
+  ),
+}))
+
+describe('sportsOrderPanelMarketInfo', () => {
+  it('uses the event icon and card title for standalone UFC auxiliary markets', () => {
+    const market = {
+      condition_id: 'fight-ko',
+      sports_market_type: 'ufc_method_of_victory',
+      sports_group_item_title: 'Fight won by KO/TKO?',
+      short_title: 'Fight won by KO/TKO?',
+      title: 'Fight won by KO/TKO?',
+      outcomes: [
+        { outcome_index: 0, outcome_text: 'Yes' },
+        { outcome_index: 1, outcome_text: 'No' },
+      ],
+    }
+    const selectedButton = {
+      key: 'fight-ko:0',
+      conditionId: 'fight-ko',
+      outcomeIndex: 0,
+      fallbackIsNoOutcome: false,
+      label: 'YES',
+      cents: 48,
+      color: null,
+      marketType: 'binary',
+      tone: 'over',
+    } as const
+    const card = {
+      title: 'Holloway vs McGregor',
+      event: {
+        icon_url: '/ufc-event.png',
+        title: 'UFC Max 1: Holloway vs McGregor',
+        sports_sport_slug: 'mma',
+        tags: [{ slug: 'sports' }],
+        main_tag: 'sports',
+      },
+      teams: [
+        { name: 'Max Holloway', abbreviation: 'MAX' },
+        { name: 'Conor McGregor', abbreviation: 'CON' },
+      ],
+      buttons: [selectedButton],
+      detailMarkets: [market],
+    }
+
+    render(
+      <SportsOrderPanelMarketInfo
+        card={card as any}
+        selectedButton={selectedButton}
+        selectedOutcome={market.outcomes[0] as any}
+        marketType="binary"
+      />,
+    )
+
+    expect(screen.getByText('Fight won by KO/TKO?')).toBeInTheDocument()
+    expect(screen.getByRole('img', { name: 'UFC Max 1: Holloway vs McGregor' })).toHaveAttribute(
+      'data-src',
+      '/ufc-event.png',
+    )
+  })
+})

--- a/tests/unit/sportsOrderBookTradeLabel.test.ts
+++ b/tests/unit/sportsOrderBookTradeLabel.test.ts
@@ -330,4 +330,38 @@ describe('sports order-book trade label', () => {
       marketType: 'total',
     })).toBe('Morocco Corners')
   })
+
+  it.each([
+    ['ufc_go_the_distance', 'Fight to Go the Distance?'],
+    ['ufc_method_of_victory', 'Holloway to win by KO/TKO?'],
+  ])('uses the standalone UFC card title for %s order panel headers', (sportsMarketType, title) => {
+    const selectedMarket = {
+      sports_market_type: sportsMarketType,
+      sports_group_item_title: title,
+      short_title: title,
+      title,
+      outcomes: [
+        { outcome_index: 0, outcome_text: 'Yes' },
+        { outcome_index: 1, outcome_text: 'No' },
+      ],
+    } as any
+
+    expect(resolveTradeHeaderTitle({
+      card: {
+        title: 'Holloway vs McGregor',
+        event: {
+          tags: [{ slug: 'sports' }],
+          main_tag: 'sports',
+          sports_sport_slug: 'mma',
+        },
+        teams: [
+          { name: 'Max Holloway', abbreviation: 'MAX' },
+          { name: 'Conor McGregor', abbreviation: 'CON' },
+        ],
+      } as any,
+      selectedButton: { label: 'YES' } as any,
+      selectedMarket,
+      marketType: 'binary',
+    })).toBe(title)
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Animate order-side prices in the event order panel for `price` odds, and fix sports market info to show the event icon and correct headers for standalone UFC auxiliary markets.

- **New Features**
  - Animate price changes with `react-animated-counter` when odds format is `price` (cents for ≤1, 1-decimal otherwise).
  - Unit tests added for animated price behavior.

- **Bug Fixes**
  - Sports order panel uses the event icon and the market/card title for standalone UFC auxiliary markets.
  - Trade header now resolves via `resolveSportsAuxiliaryMarketTitle` for these markets; expose `isStandaloneSportsAuxiliaryMarket`.
  - Unit tests added for icon/title rendering and header resolution.

<sup>Written for commit d620c2f1e13c64a9f0e365a130b8c586440fd3e8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

