### PR TITLE
fix: use reference price for market baseline

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventLiveSeriesChart.tsx
@@ -195,8 +195,6 @@ function EventLiveSeriesChartContent({
   const {
     referenceSnapshot,
     referenceSnapshotStatus,
-    baselinePrice,
-    setBaselinePrice,
     persistedFallbackPrice: snapshotFallbackPrice,
   } = useLiveSeriesPriceSnapshot({
     config,
@@ -227,7 +225,6 @@ function EventLiveSeriesChartContent({
     eventEndTimestamp: explicitEndTimestamp,
     subscriptionSymbol,
     isLiveView: isLiveView && !isEventClosed,
-    setBaselinePrice,
   })
 
   const isMarketClosed = useMemo(() => {
@@ -463,9 +460,7 @@ function EventLiveSeriesChartContent({
     requiresCanonicalClose: requiresCanonicalBinanceClose,
   })
   const axisSourceData = renderData
-  const resolvedBaselinePrice = isEventClosed
-    ? referenceOpeningPrice
-    : baselinePrice ?? referenceOpeningPrice
+  const resolvedBaselinePrice = referenceOpeningPrice
   const precisionReferencePrice = currentPrice
     ?? resolvedBaselinePrice
     ?? referenceSnapshot?.latest_price

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesPriceSnapshot.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesPriceSnapshot.ts
@@ -4,7 +4,7 @@ import type {
   PersistedLivePrice,
 } from '../_utils/eventLiveSeriesChartUtils'
 import type { EventLiveChartConfig } from '@/types'
-import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
+import { useCallback, useMemo, useSyncExternalStore } from 'react'
 import {
   LIVE_DATA_RETENTION_MS,
   normalizeLiveChartPrice,
@@ -22,8 +22,6 @@ interface UseLiveSeriesPriceSnapshotOptions {
 export interface LiveSeriesPriceSnapshotResult {
   referenceSnapshot: LiveSeriesPriceSnapshot | null
   referenceSnapshotStatus: LiveSeriesPriceSnapshotStatus
-  baselinePrice: number | null
-  setBaselinePrice: React.Dispatch<React.SetStateAction<number | null>>
   persistedFallbackPrice: PersistedLivePrice | null
 }
 
@@ -449,21 +447,9 @@ export function useLiveSeriesPriceSnapshot({
     getServerSnapshot,
   )
 
-  const [baselinePrice, setBaselinePrice] = useState<number | null>(null)
-
-  const effectiveBaselinePrice = baselinePrice ?? (
-    typeof referenceSnapshot.referenceSnapshot?.opening_price === 'number'
-    && Number.isFinite(referenceSnapshot.referenceSnapshot.opening_price)
-    && referenceSnapshot.referenceSnapshot.opening_price > 0
-      ? referenceSnapshot.referenceSnapshot.opening_price
-      : null
-  )
-
   return {
     referenceSnapshot: referenceSnapshot.referenceSnapshot,
     referenceSnapshotStatus: referenceSnapshot.referenceSnapshotStatus,
-    baselinePrice: effectiveBaselinePrice,
-    setBaselinePrice,
     persistedFallbackPrice: referenceSnapshot.persistedFallbackPrice,
   }
 }

--- a/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket.ts
@@ -21,7 +21,6 @@ interface UseLiveSeriesWebSocketOptions {
   eventEndTimestamp: number | null
   subscriptionSymbol: string
   isLiveView: boolean
-  setBaselinePrice: React.Dispatch<React.SetStateAction<number | null>>
 }
 
 export function useLiveSeriesWebSocket({
@@ -30,7 +29,6 @@ export function useLiveSeriesWebSocket({
   eventEndTimestamp,
   subscriptionSymbol,
   isLiveView,
-  setBaselinePrice,
 }: UseLiveSeriesWebSocketOptions) {
   const { wsLiveDataUrl } = usePublicRuntimeConfig()
   const wsUrl = wsLiveDataUrl
@@ -185,8 +183,6 @@ export function useLiveSeriesWebSocket({
           transitionDurationMs,
         )
       })
-
-      setBaselinePrice(current => current ?? wsUpdatesForRender[0]?.price ?? null)
     }
 
     function handleError() {
@@ -259,7 +255,7 @@ export function useLiveSeriesWebSocket({
         })
       }
     }
-  }, [eventEndTimestamp, eventType, topic, isLiveView, wsUrl, subscriptionSymbol, setBaselinePrice])
+  }, [eventEndTimestamp, eventType, topic, isLiveView, wsUrl, subscriptionSymbol])
 
   return { data, status }
 }

--- a/tests/unit/useLiveSeriesWebSocket.test.tsx
+++ b/tests/unit/useLiveSeriesWebSocket.test.tsx
@@ -1,5 +1,4 @@
 import { act, cleanup, renderHook } from '@testing-library/react'
-import { useState } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { useLiveSeriesWebSocket } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useLiveSeriesWebSocket'
 import {
@@ -62,19 +61,13 @@ describe('useLiveSeriesWebSocket', () => {
   })
 
   function mountHook(eventEndTimestamp: number | null = null) {
-    const view = renderHook(() => {
-      const [baseline, setBaseline] = useState<number | null>(null)
-      const live = useLiveSeriesWebSocket({
-        topic: 'crypto_prices',
-        eventType: 'price',
-        eventEndTimestamp,
-        subscriptionSymbol: 'BTC',
-        isLiveView: true,
-        setBaselinePrice: setBaseline,
-      })
-
-      return { ...live, baseline }
-    })
+    const view = renderHook(() => useLiveSeriesWebSocket({
+      topic: 'crypto_prices',
+      eventType: 'price',
+      eventEndTimestamp,
+      subscriptionSymbol: 'BTC',
+      isLiveView: true,
+    }))
 
     const socket = MockWebSocket.instances[0]!
     act(() => socket.emitOpen())
@@ -100,7 +93,6 @@ describe('useLiveSeriesWebSocket', () => {
     expect(result.current.data.map(point => [point.date.getTime(), point[SERIES_KEY]])).toEqual(
       snapshot.map(point => [point.timestamp, point.value]),
     )
-    expect(result.current.baseline).toBe(100)
     expect(result.current.status).toBe('live')
   })
 
@@ -146,7 +138,6 @@ describe('useLiveSeriesWebSocket', () => {
     expect(firstPrice).toBeLessThan(110)
     expect(transition.at(-1)?.date.getTime()).toBe(retargetStart + duration)
     expect(transition.at(-1)?.[SERIES_KEY]).toBe(90)
-    expect(result.current.baseline).toBe(100)
   })
 
   it('finishes the last transition at the event cutoff and ignores later updates', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use the reference opening price as the market baseline for live charts. Removes the WebSocket-derived baseline to keep the chart stable and consistent.

- **Bug Fixes**
  - Always resolve the baseline from `referenceOpeningPrice` (no fallback to first live tick).
  - Removed baseline state and setter from `useLiveSeriesPriceSnapshot` and `useLiveSeriesWebSocket`, and updated the chart accordingly.
  - Updated tests to reflect the new baseline logic.

<sup>Written for commit e33e29e61ed69eff3229d9abbd3830ae0234f9ce. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

