### PR TITLE
fix: consume binance daily reference prices

### DIFF
--- a/docs/api-reference/schemas/openapi-price-reference.json
+++ b/docs/api-reference/schemas/openapi-price-reference.json
@@ -218,8 +218,9 @@
       "Source": {
         "type": "string",
         "enum": [
+          "binance",
           "chainlink",
-          "massive"
+          "pyth"
         ]
       },
       "LastFinal": {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -13,6 +13,7 @@ import { useLiveSeriesPriceSnapshot } from '../_hooks/useLiveSeriesPriceSnapshot
 import { useLiveSeriesWebSocket } from '../_hooks/useLiveSeriesWebSocket'
 import {
   buildAxis,
+  classifyLiveSeriesReference,
   findLiveSeriesEvent,
   formatDateAtTimezone,
   formatTimeAtTimezone,
@@ -20,6 +21,7 @@ import {
   getVisibleCountdownUnits,
   hexToRgba,
   inferIntervalMsFromSeriesSlug,
+  isCanonicalBinanceDailySnapshot,
   isUsEquityMarketOpen,
   LIVE_CHART_HEIGHT,
   LIVE_CHART_MARGIN_BOTTOM,
@@ -192,6 +194,7 @@ function EventLiveSeriesChartContent({
 
   const {
     referenceSnapshot,
+    referenceSnapshotStatus,
     baselinePrice,
     setBaselinePrice,
     persistedFallbackPrice: snapshotFallbackPrice,
@@ -210,6 +213,13 @@ function EventLiveSeriesChartContent({
   const chartNowMs = isEventClosed ? endTimestamp : nowMs
 
   const persistedFallbackPrice = snapshotFallbackPrice
+  const seriesReferenceClassification = useMemo(
+    () => classifyLiveSeriesReference({
+      topic: config.topic,
+      activeWindowMinutes: config.active_window_minutes,
+    }),
+    [config.active_window_minutes, config.topic],
+  )
 
   const { data, status } = useLiveSeriesWebSocket({
     topic: config.topic,
@@ -284,13 +294,16 @@ function EventLiveSeriesChartContent({
 
     return persistedFallbackPrice.price
   }, [endTimestamp, persistedFallbackPrice])
-  const requiresCanonicalBinanceClose = requiresCanonicalBinanceDailyClose(referenceSnapshot)
+  const hasCanonicalBinanceDailySnapshot = isCanonicalBinanceDailySnapshot(referenceSnapshot)
+  const requiresCanonicalBinanceClose = requiresCanonicalBinanceDailyClose({
+    snapshot: referenceSnapshot,
+    snapshotStatus: referenceSnapshotStatus,
+    seriesClassification: seriesReferenceClassification,
+  })
   const finalPrice = isEventClosed
-    ? referenceClosingPrice ?? (
-      requiresCanonicalBinanceClose
-        ? null
-        : latestReferencePriceBeforeEnd ?? persistedFallbackPriceBeforeEnd
-    )
+    ? requiresCanonicalBinanceClose
+      ? hasCanonicalBinanceDailySnapshot ? referenceClosingPrice : null
+      : referenceClosingPrice ?? latestReferencePriceBeforeEnd ?? persistedFallbackPriceBeforeEnd
     : null
 
   const fallbackCurrentPrice = useMemo(() => {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -283,8 +283,13 @@ function EventLiveSeriesChartContent({
 
     return persistedFallbackPrice.price
   }, [endTimestamp, persistedFallbackPrice])
+  const requiresCanonicalBinanceClose = referenceSnapshot?.source === 'binance'
   const finalPrice = isEventClosed
-    ? referenceClosingPrice ?? latestReferencePriceBeforeEnd ?? persistedFallbackPriceBeforeEnd
+    ? referenceClosingPrice ?? (
+      requiresCanonicalBinanceClose
+        ? null
+        : latestReferencePriceBeforeEnd ?? persistedFallbackPriceBeforeEnd
+    )
     : null
 
   const fallbackCurrentPrice = useMemo(() => {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -37,6 +37,7 @@ import {
   normalizeLiveChartPrice,
   normalizeSubscriptionSymbol,
   parseUtcDate,
+  requiresCanonicalBinanceDailyClose,
   resolveEventEndTimestamp,
   resolveLiveSeriesDisplayPrice,
   SERIES_KEY,
@@ -283,7 +284,7 @@ function EventLiveSeriesChartContent({
 
     return persistedFallbackPrice.price
   }, [endTimestamp, persistedFallbackPrice])
-  const requiresCanonicalBinanceClose = referenceSnapshot?.source === 'binance'
+  const requiresCanonicalBinanceClose = requiresCanonicalBinanceDailyClose(referenceSnapshot)
   const finalPrice = isEventClosed
     ? referenceClosingPrice ?? (
       requiresCanonicalBinanceClose
@@ -369,7 +370,7 @@ function EventLiveSeriesChartContent({
     }
 
     if (!isFinitePositivePrice(finalPrice)) {
-      return preCloseData
+      return requiresCanonicalBinanceClose ? [] : preCloseData
     }
 
     return [
@@ -379,7 +380,7 @@ function EventLiveSeriesChartContent({
         [SERIES_KEY]: finalPrice,
       },
     ].slice(-MAX_POINTS)
-  }, [closedFallbackData, data, endTimestamp, finalPrice, isEventClosed])
+  }, [closedFallbackData, data, endTimestamp, finalPrice, isEventClosed, requiresCanonicalBinanceClose])
 
   const renderData = useMemo(() => {
     if (!dataSource.length) {
@@ -446,6 +447,7 @@ function EventLiveSeriesChartContent({
     finalPrice,
     renderedPrice,
     fallbackCurrentPrice,
+    requiresCanonicalClose: requiresCanonicalBinanceClose,
   })
   const axisSourceData = renderData
   const resolvedBaselinePrice = isEventClosed

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChartHeader.tsx
@@ -185,8 +185,11 @@ export default function EventLiveSeriesChartHeader({
         <div className={cn('h-10 w-px bg-border', liveMarketHref ? 'block' : 'hidden sm:block')} />
         <div>
           <div
-            className="flex items-center gap-0.5 text-xs font-semibold whitespace-nowrap min-[360px]:gap-1 sm:gap-2"
-            style={{ color: liveColor }}
+            className={cn(
+              'flex items-center gap-0.5 text-xs font-semibold whitespace-nowrap min-[360px]:gap-1 sm:gap-2',
+              isEventClosed && 'text-foreground',
+            )}
+            style={isEventClosed ? undefined : { color: liveColor }}
           >
             <span>{priceStatusLabel}</span>
             {delta != null && (
@@ -210,8 +213,9 @@ export default function EventLiveSeriesChartHeader({
                 sm:text-[22px]
               `,
               liveMarketHref ? 'min-[360px]:text-[20px]' : 'min-[360px]:text-[18px]',
+              isEventClosed && 'text-foreground',
             )}
-            style={{ color: liveColor }}
+            style={isEventClosed ? undefined : { color: liveColor }}
           >
             {currentPrice != null
               ? <RollingValue value={formatUsd(currentPrice, headerPriceDisplayDigits)} />

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesPriceSnapshot.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesPriceSnapshot.ts
@@ -1,4 +1,8 @@
-import type { LiveSeriesPriceSnapshot, PersistedLivePrice } from '../_utils/eventLiveSeriesChartUtils'
+import type {
+  LiveSeriesPriceSnapshot,
+  LiveSeriesPriceSnapshotStatus,
+  PersistedLivePrice,
+} from '../_utils/eventLiveSeriesChartUtils'
 import type { EventLiveChartConfig } from '@/types'
 import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
 import {
@@ -17,6 +21,7 @@ interface UseLiveSeriesPriceSnapshotOptions {
 
 export interface LiveSeriesPriceSnapshotResult {
   referenceSnapshot: LiveSeriesPriceSnapshot | null
+  referenceSnapshotStatus: LiveSeriesPriceSnapshotStatus
   baselinePrice: number | null
   setBaselinePrice: React.Dispatch<React.SetStateAction<number | null>>
   persistedFallbackPrice: PersistedLivePrice | null
@@ -24,6 +29,7 @@ export interface LiveSeriesPriceSnapshotResult {
 
 interface LiveSeriesPriceSnapshotStoreSnapshot {
   referenceSnapshot: LiveSeriesPriceSnapshot | null
+  referenceSnapshotStatus: LiveSeriesPriceSnapshotStatus
   persistedFallbackPrice: PersistedLivePrice | null
 }
 
@@ -52,6 +58,7 @@ const BINANCE_CLOSE_REFRESH_INTERVAL_MS = 10 * 1000
 const BINANCE_CLOSE_REFRESH_WINDOW_MS = 5 * 60 * 1000
 const EMPTY_LIVE_SERIES_PRICE_SNAPSHOT: LiveSeriesPriceSnapshotStoreSnapshot = {
   referenceSnapshot: null,
+  referenceSnapshotStatus: 'loading',
   persistedFallbackPrice: null,
 }
 
@@ -202,6 +209,13 @@ async function fetchLiveSeriesPriceSnapshot(
   const requestToken = entry.fetchToken + 1
   entry.fetchToken = requestToken
   entry.abortController = controller
+  if (entry.snapshot.referenceSnapshot == null) {
+    entry.snapshot = {
+      ...entry.snapshot,
+      referenceSnapshotStatus: 'loading',
+    }
+    notifyLiveSeriesPriceSnapshotStore(storeKey)
+  }
   entry.inflightFetch = (async function runLiveSeriesPriceSnapshotFetch() {
     try {
       const response = await fetch(`/api/price-reference/live-series?${buildLiveSeriesPriceSnapshotQuery(request).toString()}`, {
@@ -210,6 +224,10 @@ async function fetchLiveSeriesPriceSnapshot(
       })
 
       if (!response.ok) {
+        entry.snapshot = {
+          ...entry.snapshot,
+          referenceSnapshotStatus: 'unavailable',
+        }
         return
       }
 
@@ -217,6 +235,7 @@ async function fetchLiveSeriesPriceSnapshot(
       entry.snapshot = {
         ...entry.snapshot,
         referenceSnapshot: payload,
+        referenceSnapshotStatus: 'ready',
       }
 
       const fallbackPrice = normalizeLiveChartPrice(
@@ -239,6 +258,10 @@ async function fetchLiveSeriesPriceSnapshot(
       }
     }
     catch {
+      entry.snapshot = {
+        ...entry.snapshot,
+        referenceSnapshotStatus: 'unavailable',
+      }
     }
     finally {
       if (entry.fetchToken === requestToken) {
@@ -438,6 +461,7 @@ export function useLiveSeriesPriceSnapshot({
 
   return {
     referenceSnapshot: referenceSnapshot.referenceSnapshot,
+    referenceSnapshotStatus: referenceSnapshot.referenceSnapshotStatus,
     baselinePrice: effectiveBaselinePrice,
     setBaselinePrice,
     persistedFallbackPrice: referenceSnapshot.persistedFallbackPrice,

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesPriceSnapshot.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesPriceSnapshot.ts
@@ -47,6 +47,9 @@ interface LiveSeriesPriceSnapshotRequest {
 const liveSeriesPriceSnapshotStores = new Map<string, LiveSeriesPriceSnapshotStoreEntry>()
 const liveSeriesPriceStorageKeyPrefix = 'kuest-live-last-price'
 const LIVE_SERIES_PRICE_SNAPSHOT_STORE_TTL_MS = 10 * 60 * 1000
+const BINANCE_CLOSE_FIRST_REFRESH_DELAY_MS = 65 * 1000
+const BINANCE_CLOSE_REFRESH_INTERVAL_MS = 10 * 1000
+const BINANCE_CLOSE_REFRESH_WINDOW_MS = 5 * 60 * 1000
 const EMPTY_LIVE_SERIES_PRICE_SNAPSHOT: LiveSeriesPriceSnapshotStoreSnapshot = {
   referenceSnapshot: null,
   persistedFallbackPrice: null,
@@ -260,11 +263,45 @@ function subscribeToLiveSeriesPriceSnapshot(
   const storeKey = buildLiveSeriesPriceSnapshotStoreKey(request)
   const entry = getLiveSeriesPriceSnapshotStoreEntry(storeKey)
   entry.listeners.add(onStoreChange)
+  let binanceCloseRefreshTimer: ReturnType<typeof setTimeout> | null = null
+  let isSubscribed = true
 
   if (syncPersistedLivePriceSnapshot(storeKey, request)) {
     onStoreChange()
   }
   void fetchLiveSeriesPriceSnapshot(storeKey, request)
+
+  async function refreshBinanceCloseUntilAvailable() {
+    if (!isSubscribed) {
+      return
+    }
+
+    await fetchLiveSeriesPriceSnapshot(storeKey, request)
+    const snapshot = entry.snapshot.referenceSnapshot
+    const eventEndTimestamp = request.explicitEndTimestamp
+    if (!isSubscribed
+      || (snapshot != null && snapshot.source !== 'binance')
+      || snapshot?.closing_price != null
+      || eventEndTimestamp == null
+      || Date.now() >= eventEndTimestamp + BINANCE_CLOSE_REFRESH_WINDOW_MS) {
+      return
+    }
+
+    binanceCloseRefreshTimer = setTimeout(
+      refreshBinanceCloseUntilAvailable,
+      BINANCE_CLOSE_REFRESH_INTERVAL_MS,
+    )
+  }
+
+  if (request.explicitEndTimestamp != null) {
+    const firstRefreshAtMs = request.explicitEndTimestamp + BINANCE_CLOSE_FIRST_REFRESH_DELAY_MS
+    if (Date.now() < request.explicitEndTimestamp + BINANCE_CLOSE_REFRESH_WINDOW_MS) {
+      binanceCloseRefreshTimer = setTimeout(
+        refreshBinanceCloseUntilAvailable,
+        Math.max(0, firstRefreshAtMs - Date.now()),
+      )
+    }
+  }
 
   function refreshSnapshotAfterResume() {
     if (document.hidden) {
@@ -307,6 +344,10 @@ function subscribeToLiveSeriesPriceSnapshot(
   document.addEventListener('visibilitychange', handleVisibilityChange)
 
   return function unsubscribeFromLiveSeriesPriceSnapshot() {
+    isSubscribed = false
+    if (binanceCloseRefreshTimer) {
+      clearTimeout(binanceCloseRefreshTimer)
+    }
     entry.listeners.delete(onStoreChange)
     if (entry.listeners.size === 0 && entry.abortController) {
       entry.fetchToken += 1

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
@@ -37,7 +37,7 @@ export interface LiveSeriesPriceSnapshot {
   series_slug: string
   instrument: string
   interval: '5m' | '15m' | '1h' | '4h' | '1d'
-  source: 'chainlink' | 'massive'
+  source: 'binance' | 'chainlink' | 'pyth'
   interval_ms: number
   event_window_start_ms: number
   event_window_end_ms: number

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
@@ -49,6 +49,10 @@ export interface LiveSeriesPriceSnapshot {
   is_event_closed: boolean
 }
 
+export function requiresCanonicalBinanceDailyClose(snapshot: LiveSeriesPriceSnapshot | null) {
+  return snapshot?.source === 'binance' && snapshot.interval === '1d'
+}
+
 function normalizeTimestamp(value: unknown, fallbackTimestamp = 0) {
   const numeric = typeof value === 'number' ? value : Number(value)
   if (!Number.isFinite(numeric)) {
@@ -546,14 +550,16 @@ export function resolveLiveSeriesDisplayPrice({
   finalPrice,
   renderedPrice,
   fallbackCurrentPrice,
+  requiresCanonicalClose,
 }: {
   isEventClosed: boolean
   finalPrice: number | null
   renderedPrice: number | null
   fallbackCurrentPrice: number | null
+  requiresCanonicalClose: boolean
 }) {
   if (isEventClosed) {
-    return finalPrice ?? renderedPrice
+    return finalPrice ?? (requiresCanonicalClose ? null : renderedPrice)
   }
 
   return renderedPrice ?? fallbackCurrentPrice

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/eventLiveSeriesChartUtils.ts
@@ -49,8 +49,42 @@ export interface LiveSeriesPriceSnapshot {
   is_event_closed: boolean
 }
 
-export function requiresCanonicalBinanceDailyClose(snapshot: LiveSeriesPriceSnapshot | null) {
+export type LiveSeriesPriceSnapshotStatus = 'loading' | 'ready' | 'unavailable'
+export type LiveSeriesReferenceClassification = 'binance_daily' | 'other'
+
+export function classifyLiveSeriesReference({
+  topic,
+  activeWindowMinutes,
+}: {
+  topic: string
+  activeWindowMinutes: number
+}): LiveSeriesReferenceClassification {
+  const normalizedTopic = topic.trim().toLowerCase()
+  const normalizedWindowMinutes = Number(activeWindowMinutes)
+
+  return normalizedTopic.startsWith('crypto_prices') && normalizedWindowMinutes === 24 * 60
+    ? 'binance_daily'
+    : 'other'
+}
+
+export function isCanonicalBinanceDailySnapshot(snapshot: LiveSeriesPriceSnapshot | null) {
   return snapshot?.source === 'binance' && snapshot.interval === '1d'
+}
+
+export function requiresCanonicalBinanceDailyClose({
+  snapshot,
+  snapshotStatus,
+  seriesClassification,
+}: {
+  snapshot: LiveSeriesPriceSnapshot | null
+  snapshotStatus: LiveSeriesPriceSnapshotStatus
+  seriesClassification: LiveSeriesReferenceClassification
+}) {
+  if (seriesClassification === 'binance_daily') {
+    return true
+  }
+
+  return snapshotStatus === 'ready' && isCanonicalBinanceDailySnapshot(snapshot)
 }
 
 function normalizeTimestamp(value: unknown, fallbackTimestamp = 0) {

--- a/src/app/api/price-reference/live-series/route.ts
+++ b/src/app/api/price-reference/live-series/route.ts
@@ -2,7 +2,7 @@ import { NextResponse } from 'next/server'
 import { resolvePublicRuntimeEnv } from '@/lib/public-runtime-config.shared'
 
 type Interval = '5m' | '15m' | '1h' | '4h' | '1d'
-type Source = 'chainlink' | 'massive'
+type Source = 'binance' | 'chainlink' | 'pyth'
 
 interface SeriesMapItem {
   series_slug: string
@@ -103,6 +103,19 @@ function toPositiveInteger(value: string) {
 
 function selectMostRecentRowAtOrBefore(rows: PriceReferenceHistoryRow[], targetMs: number) {
   return rows.find(row => row.window_end_ms <= targetMs) ?? null
+}
+
+function selectClosingRow(
+  rows: PriceReferenceHistoryRow[],
+  targetMs: number,
+  source: Source,
+  interval: Interval,
+) {
+  if (source === 'binance' && interval === '1d') {
+    return rows.find(row => row.window_end_ms === targetMs) ?? null
+  }
+
+  return selectMostRecentRowAtOrBefore(rows, targetMs)
 }
 
 function sortAndFilterHistoryRows(
@@ -280,7 +293,12 @@ export async function GET(request: Request) {
 
     const openingRow = selectMostRecentRowAtOrBefore(openingHistoryRows, eventWindowStartMs)
       ?? selectMostRecentRowAtOrBefore(openingFallbackRows, eventWindowStartMs)
-    const windowRow = selectMostRecentRowAtOrBefore(closingHistoryRows, eventWindowEndMs)
+    const windowRow = selectClosingRow(
+      closingHistoryRows,
+      closingHistoryTargetMs,
+      seriesEntry.source,
+      seriesEntry.interval,
+    )
 
     const openingFromHistory = toFiniteNumber(openingRow?.settlement_price)
     const openingFromLatestPreferred = (() => {

--- a/tests/unit/EventLiveSeriesChartHeader.test.tsx
+++ b/tests/unit/EventLiveSeriesChartHeader.test.tsx
@@ -77,4 +77,17 @@ describe('eventLiveSeriesChartHeader', () => {
     expect(visualPrice).toHaveAttribute('aria-hidden', 'true')
     expect(firstDigitStack).toHaveStyle({ transform: 'translateY(-6em)' })
   })
+
+  it('uses foreground for a closed final price while preserving the delta color', () => {
+    render(<EventLiveSeriesChartHeader {...baseProps} isEventClosed />)
+
+    const finalPriceLabel = screen.getByText('Final price')
+    const readablePrice = screen.getByText('$64,702.40')
+    const finalPriceValue = readablePrice.parentElement?.parentElement
+    const delta = screen.getByText('$349.15')
+
+    expect(finalPriceLabel.parentElement).toHaveClass('text-foreground')
+    expect(finalPriceValue).toHaveClass('text-foreground')
+    expect(delta).toHaveClass('text-no')
+  })
 })

--- a/tests/unit/eventLiveSeriesChartUtils.test.ts
+++ b/tests/unit/eventLiveSeriesChartUtils.test.ts
@@ -6,6 +6,7 @@ import {
   findLiveSeriesEvent,
   LIVE_PRICE_TRANSITION_MS,
   MAX_POINTS,
+  requiresCanonicalBinanceDailyClose,
   resolveEventEndTimestamp,
   resolveLivePriceTransitionDuration,
   resolveLiveSeriesDisplayPrice,
@@ -330,6 +331,7 @@ describe('event live series chart utils', () => {
       finalPrice: 105,
       renderedPrice: 104,
       fallbackCurrentPrice: 103,
+      requiresCanonicalClose: true,
     })).toBe(105)
   })
 
@@ -339,7 +341,18 @@ describe('event live series chart utils', () => {
       finalPrice: null,
       renderedPrice: 104,
       fallbackCurrentPrice: 103,
+      requiresCanonicalClose: false,
     })).toBe(104)
+  })
+
+  it('does not use the rendered price when a closed market requires a canonical close', () => {
+    expect(resolveLiveSeriesDisplayPrice({
+      isEventClosed: true,
+      finalPrice: null,
+      renderedPrice: 104,
+      fallbackCurrentPrice: 103,
+      requiresCanonicalClose: true,
+    })).toBeNull()
   })
 
   it('uses the live fallback price only for open live series charts without rendered data', () => {
@@ -348,6 +361,29 @@ describe('event live series chart utils', () => {
       finalPrice: null,
       renderedPrice: null,
       fallbackCurrentPrice: 103,
+      requiresCanonicalClose: false,
     })).toBe(103)
+  })
+
+  it('requires a canonical close only for daily Binance snapshots', () => {
+    const snapshot = {
+      series_slug: 'btc-up-or-down-daily',
+      instrument: 'BTC/USD',
+      interval: '1d' as const,
+      source: 'binance' as const,
+      interval_ms: 86_400_000,
+      event_window_start_ms: 100,
+      event_window_end_ms: 200,
+      opening_price: 100,
+      closing_price: null,
+      latest_price: 101,
+      latest_window_end_ms: 150,
+      latest_source_timestamp_ms: 150,
+      is_event_closed: true,
+    }
+
+    expect(requiresCanonicalBinanceDailyClose(snapshot)).toBe(true)
+    expect(requiresCanonicalBinanceDailyClose({ ...snapshot, interval: '5m' })).toBe(false)
+    expect(requiresCanonicalBinanceDailyClose({ ...snapshot, source: 'chainlink' })).toBe(false)
   })
 })

--- a/tests/unit/eventLiveSeriesChartUtils.test.ts
+++ b/tests/unit/eventLiveSeriesChartUtils.test.ts
@@ -3,7 +3,9 @@ import type { DataPoint } from '@/types/PredictionChartTypes'
 import { describe, expect, it } from 'vitest'
 import {
   appendLivePriceTransition,
+  classifyLiveSeriesReference,
   findLiveSeriesEvent,
+  isCanonicalBinanceDailySnapshot,
   LIVE_PRICE_TRANSITION_MS,
   MAX_POINTS,
   requiresCanonicalBinanceDailyClose,
@@ -365,7 +367,7 @@ describe('event live series chart utils', () => {
     })).toBe(103)
   })
 
-  it('requires a canonical close only for daily Binance snapshots', () => {
+  it('requires a canonical close for confirmed daily Binance snapshots', () => {
     const snapshot = {
       series_slug: 'btc-up-or-down-daily',
       instrument: 'BTC/USD',
@@ -382,8 +384,68 @@ describe('event live series chart utils', () => {
       is_event_closed: true,
     }
 
-    expect(requiresCanonicalBinanceDailyClose(snapshot)).toBe(true)
-    expect(requiresCanonicalBinanceDailyClose({ ...snapshot, interval: '5m' })).toBe(false)
-    expect(requiresCanonicalBinanceDailyClose({ ...snapshot, source: 'chainlink' })).toBe(false)
+    expect(isCanonicalBinanceDailySnapshot(snapshot)).toBe(true)
+    expect(requiresCanonicalBinanceDailyClose({
+      snapshot,
+      snapshotStatus: 'ready',
+      seriesClassification: 'binance_daily',
+    })).toBe(true)
+    expect(requiresCanonicalBinanceDailyClose({
+      snapshot: { ...snapshot, interval: '5m' },
+      snapshotStatus: 'ready',
+      seriesClassification: 'other',
+    })).toBe(false)
+    expect(requiresCanonicalBinanceDailyClose({
+      snapshot: { ...snapshot, source: 'chainlink' },
+      snapshotStatus: 'ready',
+      seriesClassification: 'other',
+    })).toBe(false)
+  })
+
+  it('keeps an expected Binance daily close canonical while its snapshot is unavailable', () => {
+    expect(classifyLiveSeriesReference({
+      topic: 'crypto_prices_chainlink',
+      activeWindowMinutes: 1440,
+    })).toBe('binance_daily')
+    expect(requiresCanonicalBinanceDailyClose({
+      snapshot: null,
+      snapshotStatus: 'loading',
+      seriesClassification: 'binance_daily',
+    })).toBe(true)
+    expect(requiresCanonicalBinanceDailyClose({
+      snapshot: null,
+      snapshotStatus: 'unavailable',
+      seriesClassification: 'binance_daily',
+    })).toBe(true)
+    expect(requiresCanonicalBinanceDailyClose({
+      snapshot: {
+        series_slug: 'btc-up-or-down-daily',
+        instrument: 'BTC/USD',
+        interval: '1d',
+        source: 'chainlink',
+        interval_ms: 86_400_000,
+        event_window_start_ms: 100,
+        event_window_end_ms: 200,
+        opening_price: 100,
+        closing_price: 101,
+        latest_price: 101,
+        latest_window_end_ms: 200,
+        latest_source_timestamp_ms: 200,
+        is_event_closed: true,
+      },
+      snapshotStatus: 'ready',
+      seriesClassification: 'binance_daily',
+    })).toBe(true)
+  })
+
+  it('does not classify intraday crypto or daily equities as Binance daily series', () => {
+    expect(classifyLiveSeriesReference({
+      topic: 'crypto_prices_chainlink',
+      activeWindowMinutes: 60,
+    })).toBe('other')
+    expect(classifyLiveSeriesReference({
+      topic: 'equity_prices',
+      activeWindowMinutes: 390,
+    })).toBe('other')
   })
 })

--- a/tests/unit/useLiveSeriesPriceSnapshot.test.tsx
+++ b/tests/unit/useLiveSeriesPriceSnapshot.test.tsx
@@ -57,4 +57,35 @@ describe('useLiveSeriesPriceSnapshot', () => {
     const resumedUrl = new URL(String(fetchMock.mock.calls[1]?.[0]), window.location.origin)
     expect(resumedUrl.searchParams.get('eventEndMs')).toBe(String(now))
   })
+
+  it('exposes loading and unavailable states before a reference snapshot is confirmed', async () => {
+    let resolveFetch: ((value: { ok: boolean }) => void) | null = null
+    const fetchMock = vi.fn(() => new Promise<{ ok: boolean }>((resolve) => {
+      resolveFetch = resolve
+    }))
+    vi.stubGlobal('fetch', fetchMock)
+
+    const config = {
+      series_slug: 'snapshot-status-test',
+      topic: 'crypto_prices_chainlink',
+      active_window_minutes: 1440,
+    } as EventLiveChartConfig
+
+    const { result } = renderHook(() => useLiveSeriesPriceSnapshot({
+      config,
+      subscriptionSymbol: 'BTC',
+      explicitEndTimestamp: now - 1000,
+      startTimestamp: null,
+    }))
+
+    expect(result.current.referenceSnapshotStatus).toBe('loading')
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(1))
+
+    await act(async () => {
+      resolveFetch?.({ ok: false })
+    })
+
+    await waitFor(() => expect(result.current.referenceSnapshotStatus).toBe('unavailable'))
+    expect(result.current.referenceSnapshot).toBeNull()
+  })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Consume Binance daily reference prices and enforce the canonical daily close for Binance `1d`. This prevents premature closing prices in charts and API responses by hiding pre-close data until the exact close is available, even while the snapshot is pending.

- **Bug Fixes**
  - API: added `binance` and `pyth`; for Binance `1d`, the closing row must match the exact end timestamp.
  - UI: for closed Binance-style daily crypto, do not render pre-close points or use fallback/rendered price; header shows final price in foreground while keeping the delta color.
  - Hook/Logic: classify daily crypto series as requiring a canonical Binance close; expose `referenceSnapshotStatus` (loading/ready/unavailable); poll for the close after event end (~65s delay, every 10s, up to 5 minutes).
  - Docs/Types: OpenAPI and TS types updated to include `binance` and `pyth`.

<sup>Written for commit 0c4a972a15a9087d0a31f261c34d00b740a1c5b7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

