### PR TITLE
fix: load arbitrage config at runtime

### DIFF
--- a/src/app/api/arbitrage/config/route.ts
+++ b/src/app/api/arbitrage/config/route.ts
@@ -1,8 +1,9 @@
-import { NextResponse } from 'next/server'
+import { connection, NextResponse } from 'next/server'
 import { isArbitrageEnabled, isArbitrageMultiWalletEnabled } from '@/lib/arbitrage-settings'
 import { SettingsRepository } from '@/lib/db/queries/settings'
 
 export async function GET() {
+  await connection()
   const { data: settings } = await SettingsRepository.getSettings()
 
   return NextResponse.json(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Load arbitrage config at runtime so the latest DB settings are used on each request. The `/api/arbitrage/config` route now calls `connection()` from `next/server` before fetching settings to prevent stale or build-time values.

<sup>Written for commit 5e6782fad8e16ea2fbf69c0069a0e7be4fb720ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

