### PR TITLE
fix: sports scroll

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
@@ -26,6 +26,7 @@ const HOVER_MENU_CLOSE_DELAY_MS = 120
 
 interface EventOrderPanelBuySellTabsProps {
   className?: string
+  edgeToEdge?: boolean
   side: OrderSide
   type: OrderType
   availableMergeShares: number
@@ -100,6 +101,7 @@ function useHoverCloseMenu() {
 
 export default function EventOrderPanelBuySellTabs({
   className,
+  edgeToEdge = false,
   side,
   type,
   availableMergeShares,
@@ -134,7 +136,7 @@ export default function EventOrderPanelBuySellTabs({
   const orderTypeLabel = type === ORDER_TYPE.MARKET ? t('Market') : t('Limit')
 
   return (
-    <div className={cn('relative mb-4', className)}>
+    <div className={cn('relative mb-4', edgeToEdge && '-mx-4 px-4', className)}>
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-4 text-sm font-semibold">
           <button
@@ -276,7 +278,10 @@ export default function EventOrderPanelBuySellTabs({
       </div>
       <div
         aria-hidden="true"
-        className="pointer-events-none absolute -inset-x-4 bottom-0 h-px bg-border"
+        className={cn(
+          'pointer-events-none absolute bottom-0 h-px bg-border',
+          edgeToEdge ? 'inset-x-0' : '-inset-x-4',
+        )}
       />
 
       <EventMergeSharesDialog

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelBuySellTabs.tsx
@@ -25,6 +25,7 @@ const ORDER_TYPE_STORAGE_KEY = 'kuest:order-panel-type'
 const HOVER_MENU_CLOSE_DELAY_MS = 120
 
 interface EventOrderPanelBuySellTabsProps {
+  className?: string
   side: OrderSide
   type: OrderType
   availableMergeShares: number
@@ -98,6 +99,7 @@ function useHoverCloseMenu() {
 }
 
 export default function EventOrderPanelBuySellTabs({
+  className,
   side,
   type,
   availableMergeShares,
@@ -132,7 +134,7 @@ export default function EventOrderPanelBuySellTabs({
   const orderTypeLabel = type === ORDER_TYPE.MARKET ? t('Market') : t('Limit')
 
   return (
-    <div className="relative mb-4">
+    <div className={cn('relative mb-4', className)}>
       <div className="flex items-center justify-between gap-4">
         <div className="flex items-center gap-4 text-sm font-semibold">
           <button

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -805,6 +805,7 @@ export default function EventOrderPanelForm({
   initialOutcome = null,
   className,
   desktopMarketInfo,
+  stickyDesktopTabs = false,
   mobileMarketInfo,
   primaryOutcomeIndex = null,
   oddsFormat = 'price',
@@ -1789,7 +1790,8 @@ export default function EventOrderPanelForm({
         {
           'rounded-xl border lg:w-85': !isMobile,
         },
-        'relative grid w-full grid-cols-[minmax(0,1fr)] overflow-hidden lg:shadow-xl/5',
+        'relative grid w-full grid-cols-[minmax(0,1fr)] lg:shadow-xl/5',
+        stickyDesktopTabs ? 'overflow-visible' : 'overflow-hidden',
         className,
       )}
     >
@@ -1829,6 +1831,9 @@ export default function EventOrderPanelForm({
           : (
               <>
                 <EventOrderPanelBuySellTabs
+                  className={cn(
+                    !isMobile && stickyDesktopTabs && 'sticky top-0 z-10 -mx-4 bg-card px-4',
+                  )}
                   side={state.side}
                   type={state.type}
                   availableMergeShares={availableMergeShares}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -1782,6 +1782,8 @@ export default function EventOrderPanelForm({
     focusInput()
   }
 
+  const shouldStickDesktopTabs = !isMobile && stickyDesktopTabs
+
   return (
     <Form
       action={onSubmit}
@@ -1832,8 +1834,9 @@ export default function EventOrderPanelForm({
               <>
                 <EventOrderPanelBuySellTabs
                   className={cn(
-                    !isMobile && stickyDesktopTabs && 'sticky top-0 z-10 -mx-4 bg-card px-4',
+                    shouldStickDesktopTabs && 'sticky top-0 z-10 bg-card',
                   )}
+                  edgeToEdge={shouldStickDesktopTabs}
                   side={state.side}
                   type={state.type}
                   availableMergeShares={availableMergeShares}

--- a/src/app/[locale]/(platform)/event/[slug]/_types/EventOrderPanelTypes.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_types/EventOrderPanelTypes.ts
@@ -11,6 +11,7 @@ export interface EventOrderPanelFormProps {
   initialOutcome?: Outcome | null
   className?: string
   desktopMarketInfo?: ReactNode
+  stickyDesktopTabs?: boolean
   mobileMarketInfo?: ReactNode
   primaryOutcomeIndex?: number | null
   oddsFormat?: OddsFormat

--- a/src/app/[locale]/(platform)/sports/[sport]/[event]/layout.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/[event]/layout.tsx
@@ -2,6 +2,8 @@ import type { ReactNode } from 'react'
 import { setRequestLocale } from 'next-intl/server'
 import { getPublicShellStaticParams, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
+export const instant = false
+
 export async function generateStaticParams() {
   return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER, event: STATIC_PARAMS_PLACEHOLDER })
 }

--- a/src/app/[locale]/(platform)/sports/[sport]/[event]/page.tsx
+++ b/src/app/[locale]/(platform)/sports/[sport]/[event]/page.tsx
@@ -5,6 +5,8 @@ import {
 } from '@/app/[locale]/(platform)/sports/_utils/sports-event-page'
 import { getPublicShellStaticParams, STATIC_PARAMS_PLACEHOLDER } from '@/lib/static-params'
 
+export const instant = false
+
 export async function generateStaticParams() {
   return getPublicShellStaticParams({ sport: STATIC_PARAMS_PLACEHOLDER, event: STATIC_PARAMS_PLACEHOLDER })
 }
@@ -12,6 +14,8 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: PageProps<'/[locale]/sports/[sport]/[event]'>): Promise<Metadata> {
+  'use cache'
+
   return await generateSportsVerticalEventMetadata(await params)
 }
 

--- a/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsEventCenter.tsx
@@ -1675,19 +1675,13 @@ export default function SportsEventCenter({
         <SportsEventQuerySync onSelectionChange={handleQuerySelectionChange} />
       </Suspense>
       <div className={cn(`
-        min-[1200px]:grid min-[1200px]:h-full min-[1200px]:min-h-0 min-[1200px]:grid-cols-[minmax(0,1fr)_21.25rem]
-        min-[1200px]:grid-rows-[minmax(0,1fr)] min-[1200px]:[align-content:start] min-[1200px]:items-stretch
-        min-[1200px]:gap-6
+        min-[1200px]:grid min-[1200px]:grid-cols-[minmax(0,1fr)_21.25rem] min-[1200px]:[align-content:start]
+        min-[1200px]:items-start min-[1200px]:gap-6
       `)}
       >
         <section
           data-sports-scroll-pane="center"
-          className={cn(`
-            min-w-0
-            min-[1200px]:min-h-0 min-[1200px]:self-stretch min-[1200px]:overflow-y-auto min-[1200px]:overscroll-contain
-            min-[1200px]:pr-1
-            lg:ml-4
-          `)}
+          className={cn(`min-w-0 min-[1200px]:pr-1 lg:ml-4`)}
         >
           <div className="mb-4">
             <div className="relative mb-1 flex min-h-9 items-center justify-center">
@@ -1979,8 +1973,8 @@ export default function SportsEventCenter({
           data-sports-scroll-pane="aside"
           className={cn(`
             hidden gap-4
-            min-[1200px]:sticky min-[1200px]:top-0 min-[1200px]:block min-[1200px]:h-full min-[1200px]:min-h-0
-            min-[1200px]:self-stretch min-[1200px]:overflow-y-auto min-[1200px]:overscroll-contain
+            min-[1200px]:sticky min-[1200px]:top-29 min-[1200px]:block min-[1200px]:max-h-[calc(100dvh-8.25rem)]
+            min-[1200px]:self-start min-[1200px]:overflow-y-auto
           `)}
         >
           {activeTradeContext
@@ -1990,6 +1984,7 @@ export default function SportsEventCenter({
                     isMobile={false}
                     event={activeCard.event}
                     className="bg-card"
+                    stickyDesktopTabs
                     oddsFormat={oddsFormat}
                     outcomeButtonStyleVariant="sports3d"
                     optimisticallyClaimedConditionIds={claimedConditionIds}
@@ -2022,6 +2017,7 @@ export default function SportsEventCenter({
                       isMobile={false}
                       event={activeCard.event}
                       className="bg-card"
+                      stickyDesktopTabs
                       oddsFormat={oddsFormat}
                       optimisticallyClaimedConditionIds={claimedConditionIds}
                       initialMarket={pageAboutMarket}

--- a/src/app/[locale]/(platform)/sports/_components/SportsLayoutShell.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsLayoutShell.tsx
@@ -270,12 +270,11 @@ export default function SportsLayoutShell({
     && Boolean(context.sportSlug)
     && !context.isEventRoute
     && Boolean(sectionConfig?.gamesEnabled && sectionConfig?.propsEnabled)
-  const useIndependentColumns = context.mode === 'live'
+  const useIndependentColumns = !context.isEventRoute && (
+    context.mode === 'live'
     || context.mode === 'soon'
-    || (
-      context.mode === 'all'
-      && (context.section === 'games' || context.isEventRoute)
-    )
+    || (context.mode === 'all' && context.section === 'games')
+  )
   const headerInsideGamesCenter = !context.isEventRoute
     && (
       context.mode === 'live'
@@ -315,6 +314,7 @@ export default function SportsLayoutShell({
           mode={context.mode}
           activeTagSlug={context.activeTagSlug}
           countByTagSlug={sportsCountsBySlug}
+          documentScroll={context.isEventRoute}
           independentScroll={useIndependentColumns}
         />
         <div

--- a/src/app/[locale]/(platform)/sports/_components/SportsLayoutShell.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsLayoutShell.tsx
@@ -275,12 +275,7 @@ export default function SportsLayoutShell({
     || context.mode === 'soon'
     || (context.mode === 'all' && context.section === 'games')
   )
-  const headerInsideGamesCenter = !context.isEventRoute
-    && (
-      context.mode === 'live'
-      || context.mode === 'soon'
-      || (context.mode === 'all' && context.section === 'games')
-    )
+  const headerInsideGamesCenter = useIndependentColumns
   const showShellHeader = !headerInsideGamesCenter
   const showTitle = Boolean(context.title) && !context.isEventRoute
   const activeSection = context.section ?? 'games'

--- a/src/app/[locale]/(platform)/sports/_components/SportsSidebarMenu.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/SportsSidebarMenu.tsx
@@ -31,6 +31,7 @@ export default function SportsSidebarMenu({
   mode,
   activeTagSlug,
   countByTagSlug,
+  documentScroll = false,
   independentScroll = false,
 }: SportsSidebarMenuProps) {
   const verticalConfig = getSportsVerticalConfig(vertical)
@@ -355,11 +356,16 @@ export default function SportsSidebarMenu({
               min-[1200px]:justify-start min-[1200px]:overflow-y-auto min-[1200px]:overscroll-contain min-[1200px]:pt-2
               min-[1200px]:pb-8
             `
-            : `
-              min-[1200px]:sticky min-[1200px]:top-22 min-[1200px]:flex min-[1200px]:h-[calc(100vh-5.5rem)]
-              min-[1200px]:flex-col min-[1200px]:justify-start min-[1200px]:overflow-y-auto
-              min-[1200px]:overscroll-contain min-[1200px]:py-8
-            `,
+            : documentScroll
+              ? `
+                min-[1200px]:sticky min-[1200px]:top-29 min-[1200px]:flex min-[1200px]:h-[calc(100dvh-7.25rem)]
+                min-[1200px]:flex-col min-[1200px]:justify-start min-[1200px]:overflow-y-auto min-[1200px]:py-8
+              `
+              : `
+                min-[1200px]:sticky min-[1200px]:top-22 min-[1200px]:flex min-[1200px]:h-[calc(100vh-5.5rem)]
+                min-[1200px]:flex-col min-[1200px]:justify-start min-[1200px]:overflow-y-auto
+                min-[1200px]:overscroll-contain min-[1200px]:py-8
+              `,
         )}
       >
         {renderDesktopMenuEntries()}

--- a/src/app/[locale]/(platform)/sports/_components/sports-sidebar-menu/sports-sidebar-menu-utils.ts
+++ b/src/app/[locale]/(platform)/sports/_components/sports-sidebar-menu/sports-sidebar-menu-utils.ts
@@ -19,6 +19,7 @@ export interface SportsSidebarMenuProps {
   mode: SportsSidebarMode
   activeTagSlug: string | null
   countByTagSlug?: Record<string, number>
+  documentScroll?: boolean
   independentScroll?: boolean
 }
 

--- a/src/providers/ProgressIndicatorProvider.tsx
+++ b/src/providers/ProgressIndicatorProvider.tsx
@@ -16,7 +16,7 @@ function ProgressIndicatorProvider({ children }: { children: ReactNode }) {
           color="var(--primary)"
           options={{ showSpinner: false }}
           shallowRouting
-          delay={300}
+          delay={500}
         />
       )}
     </>


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixes scrolling on sports event pages by switching to document scroll and making desktop order panel tabs sticky. Also tweaks sticky offsets and loading to reduce jank.

- **Bug Fixes**
  - Use page scroll on event pages; removed nested center scroll. Aside is sticky with top-29 and `100dvh`-based heights.
  - Sidebar supports `documentScroll`; enabled on event routes to fix sticky/overflow issues.
  - Order panel tabs can stick on desktop via `stickyDesktopTabs` with edge-to-edge styling and `className`; applied in the event center.
  - Disabled instant transitions on sports event layout and page (`instant = false`), added `'use cache'` to metadata, and increased the progress delay to 500ms.

<sup>Written for commit 78f9f3631c4d96be5c30b09637999135406d79f8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

