### PR TITLE
fix: disable featured chart reveal animation

### DIFF
--- a/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
+++ b/src/app/[locale]/(platform)/(home)/_components/HomeFeaturedEventsCarousel.tsx
@@ -1845,6 +1845,7 @@ function FeaturedSlide({
               chartWidth={chartContainerWidth}
               chartHeight={HOME_FEATURED_CHART_HEIGHT}
               isSingleMarketOverride={isSingleMarket}
+              disableResetAnimation
               forceVisible
             />
           )}

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChart.tsx
@@ -71,6 +71,7 @@ function EventChartComponent({
   chartWidth: providedChartWidth,
   chartHeight,
   compactLegend = false,
+  disableResetAnimation = false,
   legendVariant,
   showControls = true,
   showSeriesNavigation = true,
@@ -616,6 +617,7 @@ function EventChartComponent({
             chartSettings={chartSettings}
             chartAnnotationMarkers={chartAnnotationMarkers}
             leadingGapStart={leadingGapStart}
+            disableResetAnimation={disableResetAnimation}
             legendContent={legendContent}
             watermark={isSingleMarket ? undefined : visibleWatermark}
             tradeFlowItems={tradeFlowItems}
@@ -686,6 +688,9 @@ function areChartPropsEqual(prev: EventChartProps, next: EventChartProps) {
     return false
   }
   if ((prev.forceVisible ?? false) !== (next.forceVisible ?? false)) {
+    return false
+  }
+  if ((prev.disableResetAnimation ?? false) !== (next.disableResetAnimation ?? false)) {
     return false
   }
   if (prev.event.id !== next.event.id) {

--- a/src/app/[locale]/(platform)/event/[slug]/_components/EventChartCanvas.tsx
+++ b/src/app/[locale]/(platform)/event/[slug]/_components/EventChartCanvas.tsx
@@ -41,6 +41,7 @@ interface EventChartCanvasProps {
   }
   chartAnnotationMarkers: PredictionChartAnnotationMarker[]
   leadingGapStart: Date | null
+  disableResetAnimation: boolean
   legendContent: ReactNode
   watermark?: { iconSvg?: string | null; iconImageUrl?: string | null; label?: string | null }
   tradeFlowItems: TradeFlowLabelItem[]
@@ -58,6 +59,7 @@ export default function EventChartCanvas({
   chartSettings,
   chartAnnotationMarkers,
   leadingGapStart,
+  disableResetAnimation,
   legendContent,
   watermark,
   tradeFlowItems,
@@ -81,6 +83,7 @@ export default function EventChartCanvas({
         showAnnotations={chartSettings.annotations && chartAnnotationMarkers.length > 0}
         annotationMarkers={chartAnnotationMarkers}
         leadingGapStart={leadingGapStart}
+        disableResetAnimation={disableResetAnimation}
         legendContent={legendContent}
         showLegend={!isSingleMarket}
         watermark={isSingleMarket ? undefined : watermark}

--- a/src/app/[locale]/(platform)/event/[slug]/_types/EventChartTypes.ts
+++ b/src/app/[locale]/(platform)/event/[slug]/_types/EventChartTypes.ts
@@ -15,4 +15,5 @@ export interface EventChartProps {
   chartHeight?: number
   isSingleMarketOverride?: boolean
   forceVisible?: boolean
+  disableResetAnimation?: boolean
 }

--- a/src/components/PredictionChart.tsx
+++ b/src/components/PredictionChart.tsx
@@ -1047,6 +1047,7 @@ export default function PredictionChart({
                 mutedPoints={mutedPoints}
                 shouldSplitByCursor={shouldSplitByCursor}
                 surgeActive={surgeActive}
+                preserveMarkersDuringSurge={disableResetAnimation}
                 markerOuterRadius={markerOuterRadius}
                 markerInnerRadius={markerInnerRadius}
                 markerPulseStyle={markerPulseStyle}

--- a/src/components/PredictionChartMarkers.tsx
+++ b/src/components/PredictionChartMarkers.tsx
@@ -11,6 +11,7 @@ interface PredictionChartMarkersProps {
   mutedPoints: DataPoint[]
   shouldSplitByCursor: boolean
   surgeActive: boolean
+  preserveMarkersDuringSurge: boolean
   markerOuterRadius: number
   markerInnerRadius: number
   markerPulseStyle: 'filled' | 'ring'
@@ -26,6 +27,7 @@ function PredictionChartMarkers({
   mutedPoints,
   shouldSplitByCursor,
   surgeActive,
+  preserveMarkersDuringSurge,
   markerOuterRadius,
   markerInnerRadius,
   markerPulseStyle,
@@ -41,7 +43,8 @@ function PredictionChartMarkers({
         const isSeriesRevealing = revealSeriesSet.has(seriesItem.key)
         const seriesMutedPoints = isSeriesRevealing ? mutedPoints : []
         const shouldShowMarker =
-          (seriesMutedPoints.length === 0 || shouldSplitByCursor) && !(surgeActive && isSeriesRevealing)
+          (seriesMutedPoints.length === 0 || shouldSplitByCursor) &&
+          !(surgeActive && isSeriesRevealing && !preserveMarkersDuringSurge)
 
         if (!shouldShowMarker) {
           return null

--- a/src/hooks/usePredictionChartAnimation.ts
+++ b/src/hooks/usePredictionChartAnimation.ts
@@ -136,7 +136,7 @@ function usePredictionChartAnimation(params: {
         })
       })
       previousSeriesKeysRef.current = currentSeriesKeys
-      surgePendingRef.current = updateType === 'reset' && !disableResetAnimation
+      surgePendingRef.current = updateType === 'reset'
 
       const canUseCrossFade =
         updateType === 'reset' &&
@@ -241,7 +241,7 @@ function usePredictionChartAnimation(params: {
       const nextLengths: Record<string, number> = {}
       revealSeriesKeys.forEach((seriesKey) => {
         const node = seriesPathRef.current[seriesKey]
-        if (node) {
+        if (node && typeof node.getTotalLength === 'function') {
           nextLengths[seriesKey] = node.getTotalLength()
         }
       })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Disable the reveal animation on featured event charts so lines render instantly in the home carousel. Surge highlight and end-of-line markers are preserved during resets.

- **Bug Fixes**
  - Added `disableResetAnimation` prop to `EventChart` and `EventChartCanvas`, and enabled it for the home featured carousel.
  - Kept surge effect on reset updates and preserved end markers during surge via `preserveMarkersDuringSurge` in `PredictionChartMarkers`.
  - Guarded `getTotalLength` usage to avoid errors on non-SVGPath nodes.

<sup>Written for commit e080f2b1d4ee3c5031b9b06de8e9d2e5c151325f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

