### PR TITLE
fix: use compact sports team labels

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
@@ -18,7 +18,7 @@ import { isEventResolvedLike } from '@/lib/home-events'
 import { resolveHomeSportsButtonChance, resolveResolvedHomeSportsMoneylineWinner } from '@/lib/sports-home-card'
 import { parseSportsScore } from '@/lib/sports-resolution'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
-import { resolveCompactSportsTeamName } from '@/lib/sports-team-label'
+import { resolveCompactSportsTeamNames } from '@/lib/sports-team-label'
 import { cn } from '@/lib/utils'
 
 export interface EventCardSportsMoneylineProps {
@@ -207,15 +207,15 @@ function getButtonToneStyles(button: HomeSportsMoneylineButton) {
 }
 
 function resolveButtonDisplayLabel(
-  model: HomeSportsMoneylineModel,
   button: HomeSportsMoneylineButton,
   drawLabel: string,
+  teamLabels: [string, string],
 ) {
   if (button.tone === 'team1') {
-    return resolveCompactSportsTeamName(model.team1.name, button.label)
+    return teamLabels[0]
   }
   if (button.tone === 'team2') {
-    return resolveCompactSportsTeamName(model.team2.name, button.label)
+    return teamLabels[1]
   }
   return drawLabel
 }
@@ -284,6 +284,10 @@ export default function EventCardSportsMoneyline({
   const parsedLiveScore = showLiveScore ? parseSportsScore(event.sports_score) : null
   const team1Score = parsedLiveScore?.team1 ?? null
   const team2Score = parsedLiveScore?.team2 ?? null
+  const compactTeamLabels = resolveCompactSportsTeamNames(
+    { name: model.team1.name, fallback: model.team1Button.label },
+    { name: model.team2.name, fallback: model.team2Button.label },
+  )
 
   return (
     <Card
@@ -403,7 +407,7 @@ export default function EventCardSportsMoneyline({
                       .filter((button): button is HomeSportsMoneylineButton => Boolean(button))
                       .map((button) => {
                         const toneStyles = getButtonToneStyles(button)
-                        const displayLabel = resolveButtonDisplayLabel(model, button, t('Draw'))
+                        const displayLabel = resolveButtonDisplayLabel(button, t('Draw'), compactTeamLabels)
 
                         return (
                           <Link

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardSportsMoneyline.tsx
@@ -18,6 +18,7 @@ import { isEventResolvedLike } from '@/lib/home-events'
 import { resolveHomeSportsButtonChance, resolveResolvedHomeSportsMoneylineWinner } from '@/lib/sports-home-card'
 import { parseSportsScore } from '@/lib/sports-resolution'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
+import { resolveCompactSportsTeamName } from '@/lib/sports-team-label'
 import { cn } from '@/lib/utils'
 
 export interface EventCardSportsMoneylineProps {
@@ -211,14 +212,12 @@ function resolveButtonDisplayLabel(
   drawLabel: string,
 ) {
   if (button.tone === 'team1') {
-    return model.team1.name
+    return resolveCompactSportsTeamName(model.team1.name, button.label)
   }
-
   if (button.tone === 'team2') {
-    return model.team2.name
+    return resolveCompactSportsTeamName(model.team2.name, button.label)
   }
-
-  return button.tone === 'draw' ? drawLabel : button.label
+  return drawLabel
 }
 
 export default function EventCardSportsMoneyline({

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -62,7 +62,11 @@ import { resolveEventOutcomePath, resolveEventPagePath } from '@/lib/events-rout
 import { formatDollarValueLabel, formatVolume } from '@/lib/formatters'
 import { resolveHomeFeaturedSportsScoreboardContent } from '@/lib/home-featured-sports-score'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
-import { resolveCompactSportsTeamName } from '@/lib/sports-team-label'
+import {
+  preserveSportsButtonPeriodSuffix,
+  resolveCompactSportsTeamNames,
+  resolveSportsButtonPeriodSuffix,
+} from '@/lib/sports-team-label'
 import { cn } from '@/lib/utils'
 
 interface HomeFeaturedEventsCarouselProps {
@@ -626,7 +630,9 @@ function SportsMoneylineButtons({
             groupLabel={t('Moneyline')}
             market={toFeaturedSportsButtonMarket(
               button,
-              isDraw ? t('Draw') : resolveMoneylineButtonLabel(card, button),
+              isDraw
+                ? preserveSportsButtonPeriodSuffix(t('Draw'), button.label)
+                : resolveMoneylineButtonLabel(card, moneylineButtons, button),
             )}
             href={resolveFeaturedSportsButtonHref(card, button, linkedHref)}
             className={cn(
@@ -660,14 +666,28 @@ function compareSportsButtonsByTone(left: SportsGamesButton, right: SportsGamesB
   return left.key.localeCompare(right.key)
 }
 
-function resolveMoneylineButtonLabel(card: SportsGamesCard, button: SportsGamesButton) {
-  if (button.tone === 'team1') {
-    return resolveCompactSportsTeamName(card.teams[0]?.name, button.label)
+function resolveMoneylineButtonLabel(
+  card: SportsGamesCard,
+  buttons: SportsGamesButton[],
+  button: SportsGamesButton,
+) {
+  if (button.tone !== 'team1' && button.tone !== 'team2') {
+    return button.label
   }
-  if (button.tone === 'team2') {
-    return resolveCompactSportsTeamName(card.teams[1]?.name, button.label)
-  }
-  return button.label
+
+  const periodSuffix = resolveSportsButtonPeriodSuffix(button.label)
+  const team1Button = buttons.find(candidate =>
+    candidate.tone === 'team1'
+    && resolveSportsButtonPeriodSuffix(candidate.label) === periodSuffix)
+  const team2Button = buttons.find(candidate =>
+    candidate.tone === 'team2'
+    && resolveSportsButtonPeriodSuffix(candidate.label) === periodSuffix)
+  const labels = resolveCompactSportsTeamNames(
+    { name: card.teams[0]?.name, fallback: team1Button?.label ?? button.label },
+    { name: card.teams[1]?.name, fallback: team2Button?.label ?? button.label },
+  )
+
+  return button.tone === 'team1' ? labels[0] : labels[1]
 }
 
 function resolveFeaturedSportsButtonTone(button: SportsGamesButton): FeaturedSportsButtonTone {

--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -62,6 +62,7 @@ import { resolveEventOutcomePath, resolveEventPagePath } from '@/lib/events-rout
 import { formatDollarValueLabel, formatVolume } from '@/lib/formatters'
 import { resolveHomeFeaturedSportsScoreboardContent } from '@/lib/home-featured-sports-score'
 import { resolveSportsTeamFallbackClassName } from '@/lib/sports-team-colors'
+import { resolveCompactSportsTeamName } from '@/lib/sports-team-label'
 import { cn } from '@/lib/utils'
 
 interface HomeFeaturedEventsCarouselProps {
@@ -661,10 +662,10 @@ function compareSportsButtonsByTone(left: SportsGamesButton, right: SportsGamesB
 
 function resolveMoneylineButtonLabel(card: SportsGamesCard, button: SportsGamesButton) {
   if (button.tone === 'team1') {
-    return card.teams[0]?.name ?? button.label
+    return resolveCompactSportsTeamName(card.teams[0]?.name, button.label)
   }
   if (button.tone === 'team2') {
-    return card.teams[1]?.name ?? button.label
+    return resolveCompactSportsTeamName(card.teams[1]?.name, button.label)
   }
   return button.label
 }

--- a/src/lib/sports-team-label.ts
+++ b/src/lib/sports-team-label.ts
@@ -76,6 +76,15 @@ function normalizeComparableLabel(value: string) {
   return value.normalize('NFKD').replace(/[\u0300-\u036F]/g, '').toLowerCase()
 }
 
+function ensureDistinctCollisionMarkers(firstMarker: string | undefined, secondMarker: string | undefined) {
+  const resolvedFirstMarker = firstMarker?.toUpperCase() ?? '1'
+  const resolvedSecondMarker = secondMarker?.toUpperCase() ?? '2'
+
+  return resolvedFirstMarker === resolvedSecondMarker
+    ? [resolvedFirstMarker, resolvedFirstMarker === '1' ? '2' : '1'] as const
+    : [resolvedFirstMarker, resolvedSecondMarker] as const
+}
+
 function resolveCollisionMarkers(firstName: string | null | undefined, secondName: string | null | undefined) {
   const firstComparable = normalizeComparableLabel(normalizeLabel(firstName)).replace(/[^a-z0-9]/g, '')
   const secondComparable = normalizeComparableLabel(normalizeLabel(secondName)).replace(/[^a-z0-9]/g, '')
@@ -83,7 +92,7 @@ function resolveCollisionMarkers(firstName: string | null | undefined, secondNam
 
   for (let index = 0; index < maxLength; index += 1) {
     if (firstComparable[index] !== secondComparable[index]) {
-      return [firstComparable[index]?.toUpperCase() ?? '1', secondComparable[index]?.toUpperCase() ?? '2'] as const
+      return ensureDistinctCollisionMarkers(firstComparable[index], secondComparable[index])
     }
   }
 

--- a/src/lib/sports-team-label.ts
+++ b/src/lib/sports-team-label.ts
@@ -1,0 +1,24 @@
+const COMPACT_SPORTS_TEAM_NAME_MAX_LENGTH = 12
+
+export function resolveCompactSportsTeamName(
+  name: string | null | undefined,
+  fallback: string,
+) {
+  const normalizedName = name?.trim().replace(/\s+/g, ' ')
+  if (!normalizedName || normalizedName.length <= COMPACT_SPORTS_TEAM_NAME_MAX_LENGTH) {
+    return normalizedName || fallback
+  }
+
+  const words = normalizedName.split(' ')
+  let compactName = words[0] ?? fallback
+
+  for (const word of words.slice(1)) {
+    const candidate = `${compactName} ${word}`
+    if (candidate.length > COMPACT_SPORTS_TEAM_NAME_MAX_LENGTH) {
+      break
+    }
+    compactName = candidate
+  }
+
+  return compactName
+}

--- a/src/lib/sports-team-label.ts
+++ b/src/lib/sports-team-label.ts
@@ -1,24 +1,126 @@
 const COMPACT_SPORTS_TEAM_NAME_MAX_LENGTH = 12
+const SPORTS_PERIOD_SUFFIX_PATTERN = /\s+([12]H)$/i
 
-export function resolveCompactSportsTeamName(
+export interface CompactSportsTeamLabelInput {
+  name: string | null | undefined
+  fallback: string
+}
+
+function normalizeLabel(value: string | null | undefined) {
+  return value?.trim().replace(/\s+/g, ' ') ?? ''
+}
+
+export function resolveSportsButtonPeriodSuffix(label: string | null | undefined) {
+  return normalizeLabel(label).match(SPORTS_PERIOD_SUFFIX_PATTERN)?.[1]?.toUpperCase() ?? null
+}
+
+export function preserveSportsButtonPeriodSuffix(label: string, sourceLabel: string) {
+  const suffix = resolveSportsButtonPeriodSuffix(sourceLabel)
+  const normalizedLabel = normalizeLabel(label)
+  return suffix && resolveSportsButtonPeriodSuffix(normalizedLabel) !== suffix
+    ? `${normalizedLabel} ${suffix}`
+    : normalizedLabel
+}
+
+function stripSportsButtonPeriodSuffix(label: string) {
+  return normalizeLabel(label).replace(SPORTS_PERIOD_SUFFIX_PATTERN, '')
+}
+
+function resolveBaseLabelMaxLength(fallback: string) {
+  const suffix = resolveSportsButtonPeriodSuffix(fallback)
+  return COMPACT_SPORTS_TEAM_NAME_MAX_LENGTH - (suffix ? suffix.length + 1 : 0)
+}
+
+function resolveBoundedFallback(name: string | null | undefined, fallback: string) {
+  const maxLength = resolveBaseLabelMaxLength(fallback)
+  const fallbackBase = stripSportsButtonPeriodSuffix(fallback)
+  const normalizedName = normalizeLabel(name)
+  const baseLabel = fallbackBase || normalizedName
+  const boundedBaseLabel = baseLabel.length <= maxLength
+    ? baseLabel
+    : baseLabel.slice(0, maxLength).trim()
+
+  return preserveSportsButtonPeriodSuffix(boundedBaseLabel, fallback)
+}
+
+function resolveCompactSportsTeamName(
   name: string | null | undefined,
   fallback: string,
 ) {
-  const normalizedName = name?.trim().replace(/\s+/g, ' ')
-  if (!normalizedName || normalizedName.length <= COMPACT_SPORTS_TEAM_NAME_MAX_LENGTH) {
-    return normalizedName || fallback
+  const normalizedName = normalizeLabel(name)
+  const maxLength = resolveBaseLabelMaxLength(fallback)
+  if (!normalizedName) {
+    return resolveBoundedFallback(name, fallback)
+  }
+  if (normalizedName.length <= maxLength) {
+    return preserveSportsButtonPeriodSuffix(normalizedName, fallback)
   }
 
   const words = normalizedName.split(' ')
-  let compactName = words[0] ?? fallback
+  let compactName = ''
 
-  for (const word of words.slice(1)) {
-    const candidate = `${compactName} ${word}`
-    if (candidate.length > COMPACT_SPORTS_TEAM_NAME_MAX_LENGTH) {
+  for (const word of words) {
+    const candidate = compactName ? `${compactName} ${word}` : word
+    if (candidate.length > maxLength) {
       break
     }
     compactName = candidate
   }
 
   return compactName
+    ? preserveSportsButtonPeriodSuffix(compactName, fallback)
+    : resolveBoundedFallback(name, fallback)
+}
+
+function normalizeComparableLabel(value: string) {
+  return value.normalize('NFKD').replace(/[\u0300-\u036F]/g, '').toLowerCase()
+}
+
+function resolveCollisionMarkers(firstName: string | null | undefined, secondName: string | null | undefined) {
+  const firstComparable = normalizeComparableLabel(normalizeLabel(firstName)).replace(/[^a-z0-9]/g, '')
+  const secondComparable = normalizeComparableLabel(normalizeLabel(secondName)).replace(/[^a-z0-9]/g, '')
+  const maxLength = Math.max(firstComparable.length, secondComparable.length)
+
+  for (let index = 0; index < maxLength; index += 1) {
+    if (firstComparable[index] !== secondComparable[index]) {
+      return [firstComparable[index]?.toUpperCase() ?? '1', secondComparable[index]?.toUpperCase() ?? '2'] as const
+    }
+  }
+
+  return ['1', '2'] as const
+}
+
+function appendCollisionMarker(label: string, fallback: string, marker: string) {
+  const maxBaseLength = Math.max(1, resolveBaseLabelMaxLength(fallback) - marker.length - 1)
+  const baseLabel = stripSportsButtonPeriodSuffix(label).slice(0, maxBaseLength).trim()
+  return preserveSportsButtonPeriodSuffix(`${baseLabel} ${marker}`, fallback)
+}
+
+export function resolveCompactSportsTeamNames(
+  first: CompactSportsTeamLabelInput,
+  second: CompactSportsTeamLabelInput,
+): [string, string] {
+  const compactLabels: [string, string] = [
+    resolveCompactSportsTeamName(first.name, first.fallback),
+    resolveCompactSportsTeamName(second.name, second.fallback),
+  ]
+
+  if (normalizeComparableLabel(compactLabels[0]) !== normalizeComparableLabel(compactLabels[1])) {
+    return compactLabels
+  }
+
+  const fallbackLabels: [string, string] = [
+    resolveBoundedFallback(first.name, first.fallback),
+    resolveBoundedFallback(second.name, second.fallback),
+  ]
+
+  if (normalizeComparableLabel(fallbackLabels[0]) !== normalizeComparableLabel(fallbackLabels[1])) {
+    return fallbackLabels
+  }
+
+  const markers = resolveCollisionMarkers(first.name, second.name)
+  return [
+    appendCollisionMarker(compactLabels[0], first.fallback, markers[0]),
+    appendCollisionMarker(compactLabels[1], second.fallback, markers[1]),
+  ]
 }


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Use compact sports team labels on moneyline buttons in home sports cards and the featured events carousel. Labels fit within 12 chars, keep 1H/2H suffixes, and use distinct markers to avoid collisions.

- **Bug Fixes**
  - Hardened `resolveCompactSportsTeamNames`: suffix-aware length, normalized comparisons, and distinct collision markers; added `resolveSportsButtonPeriodSuffix` and `preserveSportsButtonPeriodSuffix`.
  - Carousel labels resolve per period by matching team buttons via period suffix before compacting; draw uses the Draw label with suffix preserved. Applied in `EventCardSportsMoneyline` and `HomeFeaturedEventsCarousel`.

<sup>Written for commit 164fe97409f300a538795d4c618ac2fbf96eaf3a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

