### PR TITLE
fix: prevent AdminGeneralSettingsForm tests from timing out

### DIFF
--- a/knip.config.ts
+++ b/knip.config.ts
@@ -8,8 +8,11 @@ const config: KnipConfig = {
     'src/lib/db/schema/**',
     'src/components/ui/**',
   ],
+  ignoreBinaries: ['lint-staged', 'test', 'build'],
+  ignoreDependencies: ['lint-staged'],
   treatConfigHintsAsErrors: false,
   rules: {
+    binaries: 'off',
     unlisted: 'off',
   },
 }

--- a/tests/unit/AdminGeneralSettingsForm.test.tsx
+++ b/tests/unit/AdminGeneralSettingsForm.test.tsx
@@ -16,7 +16,8 @@ const mocks = vi.hoisted(() => ({
   useIsMobile: vi.fn(() => false),
 }))
 
-const marketContextProps = {
+const baseFormProps = {
+  locale: 'en',
   initialMarketContextSettings: {
     enabled: true,
     prompt: 'Summarize the current market context clearly.',
@@ -115,12 +116,12 @@ describe('adminGeneralSettingsForm', () => {
   })
 
   it('invokes the remove PDF action from the legal section', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     mocks.removeTermsOfServicePdfAction.mockResolvedValueOnce({ error: null })
 
     const { container } = render(
       <AdminGeneralSettingsForm
-        {...marketContextProps}
+        {...baseFormProps}
         initialThemeSiteSettings={{
           siteName: 'Kuest',
           siteDescription: 'Prediction market',
@@ -180,10 +181,10 @@ describe('adminGeneralSettingsForm', () => {
   })
 
   it('places Market Context above featured markets and submits it through the global form', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     const { container } = render(
       <AdminGeneralSettingsForm
-        {...marketContextProps}
+        {...baseFormProps}
         initialThemeSiteSettings={{
           siteName: 'Kuest',
           siteDescription: 'Prediction market',
@@ -267,12 +268,12 @@ describe('adminGeneralSettingsForm', () => {
   })
 
   it('uses mobile drawers for featured market editors and saves drafts from the global action', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     mocks.useIsMobile.mockReturnValue(true)
 
     render(
       <AdminGeneralSettingsForm
-        {...marketContextProps}
+        {...baseFormProps}
         initialThemeSiteSettings={{
           siteName: 'Kuest',
           siteDescription: 'Prediction market',
@@ -374,7 +375,7 @@ describe('adminGeneralSettingsForm', () => {
   })
 
   it('submits the optimized side card image instead of the original file', async () => {
-    const user = userEvent.setup()
+    const user = userEvent.setup({ delay: null })
     const originalFile = new File(['original'], 'side-card.png', { type: 'image/png' })
     const optimizedFile = new File(['optimized'], 'side-card.jpg', { type: 'image/jpeg' })
     mocks.optimizeSideCardImage.mockResolvedValueOnce(optimizedFile)
@@ -382,7 +383,7 @@ describe('adminGeneralSettingsForm', () => {
 
     const { container } = render(
       <AdminGeneralSettingsForm
-        {...marketContextProps}
+        {...baseFormProps}
         initialThemeSiteSettings={{
           siteName: 'Kuest',
           siteDescription: 'Prediction market',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,6 +5,7 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    testTimeout: 10_000,
     setupFiles: ['./vitest.setup.ts'],
     include: ['tests/unit/*.test.{ts,tsx}'],
     alias: {


### PR DESCRIPTION
## Pull Request Rules

Please make sure your PR follows these rules:

- One PR must address only one feature or one bugfix.
- Keep PRs small, focused, and easy to review.
- Use commit prefixes such as `fix:`, `feat:`, `refactor:`, `docs:`, and `style:`.
- Use English for branch names and commit subjects.
- Review your own diff before opening the PR.
- Rebase on the latest `main` before pushing. Do not merge `main` into your branch.
- If dependencies changed, include the updated `pnpm-lock.yaml`.
- Avoid unrelated refactors, drive-by fixes, or config/policy changes in the same PR.
- Avoid commented-out code and unnecessary inline comments. Keep comments only when they explain non-obvious constraints or decisions.
- If you use AI/LLM tools, use the highest reasoning mode available and full repository context/access when safe, then manually review and test the final diff before submitting. Examples: OpenAI/Codex `xhigh`; Claude extended thinking with the highest available thinking budget.
- Bugfix PRs should include a regression test whenever feasible.
- PR descriptions should clearly state scope, reason for the change, testing performed, and any relevant risks.

## Summary

Describe what changed and why.

## Testing

Describe how this was tested.

## Risks

Describe any relevant risks, tradeoffs, or follow-up work.

## Checklist

- [ ] I ran `pnpm lint`, `pnpm test`, and `pnpm build` before submitting.
- [ ] I tested the changes in my browser.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents AdminGeneralSettingsForm tests from timing out by removing artificial user-event delays and increasing the global test timeout. Also adjusts `knip` settings to reduce CI noise.

- **Bug Fixes**
  - Tests: use `userEvent.setup({ delay: null })` and standardize props via `baseFormProps` with `locale: 'en'` to speed up and stabilize runs.
  - `vitest.config.ts`: set `testTimeout: 10_000` for slower environments.
  - `knip.config.ts`: ignore `lint-staged`, `test`, and `build` binaries/deps and disable the `binaries` rule to avoid false positives.

<sup>Written for commit 1890b4b55d9e26139c5528d98876fb92d1ac15a9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

