### PR TITLE
fix: stop polling ended sports events

### DIFF
--- a/src/app/api/sync/sports-scores/route.ts
+++ b/src/app/api/sync/sports-scores/route.ts
@@ -17,6 +17,34 @@ const RECENT_WINDOW_MS = 12 * 60 * 60 * 1000
 const UPCOMING_WINDOW_MS = 15 * 60 * 1000
 const MAX_EVENTS_PER_RUN = 80
 
+interface SportsScoreSourceIdentity {
+  sports_source_provider: string | null
+  sports_source_event_id: string | null
+  sports_source_game_id: string | null
+}
+
+export function groupSportsScoreRowsBySource<T extends SportsScoreSourceIdentity>(rows: T[]) {
+  const groups = new Map<string, T[]>()
+
+  for (const row of rows) {
+    const sourceId = row.sports_source_event_id ?? row.sports_source_game_id
+    if (!row.sports_source_provider || !sourceId) {
+      continue
+    }
+
+    const key = JSON.stringify([row.sports_source_provider, sourceId])
+    const group = groups.get(key)
+    if (group) {
+      group.push(row)
+    }
+    else {
+      groups.set(key, [row])
+    }
+  }
+
+  return [...groups.values()]
+}
+
 export async function POST(request: Request) {
   if (!isCronAuthorized(request.headers.get('authorization'))) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
@@ -59,12 +87,12 @@ export async function POST(request: Request) {
         isNotNull(eventSportsTable.sports_source_game_id),
       ),
       or(
+        eq(eventSportsTable.sports_ended, false),
+        isNull(eventSportsTable.sports_ended),
+      ),
+      or(
         eq(eventSportsTable.sports_live, true),
         and(
-          or(
-            eq(eventSportsTable.sports_ended, false),
-            isNull(eventSportsTable.sports_ended),
-          ),
           gte(eventSportsTable.sports_start_time, recentStart),
           lte(eventSportsTable.sports_start_time, upcomingEnd),
         ),
@@ -74,13 +102,19 @@ export async function POST(request: Request) {
 
   let updatedCount = 0
   const errors: Array<{ eventId: string, error: string }> = []
+  const rowGroups = groupSportsScoreRowsBySource(rows)
 
-  for (const row of rows) {
+  for (const rowGroup of rowGroups) {
+    const sourceRow = rowGroup[0]
+    if (!sourceRow) {
+      continue
+    }
+
     try {
       const candidate = await resolveSportsEvent({
-        provider: row.sports_source_provider,
-        eventId: row.sports_source_event_id,
-        gameId: row.sports_source_game_id,
+        provider: sourceRow.sports_source_provider,
+        eventId: sourceRow.sports_source_event_id,
+        gameId: sourceRow.sports_source_game_id,
         auth: settings,
       })
 
@@ -88,54 +122,56 @@ export async function POST(request: Request) {
         continue
       }
 
-      const nextScore = candidate.score ?? row.sports_score ?? null
-      const nextPeriod = candidate.period ?? row.sports_period ?? null
-      const nextElapsed = candidate.elapsed ?? row.sports_elapsed ?? null
-      const nextLive = candidate.live ?? row.sports_live ?? null
-      const nextEnded = candidate.ended ?? row.sports_ended ?? null
-      const nextLivestreamUrl = candidate.livestreamUrl && !(row.livestream_url ?? '').trim()
-        ? candidate.livestreamUrl
-        : null
-      const changed = nextScore !== (row.sports_score ?? null)
-        || nextPeriod !== (row.sports_period ?? null)
-        || nextElapsed !== (row.sports_elapsed ?? null)
-        || nextLive !== (row.sports_live ?? null)
-        || nextEnded !== (row.sports_ended ?? null)
-        || nextLivestreamUrl !== null
+      for (const row of rowGroup) {
+        const nextScore = candidate.score ?? row.sports_score ?? null
+        const nextPeriod = candidate.period ?? row.sports_period ?? null
+        const nextElapsed = candidate.elapsed ?? row.sports_elapsed ?? null
+        const nextEnded = candidate.ended ?? row.sports_ended ?? null
+        const nextLive = nextEnded === true ? false : candidate.live ?? row.sports_live ?? null
+        const nextLivestreamUrl = candidate.livestreamUrl && !(row.livestream_url ?? '').trim()
+          ? candidate.livestreamUrl
+          : null
+        const changed = nextScore !== (row.sports_score ?? null)
+          || nextPeriod !== (row.sports_period ?? null)
+          || nextElapsed !== (row.sports_elapsed ?? null)
+          || nextLive !== (row.sports_live ?? null)
+          || nextEnded !== (row.sports_ended ?? null)
+          || nextLivestreamUrl !== null
 
-      if (!changed) {
-        continue
-      }
+        if (!changed) {
+          continue
+        }
 
-      await db
-        .update(eventSportsTable)
-        .set({
-          sports_score: nextScore,
-          sports_period: nextPeriod,
-          sports_elapsed: nextElapsed,
-          sports_live: nextLive,
-          sports_ended: nextEnded,
-          sports_source_payload: candidate.raw,
-          updated_at: new Date(),
-        })
-        .where(eq(eventSportsTable.event_id, row.event_id))
-
-      if (nextLivestreamUrl) {
         await db
-          .update(eventsTable)
+          .update(eventSportsTable)
           .set({
-            livestream_url: nextLivestreamUrl,
+            sports_score: nextScore,
+            sports_period: nextPeriod,
+            sports_elapsed: nextElapsed,
+            sports_live: nextLive,
+            sports_ended: nextEnded,
+            sports_source_payload: candidate.raw,
             updated_at: new Date(),
           })
-          .where(eq(eventsTable.id, row.event_id))
-      }
+          .where(eq(eventSportsTable.event_id, row.event_id))
 
-      revalidateTag(cacheTags.event(row.slug), 'max')
-      updatedCount += 1
+        if (nextLivestreamUrl) {
+          await db
+            .update(eventsTable)
+            .set({
+              livestream_url: nextLivestreamUrl,
+              updated_at: new Date(),
+            })
+            .where(eq(eventsTable.id, row.event_id))
+        }
+
+        revalidateTag(cacheTags.event(row.slug), 'max')
+        updatedCount += 1
+      }
     }
     catch (error) {
       errors.push({
-        eventId: row.event_id,
+        eventId: sourceRow.event_id,
         error: error instanceof Error ? error.message : String(error),
       })
     }

--- a/src/app/api/sync/sports-scores/route.ts
+++ b/src/app/api/sync/sports-scores/route.ts
@@ -110,19 +110,29 @@ export async function POST(request: Request) {
       continue
     }
 
+    let candidate: Awaited<ReturnType<typeof resolveSportsEvent>>
     try {
-      const candidate = await resolveSportsEvent({
+      candidate = await resolveSportsEvent({
         provider: sourceRow.sports_source_provider,
         eventId: sourceRow.sports_source_event_id,
         gameId: sourceRow.sports_source_game_id,
         auth: settings,
       })
+    }
+    catch (error) {
+      errors.push({
+        eventId: sourceRow.event_id,
+        error: error instanceof Error ? error.message : String(error),
+      })
+      continue
+    }
 
-      if (!candidate) {
-        continue
-      }
+    if (!candidate) {
+      continue
+    }
 
-      for (const row of rowGroup) {
+    for (const row of rowGroup) {
+      try {
         const nextScore = candidate.score ?? row.sports_score ?? null
         const nextPeriod = candidate.period ?? row.sports_period ?? null
         const nextElapsed = candidate.elapsed ?? row.sports_elapsed ?? null
@@ -168,12 +178,12 @@ export async function POST(request: Request) {
         revalidateTag(cacheTags.event(row.slug), 'max')
         updatedCount += 1
       }
-    }
-    catch (error) {
-      errors.push({
-        eventId: sourceRow.event_id,
-        error: error instanceof Error ? error.message : String(error),
-      })
+      catch (error) {
+        errors.push({
+          eventId: row.event_id,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
     }
   }
 

--- a/src/lib/sports-source/index.ts
+++ b/src/lib/sports-source/index.ts
@@ -886,6 +886,7 @@ function normalizeTheSportsDbEvent(raw: Record<string, unknown>): SportsSourceCa
   const startTime = normalizeIso(timestamp)
     ?? normalizeIso(`${normalizeText(String(raw.dateEvent ?? ''))}T${normalizeText(String(raw.strTime ?? '00:00:00'))}Z`)
   const status = normalizeText(String(raw.strStatus ?? ''))
+  const ended = isTheSportsDbEndedStatus(status)
   const stream = chooseBestStream([
     raw.strLiveStream ? { raw_url: raw.strLiveStream, official: true, main: true } : null,
     raw.strStream ? { raw_url: raw.strStream, official: true, main: true } : null,
@@ -909,8 +910,8 @@ function normalizeTheSportsDbEvent(raw: Record<string, unknown>): SportsSourceCa
     score: buildScore(raw.intHomeScore, raw.intAwayScore),
     period: status || null,
     elapsed: null,
-    live: isTheSportsDbLiveStatus(status) ? true : null,
-    ended: isTheSportsDbEndedStatus(status) ? true : null,
+    live: ended ? false : isTheSportsDbLiveStatus(status) ? true : null,
+    ended: ended ? true : null,
     ...stream,
     confidence: 0,
     matchReason: [],

--- a/tests/unit/sportsScoresRoute.test.ts
+++ b/tests/unit/sportsScoresRoute.test.ts
@@ -1,0 +1,122 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  isCronAuthorized: vi.fn(),
+  loadSportsSourceProviderSettings: vi.fn(),
+  resolveSportsEvent: vi.fn(),
+  revalidateTag: vi.fn(),
+  select: vi.fn(),
+  set: vi.fn(),
+  update: vi.fn(),
+}))
+
+vi.mock('next/cache', () => ({
+  revalidateTag: (...args: any[]) => mocks.revalidateTag(...args),
+}))
+
+vi.mock('@/lib/auth-cron', () => ({
+  isCronAuthorized: (...args: any[]) => mocks.isCronAuthorized(...args),
+}))
+
+vi.mock('@/lib/drizzle', () => ({
+  db: {
+    select: (...args: any[]) => mocks.select(...args),
+    update: (...args: any[]) => mocks.update(...args),
+  },
+}))
+
+vi.mock('@/lib/sports-source', () => ({
+  resolveSportsEvent: (...args: any[]) => mocks.resolveSportsEvent(...args),
+}))
+
+vi.mock('@/lib/sports-source/settings', () => ({
+  loadSportsSourceProviderSettings: (...args: any[]) => mocks.loadSportsSourceProviderSettings(...args),
+}))
+
+function makeSelectChain(result: unknown[]) {
+  return {
+    from: () => ({
+      innerJoin: () => ({
+        where: () => ({
+          limit: async () => result,
+        }),
+      }),
+    }),
+  }
+}
+
+describe('sync sports scores route', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    mocks.isCronAuthorized.mockReset()
+    mocks.loadSportsSourceProviderSettings.mockReset()
+    mocks.resolveSportsEvent.mockReset()
+    mocks.revalidateTag.mockReset()
+    mocks.select.mockReset()
+    mocks.set.mockReset()
+    mocks.update.mockReset()
+
+    mocks.isCronAuthorized.mockReturnValue(true)
+    mocks.loadSportsSourceProviderSettings.mockResolvedValue({
+      configured: true,
+      theSportsDbApiKey: '123',
+    })
+    mocks.set.mockImplementation(() => ({ where: async () => undefined }))
+    mocks.update.mockImplementation(() => ({ set: (...args: any[]) => mocks.set(...args) }))
+  })
+
+  it('resolves each provider event once and clears live state when it has ended', async () => {
+    const sharedRow = {
+      livestream_url: null,
+      sports_source_provider: 'thesportsdb',
+      sports_source_event_id: '2519345',
+      sports_source_game_id: null,
+      sports_start_time: new Date('2026-07-10T19:00:00.000Z'),
+      sports_live: true,
+      sports_ended: false,
+      sports_score: '1-1',
+      sports_period: '2H',
+      sports_elapsed: null,
+    }
+    mocks.select.mockImplementation(() => makeSelectChain([
+      { ...sharedRow, event_id: 'event-1', slug: 'main-market' },
+      { ...sharedRow, event_id: 'event-2', slug: 'exact-score' },
+      {
+        ...sharedRow,
+        event_id: 'event-3',
+        slug: 'another-game',
+        sports_source_event_id: '2519346',
+      },
+    ]))
+    mocks.resolveSportsEvent.mockResolvedValue({
+      score: '2-1',
+      period: 'FT',
+      elapsed: null,
+      live: null,
+      ended: true,
+      livestreamUrl: null,
+      raw: { strStatus: 'FT' },
+    })
+
+    const { POST } = await import('@/app/api/sync/sports-scores/route')
+    const response = await POST(new Request('https://example.com/api/sync/sports-scores', {
+      method: 'POST',
+      headers: { authorization: 'Bearer cron-secret' },
+    }))
+
+    expect(mocks.resolveSportsEvent).toHaveBeenCalledTimes(2)
+    expect(mocks.set).toHaveBeenCalledTimes(3)
+    for (const [payload] of mocks.set.mock.calls) {
+      expect(payload).toMatchObject({ sports_live: false })
+    }
+    expect(mocks.set).toHaveBeenCalledWith(expect.objectContaining({
+      sports_live: false,
+      sports_ended: true,
+    }))
+    await expect(response.json()).resolves.toEqual({
+      checkedCount: 3,
+      updatedCount: 3,
+      errors: [],
+    })
+  })
+})

--- a/tests/unit/sportsScoresRoute.test.ts
+++ b/tests/unit/sportsScoresRoute.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   select: vi.fn(),
   set: vi.fn(),
   update: vi.fn(),
+  where: vi.fn(),
 }))
 
 vi.mock('next/cache', () => ({
@@ -55,13 +56,15 @@ describe('sync sports scores route', () => {
     mocks.select.mockReset()
     mocks.set.mockReset()
     mocks.update.mockReset()
+    mocks.where.mockReset()
 
     mocks.isCronAuthorized.mockReturnValue(true)
     mocks.loadSportsSourceProviderSettings.mockResolvedValue({
       configured: true,
       theSportsDbApiKey: '123',
     })
-    mocks.set.mockImplementation(() => ({ where: async () => undefined }))
+    mocks.where.mockResolvedValue(undefined)
+    mocks.set.mockImplementation(() => ({ where: (...args: any[]) => mocks.where(...args) }))
     mocks.update.mockImplementation(() => ({ set: (...args: any[]) => mocks.set(...args) }))
   })
 
@@ -117,6 +120,54 @@ describe('sync sports scores route', () => {
       checkedCount: 3,
       updatedCount: 3,
       errors: [],
+    })
+  })
+
+  it('continues updating sibling events when one row write fails', async () => {
+    const sharedRow = {
+      livestream_url: null,
+      sports_source_provider: 'thesportsdb',
+      sports_source_event_id: '2519345',
+      sports_source_game_id: null,
+      sports_start_time: new Date('2026-07-10T19:00:00.000Z'),
+      sports_live: true,
+      sports_ended: false,
+      sports_score: '1-1',
+      sports_period: '2H',
+      sports_elapsed: null,
+    }
+    mocks.select.mockImplementation(() => makeSelectChain([
+      { ...sharedRow, event_id: 'event-1', slug: 'main-market' },
+      { ...sharedRow, event_id: 'event-2', slug: 'exact-score' },
+      { ...sharedRow, event_id: 'event-3', slug: 'player-props' },
+    ]))
+    mocks.resolveSportsEvent.mockResolvedValue({
+      score: '2-1',
+      period: 'FT',
+      elapsed: null,
+      live: false,
+      ended: true,
+      livestreamUrl: null,
+      raw: { strStatus: 'FT' },
+    })
+    mocks.where
+      .mockRejectedValueOnce(new Error('write failed'))
+      .mockResolvedValue(undefined)
+
+    const { POST } = await import('@/app/api/sync/sports-scores/route')
+    const response = await POST(new Request('https://example.com/api/sync/sports-scores', {
+      method: 'POST',
+      headers: { authorization: 'Bearer cron-secret' },
+    }))
+
+    expect(mocks.resolveSportsEvent).toHaveBeenCalledTimes(1)
+    expect(mocks.set).toHaveBeenCalledTimes(3)
+    expect(mocks.revalidateTag).toHaveBeenCalledWith('event:exact-score', 'max')
+    expect(mocks.revalidateTag).toHaveBeenCalledWith('event:player-props', 'max')
+    await expect(response.json()).resolves.toEqual({
+      checkedCount: 3,
+      updatedCount: 2,
+      errors: [{ eventId: 'event-1', error: 'write failed' }],
     })
   })
 })

--- a/tests/unit/sportsSource.test.ts
+++ b/tests/unit/sportsSource.test.ts
@@ -681,6 +681,36 @@ describe('sports source providers', () => {
     expect(candidate?.ended).toBeNull()
   })
 
+  it('marks finished TheSportsDB events as no longer live', async () => {
+    const fetchMock = vi.fn(async () => new Response(JSON.stringify({
+      events: [
+        {
+          idEvent: '2507707',
+          idLeague: '4429',
+          strLeague: 'FIFA World Cup',
+          strSport: 'Soccer',
+          strHomeTeam: 'USA',
+          strAwayTeam: 'Belgium',
+          intHomeScore: '1',
+          intAwayScore: '4',
+          strTimestamp: '2026-07-07T00:00:00',
+          strStatus: 'FT',
+        },
+      ],
+    }), { status: 200 }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const { resolveSportsEvent } = await import('@/lib/sports-source')
+    const candidate = await resolveSportsEvent({
+      provider: 'thesportsdb',
+      eventId: '2507707',
+      auth: { theSportsDbApiKey: '123' },
+    })
+
+    expect(candidate?.live).toBe(false)
+    expect(candidate?.ended).toBe(true)
+  })
+
   it('uses one TheSportsDB filename request when league and date are provided', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const url = String(input)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stop polling ended sports events and clear the live flag when a game finishes. Also reduce duplicate provider calls and isolate per-row write failures to keep sync reliable.

- **Bug Fixes**
  - Exclude ended events from the sync query; when a provider reports an event as ended, persist `sports_ended=true` and `sports_live=false`.
  - Normalize TheSportsDB: ended status forces `live=false`.
  - Isolate row update failures so sibling rows still update; collect errors per row.

- **Refactors**
  - Group rows by `sports_source_provider` + source event/game id to resolve each provider event once and update all linked rows.
  - Apply one candidate to each group, revalidate per row, and only set `livestream_url` when previously empty.

<sup>Written for commit ff1ea7681210159ba1ed7fdfc805e2eea0ea2c0f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

