### PR TITLE
perf: limit initial market sync window

### DIFF
--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -44,6 +44,9 @@ const PNL_SUBGRAPH_URL = 'https://subgraphs.kuest.com/pnl-subgraph'
 const IRYS_GATEWAY = process.env.IRYS_GATEWAY || 'https://gateway.irys.xyz'
 const SYNC_TIME_LIMIT_MS = 250_000
 const PNL_PAGE_SIZE = 200
+const INITIAL_MARKET_LOOKBACK_DAYS = 14
+const INITIAL_MARKET_LOOKBACK_SECONDS = INITIAL_MARKET_LOOKBACK_DAYS * 24 * 60 * 60
+const EXPIRED_MARKET_GRACE_MS = 24 * 60 * 60 * 1000
 const MARKET_SYNC_STATE = {
   serviceName: 'market_sync',
   subgraphName: 'pnl',
@@ -154,6 +157,7 @@ interface SyncStats {
   fetchedCount: number
   processedCount: number
   skippedCreatorCount: number
+  skippedExpiredCount: number
   errors: { conditionId: string; error: string }[]
   timeLimitReached: boolean
 }
@@ -179,6 +183,7 @@ interface ProcessMarketResult {
   changed: boolean
   listAffectingChange: boolean
   urlSetChanged: boolean
+  skippedExpired: boolean
 }
 
 interface ProcessEventResult {
@@ -232,12 +237,17 @@ export function resolveAdditionalContextUpdatedAtIso(params: {
 }
 
 const PNL_CONDITIONS_PAGE_QUERY = `
-  query PnlConditionsPage($creators: [String!]!, $pageSize: Int!) {
+  query PnlConditionsPage($creators: [String!]!, $pageSize: Int!, $minCreationTimestamp: BigInt!) {
     conditions(
       first: $pageSize
       orderBy: updatedAt
       orderDirection: asc
-      where: { creator_in: $creators }
+      where: {
+        and: [
+          { creator_in: $creators }
+          { creationTimestamp_gte: $minCreationTimestamp }
+        ]
+      }
     ) {
       id
       oracle
@@ -252,7 +262,12 @@ const PNL_CONDITIONS_PAGE_QUERY = `
 `
 
 const PNL_CONDITIONS_PAGE_SINCE_QUERY = `
-  query PnlConditionsPage($creators: [String!]!, $pageSize: Int!, $lastUpdatedAt: BigInt!, $lastConditionId: String!) {
+  query PnlConditionsPage(
+    $creators: [String!]!
+    $pageSize: Int!
+    $lastUpdatedAt: BigInt!
+    $lastConditionId: String!
+  ) {
     conditions(
       first: $pageSize
       orderBy: updatedAt
@@ -260,6 +275,48 @@ const PNL_CONDITIONS_PAGE_SINCE_QUERY = `
       where: {
         and: [
           { creator_in: $creators }
+          {
+            or: [
+              { updatedAt_gt: $lastUpdatedAt }
+              {
+                and: [
+                  { updatedAt: $lastUpdatedAt }
+                  { id_gt: $lastConditionId }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ) {
+      id
+      oracle
+      questionId
+      resolved
+      metadataHash
+      creator
+      creationTimestamp
+      updatedAt
+    }
+  }
+`
+
+const PNL_CONDITIONS_PAGE_SINCE_WITH_CUTOFF_QUERY = `
+  query PnlConditionsPage(
+    $creators: [String!]!
+    $pageSize: Int!
+    $lastUpdatedAt: BigInt!
+    $lastConditionId: String!
+    $minCreationTimestamp: BigInt!
+  ) {
+    conditions(
+      first: $pageSize
+      orderBy: updatedAt
+      orderDirection: asc
+      where: {
+        and: [
+          { creator_in: $creators }
+          { creationTimestamp_gte: $minCreationTimestamp }
           {
             or: [
               { updatedAt_gt: $lastUpdatedAt }
@@ -339,12 +396,19 @@ export async function GET(request: Request) {
       const creatorSourceRefreshPromise = refreshCreatorSourcesBeforeSync(forceCreatorSourceRefresh)
       const autoDeployNewEventsPromise = loadAutoDeployNewEventsEnabled()
       const lastCursor = await getLastPnLCursor()
+      const initialCreationTimestamp = lastCursor ? null : resolveMinCreationTimestamp()
+
       if (lastCursor) {
         console.log(
           `📊 Last PnL cursor: ${lastCursor.conditionId} @ ${new Date(lastCursor.updatedAt * 1000).toISOString()}`,
         )
       } else {
-        console.log('📊 Last PnL cursor: none (full scan from subgraph start)')
+        console.log('📊 Last PnL cursor: none (initial sync)')
+        if (initialCreationTimestamp != null) {
+          console.log(
+            `📅 Initial PnL creation cutoff: ${new Date(initialCreationTimestamp * 1000).toISOString()} (${INITIAL_MARKET_LOOKBACK_DAYS}-day lookback)`,
+          )
+        }
       }
 
       await creatorSourceRefreshPromise
@@ -352,7 +416,12 @@ export async function GET(request: Request) {
         getAllowedCreators(),
         autoDeployNewEventsPromise,
       ])
-      const syncResult = await syncMarkets(new Set(allowedCreators), { autoDeployNewEvents })
+      const syncResult = await syncMarkets(
+        new Set(allowedCreators),
+        { autoDeployNewEvents },
+        lastCursor,
+        initialCreationTimestamp,
+      )
 
       await updateSyncStatus({
         ...MARKET_SYNC_STATE,
@@ -376,6 +445,7 @@ export async function GET(request: Request) {
         processed: syncResult.processedCount,
         fetched: syncResult.fetchedCount,
         skippedCreators: syncResult.skippedCreatorCount,
+        skippedExpired: syncResult.skippedExpiredCount,
         errors: syncResult.errors.length,
         errorDetails: syncResult.errors,
         timeLimitReached: syncResult.timeLimitReached,
@@ -397,7 +467,12 @@ export async function GET(request: Request) {
   })
 }
 
-async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): Promise<SyncStats> {
+async function syncMarkets(
+  allowedCreators: Set<string>,
+  options: SyncOptions,
+  initialCursor: SyncCursor | null,
+  initialCreationTimestamp: number | null,
+): Promise<SyncStats> {
   const trackedCreators = Array.from(allowedCreators)
     .map((creator) => creator.trim().toLowerCase())
     .filter(Boolean)
@@ -407,24 +482,26 @@ async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): 
       fetchedCount: 0,
       processedCount: 0,
       skippedCreatorCount: 0,
+      skippedExpiredCount: 0,
       errors: [],
       timeLimitReached: false,
     }
   }
 
   const syncStartedAt = Date.now()
-  let cursor = await getLastPnLCursor()
+  let cursor = initialCursor
 
   if (cursor) {
     const cursorIso = new Date(cursor.updatedAt * 1000).toISOString()
     console.log(`⏱️ Resuming sync after condition ${cursor.conditionId} (updated at ${cursorIso})`)
   } else {
-    console.log('📥 No existing markets found, starting full sync')
+    console.log(`📥 No existing cursor found, starting ${INITIAL_MARKET_LOOKBACK_DAYS}-day initial sync`)
   }
 
   let fetchedCount = 0
   let processedCount = 0
   let skippedCreatorCount = 0
+  let skippedExpiredCount = 0
   const errors: { conditionId: string; error: string }[] = []
   let timeLimitReached = false
   const eventIdsNeedingStatusUpdate = new Set<string>()
@@ -436,7 +513,7 @@ async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): 
   }
 
   while (Date.now() - syncStartedAt < SYNC_TIME_LIMIT_MS) {
-    const page = await fetchPnLConditionsPage(trackedCreators, cursor)
+    const page = await fetchPnLConditionsPage(trackedCreators, cursor, initialCreationTimestamp)
 
     if (page.conditions.length === 0) {
       console.log('📦 PnL subgraph returned no additional conditions')
@@ -482,6 +559,12 @@ async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): 
 
       try {
         const processResult = await processMarket(condition, options, runtimeState)
+        if (processResult.skippedExpired) {
+          skippedExpiredCount++
+          lastPersistableCursor = conditionCursor
+          console.log(`⌛ Skipped expired market: ${condition.id}`)
+          continue
+        }
         if (processResult.eventIdForStatusUpdate && processResult.changed) {
           eventIdsNeedingStatusUpdate.add(processResult.eventIdForStatusUpdate)
         }
@@ -579,9 +662,14 @@ async function syncMarkets(allowedCreators: Set<string>, options: SyncOptions): 
     fetchedCount,
     processedCount,
     skippedCreatorCount,
+    skippedExpiredCount,
     errors,
     timeLimitReached,
   }
+}
+
+function resolveMinCreationTimestamp(nowMs = Date.now()) {
+  return Math.floor(nowMs / 1000) - INITIAL_MARKET_LOOKBACK_SECONDS
 }
 
 async function getLastPnLCursor(): Promise<SyncCursor | null> {
@@ -634,24 +722,45 @@ async function updatePnLCursor(cursor: SyncCursor) {
 async function fetchPnLConditionsPage(
   creators: string[],
   afterCursor: SyncCursor | null,
+  initialCreationTimestamp: number | null,
 ): Promise<{ conditions: SubgraphCondition[] }> {
   if (creators.length === 0) {
     return { conditions: [] }
   }
 
-  const hasCursor = afterCursor != null
-  const query = hasCursor ? PNL_CONDITIONS_PAGE_SINCE_QUERY : PNL_CONDITIONS_PAGE_QUERY
-  const variables = hasCursor
-    ? {
-        creators,
-        pageSize: PNL_PAGE_SIZE,
-        lastUpdatedAt: afterCursor.updatedAt.toString(),
-        lastConditionId: afterCursor.conditionId,
+  let query: string
+  let variables: Record<string, string | number | string[]>
+
+  if (!afterCursor) {
+    if (initialCreationTimestamp == null) {
+      throw new Error('Initial market sync requires a creation timestamp cutoff')
+    }
+
+    query = PNL_CONDITIONS_PAGE_QUERY
+    variables = {
+      creators,
+      pageSize: PNL_PAGE_SIZE,
+      minCreationTimestamp: initialCreationTimestamp.toString(),
+    }
+  } else {
+    const cursorVariables = {
+      creators,
+      pageSize: PNL_PAGE_SIZE,
+      lastUpdatedAt: afterCursor.updatedAt.toString(),
+      lastConditionId: afterCursor.conditionId,
+    }
+
+    if (initialCreationTimestamp == null) {
+      query = PNL_CONDITIONS_PAGE_SINCE_QUERY
+      variables = cursorVariables
+    } else {
+      query = PNL_CONDITIONS_PAGE_SINCE_WITH_CUTOFF_QUERY
+      variables = {
+        ...cursorVariables,
+        minCreationTimestamp: initialCreationTimestamp.toString(),
       }
-    : {
-        creators,
-        pageSize: PNL_PAGE_SIZE,
-      }
+    }
+  }
 
   const response = await fetch(PNL_SUBGRAPH_URL, {
     method: 'POST',
@@ -686,11 +795,22 @@ async function processMarket(
   runtimeState: SyncRuntimeState,
 ): Promise<ProcessMarketResult> {
   const timestamps = getMarketTimestamps(market)
-  const conditionChanged = await processCondition(market, timestamps)
   if (!market.metadataHash) {
     throw new Error(`Market ${market.id} missing required metadataHash field`)
   }
   const metadata = await fetchMetadata(market.metadataHash)
+  if (isMarketMetadataExpired(metadata) && !(await hasStoredMarket(market.id))) {
+    return {
+      eventIdForStatusUpdate: null,
+      eventIdsForCacheInvalidation: [],
+      changed: false,
+      listAffectingChange: false,
+      urlSetChanged: false,
+      skippedExpired: true,
+    }
+  }
+
+  const conditionChanged = await processCondition(market, timestamps)
   const eventResult = await processEvent(
     metadata.event,
     metadata.sports?.event,
@@ -732,7 +852,27 @@ async function processMarket(
     changed,
     listAffectingChange: eventResult.listAffectingChange || hiddenChanged,
     urlSetChanged: eventResult.urlSetChanged || marketResult.urlSetChanged,
+    skippedExpired: false,
   }
+}
+
+export function isMarketMetadataExpired(metadata: any, nowMs = Date.now()) {
+  const endTimeIso = normalizeTimestamp(metadata?.end_time) ?? normalizeTimestamp(metadata?.event?.end_time)
+  if (!endTimeIso) {
+    return false
+  }
+
+  return Date.parse(endTimeIso) < nowMs - EXPIRED_MARKET_GRACE_MS
+}
+
+async function hasStoredMarket(conditionId: string) {
+  const rows = await db
+    .select({ condition_id: marketsTable.condition_id })
+    .from(marketsTable)
+    .where(eq(marketsTable.condition_id, conditionId))
+    .limit(1)
+
+  return rows.length > 0
 }
 
 async function fetchMetadata(metadataHash: string) {

--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -46,7 +46,6 @@ const SYNC_TIME_LIMIT_MS = 250_000
 const PNL_PAGE_SIZE = 200
 const INITIAL_MARKET_LOOKBACK_DAYS = 14
 const INITIAL_MARKET_LOOKBACK_SECONDS = INITIAL_MARKET_LOOKBACK_DAYS * 24 * 60 * 60
-// Keep bootstrap state in the existing text cursor so timeouts do not require a schema change.
 const INITIAL_MARKET_CURSOR_PREFIX = 'initial-market-sync:'
 const EXPIRED_MARKET_GRACE_MS = 24 * 60 * 60 * 1000
 const MARKET_SYNC_STATE = {

--- a/src/app/api/sync/events/route.ts
+++ b/src/app/api/sync/events/route.ts
@@ -46,6 +46,8 @@ const SYNC_TIME_LIMIT_MS = 250_000
 const PNL_PAGE_SIZE = 200
 const INITIAL_MARKET_LOOKBACK_DAYS = 14
 const INITIAL_MARKET_LOOKBACK_SECONDS = INITIAL_MARKET_LOOKBACK_DAYS * 24 * 60 * 60
+// Keep bootstrap state in the existing text cursor so timeouts do not require a schema change.
+const INITIAL_MARKET_CURSOR_PREFIX = 'initial-market-sync:'
 const EXPIRED_MARKET_GRACE_MS = 24 * 60 * 60 * 1000
 const MARKET_SYNC_STATE = {
   serviceName: 'market_sync',
@@ -76,6 +78,11 @@ const MAIN_CATEGORY_TAG_BY_SLUG = new Map<string, (typeof MAIN_CATEGORY_TAGS)[nu
 interface SyncCursor {
   conditionId: string
   updatedAt: number
+}
+
+interface PnLCursorState {
+  cursor: SyncCursor
+  initialCreationTimestamp: number | null
 }
 
 interface SubgraphCondition {
@@ -395,13 +402,20 @@ export async function GET(request: Request) {
       const forceCreatorSourceRefresh = shouldForceCreatorSourceRefresh(request)
       const creatorSourceRefreshPromise = refreshCreatorSourcesBeforeSync(forceCreatorSourceRefresh)
       const autoDeployNewEventsPromise = loadAutoDeployNewEventsEnabled()
-      const lastCursor = await getLastPnLCursor()
-      const initialCreationTimestamp = lastCursor ? null : resolveMinCreationTimestamp()
+      const cursorState = await getPnLCursorState()
+      const lastCursor = cursorState?.cursor ?? null
+      const initialCreationTimestamp =
+        cursorState?.initialCreationTimestamp ?? (lastCursor ? null : resolveMinCreationTimestamp())
 
       if (lastCursor) {
         console.log(
           `📊 Last PnL cursor: ${lastCursor.conditionId} @ ${new Date(lastCursor.updatedAt * 1000).toISOString()}`,
         )
+        if (initialCreationTimestamp != null) {
+          console.log(
+            `📅 Resuming initial PnL sync with creation cutoff ${new Date(initialCreationTimestamp * 1000).toISOString()}`,
+          )
+        }
       } else {
         console.log('📊 Last PnL cursor: none (initial sync)')
         if (initialCreationTimestamp != null) {
@@ -502,6 +516,7 @@ async function syncMarkets(
   let processedCount = 0
   let skippedCreatorCount = 0
   let skippedExpiredCount = 0
+  let initialScanExhausted = false
   const errors: { conditionId: string; error: string }[] = []
   let timeLimitReached = false
   const eventIdsNeedingStatusUpdate = new Set<string>()
@@ -517,6 +532,7 @@ async function syncMarkets(
 
     if (page.conditions.length === 0) {
       console.log('📦 PnL subgraph returned no additional conditions')
+      initialScanExhausted = true
       break
     }
 
@@ -597,7 +613,7 @@ async function syncMarkets(
     }
 
     if (lastPersistableCursor) {
-      await updatePnLCursor(lastPersistableCursor)
+      await updatePnLCursor(lastPersistableCursor, initialCreationTimestamp)
       cursor = lastPersistableCursor
     } else if (!timeLimitReached) {
       // Avoid stalling forever if an entire page cannot be processed.
@@ -610,7 +626,7 @@ async function syncMarkets(
         updatedAt: pageEndTimestamp,
         conditionId: lastConditionInPage.id,
       }
-      await updatePnLCursor(pageEndCursor)
+      await updatePnLCursor(pageEndCursor, initialCreationTimestamp)
       cursor = pageEndCursor
     }
 
@@ -633,6 +649,7 @@ async function syncMarkets(
 
     if (page.conditions.length < PNL_PAGE_SIZE) {
       console.log('📭 Last fetched page was smaller than the configured page size; stopping pagination')
+      initialScanExhausted = true
       break
     }
   }
@@ -658,6 +675,11 @@ async function syncMarkets(
     console.log('🧹 Event cache invalidation summary:', invalidationSummary)
   }
 
+  if (initialCreationTimestamp != null && initialScanExhausted && cursor) {
+    await updatePnLCursor(cursor, null)
+    console.log('✅ Initial PnL sync completed; future runs will use the incremental cursor')
+  }
+
   return {
     fetchedCount,
     processedCount,
@@ -672,7 +694,31 @@ function resolveMinCreationTimestamp(nowMs = Date.now()) {
   return Math.floor(nowMs / 1000) - INITIAL_MARKET_LOOKBACK_SECONDS
 }
 
-async function getLastPnLCursor(): Promise<SyncCursor | null> {
+function parsePnLCursorId(
+  cursorId: string,
+): Pick<PnLCursorState, 'initialCreationTimestamp'> & { conditionId: string } {
+  if (!cursorId.startsWith(INITIAL_MARKET_CURSOR_PREFIX)) {
+    return { conditionId: cursorId, initialCreationTimestamp: null }
+  }
+
+  const encodedState = cursorId.slice(INITIAL_MARKET_CURSOR_PREFIX.length)
+  const separatorIndex = encodedState.indexOf(':')
+  const initialCreationTimestamp = Number(encodedState.slice(0, separatorIndex))
+  const conditionId = encodedState.slice(separatorIndex + 1)
+  if (separatorIndex <= 0 || !Number.isSafeInteger(initialCreationTimestamp) || !conditionId) {
+    throw new Error('Invalid persisted initial market sync cursor')
+  }
+
+  return { conditionId, initialCreationTimestamp }
+}
+
+function serializePnLCursorId(conditionId: string, initialCreationTimestamp: number | null) {
+  return initialCreationTimestamp == null
+    ? conditionId
+    : `${INITIAL_MARKET_CURSOR_PREFIX}${initialCreationTimestamp}:${conditionId}`
+}
+
+async function getPnLCursorState(): Promise<PnLCursorState | null> {
   const rows = await db
     .select({
       cursor_updated_at: subgraph_syncs.cursor_updated_at,
@@ -692,17 +738,21 @@ async function getLastPnLCursor(): Promise<SyncCursor | null> {
     return null
   }
 
+  const parsedCursor = parsePnLCursorId(data.cursor_id)
   return {
-    conditionId: data.cursor_id,
-    updatedAt,
+    cursor: {
+      conditionId: parsedCursor.conditionId,
+      updatedAt,
+    },
+    initialCreationTimestamp: parsedCursor.initialCreationTimestamp,
   }
 }
 
-async function updatePnLCursor(cursor: SyncCursor) {
+async function updatePnLCursor(cursor: SyncCursor, initialCreationTimestamp: number | null) {
   try {
     const cursorPayload = {
       cursor_updated_at: BigInt(cursor.updatedAt),
-      cursor_id: cursor.conditionId,
+      cursor_id: serializePnLCursorId(cursor.conditionId, initialCreationTimestamp),
     }
 
     const updatedRows = await db

--- a/tests/unit/syncEventsRoute.test.ts
+++ b/tests/unit/syncEventsRoute.test.ts
@@ -69,6 +69,7 @@ describe('sync events route', () => {
   })
 
   afterEach(() => {
+    vi.useRealTimers()
     vi.unstubAllGlobals()
     vi.restoreAllMocks()
   })
@@ -297,7 +298,26 @@ describe('sync events route', () => {
     })
   })
 
+  it('treats market metadata as expired only after the one-day grace period', async () => {
+    const { isMarketMetadataExpired } = await import('@/app/api/sync/events/route')
+    const now = Date.parse('2026-08-03T12:00:00.000Z')
+
+    expect(
+      isMarketMetadataExpired(
+        {
+          end_time: '2026-08-02T11:59:59.999Z',
+          event: { end_time: '2026-08-10T00:00:00.000Z' },
+        },
+        now,
+      ),
+    ).toBe(true)
+    expect(isMarketMetadataExpired({ event: { end_time: '2026-08-02T12:00:00.000Z' } }, now)).toBe(false)
+    expect(isMarketMetadataExpired({ event: {} }, now)).toBe(false)
+  })
+
   it('hits the PnL subgraph and exits cleanly when no markets are returned', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-03T12:00:00.000Z'))
     mocks.isCronAuthorized.mockReturnValue(true)
     mocks.loadAllowedMarketCreatorWallets.mockResolvedValue({
       data: ['0xABCDEF0000000000000000000000000000000001'],
@@ -351,7 +371,136 @@ describe('sync events route', () => {
 
     const requestBody = JSON.parse(String(mocks.fetch.mock.calls[0][1].body))
     expect(requestBody.variables.creators).toEqual(['0xabcdef0000000000000000000000000000000001'])
+    expect(requestBody.variables.minCreationTimestamp).toBe('1784548800')
+    expect(requestBody.query).toContain('creationTimestamp_gte: $minCreationTimestamp')
     expect(mocks.refreshAllowedMarketCreatorSiteSources).toHaveBeenCalledWith({ force: false })
     expect(mocks.update).toHaveBeenCalledTimes(2)
+  })
+
+  it('uses only the saved cursor after the initial sync', async () => {
+    mocks.isCronAuthorized.mockReturnValue(true)
+    mocks.loadAllowedMarketCreatorWallets.mockResolvedValue({
+      data: ['0xABCDEF0000000000000000000000000000000001'],
+      error: null,
+    })
+    mocks.loadAutoDeployNewEventsEnabled.mockResolvedValue(false)
+    mocks.refreshAllowedMarketCreatorSiteSources.mockResolvedValue({
+      scanned: 0,
+      checked: 0,
+      refreshed: 0,
+      skippedFresh: 0,
+      wallets: 0,
+      errors: [],
+    })
+    mocks.select.mockImplementation(() =>
+      makeSelectChain([
+        {
+          cursor_updated_at: BigInt(1_785_758_400),
+          cursor_id: '0xlast-condition',
+        },
+      ]),
+    )
+    mocks.update.mockImplementation(() => makeUpdateChain([{ id: 'sync-row' }]))
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { conditions: [] } }),
+    })
+
+    const { GET } = await import('@/app/api/sync/events/route')
+    const response = await GET(
+      new Request('https://example.com/api/sync/events', {
+        headers: {
+          authorization: 'Bearer cron-secret',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const requestBody = JSON.parse(String(mocks.fetch.mock.calls[0][1].body))
+    expect(requestBody.variables).toEqual({
+      creators: ['0xabcdef0000000000000000000000000000000001'],
+      pageSize: 200,
+      lastUpdatedAt: '1785758400',
+      lastConditionId: '0xlast-condition',
+    })
+    expect(requestBody.query).not.toContain('creationTimestamp_gte')
+    expect(mocks.update).toHaveBeenCalledTimes(2)
+  })
+
+  it('reads metadata and skips expired new markets before persisting them', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-03T12:00:00.000Z'))
+    mocks.isCronAuthorized.mockReturnValue(true)
+    mocks.loadAllowedMarketCreatorWallets.mockResolvedValue({
+      data: ['0xabcdef0000000000000000000000000000000001'],
+      error: null,
+    })
+    mocks.loadAutoDeployNewEventsEnabled.mockResolvedValue(false)
+    mocks.refreshAllowedMarketCreatorSiteSources.mockResolvedValue({
+      scanned: 0,
+      checked: 0,
+      refreshed: 0,
+      skippedFresh: 0,
+      wallets: 0,
+      errors: [],
+    })
+    mocks.select.mockImplementation(() => makeSelectChain([]))
+    mocks.update.mockImplementation(() => makeUpdateChain([{ id: 'sync-row' }]))
+    mocks.fetch
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          data: {
+            conditions: [
+              {
+                id: '0xcondition',
+                oracle: '0xoracle',
+                questionId: '0xquestion',
+                resolved: false,
+                metadataHash: 'metadata-hash',
+                creator: '0xabcdef0000000000000000000000000000000001',
+                creationTimestamp: '1785758400',
+                updatedAt: '1785758400',
+              },
+            ],
+          },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          name: 'Expired market',
+          slug: 'expired-market',
+          end_time: '2026-08-01T00:00:00.000Z',
+          event: {
+            title: 'Expired event',
+            slug: 'expired-event',
+            end_time: '2026-08-01T00:00:00.000Z',
+          },
+        }),
+      })
+
+    const { GET } = await import('@/app/api/sync/events/route')
+    const response = await GET(
+      new Request('https://example.com/api/sync/events', {
+        headers: {
+          authorization: 'Bearer cron-secret',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      processed: 0,
+      fetched: 1,
+      skippedCreators: 0,
+      skippedExpired: 1,
+      errors: 0,
+      errorDetails: [],
+      timeLimitReached: false,
+    })
+    expect(mocks.fetch).toHaveBeenCalledTimes(2)
+    expect(mocks.update).toHaveBeenCalledTimes(3)
   })
 })

--- a/tests/unit/syncEventsRoute.test.ts
+++ b/tests/unit/syncEventsRoute.test.ts
@@ -44,13 +44,16 @@ function makeSelectChain(result: unknown[]) {
   }
 }
 
-function makeUpdateChain(result: Array<{ id: string }>) {
+function makeUpdateChain(result: Array<{ id: string }>, onSet?: (payload: unknown) => void) {
   return {
-    set: () => ({
-      where: () => ({
-        returning: async () => result,
-      }),
-    }),
+    set: (payload: unknown) => {
+      onSet?.(payload)
+      return {
+        where: () => ({
+          returning: async () => result,
+        }),
+      }
+    },
   }
 }
 
@@ -427,6 +430,145 @@ describe('sync events route', () => {
     expect(mocks.update).toHaveBeenCalledTimes(2)
   })
 
+  it('keeps the persisted initial cutoff when the bootstrap resumes in a later invocation', async () => {
+    const updatePayloads: unknown[] = []
+    mocks.isCronAuthorized.mockReturnValue(true)
+    mocks.loadAllowedMarketCreatorWallets.mockResolvedValue({
+      data: ['0xABCDEF0000000000000000000000000000000001'],
+      error: null,
+    })
+    mocks.loadAutoDeployNewEventsEnabled.mockResolvedValue(false)
+    mocks.refreshAllowedMarketCreatorSiteSources.mockResolvedValue({
+      scanned: 0,
+      checked: 0,
+      refreshed: 0,
+      skippedFresh: 0,
+      wallets: 0,
+      errors: [],
+    })
+    mocks.select.mockImplementation(() =>
+      makeSelectChain([
+        {
+          cursor_updated_at: BigInt(1_785_758_400),
+          cursor_id: 'initial-market-sync:1784548800:0xlast-condition',
+        },
+      ]),
+    )
+    mocks.update.mockImplementation(() =>
+      makeUpdateChain([{ id: 'sync-row' }], (payload) => updatePayloads.push(payload)),
+    )
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: { conditions: [] } }),
+    })
+
+    const { GET } = await import('@/app/api/sync/events/route')
+    const response = await GET(
+      new Request('https://example.com/api/sync/events', {
+        headers: {
+          authorization: 'Bearer cron-secret',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    const requestBody = JSON.parse(String(mocks.fetch.mock.calls[0][1].body))
+    expect(requestBody.variables).toEqual({
+      creators: ['0xabcdef0000000000000000000000000000000001'],
+      pageSize: 200,
+      lastUpdatedAt: '1785758400',
+      lastConditionId: '0xlast-condition',
+      minCreationTimestamp: '1784548800',
+    })
+    expect(requestBody.query).toContain('creationTimestamp_gte: $minCreationTimestamp')
+    expect(updatePayloads).toContainEqual({
+      cursor_updated_at: BigInt(1_785_758_400),
+      cursor_id: '0xlast-condition',
+    })
+  })
+
+  it('persists the initial cutoff with the cursor when the bootstrap reaches the time limit', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-03T12:00:00.000Z'))
+    const now = Date.parse('2026-08-03T12:00:00.000Z')
+    const dateNow = vi.spyOn(Date, 'now')
+    dateNow
+      .mockReturnValueOnce(now)
+      .mockReturnValueOnce(now)
+      .mockReturnValueOnce(now)
+      .mockReturnValueOnce(now)
+      .mockReturnValue(now + 250_000)
+
+    const updatePayloads: unknown[] = []
+    mocks.isCronAuthorized.mockReturnValue(true)
+    mocks.loadAllowedMarketCreatorWallets.mockResolvedValue({
+      data: ['0xabcdef0000000000000000000000000000000001'],
+      error: null,
+    })
+    mocks.loadAutoDeployNewEventsEnabled.mockResolvedValue(false)
+    mocks.refreshAllowedMarketCreatorSiteSources.mockResolvedValue({
+      scanned: 0,
+      checked: 0,
+      refreshed: 0,
+      skippedFresh: 0,
+      wallets: 0,
+      errors: [],
+    })
+    mocks.select.mockImplementation(() => makeSelectChain([]))
+    mocks.update.mockImplementation(() =>
+      makeUpdateChain([{ id: 'sync-row' }], (payload) => updatePayloads.push(payload)),
+    )
+    mocks.fetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        data: {
+          conditions: [
+            {
+              id: '0xfirst-condition',
+              oracle: null,
+              questionId: null,
+              resolved: false,
+              metadataHash: null,
+              creator: null,
+              creationTimestamp: '1785758300',
+              updatedAt: '1785758300',
+            },
+            {
+              id: '0xsecond-condition',
+              oracle: '0xoracle',
+              questionId: '0xquestion',
+              resolved: false,
+              metadataHash: 'metadata-hash',
+              creator: '0xabcdef0000000000000000000000000000000001',
+              creationTimestamp: '1785758400',
+              updatedAt: '1785758400',
+            },
+          ],
+        },
+      }),
+    })
+
+    const { GET } = await import('@/app/api/sync/events/route')
+    const response = await GET(
+      new Request('https://example.com/api/sync/events', {
+        headers: {
+          authorization: 'Bearer cron-secret',
+        },
+      }),
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toMatchObject({
+      fetched: 2,
+      processed: 0,
+      timeLimitReached: true,
+    })
+    expect(updatePayloads).toContainEqual({
+      cursor_updated_at: BigInt(1_785_758_300),
+      cursor_id: 'initial-market-sync:1784548800:0xfirst-condition',
+    })
+  })
+
   it('reads metadata and skips expired new markets before persisting them', async () => {
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-03T12:00:00.000Z'))
@@ -501,6 +643,6 @@ describe('sync events route', () => {
       timeLimitReached: false,
     })
     expect(mocks.fetch).toHaveBeenCalledTimes(2)
-    expect(mocks.update).toHaveBeenCalledTimes(3)
+    expect(mocks.update).toHaveBeenCalledTimes(4)
   })
 })


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Limit the initial market sync to a 14‑day lookback and skip expired new markets. The cutoff is preserved across partial runs, reducing subgraph load and speeding up bootstrap.

- **New Features**
  - Initial sync uses `creationTimestamp_gte` (14‑day cutoff), persisted in the cursor as `initial-market-sync:<cutoff>:<id>` and cleared once the initial scan finishes; incremental runs use only the cursor.
  - Skip persisting new markets with expired metadata `end_time` (1‑day grace); report `skippedExpired` in sync stats and status.
  - Queries and paging honor the cutoff when resuming; added helpers for cutoff persistence, resume, and cursor‑only mode.

<sup>Written for commit 5acee9b4bb6c279115d2e0ff2489d3ac56960189. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

