### PR TITLE
fix: do not sticky mobile header

### DIFF
--- a/src/app/[locale]/(platform)/_components/Header.tsx
+++ b/src/app/[locale]/(platform)/_components/Header.tsx
@@ -6,7 +6,7 @@ import { cn } from '@/lib/utils'
 
 export default async function Header() {
   return (
-    <header className="sticky top-0 z-30 bg-background">
+    <header className="top-0 z-30 bg-background lg:sticky">
       <div
         className={cn(`
           relative z-50 container mx-auto flex min-h-15 w-full items-center justify-between gap-4 py-3 pb-1

--- a/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
+++ b/src/app/[locale]/(platform)/_components/MobileBottomNav.tsx
@@ -238,8 +238,11 @@ function MobileBottomNavContent({ pathname }: MobileBottomNavContentProps) {
 
       {!isAuthenticated && (
         <Drawer open={isGuestMenuOpen} onOpenChange={setIsGuestMenuOpen}>
-          <DrawerContent className="max-h-[88vh] rounded-t-[1.75rem] border-border/70 bg-background px-4 pt-2 pb-6">
-            <div className="grid gap-4 pt-3">
+          <DrawerContent className={cn(`
+            max-h-[88vh] overflow-hidden rounded-t-[1.75rem] border-border/70 bg-background px-4 pt-2 pb-6
+          `)}
+          >
+            <div className="grid min-h-0 auto-rows-max gap-4 overflow-y-auto overscroll-contain pt-3">
               <div className="overflow-hidden rounded-2xl border border-border/70">
                 {canShowInstallUi && (
                   <>
@@ -549,8 +552,7 @@ function MobileLocaleSwitcher({ onLocaleChange }: MobileLocaleSwitcherProps) {
 
   return (
     <div className="rounded-2xl border border-border/70 px-4 py-3">
-      <div className="mb-3 flex items-center gap-2 text-sm font-semibold">
-        <LocaleFlag locale={locale} />
+      <div className="mb-3 text-sm font-semibold">
         <span>{LOOP_LABELS[locale] ?? 'Language'}</span>
       </div>
       <div className="grid grid-cols-2 gap-2">

--- a/src/app/[locale]/(platform)/_components/NavigationTabs.tsx
+++ b/src/app/[locale]/(platform)/_components/NavigationTabs.tsx
@@ -82,7 +82,7 @@ export default function NavigationTabs() {
   useScrollActiveItemIntoView({ activeIndex, containerRef, itemRef: tabItemRef })
 
   return (
-    <nav className="sticky top-15 z-20 bg-background md:top-17">
+    <nav className="top-15 z-20 bg-background md:top-17 lg:sticky">
       <div className="pointer-events-none absolute inset-x-0 bottom-0 h-px bg-border" />
       <div className="container mx-auto flex w-full min-w-0">
         <div

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventHeader.tsx
@@ -145,7 +145,7 @@ export default function EventHeader({ event }: EventHeaderProps) {
     <div
       className={cn(
         'relative z-10 -mx-4 flex items-center gap-3 px-4 transition-all ease-in-out',
-        { 'sticky top-26 translate-y-1 bg-background py-3 pr-6 md:translate-y-3 lg:top-28 lg:translate-y-1': scrolled },
+        { 'sticky top-0 bg-background py-3 pr-6 lg:top-28 lg:translate-y-1': scrolled },
       )}
     >
       {scrolled && (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Make the header and navigation tabs non-sticky on mobile to prevent overlap and jitter. Keep sticky behavior on desktop and fix guest drawer scrolling in `MobileBottomNav`.

- **Bug Fixes**
  - Header and NavigationTabs: `sticky` now only on `lg` screens.
  - EventHeader: scrolled state uses `top-0` on mobile and `lg:top-28` on desktop.
  - MobileBottomNav: guest drawer gets proper vertical scrolling with `overflow-y-auto` and `overscroll-contain`; removed locale flag from heading to reduce layout shift.

<sup>Written for commit ec9de776687762d441925f3b8fb2f33a147046ad. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

