### PR TITLE
fix: unify arbitrage button states

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelArbitrage.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelArbitrage.tsx
@@ -863,7 +863,7 @@ function EventOrderPanelPolymarketArbitrage({
             ? (
                 <Tooltip>
                   <TooltipTrigger asChild>
-                    <span className="block" tabIndex={0}>
+                    <div className="block" tabIndex={0}>
                       <EventOrderPanelSubmitButton
                         type="button"
                         isLoading={false}
@@ -871,7 +871,7 @@ function EventOrderPanelPolymarketArbitrage({
                         onClick={() => {}}
                         label={t('Polymarket wallet unavailable')}
                       />
-                    </span>
+                    </div>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-72 text-center">
                     {t('When disabled, users can only trade arbitrage when they use the same wallet on both sites.')}
@@ -882,7 +882,7 @@ function EventOrderPanelPolymarketArbitrage({
               ? (
                   <Tooltip>
                     <TooltipTrigger asChild>
-                      <span className="block" tabIndex={0}>
+                      <div className="block" tabIndex={0}>
                         <EventOrderPanelSubmitButton
                           type="button"
                           isLoading={false}
@@ -890,7 +890,7 @@ function EventOrderPanelPolymarketArbitrage({
                           onClick={() => {}}
                           label={t('Polymarket wallet unavailable')}
                         />
-                      </span>
+                      </div>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="max-w-72 text-center">
                       {t('This wallet does not have an active Polymarket deposit wallet. Use the same wallet on Polymarket first.')}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelArbitrage.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelArbitrage.tsx
@@ -793,13 +793,12 @@ function EventOrderPanelPolymarketArbitrage({
   }
 
   const connectButton = (
-    <Button
+    <EventOrderPanelSubmitButton
       type="button"
-      className="h-12 w-full bg-[#2E5CFF] text-white hover:bg-[#244bd4]"
-      disabled={walletStatus === 'connecting'}
+      isLoading={walletStatus === 'connecting'}
+      isDisabled={walletStatus === 'connecting'}
       onClick={() => void handleConnect()}
-    >
-      {t.rich('Connect <polymarket>Polymarket</polymarket> wallet', {
+      label={t.rich('Connect <polymarket>Polymarket</polymarket> wallet', {
         polymarket: () => (
           <Image
             src="/images/logos/polymarket-logo-black.svg"
@@ -810,7 +809,8 @@ function EventOrderPanelPolymarketArbitrage({
           />
         ),
       })}
-    </Button>
+      loadingLabel={t('Loading...')}
+    />
   )
   const submitButtonLabel = submissionStep === 1
     ? t('Sign {siteName} order · 1/2', { siteName: site.name })
@@ -848,9 +848,13 @@ function EventOrderPanelPolymarketArbitrage({
     : submitButton
   const actionButton = !siteWalletReady
     ? (
-        <Button type="button" className="h-12 w-full" onClick={onRequireSiteWallet}>
-          {t('Trade')}
-        </Button>
+        <EventOrderPanelSubmitButton
+          type="button"
+          isLoading={false}
+          isDisabled={false}
+          onClick={onRequireSiteWallet}
+          label={t('Trade')}
+        />
       )
     : !polymarketWalletReady
         ? multiWalletEnabled
@@ -860,9 +864,13 @@ function EventOrderPanelPolymarketArbitrage({
                 <Tooltip>
                   <TooltipTrigger asChild>
                     <span className="block" tabIndex={0}>
-                      <Button type="button" className="h-12 w-full" disabled>
-                        {t('Polymarket wallet unavailable')}
-                      </Button>
+                      <EventOrderPanelSubmitButton
+                        type="button"
+                        isLoading={false}
+                        isDisabled
+                        onClick={() => {}}
+                        label={t('Polymarket wallet unavailable')}
+                      />
                     </span>
                   </TooltipTrigger>
                   <TooltipContent side="top" className="max-w-72 text-center">
@@ -875,9 +883,13 @@ function EventOrderPanelPolymarketArbitrage({
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span className="block" tabIndex={0}>
-                        <Button type="button" className="h-12 w-full" disabled>
-                          {t('Polymarket wallet unavailable')}
-                        </Button>
+                        <EventOrderPanelSubmitButton
+                          type="button"
+                          isLoading={false}
+                          isDisabled
+                          onClick={() => {}}
+                          label={t('Polymarket wallet unavailable')}
+                        />
                       </span>
                     </TooltipTrigger>
                     <TooltipContent side="top" className="max-w-72 text-center">
@@ -886,14 +898,14 @@ function EventOrderPanelPolymarketArbitrage({
                   </Tooltip>
                 )
               : (
-                  <Button
+                  <EventOrderPanelSubmitButton
                     type="button"
-                    className="h-12 w-full bg-[#2E5CFF] text-white hover:bg-[#244bd4]"
-                    disabled={walletStatus === 'connecting'}
+                    isLoading={walletStatus === 'connecting'}
+                    isDisabled={walletStatus === 'connecting'}
                     onClick={() => void handleSameWalletConnect()}
-                  >
-                    {walletStatus === 'connecting' ? t('Loading...') : t('Connect your Polymarket wallet')}
-                  </Button>
+                    label={t('Connect your Polymarket wallet')}
+                    loadingLabel={t('Loading...')}
+                  />
                 )
         : submitButtonWithStatus
   const percentageTooltipLabel = siteWalletReady
@@ -1275,13 +1287,13 @@ function EventOrderPanelPolymarketArbitrage({
             </div>
           </div>
           <DialogFooter className="px-6 pb-6">
-            <Button
+            <EventOrderPanelSubmitButton
               type="button"
-              className="h-12 w-full bg-[#2E5CFF] text-white hover:bg-[#244bd4]"
+              isLoading={false}
+              isDisabled={false}
               onClick={dismissIntro}
-            >
-              {t('Continue')}
-            </Button>
+              label={t('Continue')}
+            />
           </DialogFooter>
         </DialogContent>
       </Dialog>

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeArbitrage.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeArbitrage.tsx
@@ -658,7 +658,15 @@ export default function EventOrderPanelOutcomeArbitrage({
       )}
 
       {!siteWalletReady
-        ? <Button type="button" className="h-12 w-full" onClick={onRequireSiteWallet}>{t('Trade')}</Button>
+        ? (
+            <EventOrderPanelSubmitButton
+              type="button"
+              isLoading={false}
+              isDisabled={false}
+              onClick={onRequireSiteWallet}
+              label={t('Trade')}
+            />
+          )
         : submitButtonWithStatus}
     </div>
   )

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelSubmitButton.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelSubmitButton.tsx
@@ -1,4 +1,4 @@
-import type { MouseEvent } from 'react'
+import type { MouseEvent, ReactNode } from 'react'
 import type { EventOrderPanelOutcomeSelectedAccent }
   from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelOutcomeButton'
 import { useExtracted } from 'next-intl'
@@ -9,8 +9,8 @@ interface EventOrderPanelSubmitButtonProps {
   isLoading: boolean
   isDisabled: boolean
   onClick: (event: MouseEvent<HTMLButtonElement>) => void
-  label?: string
-  loadingLabel?: string
+  label?: ReactNode
+  loadingLabel?: ReactNode
   className?: string
   type?: 'button' | 'submit'
   selectedAccent?: EventOrderPanelOutcomeSelectedAccent | null
@@ -30,9 +30,13 @@ export default function EventOrderPanelSubmitButton({
 }: EventOrderPanelSubmitButtonProps) {
   const t = useExtracted()
   const useSportsDepth = styleVariant === 'sports3d'
+  const isInactive = isDisabled && !isLoading
+  const loadingStyle = isLoading && !selectedAccent
+    ? { backgroundColor: 'var(--primary)', color: 'var(--primary-foreground)' }
+    : undefined
 
   return (
-    <div className="relative w-full pb-1.25">
+    <div className={cn('relative w-full pb-1.25', isInactive && 'opacity-50')}>
       <div
         className={cn(
           'pointer-events-none absolute inset-x-0 bottom-0 h-4 rounded-b-md',
@@ -53,13 +57,14 @@ export default function EventOrderPanelSubmitButton({
             duration-150 ease-out
             hover:translate-y-px
             active:translate-y-0.5
-            disabled:opacity-100
+            disabled:translate-y-0 disabled:opacity-100 disabled:brightness-100
           `,
           useSportsDepth ? 'hover:brightness-95' : 'hover:bg-primary',
           selectedAccent?.buttonClassName,
           className,
+          isLoading && 'bg-primary text-primary-foreground hover:bg-primary',
         )}
-        style={selectedAccent?.buttonStyle}
+        style={loadingStyle ?? selectedAccent?.buttonStyle}
       >
         {selectedAccent?.overlayStyle && (
           <span

--- a/tests/unit/EventOrderPanelSubmitButton.test.tsx
+++ b/tests/unit/EventOrderPanelSubmitButton.test.tsx
@@ -1,0 +1,47 @@
+import { render, screen } from '@testing-library/react'
+import EventOrderPanelSubmitButton
+  from '@/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelSubmitButton'
+
+vi.mock('next-intl', () => ({
+  useExtracted: () => (message: string) => message,
+}))
+
+describe('event order panel submit button', () => {
+  it('keeps the raised shape but uses muted colors when inactive', () => {
+    render(
+      <EventOrderPanelSubmitButton
+        type="button"
+        isLoading={false}
+        isDisabled
+        onClick={() => {}}
+        label="No profitable trade right now"
+      />,
+    )
+
+    const button = screen.getByRole('button')
+    const depth = button.parentElement?.firstElementChild
+
+    expect(button.parentElement).toHaveClass('opacity-50')
+    expect(button).toHaveClass('bg-primary', 'text-primary-foreground')
+    expect(depth).toHaveClass('bg-primary/80')
+  })
+
+  it('keeps the theme primary color while loading', () => {
+    render(
+      <EventOrderPanelSubmitButton
+        type="button"
+        isLoading
+        isDisabled
+        onClick={() => {}}
+        label="Connect wallet"
+        loadingLabel="Loading..."
+      />,
+    )
+
+    const button = screen.getByRole('button')
+
+    expect(button).toHaveClass('bg-primary', 'text-primary-foreground')
+    expect(button).not.toHaveClass('bg-muted')
+    expect(screen.getByText('Loading...')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Unified arbitrage action button states across event order panels for consistent loading and disabled behavior. Replaced scattered button usages with the shared submit button, corrected tooltip trigger markup, and added tests to lock styling.

- **Bug Fixes**
  - Use `EventOrderPanelSubmitButton` for Connect, Trade, Continue, and wallet unavailable states in arbitrage views; tooltip trigger now uses a valid block element.
  - Loading keeps primary color and switches to `loadingLabel`; disabled uses muted opacity while keeping the raised shape.
  - Labels now support `ReactNode` (e.g., Polymarket logo in the connect label).

<sup>Written for commit 66be21ca105b1d9f08a9d5492bc3f9cf8eef609a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

