### PR TITLE
fix: show home card chance from planted orders

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/EventCard.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCard.tsx
@@ -127,7 +127,9 @@ export default function EventCard({
   }
 
   const primaryDisplayChance =
-    primaryMarket && hasHomeCardMarketChance(primaryMarket) ? getDisplayChance(primaryMarket.condition_id) : null
+    primaryMarket && hasHomeCardMarketChance(primaryMarket, priceOverridesByMarket[primaryMarket.condition_id])
+      ? getDisplayChance(primaryMarket.condition_id)
+      : null
   const roundedPrimaryDisplayChance = primaryDisplayChance == null ? null : Math.round(primaryDisplayChance)
   const endedLabel =
     !isResolvedEvent || !isSingleMarket || !event.resolved_at
@@ -185,6 +187,7 @@ export default function EventCard({
                 markets={marketsToDisplay}
                 isResolvedEvent={isResolvedEvent}
                 getDisplayChance={getDisplayChance}
+                priceOverridesByMarket={priceOverridesByMarket}
                 resolvedOutcomeIndexByConditionId={resolvedOutcomeIndexByConditionId}
               />
             )}

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardHeader.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardHeader.tsx
@@ -93,7 +93,7 @@ export default function EventCardHeader({
         )}
       </Link>
 
-      {isSingleMarket && !isResolvedEvent && (
+      {isSingleMarket && !isResolvedEvent && hasPrimaryDisplayChance && (
         <div className="relative -mt-3 flex flex-col items-center">
           <div className="relative">
             <svg width="72" height="52" viewBox="0 0 72 52" className="rotate-0 transform">

--- a/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/EventCardMarketsList.tsx
@@ -21,14 +21,18 @@ interface EventCardMarketsListProps {
   markets: Market[]
   isResolvedEvent: boolean
   getDisplayChance: (marketId: string) => number
+  priceOverridesByMarket?: Record<string, number>
   resolvedOutcomeIndexByConditionId: Partial<Record<string, typeof OUTCOME_INDEX.YES | typeof OUTCOME_INDEX.NO>>
 }
+
+const EMPTY_PRICE_OVERRIDES: Record<string, number> = {}
 
 export default function EventCardMarketsList({
   event,
   markets,
   isResolvedEvent,
   getDisplayChance,
+  priceOverridesByMarket = EMPTY_PRICE_OVERRIDES,
   resolvedOutcomeIndexByConditionId,
 }: EventCardMarketsListProps) {
   const t = useExtracted()
@@ -52,7 +56,9 @@ export default function EventCardMarketsList({
         .map((market, index) => ({
           market,
           index,
-          displayChance: hasHomeCardMarketChance(market) ? getDisplayChance(market.condition_id) : 0,
+          displayChance: hasHomeCardMarketChance(market, priceOverridesByMarket[market.condition_id])
+            ? getDisplayChance(market.condition_id)
+            : 0,
         }))
         .sort((a, b) => b.displayChance - a.displayChance || a.index - b.index)
         .map((item) => item.market)
@@ -69,13 +75,16 @@ export default function EventCardMarketsList({
         const resolvedLabel = resolvedOutcome?.outcome_text
         const isYesOutcome = resolvedOutcomeIndex === OUTCOME_INDEX.YES
         const displayResolvedLabel = normalizeOutcomeLabel(resolvedLabel) ?? resolvedLabel
-        const displayChance = hasHomeCardMarketChance(market) ? Math.round(getDisplayChance(market.condition_id)) : null
+        const hasDisplayChance = hasHomeCardMarketChance(market, priceOverridesByMarket[market.condition_id])
+        const displayChance = hasDisplayChance ? Math.round(getDisplayChance(market.condition_id)) : null
         const oppositeChance = displayChance == null ? null : Math.max(0, Math.min(100, 100 - displayChance))
         const displayChanceLabel = formatHomeCardChanceLabel(displayChance)
         const oppositeChanceLabel = formatHomeCardChanceLabel(oppositeChance)
         const unresolvedMarketContent = (
           <>
-            <span className="text-base font-semibold text-foreground">{displayChanceLabel}</span>
+            {hasDisplayChance ? (
+              <span className="text-base font-semibold text-foreground">{displayChanceLabel}</span>
+            ) : null}
             <div className="flex gap-1">
               <Button asChild variant="yes" className="group/yes h-7 w-10 px-2 py-1 text-xs">
                 <Link
@@ -84,10 +93,12 @@ export default function EventCardMarketsList({
                     outcomeIndex: yesOutcome.outcome_index,
                   })}
                 >
-                  <span className="truncate group-hover/yes:hidden">
+                  <span className={cn('truncate', hasDisplayChance && 'group-hover/yes:hidden')}>
                     {normalizeOutcomeLabel(yesOutcome.outcome_text) ?? yesOutcome.outcome_text}
                   </span>
-                  <span className="hidden group-hover/yes:inline">{displayChanceLabel}</span>
+                  {hasDisplayChance ? (
+                    <span className="hidden group-hover/yes:inline">{displayChanceLabel}</span>
+                  ) : null}
                 </Link>
               </Button>
               <Button asChild variant="no" size="sm" className="group/no h-auto w-11 px-2 py-1 text-xs">
@@ -97,10 +108,12 @@ export default function EventCardMarketsList({
                     outcomeIndex: noOutcome.outcome_index,
                   })}
                 >
-                  <span className="truncate group-hover/no:hidden">
+                  <span className={cn('truncate', hasDisplayChance && 'group-hover/no:hidden')}>
                     {normalizeOutcomeLabel(noOutcome.outcome_text) ?? noOutcome.outcome_text}
                   </span>
-                  <span className="hidden group-hover/no:inline">{oppositeChanceLabel}</span>
+                  {hasDisplayChance ? (
+                    <span className="hidden group-hover/no:inline">{oppositeChanceLabel}</span>
+                  ) : null}
                 </Link>
               </Button>
             </div>

--- a/src/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay.ts
+++ b/src/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay.ts
@@ -15,13 +15,27 @@ function hasPositiveNumber(value: unknown) {
   return typeof value === 'number' && Number.isFinite(value) && value > 0
 }
 
+function hasFiniteNumber(value: unknown) {
+  return typeof value === 'number' && Number.isFinite(value)
+}
+
 export function hasHomeCardMarketChance(
-  market: Pick<Market, 'volume' | 'volume_24h' | 'condition'> | null | undefined,
+  market: Pick<Market, 'volume' | 'volume_24h' | 'condition' | 'outcomes'> | null | undefined,
+  priceOverride?: number | null,
 ) {
   return (
+    hasFiniteNumber(priceOverride) ||
     hasPositiveNumber(market?.volume) ||
     hasPositiveNumber(market?.volume_24h) ||
-    hasPositiveNumber(market?.condition?.volume)
+    hasPositiveNumber(market?.condition?.volume) ||
+    Boolean(
+      market?.outcomes.some(
+        (outcome) =>
+          hasFiniteNumber(outcome.buy_price) ||
+          hasFiniteNumber(outcome.sell_price) ||
+          hasFiniteNumber(outcome.last_trade_price),
+      ),
+    )
   )
 }
 

--- a/src/lib/db/queries/event.ts
+++ b/src/lib/db/queries/event.ts
@@ -381,18 +381,18 @@ function applyPriceBatch(
       continue
     }
 
-    const parsedBuy = priceBySide.BUY != null ? Number(priceBySide.BUY) : undefined
-    const parsedSell = priceBySide.SELL != null ? Number(priceBySide.SELL) : undefined
-    const normalizedBuy = parsedBuy != null && Number.isFinite(parsedBuy) ? parsedBuy : undefined
-    const normalizedSell = parsedSell != null && Number.isFinite(parsedSell) ? parsedSell : undefined
+    const parsedBestAsk = priceBySide.BUY != null ? Number(priceBySide.BUY) : undefined
+    const parsedBestBid = priceBySide.SELL != null ? Number(priceBySide.SELL) : undefined
+    const normalizedBestAsk = parsedBestAsk != null && Number.isFinite(parsedBestAsk) ? parsedBestAsk : undefined
+    const normalizedBestBid = parsedBestBid != null && Number.isFinite(parsedBestBid) ? parsedBestBid : undefined
 
-    if (normalizedBuy == null && normalizedSell == null) {
+    if (normalizedBestAsk == null && normalizedBestBid == null) {
       continue
     }
 
     priceMap.set(tokenId, {
-      buy: normalizedSell ?? normalizedBuy,
-      sell: normalizedBuy ?? normalizedSell,
+      buy: normalizedBestAsk ?? normalizedBestBid,
+      sell: normalizedBestBid ?? normalizedBestAsk,
     })
     missingTokenIds.delete(tokenId)
   }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -335,6 +335,7 @@ export interface Outcome {
   is_winning_outcome: boolean
   payout_value?: number
   buy_price?: number
+  last_trade_price?: number
   sell_price?: number
   created_at: string
   updated_at: string

--- a/tests/unit/EventCard.test.tsx
+++ b/tests/unit/EventCard.test.tsx
@@ -165,6 +165,51 @@ describe('eventCard', () => {
     )
   })
 
+  it('shows a quote-derived chance when a market has planted orders but no matched volume', () => {
+    mocks.buildHomeSportsMoneylineModel.mockReturnValue(null)
+
+    render(
+      <EventCard
+        event={
+          {
+            ...EVENT,
+            markets: [
+              {
+                ...EVENT.markets[0],
+                volume: 0,
+                volume_24h: 0,
+                outcomes: [
+                  {
+                    outcome_index: 0,
+                    outcome_text: 'Yes',
+                    buy_price: 0.66,
+                    sell_price: 0.58,
+                  },
+                  {
+                    outcome_index: 1,
+                    outcome_text: 'No',
+                    buy_price: 0.42,
+                    sell_price: 0.34,
+                  },
+                ],
+                condition: {
+                  resolved: false,
+                  volume: 0,
+                },
+              },
+            ],
+          } as any
+        }
+      />,
+    )
+
+    expect(mocks.eventCardHeader).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roundedPrimaryDisplayChance: 62,
+      }),
+    )
+  })
+
   it('uses the canonical crypto cadence title on event cards', () => {
     mocks.buildHomeSportsMoneylineModel.mockReturnValue(null)
 

--- a/tests/unit/EventCardHeader.test.tsx
+++ b/tests/unit/EventCardHeader.test.tsx
@@ -55,7 +55,7 @@ const EVENT = {
 } as any
 
 describe('eventCardHeader', () => {
-  it('shows an unavailable chance label for single-market cards without displayable volume', () => {
+  it('hides the chance block for single-market cards without quotes or trades', () => {
     render(
       <EventCardHeader
         event={EVENT}
@@ -77,7 +77,7 @@ describe('eventCardHeader', () => {
       />,
     )
 
-    expect(screen.getByText('—')).toBeInTheDocument()
-    expect(screen.getByText('chance')).toBeInTheDocument()
+    expect(screen.queryByText('—')).not.toBeInTheDocument()
+    expect(screen.queryByText('chance')).not.toBeInTheDocument()
   })
 })

--- a/tests/unit/EventCardMarketsList.test.tsx
+++ b/tests/unit/EventCardMarketsList.test.tsx
@@ -76,7 +76,7 @@ describe('eventCardMarketsList', () => {
     expect(marketLinks.map((link) => link.textContent)).toEqual(['Higher chance', 'Lower chance'])
   })
 
-  it('keeps zero-volume market outcomes visible with an unavailable chance label', () => {
+  it('keeps zero-volume market outcomes visible without a chance when there are no quotes or trades', () => {
     render(
       <EventCardMarketsList
         event={EVENT}
@@ -106,13 +106,59 @@ describe('eventCardMarketsList', () => {
     expect(screen.getByText('Sao Paulo temperature')).toBeInTheDocument()
     expect(screen.getByText('Yes')).toBeInTheDocument()
     expect(screen.getByText('No')).toBeInTheDocument()
-    expect(screen.getAllByText('—').length).toBeGreaterThan(0)
+    expect(screen.queryByText('—')).not.toBeInTheDocument()
+    expect(screen.queryByText('50%')).not.toBeInTheDocument()
     expect(screen.getAllByRole('link').map((link) => link.getAttribute('href'))).toEqual(
       expect.arrayContaining([
         '/event/highest-temperature-sao-paulo/highest-temperature-in-sao-paulo-on-june-9?outcomeIndex=0',
         '/event/highest-temperature-sao-paulo/highest-temperature-in-sao-paulo-on-june-9?outcomeIndex=1',
       ]),
     )
+  })
+
+  it('shows a chance for a zero-volume market with planted orders', () => {
+    render(
+      <EventCardMarketsList
+        event={EVENT}
+        markets={
+          [
+            {
+              condition_id: 'market-1',
+              slug: 'quoted-market',
+              title: 'Quoted market',
+              short_title: 'Quoted market',
+              volume: 0,
+              volume_24h: 0,
+              outcomes: [
+                {
+                  outcome_index: 0,
+                  outcome_text: 'Yes',
+                  buy_price: 0.66,
+                  sell_price: 0.62,
+                },
+                {
+                  outcome_index: 1,
+                  outcome_text: 'No',
+                  buy_price: 0.38,
+                  sell_price: 0.34,
+                },
+              ],
+              condition: {
+                volume: 0,
+                resolved: false,
+              },
+            },
+          ] as any
+        }
+        isResolvedEvent={false}
+        getDisplayChance={() => 64}
+        resolvedOutcomeIndexByConditionId={{}}
+      />,
+    )
+
+    expect(screen.getAllByText('64%').length).toBeGreaterThan(0)
+    expect(screen.getByText('36%')).toBeInTheDocument()
+    expect(screen.queryByText('—')).not.toBeInTheDocument()
   })
 
   it('preserves positional outcome indices when falling back to existing outcome rows', () => {

--- a/tests/unit/homeCardMarketDisplay.test.ts
+++ b/tests/unit/homeCardMarketDisplay.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { hasHomeCardMarketChance } from '@/app/[locale]/(platform)/(home)/_utils/homeCardMarketDisplay'
+
+function createMarket(overrides: Record<string, unknown> = {}) {
+  return {
+    volume: 0,
+    volume_24h: 0,
+    outcomes: [],
+    condition: {
+      volume: 0,
+    },
+    ...overrides,
+  } as any
+}
+
+describe('home card market chance availability', () => {
+  it('is unavailable without quotes, trades, or matched volume', () => {
+    expect(hasHomeCardMarketChance(createMarket())).toBe(false)
+  })
+
+  it('is available from a planted order without matched volume', () => {
+    expect(
+      hasHomeCardMarketChance(
+        createMarket({
+          outcomes: [{ buy_price: 0.64 }],
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('is available from a last trade even when aggregate volume is delayed', () => {
+    expect(
+      hasHomeCardMarketChance(
+        createMarket({
+          outcomes: [{ last_trade_price: 0.61 }],
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('is available from a live price override', () => {
+    expect(hasHomeCardMarketChance(createMarket(), 0.58)).toBe(true)
+  })
+})

--- a/tests/unit/marketChance.test.ts
+++ b/tests/unit/marketChance.test.ts
@@ -25,6 +25,26 @@ describe('market chance normalization', () => {
     ).toBe(0.64)
   })
 
+  it('uses the midpoint for a wide spread without a matched trade', () => {
+    expect(
+      resolveDisplayPrice({
+        bid: 0.2,
+        ask: 0.8,
+        lastTrade: null,
+      }),
+    ).toBe(0.5)
+  })
+
+  it('uses the last matched trade for a wide spread when one exists', () => {
+    expect(
+      resolveDisplayPrice({
+        bid: 0.2,
+        ask: 0.8,
+        lastTrade: 0.42,
+      }),
+    ).toBe(0.42)
+  })
+
   it('builds chances from percent-style overrides without inflating to 100%', () => {
     expect(
       buildChanceByMarket(


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Show the home card chance for markets with planted orders or last trades, even when matched volume is zero. Hide the chance UI entirely when no quotes or trades are available.

- **Bug Fixes**
  - Use quotes (best bid/ask), last trade, or live overrides to compute display chance; also used for sorting.
  - Hide the chance block on single-market cards and outcome rows when unavailable; keep buy/sell buttons visible.
  - Fix price mapping in `applyPriceBatch` by treating BUY as best ask and SELL as best bid to compute correct overrides.
  - Add `Outcome.last_trade_price` and update `hasHomeCardMarketChance` to consider quotes, last trades, and overrides; pass `priceOverridesByMarket` through `EventCard` and the markets list.
  - Expand unit tests to cover planted orders, wide spreads (midpoint vs last trade), and the new UI behavior.

<sup>Written for commit 3bc9a74c20c304a64d347761d3f3e97d016d6a3d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

