### PR TITLE
feat: stop Chainlink orders at market end

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -62,7 +62,11 @@ import { CLOB_ORDER_TYPE, getExchangeEip712Domain, ORDER_SIDE, ORDER_TYPE, OUTCO
 import { resolveEventPagePath } from '@/lib/events-routing'
 import { formatCentsLabel, formatCentsValueLabel, formatCurrency, formatDollarValueLabel, formatSharesLabel, toCents } from '@/lib/formatters'
 import { resolveFallbackOutcomeUnitPrice, resolveMarketOutcome } from '@/lib/market-pricing'
-import { isChainlinkMarketEnded } from '@/lib/mirror-resolution'
+import {
+  getMarketEndTimestamp,
+  getMirrorResolutionType,
+  isChainlinkMarketEnded,
+} from '@/lib/mirror-resolution'
 import {
   isCurrentNegRiskAdapterAddress,
   resolveNegRiskAdapterAddressFromMetadata,
@@ -808,6 +812,48 @@ function useOrderValidationFeedback() {
   }
 }
 
+const MAX_MARKET_END_TIMEOUT_MS = 2_147_483_647
+
+function useHasReachedChainlinkEnd(market: Market | null | undefined) {
+  const mirrorResolutionType = market ? getMirrorResolutionType(market) : null
+  const endTimestamp = market ? getMarketEndTimestamp(market) : null
+  const subscribe = useCallback((onStoreChange: () => void) => {
+    if (mirrorResolutionType !== 'chainlink' || endTimestamp == null) {
+      return () => {}
+    }
+
+    let timeout: number | null = null
+    const scheduledEndTimestamp = endTimestamp
+
+    function scheduleMarketEndUpdate() {
+      const remainingMs = scheduledEndTimestamp - Date.now()
+      timeout = window.setTimeout(() => {
+        if (Date.now() >= scheduledEndTimestamp) {
+          onStoreChange()
+          return
+        }
+        scheduleMarketEndUpdate()
+      }, Math.max(0, Math.min(remainingMs, MAX_MARKET_END_TIMEOUT_MS)))
+    }
+
+    scheduleMarketEndUpdate()
+    return () => {
+      if (timeout != null) {
+        window.clearTimeout(timeout)
+      }
+    }
+  }, [endTimestamp, mirrorResolutionType])
+  const getSnapshot = useCallback(
+    () => mirrorResolutionType === 'chainlink'
+      && endTimestamp != null
+      && Date.now() >= endTimestamp,
+    [endTimestamp, mirrorResolutionType],
+  )
+  const getServerSnapshot = useCallback(() => false, [])
+
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot)
+}
+
 export default function EventOrderPanelForm({
   event,
   isMobile,
@@ -834,7 +880,7 @@ export default function EventOrderPanelForm({
   const site = useSiteIdentity()
   const arbitrageConfig = useArbitrageConfig()
   const locale = useLocale()
-  const currentTimestamp = useCurrentTimestamp({ intervalMs: 1_000 })
+  const currentTimestamp = useCurrentTimestamp({ intervalMs: 60_000 })
   const normalizeOutcomeLabel = useOutcomeLabel()
   const affiliateMetadata = useAffiliateOrderMetadata()
   const builderCode = useMemo(
@@ -978,11 +1024,7 @@ export default function EventOrderPanelForm({
     currentTimestamp,
     resolveDisplayOutcomeLabel,
   })
-  const hasReachedChainlinkEnd = Boolean(
-    activeMarket
-    && currentTimestamp != null
-    && isChainlinkMarketEnded(activeMarket, currentTimestamp),
-  )
+  const hasReachedChainlinkEnd = useHasReachedChainlinkEnd(activeMarket)
   const isPausedMarket = Boolean(
     activeMarket
     && (activeMarket.accepting_orders === false || hasReachedChainlinkEnd)
@@ -1219,7 +1261,20 @@ export default function EventOrderPanelForm({
     setTimeout(setShouldShakeInput, 320, false)
   }
 
+  function ensureChainlinkMarketAcceptsSubmission(market: Market | null | undefined) {
+    if (!market || !isChainlinkMarketEnded(market, Date.now())) {
+      return true
+    }
+
+    toast.info(t('Market Paused'))
+    return false
+  }
+
   async function submitOrderFlow(options: { confirmedSlippageWarning?: boolean } = {}) {
+    if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
+      return
+    }
+
     if (options.confirmedSlippageWarning) {
       clearSlippageWarning()
     }
@@ -1467,6 +1522,10 @@ export default function EventOrderPanelForm({
 
     state.setIsLoading(true)
     try {
+      if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
+        return
+      }
+
       const result = await submitOrder({
         order: payload,
         signature,
@@ -1605,8 +1664,7 @@ export default function EventOrderPanelForm({
   }
 
   async function onSubmit() {
-    if (activeMarket && isChainlinkMarketEnded(activeMarket, Date.now())) {
-      toast.info(t('Market Paused'))
+    if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
       return
     }
     await submitOrderFlow()
@@ -1789,6 +1847,9 @@ export default function EventOrderPanelForm({
     if (!ensureTradingReady() || !activeMarket || !makerAddress || !userAddress) {
       return
     }
+    if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
+      return
+    }
     if (!(quote.totalCost > 0) || !(quote.shares > 0)) {
       toast.error(t('Enter a valid amount.'))
       return
@@ -1903,6 +1964,10 @@ export default function EventOrderPanelForm({
       )
 
       setArbitrageSubmissionStep(3)
+      if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
+        return
+      }
+
       const [kuestResult, polymarketResult] = await Promise.allSettled([
         submitOrder({
           order: kuestOrder,
@@ -2000,6 +2065,9 @@ export default function EventOrderPanelForm({
 
   async function handleOutcomeArbitrageSubmit(quote: OutcomeArbitrageQuote) {
     if (!ensureTradingReady() || !activeMarket || !makerAddress || !userAddress) {
+      return
+    }
+    if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
       return
     }
     if (isNegRiskMarket && !isCurrentNegRiskAdapterAddress(negRiskAdapterAddress)) {
@@ -2126,6 +2194,10 @@ export default function EventOrderPanelForm({
       )
 
       setArbitrageSubmissionStep(3)
+      if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
+        return
+      }
+
       const batchResult = await submitOrders([
         {
           order: yesOrder,

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -62,6 +62,7 @@ import { CLOB_ORDER_TYPE, getExchangeEip712Domain, ORDER_SIDE, ORDER_TYPE, OUTCO
 import { resolveEventPagePath } from '@/lib/events-routing'
 import { formatCentsLabel, formatCentsValueLabel, formatCurrency, formatDollarValueLabel, formatSharesLabel, toCents } from '@/lib/formatters'
 import { resolveFallbackOutcomeUnitPrice, resolveMarketOutcome } from '@/lib/market-pricing'
+import { isChainlinkMarketEnded } from '@/lib/mirror-resolution'
 import {
   isCurrentNegRiskAdapterAddress,
   resolveNegRiskAdapterAddressFromMetadata,
@@ -833,7 +834,7 @@ export default function EventOrderPanelForm({
   const site = useSiteIdentity()
   const arbitrageConfig = useArbitrageConfig()
   const locale = useLocale()
-  const currentTimestamp = useCurrentTimestamp({ intervalMs: 60_000 })
+  const currentTimestamp = useCurrentTimestamp({ intervalMs: 1_000 })
   const normalizeOutcomeLabel = useOutcomeLabel()
   const affiliateMetadata = useAffiliateOrderMetadata()
   const builderCode = useMemo(
@@ -977,7 +978,16 @@ export default function EventOrderPanelForm({
     currentTimestamp,
     resolveDisplayOutcomeLabel,
   })
-  const isPausedMarket = Boolean(activeMarket && activeMarket.accepting_orders === false && !isResolvedMarket)
+  const hasReachedChainlinkEnd = Boolean(
+    activeMarket
+    && currentTimestamp != null
+    && isChainlinkMarketEnded(activeMarket, currentTimestamp),
+  )
+  const isPausedMarket = Boolean(
+    activeMarket
+    && (activeMarket.accepting_orders === false || hasReachedChainlinkEnd)
+    && !isResolvedMarket,
+  )
   const isTradingDisabled = isResolvedMarket || isPausedMarket
   const orderDomain = useMemo(() => getExchangeEip712Domain(isNegRiskMarket), [isNegRiskMarket])
   const { positionsQuery, aggregatedPositionShares } = useEventOrderPanelPositions({
@@ -1595,6 +1605,10 @@ export default function EventOrderPanelForm({
   }
 
   async function onSubmit() {
+    if (activeMarket && isChainlinkMarketEnded(activeMarket, Date.now())) {
+      toast.info(t('Market Paused'))
+      return
+    }
     await submitOrderFlow()
   }
 

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventRules.tsx
@@ -20,6 +20,7 @@ import {
   UMA_NEG_RISK_ADAPTER_POLYMARKET_ADDRESS,
 } from '@/lib/contracts'
 import { isDirectResolutionMarket } from '@/lib/direct-resolution'
+import { getMirrorResolutionType } from '@/lib/mirror-resolution'
 import { resolveUmaProposeTarget } from '@/lib/uma'
 import { cn } from '@/lib/utils'
 import { normalizeAddress } from '@/lib/wallet'
@@ -281,6 +282,12 @@ export default function EventRules({ event, mode = 'accordion', showEndDate = fa
   }
 
   const primaryMarket = event.markets[0]
+  const mirrorResolutionType = primaryMarket ? getMirrorResolutionType(primaryMarket) : null
+  const mirrorResolutionLabel = mirrorResolutionType === 'chainlink'
+    ? 'Chainlink'
+    : mirrorResolutionType === 'uma'
+      ? 'UMA'
+      : null
   const isDirectResolver = primaryMarket ? isDirectResolutionMarket(primaryMarket) : false
   const proposeTarget = isDirectResolver ? null : resolveUmaProposeTarget(primaryMarket?.condition, siteIdentity.name)
   const resolverAddress = proposeTarget?.isMirror
@@ -402,6 +409,7 @@ export default function EventRules({ event, mode = 'accordion', showEndDate = fa
             <div className="min-w-0">
               <div className="text-xs text-muted-foreground">
                 {t('Resolution Source')}
+                {mirrorResolutionLabel ? ` · ${mirrorResolutionLabel}` : ''}
               </div>
               <a
                 href={resolutionSourceUrl}

--- a/src/lib/mirror-resolution.ts
+++ b/src/lib/mirror-resolution.ts
@@ -1,0 +1,52 @@
+import type { Market } from '@/types'
+
+export type MirrorResolutionType = 'chainlink' | 'uma'
+
+function parseMetadata(market: Market): Record<string, unknown> {
+  if (!market.metadata) {
+    return {}
+  }
+  if (typeof market.metadata === 'string') {
+    try {
+      const parsed = JSON.parse(market.metadata) as unknown
+      return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
+        ? parsed as Record<string, unknown>
+        : {}
+    }
+    catch {
+      return {}
+    }
+  }
+  return typeof market.metadata === 'object' && !Array.isArray(market.metadata)
+    ? market.metadata as Record<string, unknown>
+    : {}
+}
+
+export function getMirrorResolutionType(market: Market): MirrorResolutionType | null {
+  const value = parseMetadata(market).mirror_resolution_type
+  return value === 'chainlink' || value === 'uma' ? value : null
+}
+
+export function getMirrorOracleAddress(market: Market): string | null {
+  const value = parseMetadata(market).mirror_oracle_address
+  return typeof value === 'string' && value.trim() ? value.trim() : null
+}
+
+export function getMarketEndTimestamp(market: Market): number | null {
+  const metadataEndTime = parseMetadata(market).end_time
+  const value = market.end_time
+    ?? (typeof metadataEndTime === 'string' ? metadataEndTime : null)
+  if (!value) {
+    return null
+  }
+  const timestamp = Date.parse(value)
+  return Number.isFinite(timestamp) ? timestamp : null
+}
+
+export function isChainlinkMarketEnded(market: Market, nowMs: number): boolean {
+  if (getMirrorResolutionType(market) !== 'chainlink') {
+    return false
+  }
+  const endTimestamp = getMarketEndTimestamp(market)
+  return endTimestamp != null && nowMs >= endTimestamp
+}

--- a/src/lib/mirror-resolution.ts
+++ b/src/lib/mirror-resolution.ts
@@ -32,15 +32,40 @@ export function getMirrorOracleAddress(market: Market): string | null {
   return typeof value === 'string' && value.trim() ? value.trim() : null
 }
 
-export function getMarketEndTimestamp(market: Market): number | null {
-  const metadataEndTime = parseMetadata(market).end_time
-  const value = market.end_time
-    ?? (typeof metadataEndTime === 'string' ? metadataEndTime : null)
-  if (!value) {
+function normalizeEndTimestamp(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    const timestamp = value > 10_000_000_000 ? value : value * 1000
+    return Number.isFinite(timestamp) ? timestamp : null
+  }
+
+  if (typeof value !== 'string') {
     return null
   }
-  const timestamp = Date.parse(value)
+
+  const text = value.trim()
+  if (!text) {
+    return null
+  }
+
+  if (/^\d+(?:\.\d+)?$/.test(text)) {
+    const numeric = Number(text)
+    if (Number.isFinite(numeric)) {
+      const timestamp = numeric > 10_000_000_000 ? numeric : numeric * 1000
+      return Number.isFinite(timestamp) ? timestamp : null
+    }
+  }
+
+  const normalized = /^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}$/.test(text)
+    ? `${text.replace(' ', 'T')}Z`
+    : text
+  const timestamp = Date.parse(normalized)
   return Number.isFinite(timestamp) ? timestamp : null
+}
+
+export function getMarketEndTimestamp(market: Market): number | null {
+  const metadataEndTime = parseMetadata(market).end_time
+  return normalizeEndTimestamp(market.end_time)
+    ?? normalizeEndTimestamp(metadataEndTime)
 }
 
 export function isChainlinkMarketEnded(market: Market, nowMs: number): boolean {

--- a/tests/unit/mirrorResolution.test.ts
+++ b/tests/unit/mirrorResolution.test.ts
@@ -1,0 +1,39 @@
+import type { Market } from '@/types'
+import { describe, expect, it } from 'vitest'
+import {
+  getMarketEndTimestamp,
+  getMirrorOracleAddress,
+  getMirrorResolutionType,
+  isChainlinkMarketEnded,
+} from '@/lib/mirror-resolution'
+
+function market(metadata: Record<string, unknown>, endTime = '2026-07-27T12:00:00Z') {
+  return {
+    metadata,
+    end_time: endTime,
+  } as Market
+}
+
+describe('mirror resolution metadata', () => {
+  it('reads the validated mirror source fields', () => {
+    const value = market({
+      mirror_resolution_type: 'chainlink',
+      mirror_oracle_address: '0x58e1745bEdda7312C4CDdb72618923da1B90EfDE',
+    })
+
+    expect(getMirrorResolutionType(value)).toBe('chainlink')
+    expect(getMirrorOracleAddress(value)).toBe('0x58e1745bEdda7312C4CDdb72618923da1B90EfDE')
+    expect(getMarketEndTimestamp(value)).toBe(Date.parse('2026-07-27T12:00:00Z'))
+  })
+
+  it('closes Chainlink trading exactly at end_time', () => {
+    const value = market({ mirror_resolution_type: 'chainlink' })
+    expect(isChainlinkMarketEnded(value, Date.parse('2026-07-27T11:59:59.999Z'))).toBe(false)
+    expect(isChainlinkMarketEnded(value, Date.parse('2026-07-27T12:00:00Z'))).toBe(true)
+  })
+
+  it('does not infer the source oracle from the interval', () => {
+    const value = market({ mirror_resolution_type: 'uma' })
+    expect(isChainlinkMarketEnded(value, Date.parse('2026-07-27T12:00:01Z'))).toBe(false)
+  })
+})

--- a/tests/unit/mirrorResolution.test.ts
+++ b/tests/unit/mirrorResolution.test.ts
@@ -7,7 +7,10 @@ import {
   isChainlinkMarketEnded,
 } from '@/lib/mirror-resolution'
 
-function market(metadata: Record<string, unknown>, endTime = '2026-07-27T12:00:00Z') {
+function market(
+  metadata: Record<string, unknown>,
+  endTime: string | null = '2026-07-27T12:00:00Z',
+) {
   return {
     metadata,
     end_time: endTime,
@@ -30,6 +33,33 @@ describe('mirror resolution metadata', () => {
     const value = market({ mirror_resolution_type: 'chainlink' })
     expect(isChainlinkMarketEnded(value, Date.parse('2026-07-27T11:59:59.999Z'))).toBe(false)
     expect(isChainlinkMarketEnded(value, Date.parse('2026-07-27T12:00:00Z'))).toBe(true)
+  })
+
+  it('normalizes numeric metadata end_time in Unix seconds or milliseconds', () => {
+    const expected = Date.parse('2026-07-27T12:00:00Z')
+    const seconds = market({
+      mirror_resolution_type: 'chainlink',
+      end_time: expected / 1000,
+    }, null)
+    const milliseconds = market({
+      mirror_resolution_type: 'chainlink',
+      end_time: expected,
+    }, null)
+
+    expect(getMarketEndTimestamp(seconds)).toBe(expected)
+    expect(getMarketEndTimestamp(milliseconds)).toBe(expected)
+    expect(isChainlinkMarketEnded(seconds, expected)).toBe(true)
+    expect(isChainlinkMarketEnded(milliseconds, expected)).toBe(true)
+  })
+
+  it('falls back to metadata when the market end_time is invalid', () => {
+    const expected = Date.parse('2026-07-27T12:00:00Z')
+    const value = market({
+      mirror_resolution_type: 'chainlink',
+      end_time: expected / 1000,
+    }, 'invalid')
+
+    expect(getMarketEndTimestamp(value)).toBe(expected)
   })
 
   it('does not infer the source oracle from the interval', () => {


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Stops new orders on Chainlink‑mirrored markets exactly at `end_time`, treating the market as paused and blocking late submissions across all flows. Also shows the resolution source in Event Rules.

- **New Features**
  - Treats Chainlink markets as paused at `end_time`; disables inputs and shows “Market Paused”.
  - Enforces the cutoff on every submit path (single, arbitrage, batch) before signing/sending.
  - Adds `mirror-resolution` utils to detect source and normalize `end_time` from market or metadata.
  - Displays “Chainlink” or “UMA” next to “Resolution Source” in Event Rules.
  - Adds unit tests for metadata parsing and the exact boundary behavior.

<sup>Written for commit d1d985f7df385aa1cd5a5eb68028e57a5a98711a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

