### PR TITLE
refactor: harden market context to only active events

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -1546,10 +1546,10 @@ function FeaturedRightRail({
               className="group/topic grid grid-cols-[auto_minmax(0,1fr)_auto_auto] items-center gap-2 rounded-md py-0.5"
             >
               <span className="w-3.5 text-xs font-medium text-muted-foreground/65 tabular-nums">{index + 1}</span>
-              <span className="
+              <span className={cn(`
                 truncate text-sm font-medium text-foreground/90 underline-offset-2 transition-colors
                 group-hover/topic:text-foreground group-hover/topic:underline
-              "
+              `)}
               >
                 {topic.label}
               </span>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContext.tsx
@@ -43,6 +43,14 @@ function formatContextUpdatedLabel(updatedAtMs: number | null) {
 }
 
 export default function EventMarketContext({ event, marketConditionId = null }: EventMarketContextProps) {
+  if (event.status !== 'active') {
+    return null
+  }
+
+  return <ActiveEventMarketContext event={event} marketConditionId={marketConditionId} />
+}
+
+function ActiveEventMarketContext({ event, marketConditionId }: EventMarketContextProps) {
   const state = useOrder()
   const resolvedMarketConditionId = marketConditionId ?? state.market?.condition_id ?? undefined
   const contextKey = `${event.slug}:${resolvedMarketConditionId ?? 'none'}`

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContextSlot.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventMarketContextSlot.tsx
@@ -15,7 +15,7 @@ interface EventMarketContextSlotProps {
 }
 
 export default function EventMarketContextSlot({ enabled, event }: EventMarketContextSlotProps) {
-  if (!enabled) {
+  if (!enabled || event.status !== 'active') {
     return null
   }
 

--- a/src/lib/market-context-service.ts
+++ b/src/lib/market-context-service.ts
@@ -59,6 +59,13 @@ export async function resolveMarketContextRequest(
       return { error: 'Event could not be located.' }
     }
 
+    if (!readOnly && event.status !== 'active') {
+      return {
+        error: 'Market context can only be generated for active events.',
+        status: 409,
+      }
+    }
+
     const market = event.markets.find(candidate => candidate.condition_id === marketConditionId) ?? event.markets[0]
 
     if (!market) {

--- a/tests/unit/EventMarketContextSlot.test.tsx
+++ b/tests/unit/EventMarketContextSlot.test.tsx
@@ -24,6 +24,12 @@ describe('eventMarketContextSlot', () => {
     expect(screen.getByTestId('event-market-context')).toBeInTheDocument()
   })
 
+  it('hides market context when disabled', () => {
+    render(<EventMarketContextSlot enabled={false} event={createEvent('active')} />)
+
+    expect(screen.queryByTestId('event-market-context')).not.toBeInTheDocument()
+  })
+
   it.each(['draft', 'resolved', 'archived'] as const)('hides market context for %s events', (status) => {
     render(<EventMarketContextSlot enabled event={createEvent(status)} />)
 

--- a/tests/unit/EventMarketContextSlot.test.tsx
+++ b/tests/unit/EventMarketContextSlot.test.tsx
@@ -1,0 +1,32 @@
+import type { Event } from '@/types'
+import { render, screen } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('next/dynamic', () => ({
+  __esModule: true,
+  default: () => function MockEventMarketContext() {
+    return <div data-testid="event-market-context" />
+  },
+}))
+
+const { default: EventMarketContextSlot } = await import(
+  '@/app/[locale]/(platform)/event/[slug]/_components/EventMarketContextSlot',
+)
+
+function createEvent(status: Event['status']): Event {
+  return { status } as Event
+}
+
+describe('eventMarketContextSlot', () => {
+  it('shows market context for active events when enabled', () => {
+    render(<EventMarketContextSlot enabled event={createEvent('active')} />)
+
+    expect(screen.getByTestId('event-market-context')).toBeInTheDocument()
+  })
+
+  it.each(['draft', 'resolved', 'archived'] as const)('hides market context for %s events', (status) => {
+    render(<EventMarketContextSlot enabled event={createEvent(status)} />)
+
+    expect(screen.queryByTestId('event-market-context')).not.toBeInTheDocument()
+  })
+})

--- a/tests/unit/generateMarketContextAction.test.ts
+++ b/tests/unit/generateMarketContextAction.test.ts
@@ -38,10 +38,12 @@ function mockConfiguredSettings() {
   })
 }
 
-function makeEvent() {
+function makeEvent(overrides: Record<string, unknown> = {}) {
   return {
     slug: 'event-slug',
+    status: 'active',
     markets: [{ condition_id: 'condition-1' }],
+    ...overrides,
   } as any
 }
 
@@ -111,6 +113,27 @@ describe('resolveMarketContextRequest', () => {
     expect(mocks.generateMarketContext).not.toHaveBeenCalled()
     expect(mocks.upsertContext).not.toHaveBeenCalled()
     expect(mocks.loadMarketContextSettings).not.toHaveBeenCalled()
+  })
+
+  it.each(['draft', 'resolved', 'archived'])('does not generate for a %s event', async (status) => {
+    mocks.getEventBySlug.mockResolvedValue({ data: makeEvent({ status }), error: null })
+
+    const { resolveMarketContextRequest } = await import('@/lib/market-context-service')
+
+    const result = await resolveMarketContextRequest({
+      slug: 'event-slug',
+      marketConditionId: 'condition-1',
+      locale: 'en',
+    })
+
+    expect(result).toEqual({
+      error: 'Market context can only be generated for active events.',
+      status: 409,
+    })
+    expect(mocks.getValidContext).not.toHaveBeenCalled()
+    expect(mocks.loadMarketContextSettings).not.toHaveBeenCalled()
+    expect(mocks.generateMarketContext).not.toHaveBeenCalled()
+    expect(mocks.upsertContext).not.toHaveBeenCalled()
   })
 
   it('generates and persists a new cache entry when cache is missing', async () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restricts market context to active events only across UI and backend. Hides the widget for non‑active events and blocks context generation with a 409 error.

- **Refactors**
  - UI: `EventMarketContext` and `EventMarketContextSlot` now return null unless `event.status` is `active`; minor `HomeFeaturedEventsCarousel` className cleanup using `cn`.
  - Service: `resolveMarketContextRequest` rejects non‑active events with `409` and a clear error, skipping cache and generation.
  - Tests: added `EventMarketContextSlot` unit test and expanded service tests (with assertion fix) to cover draft/resolved/archived events.

<sup>Written for commit e88dcf2a18e8468bf04986930f74e881904b4db1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

