### PR TITLE
fix: limit pending resolution state to chainlink

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelAwaitingResolutionDisplay.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelAwaitingResolutionDisplay.tsx
@@ -19,7 +19,7 @@ export default function EventOrderPanelAwaitingResolutionDisplay({
       aria-live="polite"
     >
       <Loader2Icon className="size-10 animate-spin text-primary" aria-hidden="true" />
-      <h2 className="text-xl font-semibold text-foreground">
+      <h2 className="text-lg font-semibold text-foreground">
         {t('Hold on, determining winner...')}
       </h2>
       <div className="text-base/snug text-muted-foreground">

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventOrderPanelForm.tsx
@@ -67,7 +67,8 @@ import { formatCentsLabel, formatCentsValueLabel, formatCurrency, formatDollarVa
 import { resolveFallbackOutcomeUnitPrice, resolveMarketOutcome } from '@/lib/market-pricing'
 import {
   getMarketEndTimestamp,
-  isMarketEnded,
+  getMirrorResolutionType,
+  isChainlinkMarketEnded,
 } from '@/lib/mirror-resolution'
 import {
   isCurrentNegRiskAdapterAddress,
@@ -816,10 +817,11 @@ function useOrderValidationFeedback() {
 
 const MAX_MARKET_END_TIMEOUT_MS = 2_147_483_647
 
-function useHasReachedMarketEnd(market: Market | null | undefined) {
+function useHasReachedChainlinkEnd(market: Market | null | undefined) {
+  const mirrorResolutionType = market ? getMirrorResolutionType(market) : null
   const endTimestamp = market ? getMarketEndTimestamp(market) : null
   const subscribe = useCallback((onStoreChange: () => void) => {
-    if (endTimestamp == null) {
+    if (mirrorResolutionType !== 'chainlink' || endTimestamp == null) {
       return () => {}
     }
 
@@ -843,10 +845,12 @@ function useHasReachedMarketEnd(market: Market | null | undefined) {
         window.clearTimeout(timeout)
       }
     }
-  }, [endTimestamp])
+  }, [endTimestamp, mirrorResolutionType])
   const getSnapshot = useCallback(
-    () => endTimestamp != null && Date.now() >= endTimestamp,
-    [endTimestamp],
+    () => mirrorResolutionType === 'chainlink'
+      && endTimestamp != null
+      && Date.now() >= endTimestamp,
+    [endTimestamp, mirrorResolutionType],
   )
   const getServerSnapshot = useCallback(() => false, [])
 
@@ -1045,10 +1049,10 @@ export default function EventOrderPanelForm({
     currentTimestamp,
     resolveDisplayOutcomeLabel,
   })
-  const hasReachedMarketEnd = useHasReachedMarketEnd(activeMarket)
+  const hasReachedChainlinkEnd = useHasReachedChainlinkEnd(activeMarket)
   const isAwaitingResolution = Boolean(
     activeMarket
-    && hasReachedMarketEnd
+    && hasReachedChainlinkEnd
     && !isResolvedMarket,
   )
   const isPausedMarket = Boolean(
@@ -1289,8 +1293,8 @@ export default function EventOrderPanelForm({
     setTimeout(setShouldShakeInput, 320, false)
   }
 
-  function ensureMarketAcceptsSubmission(market: Market | null | undefined) {
-    if (!market || !isMarketEnded(market, Date.now())) {
+  function ensureChainlinkMarketAcceptsSubmission(market: Market | null | undefined) {
+    if (!market || !isChainlinkMarketEnded(market, Date.now())) {
       return true
     }
 
@@ -1299,7 +1303,7 @@ export default function EventOrderPanelForm({
   }
 
   async function submitOrderFlow(options: { confirmedSlippageWarning?: boolean } = {}) {
-    if (!ensureMarketAcceptsSubmission(activeMarket)) {
+    if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
       return
     }
 
@@ -1550,7 +1554,7 @@ export default function EventOrderPanelForm({
 
     state.setIsLoading(true)
     try {
-      if (!ensureMarketAcceptsSubmission(activeMarket)) {
+      if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
         return
       }
 
@@ -1692,7 +1696,7 @@ export default function EventOrderPanelForm({
   }
 
   async function onSubmit() {
-    if (!ensureMarketAcceptsSubmission(activeMarket)) {
+    if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
       return
     }
     await submitOrderFlow()
@@ -1875,7 +1879,7 @@ export default function EventOrderPanelForm({
     if (!ensureTradingReady() || !activeMarket || !makerAddress || !userAddress) {
       return
     }
-    if (!ensureMarketAcceptsSubmission(activeMarket)) {
+    if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
       return
     }
     if (!(quote.totalCost > 0) || !(quote.shares > 0)) {
@@ -1992,7 +1996,7 @@ export default function EventOrderPanelForm({
       )
 
       setArbitrageSubmissionStep(3)
-      if (!ensureMarketAcceptsSubmission(activeMarket)) {
+      if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
         return
       }
 
@@ -2095,7 +2099,7 @@ export default function EventOrderPanelForm({
     if (!ensureTradingReady() || !activeMarket || !makerAddress || !userAddress) {
       return
     }
-    if (!ensureMarketAcceptsSubmission(activeMarket)) {
+    if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
       return
     }
     if (isNegRiskMarket && !isCurrentNegRiskAdapterAddress(negRiskAdapterAddress)) {
@@ -2222,7 +2226,7 @@ export default function EventOrderPanelForm({
       )
 
       setArbitrageSubmissionStep(3)
-      if (!ensureMarketAcceptsSubmission(activeMarket)) {
+      if (!ensureChainlinkMarketAcceptsSubmission(activeMarket)) {
         return
       }
 

--- a/tests/unit/EventOrderPanelAwaitingResolutionDisplay.test.tsx
+++ b/tests/unit/EventOrderPanelAwaitingResolutionDisplay.test.tsx
@@ -14,7 +14,10 @@ describe('event order panel awaiting resolution display', () => {
       />,
     )
 
-    expect(screen.getByRole('status')).toHaveTextContent('Hold on, determining winner...')
+    const heading = screen.getByRole('heading', { name: 'Hold on, determining winner...' })
+
+    expect(heading).toHaveClass('text-lg')
+    expect(heading).not.toHaveClass('text-xl')
     expect(screen.getByText('Bitcoin Up or Down - July 27, 4PM ET')).toBeInTheDocument()
     expect(screen.getByRole('status')).toHaveTextContent(
       'This market has ended. Final resolution will appear automatically as soon as it is available on-chain.',

--- a/tests/unit/mirrorResolution.test.ts
+++ b/tests/unit/mirrorResolution.test.ts
@@ -68,6 +68,11 @@ describe('mirror resolution metadata', () => {
     expect(isChainlinkMarketEnded(value, Date.parse('2026-07-27T12:00:01Z'))).toBe(false)
   })
 
+  it('does not close a regular market only because its end_time is in the past', () => {
+    const value = market({}, '2026-07-24T12:00:00Z')
+    expect(isChainlinkMarketEnded(value, Date.parse('2026-07-27T12:00:00Z'))).toBe(false)
+  })
+
   it('closes UMA trading at the same market end_time boundary', () => {
     const value = market({ mirror_resolution_type: 'uma' })
     expect(isMarketEnded(value, Date.parse('2026-07-27T11:59:59.999Z'))).toBe(false)


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Restricts the “Awaiting resolution” banner and trading lock to Chainlink markets only. Non-Chainlink markets won’t show the pending state or block orders just because end_time passed; also reduces the banner heading to text-lg.

- **Bug Fixes**
  - End-time gating now applies only to `mirror_resolution_type: 'chainlink'` using `getMirrorResolutionType`, `isChainlinkMarketEnded`, and `useHasReachedChainlinkEnd`.
  - Order submission is guarded by `ensureChainlinkMarketAcceptsSubmission`, allowing post-end trading on non-Chainlink markets.
  - Tests updated to cover non-Chainlink behavior and to assert the banner heading size.

<sup>Written for commit c780918a51464d2535b656eeb433f3090c63734a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

