### PR TITLE
fix: extend quote-only market chart lines

### DIFF
--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -25,6 +25,7 @@ import {
   resolveTweetCountdownTargetMs,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventChartInternalHelpers'
 import {
+  buildHistoryWithLatestPointOverride,
   buildChartSeries,
   buildMarketSignature,
   filterChartDataForSeries,
@@ -32,6 +33,7 @@ import {
   getOutcomeLabelForMarket,
   getSportsMoneylineMarketIds,
   getTopMarketIds,
+  resolveChartRangeStartMs,
   resolveEventHistoryEndAt,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils'
 import { isTweetMarketsEvent } from '@/app/[locale]/(platform)/event/[slug]/_utils/eventTweetMarkets'
@@ -59,65 +61,6 @@ import EventChartHeader from './EventChartHeader'
 import EventChartLayout from './EventChartLayout'
 import EventChartLegend from './EventChartLegend'
 import EventMetaInformation from './EventMetaInformation'
-
-function buildHistoryWithLatestPointOverride(
-  normalizedHistory: Array<Record<string, number | Date> & { date: Date }>,
-  valueByKey: Record<string, number>,
-  nowMs: number | null,
-) {
-  const fallbackTimestamp = normalizedHistory.at(-1)?.date.getTime()
-  if (!Number.isFinite(nowMs) && !Number.isFinite(fallbackTimestamp)) {
-    return normalizedHistory
-  }
-  const nextTimestamp = Number.isFinite(nowMs) ? (nowMs as number) : (fallbackTimestamp as number)
-  const nextDate = new Date(nextTimestamp)
-  const sanitizedEntries = Object.entries(valueByKey)
-    .filter(([, value]) => typeof value === 'number' && Number.isFinite(value))
-    .map(([key, value]) => [key, Math.max(0, Math.min(100, value))] as const)
-
-  if (!sanitizedEntries.length) {
-    return normalizedHistory
-  }
-
-  if (normalizedHistory.length === 0) {
-    return [
-      Object.fromEntries([['date', nextDate], ...sanitizedEntries]) as Record<string, number | Date> & { date: Date },
-    ]
-  }
-
-  const lastPoint = normalizedHistory.at(-1)
-  if (!lastPoint) {
-    return normalizedHistory
-  }
-
-  const hasSameLatestValues = sanitizedEntries.every(([key, value]) => {
-    const lastValue = lastPoint[key]
-    return typeof lastValue === 'number' && Number.isFinite(lastValue) && Math.abs(lastValue - value) < 0.0001
-  })
-
-  if (hasSameLatestValues) {
-    return normalizedHistory
-  }
-
-  const lastTimestamp = lastPoint.date.getTime()
-  if (Number.isFinite(lastTimestamp) && lastTimestamp >= nextTimestamp) {
-    return [
-      ...normalizedHistory.slice(0, -1),
-      {
-        ...lastPoint,
-        ...Object.fromEntries(sanitizedEntries),
-      },
-    ]
-  }
-
-  return [
-    ...normalizedHistory,
-    {
-      date: nextDate,
-      ...Object.fromEntries(sanitizedEntries),
-    },
-  ]
-}
 
 function EventChartComponent({
   event,
@@ -488,12 +431,12 @@ function EventChartComponent({
     yesSeriesKey,
   ])
   const normalizedHistoryForChart = useMemo(() => {
-    if (Object.keys(latestPointOverrides).length === 0) {
-      return normalizedHistory
-    }
+    const resolvedEndMs = parseTimestampToMs(eventHistoryEndAt)
+    const chartEndMs = resolvedEndMs ?? nowMs
+    const chartStartMs = resolveChartRangeStartMs(activeTimeRange, event.created_at, chartEndMs)
 
-    return buildHistoryWithLatestPointOverride(normalizedHistory, latestPointOverrides, nowMs)
-  }, [latestPointOverrides, normalizedHistory, nowMs])
+    return buildHistoryWithLatestPointOverride(normalizedHistory, latestPointOverrides, chartEndMs, chartStartMs)
+  }, [activeTimeRange, event.created_at, eventHistoryEndAt, latestPointOverrides, normalizedHistory, nowMs])
   const leadingGapStart = normalizedHistoryForChart[0]?.date ?? null
   const latestSnapshot = showBothOutcomes ? bothOutcomeHistory.latestSnapshot : chartHistory.latestSnapshot
 

--- a/src/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils.ts
@@ -1,3 +1,4 @@
+import type { TimeRange } from '@/app/[locale]/(platform)/event/[slug]/_hooks/useEventPriceHistory'
 import type { HomeSportsMoneylineButton } from '@/lib/sports-home-card'
 import type { Event } from '@/types'
 
@@ -6,6 +7,13 @@ import { buildHomeSportsMoneylineModel } from '@/lib/sports-home-card'
 const CHART_COLOR_VARIABLES = ['var(--chart-1)', 'var(--chart-2)', 'var(--chart-3)', 'var(--chart-4)']
 const MAX_SERIES = 4
 const TWELVE_HOURS_MS = 12 * 60 * 60 * 1000
+const CHART_RANGE_WINDOW_MS: Record<Exclude<TimeRange, 'ALL'>, number> = {
+  '1H': 60 * 60 * 1000,
+  '6H': 6 * 60 * 60 * 1000,
+  '1D': 24 * 60 * 60 * 1000,
+  '1W': 7 * 24 * 60 * 60 * 1000,
+  '1M': 30 * 24 * 60 * 60 * 1000,
+}
 
 export function getMaxSeriesCount() {
   return MAX_SERIES
@@ -40,6 +48,95 @@ export function resolveEventHistoryEndAt(event: Event) {
   }
 
   return null
+}
+
+export function buildHistoryWithLatestPointOverride(
+  normalizedHistory: Array<Record<string, number | Date> & { date: Date }>,
+  valueByKey: Record<string, number>,
+  endMs: number | null,
+  startMs: number | null = null,
+): Array<Record<string, number | Date> & { date: Date }> {
+  const fallbackTimestamp = normalizedHistory.at(-1)?.date.getTime()
+  if (!Number.isFinite(endMs) && !Number.isFinite(fallbackTimestamp)) {
+    return normalizedHistory
+  }
+
+  const nextTimestamp = Number.isFinite(endMs) ? (endMs as number) : (fallbackTimestamp as number)
+  const nextDate = new Date(nextTimestamp)
+  const sanitizedEntries = Object.entries(valueByKey)
+    .filter(([, value]) => typeof value === 'number' && Number.isFinite(value))
+    .map(([key, value]) => [key, Math.max(0, Math.min(100, value))] as const)
+
+  if (normalizedHistory.length === 0) {
+    if (!sanitizedEntries.length) {
+      return normalizedHistory
+    }
+
+    if (Number.isFinite(startMs) && (startMs as number) < nextTimestamp) {
+      return [
+        Object.fromEntries([['date', new Date(startMs as number)], ...sanitizedEntries]) as Record<
+          string,
+          number | Date
+        > & { date: Date },
+        Object.fromEntries([['date', nextDate], ...sanitizedEntries]) as Record<string, number | Date> & { date: Date },
+      ]
+    }
+
+    return [
+      Object.fromEntries([['date', nextDate], ...sanitizedEntries]) as Record<string, number | Date> & { date: Date },
+    ]
+  }
+
+  const lastPoint = normalizedHistory.at(-1)
+  if (!lastPoint) {
+    return normalizedHistory
+  }
+
+  const lastTimestamp = lastPoint.date.getTime()
+  const latestValues = {
+    ...lastPoint,
+    ...Object.fromEntries(sanitizedEntries),
+  }
+
+  if (Number.isFinite(lastTimestamp) && nextTimestamp > lastTimestamp) {
+    return [
+      ...normalizedHistory,
+      {
+        ...latestValues,
+        date: nextDate,
+      },
+    ]
+  }
+
+  const hasChangedLatestValues = sanitizedEntries.some(([key, value]) => {
+    const lastValue = lastPoint[key]
+    return typeof lastValue !== 'number' || !Number.isFinite(lastValue) || Math.abs(lastValue - value) >= 0.0001
+  })
+
+  if (!hasChangedLatestValues) {
+    return normalizedHistory
+  }
+
+  return [
+    ...normalizedHistory.slice(0, -1),
+    {
+      ...latestValues,
+      date: lastPoint.date,
+    },
+  ]
+}
+
+export function resolveChartRangeStartMs(range: TimeRange, eventCreatedAt: string, endMs: number | null) {
+  const createdMs = Date.parse(eventCreatedAt)
+  if (!Number.isFinite(createdMs)) {
+    return null
+  }
+
+  if (range === 'ALL' || !Number.isFinite(endMs)) {
+    return createdMs
+  }
+
+  return Math.max(createdMs, (endMs as number) - CHART_RANGE_WINDOW_MS[range])
 }
 
 export function computeChanceChanges(

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameGraph.tsx
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/SportsGameGraph.tsx
@@ -207,6 +207,7 @@ export default function SportsGameGraph({
             margin={chartMargin}
             xDomain={chartXDomain}
             dataSignature={`${card.id}:${chartSeries.map((series) => series.key).join(',')}:${activeTimeRange}`}
+            dataSyncMode="replace"
             onCursorDataChange={setCursorSnapshot}
             xAxisTickCount={3}
             yAxis={undefined}

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
@@ -15,6 +15,7 @@ import {
   buildHistoryWithLatestPointOverride,
   resolveChartRangeStartMs,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils'
+import { useCurrentTimestamp } from '@/hooks/useCurrentTimestamp'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { resolveDisplayPrice } from '@/lib/market-chance'
 import { calculateYAxisBounds } from '@/lib/prediction-chart'
@@ -410,6 +411,7 @@ export function useSportsGameGraphHistory({
   chartSeries: Array<{ key: string; name: string; color: string }>
   shouldPairOutcomeHistory: boolean
 }) {
+  const chartClockMs = useCurrentTimestamp({ intervalMs: card.eventResolvedAt ? false : 30_000 })
   const { normalizedHistory } = useEventPriceHistory({
     eventId: card.id,
     range: activeTimeRange,
@@ -497,8 +499,9 @@ export function useSportsGameGraphHistory({
         eventCreatedAt: card.eventCreatedAt,
         eventResolvedAt: card.eventResolvedAt,
         activeTimeRange,
+        now: chartClockMs == null ? undefined : new Date(chartClockMs),
       }),
-    [activeTimeRange, card.eventCreatedAt, card.eventResolvedAt, livePointValues, pairedHistoryChartData],
+    [activeTimeRange, card.eventCreatedAt, card.eventResolvedAt, chartClockMs, livePointValues, pairedHistoryChartData],
   )
 
   const latestSnapshot = useMemo(() => {

--- a/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
+++ b/src/app/[locale]/(platform)/sports/_components/_sports-games-center/useSportsGameGraph.ts
@@ -11,6 +11,10 @@ import {
   loadStoredChartSettings,
   storeChartSettings,
 } from '@/app/[locale]/(platform)/event/[slug]/_utils/chartSettingsStorage'
+import {
+  buildHistoryWithLatestPointOverride,
+  resolveChartRangeStartMs,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils'
 import { OUTCOME_INDEX } from '@/lib/constants'
 import { resolveDisplayPrice } from '@/lib/market-chance'
 import { calculateYAxisBounds } from '@/lib/prediction-chart'
@@ -374,50 +378,23 @@ export function useSportsGameGraphSeries({
 export function appendLiveSportsHistoryPoint({
   history,
   livePointValues,
+  eventCreatedAt,
   eventResolvedAt,
+  activeTimeRange,
   now = new Date(),
 }: {
   history: DataPoint[]
   livePointValues: Record<string, number>
+  eventCreatedAt: string
   eventResolvedAt?: string | null
+  activeTimeRange: (typeof TIME_RANGES)[number]
   now?: Date
 }) {
-  if (eventResolvedAt) {
-    return history
-  }
+  const resolvedAtMs = eventResolvedAt ? Date.parse(eventResolvedAt) : Number.NaN
+  const chartEndMs = Number.isFinite(resolvedAtMs) ? resolvedAtMs : now.getTime()
+  const chartStartMs = resolveChartRangeStartMs(activeTimeRange, eventCreatedAt, chartEndMs)
 
-  const liveEntries = Object.entries(livePointValues).filter(
-    ([, value]) => typeof value === 'number' && Number.isFinite(value),
-  )
-  if (liveEntries.length === 0) {
-    return history
-  }
-
-  const sanitizedLiveValues = Object.fromEntries(
-    liveEntries.map(([key, value]) => [key, Math.max(0, Math.min(100, value))]),
-  )
-  if (history.length === 0) {
-    return [{ date: now, ...sanitizedLiveValues }]
-  }
-
-  const lastPoint = history.at(-1)
-  if (!lastPoint) {
-    return history
-  }
-
-  const nextPoint: DataPoint = {
-    ...lastPoint,
-    date: now,
-    ...sanitizedLiveValues,
-  }
-  const lastTimestamp = lastPoint.date.getTime()
-  const nowTimestamp = now.getTime()
-
-  if (Number.isFinite(lastTimestamp) && lastTimestamp >= nowTimestamp) {
-    return [...history.slice(0, -1), nextPoint]
-  }
-
-  return [...history, nextPoint]
+  return buildHistoryWithLatestPointOverride(history, livePointValues, chartEndMs, chartStartMs)
 }
 
 export function useSportsGameGraphHistory({
@@ -517,9 +494,11 @@ export function useSportsGameGraphHistory({
       appendLiveSportsHistoryPoint({
         history: pairedHistoryChartData,
         livePointValues,
+        eventCreatedAt: card.eventCreatedAt,
         eventResolvedAt: card.eventResolvedAt,
+        activeTimeRange,
       }),
-    [card.eventResolvedAt, livePointValues, pairedHistoryChartData],
+    [activeTimeRange, card.eventCreatedAt, card.eventResolvedAt, livePointValues, pairedHistoryChartData],
   )
 
   const latestSnapshot = useMemo(() => {

--- a/tests/unit/EventChartUtils.test.ts
+++ b/tests/unit/EventChartUtils.test.ts
@@ -1,6 +1,64 @@
-import { getSportsMoneylineMarketIds } from '@/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils'
+import {
+  buildHistoryWithLatestPointOverride,
+  getSportsMoneylineMarketIds,
+  resolveChartRangeStartMs,
+} from '@/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils'
 
 describe('eventChartUtils', () => {
+  it('builds a flat series across the selected range when only a current quote exists', () => {
+    const start = new Date('2026-07-30T12:00:00.000Z')
+    const end = new Date('2026-07-30T13:00:00.000Z')
+
+    expect(buildHistoryWithLatestPointOverride([], { market: 50 }, end.getTime(), start.getTime())).toEqual([
+      { date: start, market: 50 },
+      { date: end, market: 50 },
+    ])
+  })
+
+  it('anchors quote-only charts to the selected time range without preceding event creation', () => {
+    const createdAt = '2026-07-30T12:30:00.000Z'
+    const end = new Date('2026-07-30T14:00:00.000Z')
+
+    expect(resolveChartRangeStartMs('ALL', createdAt, end.getTime())).toBe(Date.parse(createdAt))
+    expect(resolveChartRangeStartMs('1H', createdAt, end.getTime())).toBe(Date.parse('2026-07-30T13:00:00.000Z'))
+    expect(resolveChartRangeStartMs('6H', createdAt, end.getTime())).toBe(Date.parse(createdAt))
+  })
+
+  it('extends an unchanged price through the chart end', () => {
+    const start = new Date('2026-07-30T12:00:00.000Z')
+    const end = new Date('2026-07-30T13:00:00.000Z')
+
+    expect(buildHistoryWithLatestPointOverride([{ date: start, market: 42 }], { market: 42 }, end.getTime())).toEqual([
+      { date: start, market: 42 },
+      { date: end, market: 42 },
+    ])
+  })
+
+  it('extends the last known values when live quotes are unavailable', () => {
+    const start = new Date('2026-07-30T12:00:00.000Z')
+    const end = new Date('2026-07-30T13:00:00.000Z')
+
+    expect(buildHistoryWithLatestPointOverride([{ date: start, first: 35, second: 65 }], {}, end.getTime())).toEqual([
+      { date: start, first: 35, second: 65 },
+      { date: end, first: 35, second: 65 },
+    ])
+  })
+
+  it('uses the resolved chart end instead of adding a later point', () => {
+    const resolvedAt = new Date('2026-07-30T13:00:00.000Z')
+    const laterNow = new Date('2026-07-30T14:00:00.000Z')
+    const history = [
+      { date: new Date('2026-07-30T12:00:00.000Z'), market: 42 },
+      { date: resolvedAt, market: 58 },
+    ]
+
+    expect(buildHistoryWithLatestPointOverride(history, { market: 58 }, resolvedAt.getTime())).toBe(history)
+    expect(buildHistoryWithLatestPointOverride(history, { market: 58 }, laterNow.getTime())).toEqual([
+      ...history,
+      { date: laterNow, market: 58 },
+    ])
+  })
+
   it('uses separated sports moneyline markets in team draw team order', () => {
     const event = {
       sports_sport_slug: 'soccer',

--- a/tests/unit/PredictionChart.test.tsx
+++ b/tests/unit/PredictionChart.test.tsx
@@ -1,5 +1,6 @@
 import { render, waitFor, within } from '@testing-library/react'
 
+import { buildHistoryWithLatestPointOverride } from '@/app/[locale]/(platform)/event/[slug]/_utils/EventChartUtils'
 import PredictionChart from '@/components/PredictionChart'
 
 const data = [
@@ -26,6 +27,29 @@ beforeAll(() => {
 })
 
 describe('predictionChart', () => {
+  it('renders a horizontal path for a quote-only market without trade history', async () => {
+    const start = new Date('2026-07-30T12:00:00.000Z')
+    const end = new Date('2026-07-30T13:00:00.000Z')
+    const quoteOnlyData = buildHistoryWithLatestPointOverride([], { price: 50 }, end.getTime(), start.getTime())
+    const { container } = render(
+      <PredictionChart
+        data={quoteOnlyData}
+        series={series}
+        width={400}
+        height={220}
+        showXAxis={false}
+        showYAxis={false}
+        showHorizontalGrid={false}
+        disableResetAnimation
+      />,
+    )
+
+    await waitFor(() => {
+      const linePath = container.querySelector('path[stroke="#F59E0B"]')
+      expect(linePath?.getAttribute('d')).toMatch(/^M[^L]+L/)
+    })
+  })
+
   it('honors explicit empty y-axis ticks', async () => {
     const { container } = render(
       <PredictionChart data={data} series={series} width={400} height={220} showXAxis={false} yAxis={{ ticks: [] }} />,

--- a/tests/unit/sportsGameGraphHeroLegend.test.tsx
+++ b/tests/unit/sportsGameGraphHeroLegend.test.tsx
@@ -23,15 +23,20 @@ const chartData = [
 ]
 
 describe('sportsGameGraphHistory', () => {
-  it('keeps a real live-only point without fabricating a historical baseline', () => {
+  it('renders live-only sports quotes across the selected range', () => {
     expect(
       appendLiveSportsHistoryPoint({
         history: [],
         livePointValues: { chiefs: 59, gloucester: 17, draw: 20 },
+        eventCreatedAt: '2026-07-27T10:00:00.000Z',
         eventResolvedAt: null,
+        activeTimeRange: '1H',
         now: new Date('2026-07-27T12:00:00.000Z'),
       }),
-    ).toEqual([{ date: new Date('2026-07-27T12:00:00.000Z'), chiefs: 59, gloucester: 17, draw: 20 }])
+    ).toEqual([
+      { date: new Date('2026-07-27T11:00:00.000Z'), chiefs: 59, gloucester: 17, draw: 20 },
+      { date: new Date('2026-07-27T12:00:00.000Z'), chiefs: 59, gloucester: 17, draw: 20 },
+    ])
   })
 
   it('does not fabricate chart data when neither history nor live quotes exist', () => {
@@ -39,7 +44,9 @@ describe('sportsGameGraphHistory', () => {
       appendLiveSportsHistoryPoint({
         history: [],
         livePointValues: {},
+        eventCreatedAt: '2026-07-27T10:00:00.000Z',
         eventResolvedAt: null,
+        activeTimeRange: '1H',
         now: new Date('2026-07-27T12:00:00.000Z'),
       }),
     ).toEqual([])
@@ -55,7 +62,9 @@ describe('sportsGameGraphHistory', () => {
       appendLiveSportsHistoryPoint({
         history,
         livePointValues: { chiefs: 59, gloucester: 17, draw: 20 },
+        eventCreatedAt: '2026-07-26T12:00:00.000Z',
         eventResolvedAt: null,
+        activeTimeRange: '1W',
         now: new Date('2026-07-27T12:00:00.000Z'),
       }),
     ).toEqual([...history, { date: new Date('2026-07-27T12:00:00.000Z'), chiefs: 59, gloucester: 17, draw: 20 }])

--- a/tests/unit/sportsGameGraphHeroLegend.test.tsx
+++ b/tests/unit/sportsGameGraphHeroLegend.test.tsx
@@ -39,6 +39,28 @@ describe('sportsGameGraphHistory', () => {
     ])
   })
 
+  it('moves the flat endpoint forward when the active chart clock refreshes', () => {
+    const params = {
+      history: [],
+      livePointValues: { chiefs: 59, gloucester: 17, draw: 20 },
+      eventCreatedAt: '2026-07-27T10:00:00.000Z',
+      eventResolvedAt: null,
+      activeTimeRange: '1H' as const,
+    }
+
+    const firstChart = appendLiveSportsHistoryPoint({
+      ...params,
+      now: new Date('2026-07-27T12:00:00.000Z'),
+    })
+    const refreshedChart = appendLiveSportsHistoryPoint({
+      ...params,
+      now: new Date('2026-07-27T12:00:30.000Z'),
+    })
+
+    expect(firstChart.at(-1)?.date).toEqual(new Date('2026-07-27T12:00:00.000Z'))
+    expect(refreshedChart.at(-1)?.date).toEqual(new Date('2026-07-27T12:00:30.000Z'))
+  })
+
   it('does not fabricate chart data when neither history nor live quotes exist', () => {
     expect(
       appendLiveSportsHistoryPoint({


### PR DESCRIPTION
## Summary

- render quote-only markets as flat lines across the selected time range instead of a single dot
- extend the latest known price through the chart end when trading stops
- apply the behavior to standard, neg-risk, featured, and sports charts
- preserve the existing dotted leading-gap treatment for outcomes that begin trading later

## Root cause

Markets without trades return an empty price history. Their current order-book midpoint was added as a single point, so the chart could only render a marker. Sports charts used a separate history pipeline with the same single-point behavior.

The chart history now uses the current quote at both the start and end of the selected range when no trade history exists. Once real history exists, the final known value is carried to the current or resolved chart endpoint.

## Impact

Non-live markets keep a visible horizontal price line even when there is no trading activity, while real historical changes and late-outcome dotted segments remain unchanged.

## Validation

- `vitest run`: 289 test files, 1,500 tests passed
- production Next.js build passed
- TypeScript passed
- oxlint and oxfmt passed
- manually verified standard and sports quote-only markets locally

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extend quote-only market chart lines across the selected time range and carry the latest price to the chart end. Applies to standard, neg-risk, featured, and sports charts; sports endpoints now refresh as time moves.

- **Bug Fixes**
  - Render quote-only markets as a flat line from range start to end instead of a single dot.
  - Carry the last known price to the chart end (now or resolved time).
  - Keep sports charts’ flat endpoints in sync as the chart clock updates.
  - Preserve dotted leading gaps for outcomes that start trading later.
  - Centralize range/override logic in `buildHistoryWithLatestPointOverride` and `resolveChartRangeStartMs` with new tests.

<sup>Written for commit e435a725e2526519b989889c0abd480e49f2fb48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

